### PR TITLE
fix(progress-bar): stop loading in case of error

### DIFF
--- a/src/app/core/progress.interceptor.ts
+++ b/src/app/core/progress.interceptor.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpResponse} from '@angular/common/http';
 
 import { Observable } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { tap, catchError } from 'rxjs/operators';
 
 import { ProgressBarService } from './progress-bar.service';
 
@@ -13,12 +13,18 @@ export class ProgressInterceptor implements HttpInterceptor {
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     this.progressBarService.increase();
-    return next
-      .handle(request).pipe(
+    return next.handle(request)
+      .pipe(
         tap(event => {
           if (event instanceof HttpResponse) {
             this.progressBarService.decrease();
           }
+        })
+      )
+      .pipe(
+        catchError(error => {
+          this.progressBarService.decrease();
+          throw error;
         })
       );
   }


### PR DESCRIPTION
## Description
Stop progress bar loading indicator in case of an HTTP Error Response.

## Related issues and discussion
#141 

## Screenshots, if any
NA

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
