### PR TITLE
fix: make sidebar options visible in dark themes

### DIFF
--- a/src/app/core/shell/shell.component.scss
+++ b/src/app/core/shell/shell.component.scss
@@ -3,7 +3,6 @@
   height: 100vh;
 
   .sidebar-panel {
-    background-color: #fff;
     min-height: 100vh;
     overflow: auto;
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);

--- a/src/app/core/shell/sidenav/sidenav.component.scss
+++ b/src/app/core/shell/sidenav/sidenav.component.scss
@@ -4,7 +4,6 @@
     width: 100%;
     height: 100%;
     padding-top: 20%;
-    background: hsla(0, 0%, 100%, 0.95);
   }
 
   img {


### PR DESCRIPTION
## Description
- Removes styles from shell.component.scss and sidenav.component.scss which are overriding the styles provided by angular material theme css file.

## Related issues and discussion
#366

## Screenshots, if any
![screenshot from 2019-01-18 02-45-00](https://user-images.githubusercontent.com/15383669/51349549-bb071e80-1acb-11e9-8f9d-410723766fbb.png)
![screenshot from 2019-01-18 02-45-10](https://user-images.githubusercontent.com/15383669/51349558-c0646900-1acb-11e9-8d99-9ab6ae1e3cda.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
