### PR TITLE
Replace Material Icons by Angular Font Awesome Icons

### DIFF
--- a/src/app/centers/centers.component.html
+++ b/src/app/centers/centers.component.html
@@ -29,9 +29,11 @@
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef mat-sort-header='status'> Status </th>
         <td mat-cell *matCellDef="let row"> <div [className]="row.active === true ? 'active' : 'inactive'">
-            <i class="fa fa-circle fa-2x"> </i>
+          <div [className]="row.active === true ? 'active' : 'inactive'">
+            <fa-icon matTooltip="{{ row.active === true ? 'Active' : 'Inactive' }}" matTooltipPosition="right" icon="circle" size="lg"></fa-icon>
+          </div>
         </div> </td>
-        
+
       </ng-container>
 
 
@@ -45,7 +47,7 @@
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;" [routerLink]="[ ]">
-         
+
       </tr>
     </table>
 

--- a/src/app/clients/clients.component.html
+++ b/src/app/clients/clients.component.html
@@ -30,11 +30,13 @@
       <!-- Status Column -->
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef mat-sort-header='active'> Status </th>
-        <td mat-cell *matCellDef="let row"> 
+        <td mat-cell *matCellDef="let row">
           <div [className]="row.active === true ? 'active' : 'inactive'">
-            <i class="fa fa-circle fa-2x"> </i>
+            <div [className]="row.active === true ? 'active' : 'inactive'">
+              <fa-icon matTooltip="{{ row.active === true ? 'Active' : 'Inactive' }}" matTooltipPosition="right" icon="circle" size="lg"></fa-icon>
+            </div>
           </div>
-       </td> 
+       </td>
       </ng-container>
 
       <!-- Color Column -->
@@ -52,7 +54,7 @@
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;" [routerLink]="['view', row.id]">
-         
+
       </tr>
     </table>
 

--- a/src/app/clients/clients.component.html
+++ b/src/app/clients/clients.component.html
@@ -25,8 +25,6 @@
         <td mat-cell *matCellDef="let row"> {{row.externalId}} </td>
       </ng-container>
 
-
-
       <!-- Status Column -->
       <ng-container matColumnDef="status">
         <th mat-header-cell *matHeaderCellDef mat-sort-header='active'> Status </th>

--- a/src/app/groups/groups.component.html
+++ b/src/app/groups/groups.component.html
@@ -3,49 +3,51 @@
     <mat-form-field class="filter">
       <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Filter">
     </mat-form-field>
-  
+
     <div class="mat-elevation-z8">
       <table mat-table [dataSource]="dataSource" matSort>
-  
+
         <!-- Name Column -->
         <ng-container matColumnDef="name">
           <th mat-header-cell *matHeaderCellDef mat-sort-header='name'> Name </th>
           <td mat-cell *matCellDef="let row"> {{row?.name}} </td>
         </ng-container>
-  
+
         <!-- Name Column -->
         <ng-container matColumnDef="accountno">
           <th mat-header-cell *matHeaderCellDef mat-sort-header='accountno'> Account # </th>
           <td mat-cell *matCellDef="let row"> {{row?.accountNo}} </td>
         </ng-container>
-  
+
         <!-- Account no Column -->
         <ng-container matColumnDef="externalid">
           <th mat-header-cell *matHeaderCellDef mat-sort-header='externalid'> ExternalID </th>
           <td mat-cell *matCellDef="let row"> {{row?.externalId}} </td>
         </ng-container>
-  
+
         <!-- External ID Column -->
         <ng-container matColumnDef="status">
           <th mat-header-cell *matHeaderCellDef mat-sort-header='status'> Status </th>
           <td mat-cell *matCellDef="let row"> <div [className]="row.active === true ? 'active' : 'inactive'">
-              <i class="fa fa-circle fa-2x"> </i>
+            <div [className]="row.active === true ? 'active' : 'inactive'">
+              <fa-icon matTooltip="{{ row.active === true ? 'Active' : 'Inactive' }}" matTooltipPosition="right" icon="circle" size="lg"></fa-icon>
+            </div>
           </div> </td>
-          
+
         </ng-container>
-  
+
         <!-- Status Column -->
         <ng-container matColumnDef="office">
           <th mat-header-cell *matHeaderCellDef mat-sort-header='office'> Office </th>
           <td mat-cell *matCellDef="let row"> {{row?.officeName}} </td>
         </ng-container>
-  
-  
+
+
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns;" [routerLink]="[ ]">
-           
+
         </tr>
       </table>
-  
+
       <mat-paginator [pageSizeOptions]="[10, 25, 100]"></mat-paginator>
     </div>

--- a/src/app/navigation/navigation.component.html
+++ b/src/app/navigation/navigation.component.html
@@ -1,7 +1,7 @@
 <div class="container">
 
-  <p>
-    TODO: navigation component.
-  </p>
+    <p>
+      TODO: navigation component.
+    </p>
 
-</div>
+  </div>


### PR DESCRIPTION
## Description
I have replaced the material icons by the Angular Font Awesome icons in Clients, Groups and Centers components. 
This is because all components are being refactored to use angular font awesome icons so as to remove the material icons dependencies.

## Related issues and discussion
#138

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.