### PR TITLE
feat: add clients document upload list

### DIFF
--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -16,6 +16,7 @@ import { AddFamilyMemberComponent } from './clients-view/family-members-tab/add-
 import { EditFamilyMemberComponent } from './clients-view/family-members-tab/edit-family-member/edit-family-member.component';
 import { IdentitiesTabComponent } from './clients-view/identities-tab/identities-tab.component';
 import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component';
+import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
 
 /** Custom Resolvers */
 import { ClientsResolver } from './common-resolvers/clients.resolver';
@@ -28,6 +29,7 @@ import { ClientFamilyMemberResolver } from './common-resolvers/client-family-mem
 import { ClientTemplateResolver } from './common-resolvers/client-template.resolver';
 import { ClientIdentitiesResolver } from './common-resolvers/client-identities.resolver';
 import { ClientNotesResolver } from './common-resolvers/client-notes.resolver';
+import { ClientDocumentsResolver } from './common-resolvers/client-document.resolver';
 
 const routes: Routes = [
   Route.withShell([{
@@ -96,6 +98,13 @@ const routes: Routes = [
             }
           },
           {
+            path: 'documents',
+            component: DocumentsTabComponent,
+            resolve: {
+              clientDocuments: ClientDocumentsResolver
+            }
+          },
+          {
             path: 'notes',
             component: NotesTabComponent,
             resolve: {
@@ -122,7 +131,8 @@ const routes: Routes = [
     ClientFamilyMemberResolver,
     ClientTemplateResolver,
     ClientIdentitiesResolver,
-    ClientNotesResolver
+    ClientNotesResolver,
+    ClientDocumentsResolver
   ]
 })
 export class ClientsRoutingModule { }

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -56,6 +56,10 @@
         [active]="identities.isActive">
         Identities
       </a>
+      <a mat-tab-link [routerLink]="['./documents']" routerLinkActive #documents="routerLinkActive"
+        [active]="documents.isActive">
+        Documents
+      </a>
       <a mat-tab-link [routerLink]="['./notes']" routerLinkActive #notes="routerLinkActive"
         [active]="notes.isActive">
         Notes

--- a/src/app/clients/clients-view/documents-tab/documents-tab.component.html
+++ b/src/app/clients/clients-view/documents-tab/documents-tab.component.html
@@ -1,0 +1,46 @@
+<div class="tab-container mat-typography">
+
+  <!-- Documents Table -->
+
+  <h3>Documents</h3>
+
+  <button mat-raised-button class="f-right" color="primary">
+    <fa-icon icon="plus"></fa-icon>&nbsp;&nbsp; Add
+  </button>
+
+  <table mat-table #documentsTable [dataSource]="clientDocuments" class="mat-elevation-z1">
+
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef> Name </th>
+      <td mat-cell *matCellDef="let document">
+        {{document.name}} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="description">
+      <th mat-header-cell *matHeaderCellDef> Description </th>
+      <td mat-cell *matCellDef="let document"> {{document.description}} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="fileName">
+      <th mat-header-cell *matHeaderCellDef> File Name </th>
+      <td mat-cell *matCellDef="let document"> {{document.fileName}} 
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef> Actions </th>
+      <td mat-cell *matCellDef="let document; let i = index">
+        <button class="document-action-button" mat-raised-button color="primary" (click)="download(document.parentEntityId,document.id)">
+          <fa-icon icon="cloud-download-alt"></fa-icon>
+        </button>
+        <button class="document-action-button" mat-raised-button color="warn" (click)="deleteDocument(document.parentEntityId,document.id,index)">
+          <fa-icon icon="times"></fa-icon>
+        </button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="documentsColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: documentsColumns;"></tr>
+  </table>
+
+</div>

--- a/src/app/clients/clients-view/documents-tab/documents-tab.component.scss
+++ b/src/app/clients/clients-view/documents-tab/documents-tab.component.scss
@@ -1,0 +1,17 @@
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+
+  h3 {
+    margin: 1% auto;
+  }
+  table {
+    width: 100%;
+    .document-action-button {
+      min-width: 26px;
+      padding: 0 6px;
+      margin: 4px;
+      line-height: 25px;
+    }
+  }
+}

--- a/src/app/clients/clients-view/documents-tab/documents-tab.component.spec.ts
+++ b/src/app/clients/clients-view/documents-tab/documents-tab.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DocumentsTabComponent } from './documents-tab.component';
+
+describe('DocumentsTabComponent', () => {
+  let component: DocumentsTabComponent;
+  let fixture: ComponentFixture<DocumentsTabComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DocumentsTabComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DocumentsTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/clients/clients-view/documents-tab/documents-tab.component.ts
+++ b/src/app/clients/clients-view/documents-tab/documents-tab.component.ts
@@ -1,0 +1,54 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { MatTable } from '@angular/material/table';
+import { MatDialog } from '@angular/material';
+
+/** Custom Services */
+import { ClientsService } from '../../clients.service';
+import { DeleteDialogComponent } from '../../../shared/delete-dialog/delete-dialog.component';
+
+
+@Component({
+  selector: 'mifosx-documents-tab',
+  templateUrl: './documents-tab.component.html',
+  styleUrls: ['./documents-tab.component.scss']
+})
+export class DocumentsTabComponent implements OnInit {
+  @ViewChild('documentsTable') documentsTable: MatTable<Element>;
+  documentsColumns: string[] = ['name', 'description', 'fileName', 'actions'];
+  clientDocuments: any;
+
+
+  constructor(private route: ActivatedRoute,
+    private clientService: ClientsService,
+    public dialog: MatDialog) {
+    this.route.data.subscribe((data: { clientDocuments: any }) => {
+      this.clientDocuments = data.clientDocuments;
+    });
+  }
+
+  ngOnInit() {
+  }
+
+  download(parentEntityId: string, documentId: string) {
+    this.clientService.downloadClientDocument(parentEntityId, documentId).subscribe(res => {
+      const url = window.URL.createObjectURL(res);
+      window.open(url);
+    });
+  }
+
+  deleteDocument(parentEntityId: string, documentId: string, index: number) {
+    const deleteFamilyMemberDialogRef = this.dialog.open(DeleteDialogComponent, {
+      data: { deleteContext: `document id:${documentId}` }
+    });
+    deleteFamilyMemberDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.delete) {
+        this.clientService.deleteClientDocument(parentEntityId, documentId).subscribe(res => {
+          this.clientDocuments.splice(index, 1);
+          this.documentsTable.renderRows();
+        });
+      }
+    });
+  }
+
+}

--- a/src/app/clients/clients.module.ts
+++ b/src/app/clients/clients.module.ts
@@ -18,6 +18,7 @@ import { IdentitiesTabComponent } from './clients-view/identities-tab/identities
 import { UploadDocumentDialogComponent } from './clients-view/upload-document-dialog/upload-document-dialog.component';
 import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component';
 import { EditNotesDialogComponent } from './clients-view/edit-notes-dialog/edit-notes-dialog.component';
+import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
 
 
 /**
@@ -41,7 +42,8 @@ import { EditNotesDialogComponent } from './clients-view/edit-notes-dialog/edit-
     IdentitiesTabComponent,
     UploadDocumentDialogComponent,
     NotesTabComponent,
-    EditNotesDialogComponent
+    EditNotesDialogComponent,
+    DocumentsTabComponent
   ],
   entryComponents: [
     UploadDocumentDialogComponent,

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -88,6 +88,18 @@ export class ClientsService {
     return this.http.post(`/client_identifiers/${identifierId}/documents`, documentData);
   }
 
+  getClientDocuments(clientId: string) {
+    return this.http.get(`/clients/${clientId}/documents`);
+  }
+
+  downloadClientDocument(parentEntityId: string, documentId: string) {
+    return this.http.get(`/clients/${parentEntityId}/documents/${documentId}/attachment`, { responseType: 'blob' });
+  }
+
+  deleteClientDocument(parentEntityId: string, documentId: string) {
+    return this.http.delete(`/clients/${parentEntityId}/documents/${documentId}`);
+  }
+
   getClientNotes(clientId: string) {
     return this.http.get(`/clients/${clientId}/notes`);
   }

--- a/src/app/clients/common-resolvers/client-document.resolver.ts
+++ b/src/app/clients/common-resolvers/client-document.resolver.ts
@@ -1,0 +1,31 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { ClientsService } from '../clients.service';
+
+/**
+ * Client Documents resolver.
+ */
+@Injectable()
+export class ClientDocumentsResolver implements Resolve<Object> {
+
+    /**
+     * @param {ClientsService} ClientsService Clients service.
+     */
+    constructor(private clientsService: ClientsService) { }
+
+    /**
+     * Returns the Client's Documents data.
+     * @returns {Observable<any>}
+     */
+    resolve(route: ActivatedRouteSnapshot): Observable<any> {
+        const clientId = route.parent.paramMap.get('clientId');
+        return this.clientsService.getClientDocuments(clientId);
+    }
+
+}


### PR DESCRIPTION
## Description
- add document-tab.component to view list of uploaded documents
## Related issues and discussion
#264
## Screenshots, if any
![screencapture-localhost-4200-clients-1-documents-2019-06-26-05_50_28](https://user-images.githubusercontent.com/15383669/60142194-608a9080-97d6-11e9-9e97-783458848c93.png)

## Checklist
- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
