### PR TITLE
feat: view client image on the view client page

### DIFF
--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -1,14 +1,16 @@
 import { Injectable } from '@angular/core';
 import { Http, Headers, Response, RequestOptions, URLSearchParams } from '@angular/http';
-/* import { HttpHeaders, HttpClient } from '@angular/common/http';
- */
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { DomSanitizer } from '@angular/platform-browser';
 import { Observable } from 'rxjs';
 import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 @Injectable()
 export class ClientsService {
-  constructor(private http: Http) {} // tslint:disable-line
+  constructor(private http: Http,
+              private httpClient: HttpClient,
+              private sanitizer: DomSanitizer) {} // tslint:disable-line
 
   createAuthorizationHeader(headers: Headers) { // tslint:disable-line
     const username = 'mifos';
@@ -49,6 +51,28 @@ export class ClientsService {
             response = response.json();
             return response;
 
+          }
+        )
+      );
+  }
+
+
+  /**
+   * Fetches the client image from the API
+   * @param clientId Id of the client whose image is to be fetched
+   */
+  getClientImage(clientId: any) {
+    const httpParams = new HttpParams().set('maxHeight', '150');
+    return this.httpClient.get(`/clients/${clientId}/images`,
+        {
+          responseType: 'text',
+          params: httpParams
+        }
+      )
+      .pipe(
+        map(
+          (response) => { // tslint:disable-line
+            return this.sanitizer.bypassSecurityTrustUrl(response);
           }
         )
       );

--- a/src/app/clients/view-client/view-client.component.html
+++ b/src/app/clients/view-client/view-client.component.html
@@ -10,7 +10,7 @@
               </mat-card-title>
               <mat-card-subtitle> </mat-card-subtitle>
             </mat-card-header>
-            <img mat-card-image src="https://material.angular.io/assets/img/examples/shiba2.jpg" alt="Photo of a Shiba Inu">
+            <img mat-card-image [src]="clientImg" alt="Avatar">
             <mat-card-content class="border">
 
               <table>
@@ -378,7 +378,7 @@
             <td mat-cell *matCellDef="let row">
               <i class="fa fa-cloud-download"></i>
               <!-- <i class="p-l-5 fa fa-eye"></i> -->
-              <i class="p-l-5 fa fa-times" (click)="$event.stopPropagation(); deleteClientDocuments(id, row.id)"></i>              
+              <i class="p-l-5 fa fa-times" (click)="$event.stopPropagation(); deleteClientDocuments(id, row.id)"></i>
             </td>
           </ng-container>
 

--- a/src/app/clients/view-client/view-client.component.ts
+++ b/src/app/clients/view-client/view-client.component.ts
@@ -15,6 +15,7 @@ import { Router } from '@angular/router';
 export class ViewClientComponent implements OnInit, OnDestroy {
   notes: any = undefined;
   id: number = undefined;
+  clientImg: any = '../../../assets/images/user_placeholder.png';
   loanAccounts: any = undefined;
   savingsAccounts: any = undefined;
   shareAccounts: any = undefined;
@@ -75,15 +76,31 @@ export class ViewClientComponent implements OnInit, OnDestroy {
         (res => {
           const groupArray = new Array;
           this.clientInfo = res;
-          this.clientInfo.dateOfBirth = this.clientInfo.dateOfBirth.reverse().join('-');
+          if (this.clientInfo.imagePresent) {
+            this.getClientImage(this.id);
+          }
+          // this.clientInfo.dateOfBirth = this.clientInfo.dateOfBirth.reverse().join('-');
           this.clientInfo.activationDate = this.clientInfo.activationDate.reverse().join('-');
-
           this.clientInfo.groups.forEach(function (item: any) {
             groupArray.push(item.name);
           });
           this.clientInfo.groupNames = groupArray.join('|');
 
         })
+      );
+  }
+
+  /**
+   * Fetches the image of the client if it exists.
+   * @param id Id of the client whose image is to be fetched
+   */
+  getClientImage(id: any) {
+    // TODO: Shift into resolver when code will be refactored.
+    this.clientService.getClientImage(id)
+      .subscribe(
+        (res: any) => {
+          this.clientImg = res;
+        }
       );
   }
 


### PR DESCRIPTION
## Description
 - Add `getClientImage` method in `clients.service.ts`
 - Replace the dummy image with the fetched one

## Related issues and discussion
#107 

## Screenshots, if any
![clientimg](https://user-images.githubusercontent.com/21988675/53035642-ebabf080-349b-11e9-94a9-ef48a408f3b9.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
