### PR TITLE
Fix-make system and product module routes accessible

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,7 +33,7 @@ import { AccountingModule } from './accounting/accounting.module';
 import { SelfServiceModule } from './self-service/self-service.module';
 import { SystemModule } from './system/system.module';
 import { ProductsModule } from './products/products.module';
-import { LoansModule } from './loans/loans.module';
+
 
 /** Main Routing Module */
 import { AppRoutingModule } from './app-routing.module';
@@ -61,7 +61,6 @@ import { AppRoutingModule } from './app-routing.module';
     CentersModule,
     AccountingModule,
     SelfServiceModule,
-    LoansModule,
     SystemModule,
     ProductsModule,
     AppRoutingModule

--- a/src/app/loans/loans-routing.module.ts
+++ b/src/app/loans/loans-routing.module.ts
@@ -2,9 +2,6 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
-/** Routing Imports */
-import { Route } from '../core/route/route.service';
-
 /** Translation Imports */
 import { extract } from '../core/i18n/i18n.service';
 
@@ -12,49 +9,28 @@ import { extract } from '../core/i18n/i18n.service';
 import { AddLoanChargeComponent } from './add-loan-charge/add-loan-charge.component';
 
 /** Custom Resolvers */
-import {LoanChargeTemplateResolver} from './common-resolvers/loan-charge-template.resolver';
+import { LoanChargeTemplateResolver } from './common-resolvers/loan-charge-template.resolver';
 
 const routes: Routes = [
-  Route.withShell([
-    {
-      path: ':clientType',
-      data: { title: extract('Clients'), routeParamBreadcrumb: 'clientType' },
+  {
+    path: '',
+    // Component to View All existing Loans Comes Here
+    children: [{
+      path: ':loanId',
+      data: { title: extract('Loan View'), routeParamBreadcrumb: 'loanId' },
+      // Component For Loan View Comes Here
       children: [
         {
-          path: 'view',
-          children: [
-            {
-              path: ':clientId',
-              data: { title: extract('Client View'), routeParamBreadcrumb: 'clientId' },
-              children: [
-                {
-                  path: 'loans',
-                  data: { title: extract('All Loans'), breadcrumb: 'Loans', routeParamBreadcrumb: false },
-                  children: [
-                    {
-                      path: ':loanId',
-                      data: { title: extract('Loan View'), routeParamBreadcrumb: 'loanId' },
-                      // Component For Loan View Comes Here
-                      children: [
-                        {
-                          path: 'add-loan-charge',
-                          component: AddLoanChargeComponent,
-                          data: {title: extract('Add Loan Charge'), breadcrumb: 'Add Loan Charge', routeParamBreadcrumb: false},
-                          resolve: {
-                            loanChargeTemplate: LoanChargeTemplateResolver
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
+          path: 'add-loan-charge',
+          component: AddLoanChargeComponent,
+          data: { title: extract('Add Loan Charge'), breadcrumb: 'Add Loan Charge', routeParamBreadcrumb: false },
+          resolve: {
+            loanChargeTemplate: LoanChargeTemplateResolver
+          }
         }
       ]
-    }
-  ])
+    }]
+  }
 ];
 @NgModule({
   imports: [RouterModule.forChild(routes)],
@@ -62,4 +38,4 @@ const routes: Routes = [
   declarations: [],
   providers: [LoanChargeTemplateResolver]
 })
-export class LoansRoutingModule {}
+export class LoansRoutingModule { }


### PR DESCRIPTION
## Description
Routes defined in loans-routing module were overriding the routes defined in System Module so had to refactor the loans module routes.So it can be lazy loaded in clients/groups/centers module once they are refactored

Given below is screenshot of how to use this module once they are refactored.
![screenshot from 2019-02-18 02-50-44](https://user-images.githubusercontent.com/15383669/52919755-aec0ec00-332b-11e9-8dd1-a783f3206959.png)


## Related issues and discussion
#383 

## Screenshots, if any
![screenshot from 2019-02-18 03-05-14](https://user-images.githubusercontent.com/15383669/52919699-34906780-332b-11e9-9e24-a72d62f7f1dd.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
