### PR TITLE
feat(clients): upload document page

### DIFF
--- a/src/app/clients/clients-view/documents-tab/documents-tab.component.html
+++ b/src/app/clients/clients-view/documents-tab/documents-tab.component.html
@@ -1,46 +1,47 @@
 <div class="tab-container mat-typography">
 
-  <!-- Documents Table -->
+    <!-- Documents Table -->
 
-  <h3>Documents</h3>
+    <h3>Documents</h3>
 
-  <button mat-raised-button class="f-right" color="primary">
-    <fa-icon icon="plus"></fa-icon>&nbsp;&nbsp; Add
+    <button mat-raised-button class="f-right" color="primary" (click)="uploadDocument()">
+    <fa-icon icon="plus"></fa-icon>
+    &nbsp;&nbsp; Add
   </button>
 
-  <table mat-table #documentsTable [dataSource]="clientDocuments" class="mat-elevation-z1">
+    <table mat-table #documentsTable [dataSource]="clientDocuments" class="mat-elevation-z1">
 
-    <ng-container matColumnDef="name">
-      <th mat-header-cell *matHeaderCellDef> Name </th>
-      <td mat-cell *matCellDef="let document">
-        {{document.name}} </td>
-    </ng-container>
+        <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef> Name </th>
+            <td mat-cell *matCellDef="let document">
+                {{document.name}} </td>
+        </ng-container>
 
-    <ng-container matColumnDef="description">
-      <th mat-header-cell *matHeaderCellDef> Description </th>
-      <td mat-cell *matCellDef="let document"> {{document.description}} </td>
-    </ng-container>
+        <ng-container matColumnDef="description">
+            <th mat-header-cell *matHeaderCellDef> Description </th>
+            <td mat-cell *matCellDef="let document"> {{document.description}} </td>
+        </ng-container>
 
-    <ng-container matColumnDef="fileName">
-      <th mat-header-cell *matHeaderCellDef> File Name </th>
-      <td mat-cell *matCellDef="let document"> {{document.fileName}} 
-      </td>
-    </ng-container>
+        <ng-container matColumnDef="fileName">
+            <th mat-header-cell *matHeaderCellDef> File Name </th>
+            <td mat-cell *matCellDef="let document"> {{document.fileName}}
+            </td>
+        </ng-container>
 
-    <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef> Actions </th>
-      <td mat-cell *matCellDef="let document; let i = index">
-        <button class="document-action-button" mat-raised-button color="primary" (click)="download(document.parentEntityId,document.id)">
+        <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef> Actions </th>
+            <td mat-cell *matCellDef="let document; let i = index">
+                <button class="document-action-button" mat-raised-button color="primary" (click)="download(document.parentEntityId,document.id)">
           <fa-icon icon="cloud-download-alt"></fa-icon>
         </button>
-        <button class="document-action-button" mat-raised-button color="warn" (click)="deleteDocument(document.parentEntityId,document.id,index)">
+                <button class="document-action-button" mat-raised-button color="warn" (click)="deleteDocument(document.parentEntityId,document.id,i)">
           <fa-icon icon="times"></fa-icon>
         </button>
-      </td>
-    </ng-container>
+            </td>
+        </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="documentsColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: documentsColumns;"></tr>
-  </table>
+        <tr mat-header-row *matHeaderRowDef="documentsColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: documentsColumns;"></tr>
+    </table>
 
 </div>

--- a/src/app/clients/clients-view/documents-tab/documents-tab.component.ts
+++ b/src/app/clients/clients-view/documents-tab/documents-tab.component.ts
@@ -5,6 +5,9 @@ import { MatDialog } from '@angular/material';
 
 /** Custom Services */
 import { ClientsService } from '../../clients.service';
+
+/** Custom Components */
+import { UploadDocumentDialogComponent } from '../upload-document-dialog/upload-document-dialog.component';
 import { DeleteDialogComponent } from '../../../shared/delete-dialog/delete-dialog.component';
 
 
@@ -17,6 +20,7 @@ export class DocumentsTabComponent implements OnInit {
   @ViewChild('documentsTable') documentsTable: MatTable<Element>;
   documentsColumns: string[] = ['name', 'description', 'fileName', 'actions'];
   clientDocuments: any;
+  clientId: string;
 
 
   constructor(private route: ActivatedRoute,
@@ -24,7 +28,10 @@ export class DocumentsTabComponent implements OnInit {
     public dialog: MatDialog) {
     this.route.data.subscribe((data: { clientDocuments: any }) => {
       this.clientDocuments = data.clientDocuments;
+      console.log(this.clientDocuments);
+
     });
+    this.clientId = this.route.parent.snapshot.paramMap.get('clientId');
   }
 
   ngOnInit() {
@@ -38,14 +45,41 @@ export class DocumentsTabComponent implements OnInit {
   }
 
   deleteDocument(parentEntityId: string, documentId: string, index: number) {
-    const deleteFamilyMemberDialogRef = this.dialog.open(DeleteDialogComponent, {
+    const deleteDocumentDialogRef = this.dialog.open(DeleteDialogComponent, {
       data: { deleteContext: `document id:${documentId}` }
     });
-    deleteFamilyMemberDialogRef.afterClosed().subscribe((response: any) => {
+    deleteDocumentDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
         this.clientService.deleteClientDocument(parentEntityId, documentId).subscribe(res => {
           this.clientDocuments.splice(index, 1);
           this.documentsTable.renderRows();
+        });
+      }
+    });
+  }
+
+  uploadDocument() {
+    const uploadDocumentDialogRef = this.dialog.open(UploadDocumentDialogComponent, {
+      data: { documentIdentifier: false }
+    });
+    uploadDocumentDialogRef.afterClosed().subscribe((dialogResponse: any) => {
+      console.log(dialogResponse);
+      if (dialogResponse) {
+        const formData: FormData = new FormData;
+        formData.append('name', dialogResponse.fileName);
+        formData.append('file', dialogResponse.file);
+        formData.append('description', dialogResponse.description);
+        this.clientService.uploadClientDocument(this.clientId, formData).subscribe((res: any) => {
+          this.clientDocuments.push({
+            id: res.resourceId,
+            parentEntityType: 'clients',
+            parentEntityId: this.clientId,
+            name: dialogResponse.fileName,
+            description: dialogResponse.description,
+            fileName: dialogResponse.file.name
+          });
+          this.documentsTable.renderRows();
+          console.log('document Uploaded');
         });
       }
     });

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.html
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.html
@@ -49,7 +49,7 @@
         <button class="identity-action-button" mat-raised-button color="primary" (click)="uploadDocument(i,identity.id)">
           <fa-icon icon="cloud-upload-alt"></fa-icon>
         </button>
-        <button class="identity-action-button" mat-raised-button color="warn" (click)="deleteIdentifier(identity.clientId,identity.id,index)">
+        <button class="identity-action-button" mat-raised-button color="warn" (click)="deleteIdentifier(identity.clientId,identity.id,i)">
           <fa-icon icon="times"></fa-icon>
         </button>
       </td>

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
@@ -53,7 +53,9 @@ export class IdentitiesTabComponent implements OnInit {
   }
 
   uploadDocument(index: number, identifierId: string) {
-    const uploadDocumentDialogRef = this.dialog.open(UploadDocumentDialogComponent);
+    const uploadDocumentDialogRef = this.dialog.open(UploadDocumentDialogComponent, {
+      data: { documentIdentifier: true }
+    });
     uploadDocumentDialogRef.afterClosed().subscribe((dialogResponse: any) => {
       if (dialogResponse) {
         const formData: FormData = new FormData;
@@ -65,7 +67,7 @@ export class IdentitiesTabComponent implements OnInit {
             parentEntityType: 'client_identifiers',
             parentEntityId: identifierId,
             name: dialogResponse.fileName,
-            fileName: dialogResponse.file.fileName
+            fileName: dialogResponse.file.name
           });
           this.identifiersTable.renderRows();
         });

--- a/src/app/clients/clients-view/upload-document-dialog/upload-document-dialog.component.html
+++ b/src/app/clients/clients-view/upload-document-dialog/upload-document-dialog.component.html
@@ -1,22 +1,26 @@
 <h1 mat-dialog-title>Upload Client Documents</h1>
 <div>
-  <form [formGroup]="uploadDocumentForm" fxLayout="column">
+    <form [formGroup]="uploadDocumentForm" fxLayout="column">
 
-    <mat-form-field fxFlex>
-      <mat-label>File Name</mat-label>
-      <input formControlName="fileName" required matInput />
-      <mat-error *ngIf="uploadDocumentForm.controls.fileName.hasError('required')">
-        File Name is <strong>required</strong>
-      </mat-error>
-    </mat-form-field>
+        <mat-form-field fxFlex>
+            <mat-label>File Name</mat-label>
+            <input formControlName="fileName" required matInput />
+            <mat-error *ngIf="uploadDocumentForm.controls.fileName.hasError('required')">
+                File Name is <strong>required</strong>
+            </mat-error>
+        </mat-form-field>
 
-    <input type="file" name="file" (change)="onFileSelect($event)" />
+        <mat-form-field fxFlex *ngIf="!documentIdentifier">
+            <mat-label>Description</mat-label>
+            <input formControlName="description" matInput />
+        </mat-form-field>
 
-    <mat-dialog-actions align="end">
-      <button mat-raised-button mat-dialog-close>Cancel</button>
-      <button mat-raised-button color="primary" [disabled]="!uploadDocumentForm.valid"
-        [mat-dialog-close]="uploadDocumentForm.value">Confirm</button>
-    </mat-dialog-actions>
+        <input type="file" name="file" (change)="onFileSelect($event)" />
 
-  </form>
+        <mat-dialog-actions align="end">
+            <button mat-raised-button mat-dialog-close>Cancel</button>
+            <button mat-raised-button color="primary" [disabled]="!uploadDocumentForm.valid" [mat-dialog-close]="uploadDocumentForm.value">Confirm</button>
+        </mat-dialog-actions>
+
+    </form>
 </div>

--- a/src/app/clients/clients-view/upload-document-dialog/upload-document-dialog.component.ts
+++ b/src/app/clients/clients-view/upload-document-dialog/upload-document-dialog.component.ts
@@ -12,10 +12,12 @@ export class UploadDocumentDialogComponent implements OnInit {
   uploadDocumentForm: FormGroup;
   file: any;
   uploadDocumentData: any = [];
-
+  documentIdentifier = false;
   constructor(public dialogRef: MatDialogRef<UploadDocumentDialogComponent>,
     private formBuilder: FormBuilder,
-    @Inject(MAT_DIALOG_DATA) public data: any) { }
+    @Inject(MAT_DIALOG_DATA) public data: any) {
+    this.documentIdentifier = data.documentIdentifier;
+  }
 
   ngOnInit() {
     this.createUploadDocumentForm();
@@ -27,6 +29,7 @@ export class UploadDocumentDialogComponent implements OnInit {
   createUploadDocumentForm() {
     this.uploadDocumentForm = this.formBuilder.group({
       'fileName': ['', Validators.required],
+      'description': [''],
       'file': ['']
     });
   }

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -105,6 +105,10 @@ export class ClientsService {
     return this.http.get(`/clients/${parentEntityId}/documents/${documentId}/attachment`, { responseType: 'blob' });
   }
 
+  uploadClientDocument(clientId: string, documentData: any) {
+    return this.http.post(`/clients/${clientId}/documents`, documentData);
+  }
+
   deleteClientDocument(parentEntityId: string, documentId: string) {
     return this.http.delete(`/clients/${parentEntityId}/documents/${documentId}`);
   }


### PR DESCRIPTION
## Description
- Used the existing document upload dialog component to upload documents in documents tab of client view page

## Related issues and discussion
#265 



## Screenshots, if any
![issue265](https://user-images.githubusercontent.com/15383669/61084287-40500800-a44b-11e9-9078-2b6dfa341507.PNG)

## Checklist
- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
