### PR TITLE
feat: add datatable tabs in clients view component

### DIFF
--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -17,6 +17,7 @@ import { EditFamilyMemberComponent } from './clients-view/family-members-tab/edi
 import { IdentitiesTabComponent } from './clients-view/identities-tab/identities-tab.component';
 import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component';
 import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
+import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
 
 /** Custom Resolvers */
 import { ClientsResolver } from './common-resolvers/clients.resolver';
@@ -30,6 +31,8 @@ import { ClientTemplateResolver } from './common-resolvers/client-template.resol
 import { ClientIdentitiesResolver } from './common-resolvers/client-identities.resolver';
 import { ClientNotesResolver } from './common-resolvers/client-notes.resolver';
 import { ClientDocumentsResolver } from './common-resolvers/client-document.resolver';
+import { ClientDatatablesResolver } from './common-resolvers/client-datatables.resolver';
+import { ClientDatatableResolver } from './common-resolvers/client-datatable.resolver';
 
 const routes: Routes = [
   Route.withShell([{
@@ -49,6 +52,7 @@ const routes: Routes = [
         data: { title: extract('Clients View'), routeParamBreadcrumb: 'clientId' },
         resolve: {
           clientViewData: ClientViewResolver,
+          clientDatatables: ClientDatatablesResolver
         },
         children: [
           {
@@ -110,6 +114,16 @@ const routes: Routes = [
             resolve: {
               clientNotes: ClientNotesResolver
             }
+          },
+          {
+            path: 'datatables',
+            children: [{
+              path: ':datatableName',
+              component: DatatableTabComponent,
+              resolve: {
+                clientDatatable: ClientDatatableResolver
+              }
+            }]
           }
         ]
       }
@@ -132,7 +146,9 @@ const routes: Routes = [
     ClientTemplateResolver,
     ClientIdentitiesResolver,
     ClientNotesResolver,
-    ClientDocumentsResolver
+    ClientDocumentsResolver,
+    ClientDatatablesResolver,
+    ClientDatatableResolver
   ]
 })
 export class ClientsRoutingModule { }

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -43,7 +43,7 @@
     </mat-card-actions>
   </mat-card-header>
   <mat-card-content>
-    <nav mat-tab-nav-bar>
+    <nav mat-tab-nav-bar class="navigation-tabs">
       <a mat-tab-link [routerLink]="['./general']" routerLinkActive #general="routerLinkActive"
         [active]="general.isActive">
         General
@@ -60,9 +60,12 @@
         [active]="documents.isActive">
         Documents
       </a>
-      <a mat-tab-link [routerLink]="['./notes']" routerLinkActive #notes="routerLinkActive"
-        [active]="notes.isActive">
+      <a mat-tab-link [routerLink]="['./notes']" routerLinkActive #notes="routerLinkActive" [active]="notes.isActive">
         Notes
+      </a>
+      <a mat-tab-link *ngFor="let clientDatatable of clientDatatables" [routerLink]="['./datatables',clientDatatable.registeredTableName]"
+        routerLinkActive #datatable="routerLinkActive" [active]="datatable.isActive">
+        {{clientDatatable.registeredTableName}}
       </a>
     </nav>
     <router-outlet></router-outlet>

--- a/src/app/clients/clients-view/clients-view.component.scss
+++ b/src/app/clients/clients-view/clients-view.component.scss
@@ -26,4 +26,7 @@
       margin: 0 1%;
     }
   }
+  .navigation-tabs {
+    overflow: auto;
+  }
 }

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -12,13 +12,18 @@ import { ClientsService } from '../clients.service';
 })
 export class ClientsViewComponent implements OnInit {
   clientViewData: any;
+  clientDatatables: any;
   clientImage: any;
   clientTemplate: any;
   constructor(private route: ActivatedRoute,
     private clientsService: ClientsService,
     private _sanitizer: DomSanitizer) {
-    this.route.data.subscribe((data: { clientViewData: any }) => {
+    this.route.data.subscribe((data: {
+      clientViewData: any,
+      clientDatatables: any
+    }) => {
       this.clientViewData = data.clientViewData;
+      this.clientDatatables = data.clientDatatables;
     });
   }
 

--- a/src/app/clients/clients-view/datatable-tab/datatable-tab.component.html
+++ b/src/app/clients/clients-view/datatable-tab/datatable-tab.component.html
@@ -1,0 +1,4 @@
+<div>
+  <mifosx-multi-row *ngIf="multiRowDatatableFlag" [dataObject]="clientDatatable"></mifosx-multi-row>
+  <mifosx-single-row *ngIf="!multiRowDatatableFlag" [dataObject]="clientDatatable"></mifosx-single-row>
+</div>

--- a/src/app/clients/clients-view/datatable-tab/datatable-tab.component.spec.ts
+++ b/src/app/clients/clients-view/datatable-tab/datatable-tab.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DatatableTabComponent } from './datatable-tab.component';
+
+describe('DatatableTabComponent', () => {
+  let component: DatatableTabComponent;
+  let fixture: ComponentFixture<DatatableTabComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DatatableTabComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DatatableTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/clients/clients-view/datatable-tab/datatable-tab.component.ts
+++ b/src/app/clients/clients-view/datatable-tab/datatable-tab.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'mifosx-datatable-tab',
+  templateUrl: './datatable-tab.component.html',
+  styleUrls: ['./datatable-tab.component.scss']
+})
+export class DatatableTabComponent implements OnInit {
+  clientDatatable: any;
+  multiRowDatatableFlag: boolean;
+  constructor(private route: ActivatedRoute) {
+    this.route.data.subscribe((data: { clientDatatable: any }) => {
+      this.clientDatatable = data.clientDatatable;
+      this.multiRowDatatableFlag = this.clientDatatable.columnHeaders[0].columnName === 'id' ? true : false;
+    });
+
+  }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/clients/clients-view/datatable-tab/multi-row/multi-row.component.html
+++ b/src/app/clients/clients-view/datatable-tab/multi-row/multi-row.component.html
@@ -1,0 +1,20 @@
+<div class="tab-container mat-typography">
+  <h3>{{datatableName}}</h3>
+  <div fxLayout="row" fxLayoutAlign="flex-end">
+    <button mat-raised-button color="primary">
+      <fa-icon icon="plus"></fa-icon>&nbsp;&nbsp;Add
+    </button>
+  </div>
+  <table mat-table *ngIf="dataObject.data[0]" [dataSource]="datatableData" class="mat-elevation-z1">
+
+    <ng-container *ngFor="let datatableColumn of datatableColumns;let i = index" [matColumnDef]="datatableColumn">
+      <th mat-header-cell *matHeaderCellDef> {{datatableColumn}} </th>
+      <td mat-cell *matCellDef="let data"> {{data.row[i]}} </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="datatableColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: datatableColumns;"></tr>
+  </table>
+
+
+</div>

--- a/src/app/clients/clients-view/datatable-tab/multi-row/multi-row.component.scss
+++ b/src/app/clients/clients-view/datatable-tab/multi-row/multi-row.component.scss
@@ -1,0 +1,8 @@
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+
+  table {
+    width: 100%;
+  }
+}

--- a/src/app/clients/clients-view/datatable-tab/multi-row/multi-row.component.spec.ts
+++ b/src/app/clients/clients-view/datatable-tab/multi-row/multi-row.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MultiRowComponent } from './multi-row.component';
+
+describe('MultiRowComponent', () => {
+  let component: MultiRowComponent;
+  let fixture: ComponentFixture<MultiRowComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MultiRowComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MultiRowComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/clients/clients-view/datatable-tab/multi-row/multi-row.component.ts
+++ b/src/app/clients/clients-view/datatable-tab/multi-row/multi-row.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit, Input, OnChanges } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'mifosx-multi-row',
+  templateUrl: './multi-row.component.html',
+  styleUrls: ['./multi-row.component.scss']
+})
+export class MultiRowComponent implements OnInit, OnChanges {
+  @Input() dataObject: any;
+  datatableName: String;
+  datatableColumns: string[] = [];
+  datatableData: any;
+
+
+  constructor(private route: ActivatedRoute) { }
+
+  ngOnInit() {
+    this.route.params.subscribe((routeParams: any) => {
+      this.datatableName = routeParams.datatableName;
+    });
+  }
+  ngOnChanges() {
+    this.datatableColumns = this.dataObject.columnHeaders.map((columnHeader: any) => {
+      return columnHeader.columnName;
+    });
+    this.datatableData = this.dataObject.data;
+  }
+}

--- a/src/app/clients/clients-view/datatable-tab/single-row/single-row.component.html
+++ b/src/app/clients/clients-view/datatable-tab/single-row/single-row.component.html
@@ -1,0 +1,13 @@
+<div class="tab-container mat-typography">
+  <h3>{{datatableName}}</h3>
+  <div fxLayout="row" fxLayoutAlign="flex-end">
+    <button mat-raised-button color="primary">
+      <fa-icon icon="plus"></fa-icon>&nbsp;&nbsp;Add
+    </button>
+  </div>
+  <mat-list role="list" *ngIf="dataObject.data[0]">
+    <mat-list-item role="listitem" *ngFor="let columnHeader of dataObject.columnHeaders;let i = index">
+      {{columnHeader.columnName}} : {{dataObject.data[0].row[i]}}
+    </mat-list-item>
+  </mat-list>
+</div>

--- a/src/app/clients/clients-view/datatable-tab/single-row/single-row.component.scss
+++ b/src/app/clients/clients-view/datatable-tab/single-row/single-row.component.scss
@@ -1,0 +1,4 @@
+.tab-container {
+    padding:1%;
+    margin: 1%;
+}

--- a/src/app/clients/clients-view/datatable-tab/single-row/single-row.component.spec.ts
+++ b/src/app/clients/clients-view/datatable-tab/single-row/single-row.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SingleRowComponent } from './single-row.component';
+
+describe('SingleRowComponent', () => {
+  let component: SingleRowComponent;
+  let fixture: ComponentFixture<SingleRowComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SingleRowComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SingleRowComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/clients/clients-view/datatable-tab/single-row/single-row.component.ts
+++ b/src/app/clients/clients-view/datatable-tab/single-row/single-row.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'mifosx-single-row',
+  templateUrl: './single-row.component.html',
+  styleUrls: ['./single-row.component.scss']
+})
+export class SingleRowComponent implements OnInit {
+  @Input() dataObject: any;
+  datatableName: String;
+  constructor(private route: ActivatedRoute) { }
+
+  ngOnInit() {
+    this.route.params.subscribe((routeParams: any) => {
+      this.datatableName = routeParams.datatableName;
+    });
+  }
+
+}

--- a/src/app/clients/clients.module.ts
+++ b/src/app/clients/clients.module.ts
@@ -19,6 +19,9 @@ import { UploadDocumentDialogComponent } from './clients-view/upload-document-di
 import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component';
 import { EditNotesDialogComponent } from './clients-view/edit-notes-dialog/edit-notes-dialog.component';
 import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
+import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
+import { MultiRowComponent } from './clients-view/datatable-tab/multi-row/multi-row.component';
+import { SingleRowComponent } from './clients-view/datatable-tab/single-row/single-row.component';
 
 
 /**
@@ -43,7 +46,10 @@ import { DocumentsTabComponent } from './clients-view/documents-tab/documents-ta
     UploadDocumentDialogComponent,
     NotesTabComponent,
     EditNotesDialogComponent,
-    DocumentsTabComponent
+    DocumentsTabComponent,
+    DatatableTabComponent,
+    MultiRowComponent,
+    SingleRowComponent
   ],
   entryComponents: [
     UploadDocumentDialogComponent,

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -28,6 +28,15 @@ export class ClientsService {
     return this.http.get(`/clients/${clientId}`);
   }
 
+  getClientDatatables() {
+    const httpParams = new HttpParams().set('apptable', 'm_client');
+    return this.http.get(`/datatables`, { params: httpParams });
+  }
+  getClientDatatable(clientId: string, datatableName: string) {
+    const httpParams = new HttpParams().set('genericResultSet', 'true');
+    return this.http.get(`/datatables/${datatableName}/${clientId}`, { params: httpParams });
+  }
+
   getClientAccountData(clientId: string) {
     return this.http.get(`/clients/${clientId}/accounts`);
   }

--- a/src/app/clients/common-resolvers/client-datatable.resolver.ts
+++ b/src/app/clients/common-resolvers/client-datatable.resolver.ts
@@ -1,0 +1,32 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { ClientsService } from '../clients.service';
+
+/**
+ * Client datatable resolver.
+ */
+@Injectable()
+export class ClientDatatableResolver implements Resolve<Object> {
+
+    /**
+     * @param {ClientsService} ClientsService Clients service.
+     */
+    constructor(private clientsService: ClientsService) { }
+
+    /**
+     * Returns the Client datatables.
+     * @returns {Observable<any>}
+     */
+    resolve(route: ActivatedRouteSnapshot): Observable<any> {
+        const clientId = route.parent.parent.paramMap.get('clientId');
+        const datatableName = route.paramMap.get('datatableName');
+        return this.clientsService.getClientDatatable(clientId, datatableName);
+    }
+
+}

--- a/src/app/clients/common-resolvers/client-datatables.resolver.ts
+++ b/src/app/clients/common-resolvers/client-datatables.resolver.ts
@@ -1,0 +1,30 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { ClientsService } from '../clients.service';
+
+/**
+ * Client datatables resolver.
+ */
+@Injectable()
+export class ClientDatatablesResolver implements Resolve<Object> {
+
+    /**
+     * @param {ClientsService} ClientsService Clients service.
+     */
+    constructor(private clientsService: ClientsService) { }
+
+    /**
+     * Returns the Client datatables.
+     * @returns {Observable<any>}
+     */
+    resolve(): Observable<any> {
+        return this.clientsService.getClientDatatables();
+    }
+
+}


### PR DESCRIPTION
## Description
Added the following component to implement the required feature:
- datatable-tab component
- single-row component
-  multi-row component

## Related issues and discussion
#431 

## Screenshots, if any
![Screen Shot 2019-07-08 at 12 54 18 AM](https://user-images.githubusercontent.com/15383669/60772974-88092380-a11b-11e9-8972-b112ced2b29f.png)
![Screen Shot 2019-07-08 at 12 54 31 AM](https://user-images.githubusercontent.com/15383669/60772975-89d2e700-a11b-11e9-9f71-a1a807e7755b.png)

## Checklist
- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
