### PR TITLE
feat (clients): add client's address page

### DIFF
--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -18,11 +18,13 @@ import { IdentitiesTabComponent } from './clients-view/identities-tab/identities
 import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component';
 import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
 import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
+import { AddressTabComponent } from './clients-view/address-tab/address-tab.component';
 
 /** Custom Resolvers */
 import { ClientsResolver } from './common-resolvers/clients.resolver';
 import { ClientViewResolver } from './common-resolvers/client-view.resolver';
 import { ClientAccountsResolver } from './common-resolvers/client-accounts.resolver';
+import { ClientAddressResolver } from './common-resolvers/client-address.resolver';
 import { ClientChargesResolver } from './common-resolvers/client-charges.resolver';
 import { ClientSummaryResolver } from './common-resolvers/client-summary.resolver';
 import { ClientFamilyMembersResolver } from './common-resolvers/client-family-members.resolver';
@@ -34,6 +36,8 @@ import { ClientDocumentsResolver } from './common-resolvers/client-document.reso
 import { ClientDatatablesResolver } from './common-resolvers/client-datatables.resolver';
 import { ClientDatatableResolver } from './common-resolvers/client-datatable.resolver';
 import { ClientIdentifierTemplateResolver } from './common-resolvers/client-identifier-template.resolver';
+import { ClientAddressFieldConfigurationResolver } from './common-resolvers/client-address-fieldconfiguration.resolver';
+import { ClientAddressTemplateResolver } from './common-resolvers/client-address-template.resolver';
 
 const routes: Routes = [
   Route.withShell([{
@@ -53,6 +57,7 @@ const routes: Routes = [
         data: { title: extract('Clients View'), routeParamBreadcrumb: 'clientId' },
         resolve: {
           clientViewData: ClientViewResolver,
+          clientTemplateData: ClientTemplateResolver,
           clientDatatables: ClientDatatablesResolver
         },
         children: [
@@ -63,6 +68,15 @@ const routes: Routes = [
               clientAccountsData: ClientAccountsResolver,
               clientChargesData: ClientChargesResolver,
               clientSummary: ClientSummaryResolver
+            }
+          },
+          {
+            path: 'address',
+            component: AddressTabComponent,
+            resolve: {
+              clientAddressFieldConfig: ClientAddressFieldConfigurationResolver,
+              clientAddressTemplateData: ClientAddressTemplateResolver,
+              clientAddressData: ClientAddressResolver
             }
           },
           {
@@ -141,6 +155,7 @@ const routes: Routes = [
     ClientsResolver,
     ClientViewResolver,
     ClientAccountsResolver,
+    ClientAddressResolver,
     ClientChargesResolver,
     ClientSummaryResolver,
     ClientFamilyMembersResolver,
@@ -151,7 +166,9 @@ const routes: Routes = [
     ClientDocumentsResolver,
     ClientDatatablesResolver,
     ClientDatatableResolver,
-    ClientIdentifierTemplateResolver
+    ClientIdentifierTemplateResolver,
+    ClientAddressFieldConfigurationResolver,
+    ClientAddressTemplateResolver
   ]
 })
 export class ClientsRoutingModule { }

--- a/src/app/clients/clients-view/address-tab/address-tab.component.html
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.html
@@ -1,0 +1,40 @@
+<div class="tab-container mat-typography">
+  <h3>Address</h3>
+  <div fxLayout="row" fxLayoutAlign="flex-end">
+    <button mat-raised-button color="primary">
+      <fa-icon icon="plus"></fa-icon>&nbsp;&nbsp;Add
+    </button>
+  </div>
+  <mat-accordion>
+    <mat-expansion-panel *ngFor="let address of clientAddressData;index as i" class="address">
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          {{address.addressType}}
+        </mat-panel-title>
+        <mat-panel-description>
+          {{address.relationship}}
+        </mat-panel-description>
+      </mat-expansion-panel-header>
+      <mat-divider [inset]="true"></mat-divider>
+      <div class="address-actions" fxLayout="row" fxLayoutAlign="flex-end">
+        <button mat-button color="primary">
+          <fa-icon icon="edit"></fa-icon>
+        </button>
+      </div>
+      <p>
+        <span *ngIf="isFieldEnabled('street')">Street : {{address.street}}<br /></span>
+        <span *ngIf="isFieldEnabled('addressLine1')">Address Line 1 : {{address.addressLine1}}<br /></span>
+        <span *ngIf="isFieldEnabled('addressLine2')">Address Line 2 : {{address.addressLine2}}<br /></span>
+        <span *ngIf="isFieldEnabled('addressLine3')">Address Line 3 : {{address.addressLine3}}<br /></span>
+        <span *ngIf="isFieldEnabled('townVillage')">Town / Village : {{address.townVillage}}<br /></span>
+        <span *ngIf="isFieldEnabled('city')">City : {{address.city}}<br /></span>
+        <span *ngIf="isFieldEnabled('stateProvinceId')">State / Province :
+          {{getSelectedValue('stateProvinceIdOptions',address.stateProvinceId)?.name}}<br /></span>
+        <span *ngIf="isFieldEnabled('countryId')">Country :
+          {{getSelectedValue('countryIdOptions',address.countryId)?.name}}<br /></span>
+        <span *ngIf="isFieldEnabled('postalCode')">Postal Code : {{address.postalCode}}<br /></span>
+        <span *ngIf="isFieldEnabled('isActive')">Active Status : {{address.isActive}}<br /></span>
+      </p>
+    </mat-expansion-panel>
+  </mat-accordion>
+</div>

--- a/src/app/clients/clients-view/address-tab/address-tab.component.scss
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.scss
@@ -1,0 +1,22 @@
+.tab-container {
+    padding:1%;
+    margin: 1%;
+  
+    .address {
+      .address-actions{
+        margin-top: 1%;
+        button{
+          margin-right: 1%;
+        }
+      }
+      h3 {
+        margin: 1% auto;
+      }
+  
+      p {
+        line-height: 30px;
+        margin-left: 2%;
+      }
+    }
+  }
+  

--- a/src/app/clients/clients-view/address-tab/address-tab.component.spec.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddressTabComponent } from './address-tab.component';
+
+describe('AddressTabComponent', () => {
+  let component: AddressTabComponent;
+  let fixture: ComponentFixture<AddressTabComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AddressTabComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddressTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/clients/clients-view/address-tab/address-tab.component.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'mifosx-address-tab',
+  templateUrl: './address-tab.component.html',
+  styleUrls: ['./address-tab.component.scss']
+})
+export class AddressTabComponent implements OnInit {
+
+  clientAddressData: any;
+  clientAddressFieldConfig: any;
+  clientAddressTemplate: any;
+
+  constructor(private route: ActivatedRoute) {
+    this.route.data.subscribe((data: {
+      clientAddressData: any,
+      clientAddressFieldConfig: any,
+      clientAddressTemplateData: any
+    }) => {
+      this.clientAddressData = data.clientAddressData;
+      this.clientAddressFieldConfig = data.clientAddressFieldConfig;
+      this.clientAddressTemplate = data.clientAddressTemplateData;
+    });
+  }
+
+  ngOnInit() {
+  }
+
+  isFieldEnabled(fieldName: any) {
+    return (this.clientAddressFieldConfig.find((fieldObj: any) => fieldObj.field === fieldName)).is_enabled;
+  }
+
+  getSelectedValue(fieldName: any, fieldId: any) {
+    return (this.clientAddressTemplate[fieldName].find((fieldObj: any) => fieldObj.id === fieldId));
+  }
+
+}

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -48,6 +48,10 @@
         [active]="general.isActive">
         General
       </a>
+      <a mat-tab-link [routerLink]="['./address']" routerLinkActive #address="routerLinkActive"
+        [active]="address.isActive" *ngIf="clientTemplateData.isAddressEnabled">
+        Address
+      </a>
       <a mat-tab-link [routerLink]="['./family-members']" routerLinkActive #familyMembers="routerLinkActive"
         [active]="familyMembers.isActive">
         Family Members

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -14,16 +14,19 @@ export class ClientsViewComponent implements OnInit {
   clientViewData: any;
   clientDatatables: any;
   clientImage: any;
-  clientTemplate: any;
+  clientTemplateData: any;
+
   constructor(private route: ActivatedRoute,
     private clientsService: ClientsService,
     private _sanitizer: DomSanitizer) {
     this.route.data.subscribe((data: {
       clientViewData: any,
+      clientTemplateData: any,
       clientDatatables: any
     }) => {
       this.clientViewData = data.clientViewData;
       this.clientDatatables = data.clientDatatables;
+      this.clientTemplateData = data.clientTemplateData;
     });
   }
 

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.html
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.html
@@ -49,7 +49,7 @@
                 <button class="identity-action-button" mat-raised-button color="primary" (click)="uploadDocument(i,identity.id)">
           <fa-icon icon="cloud-upload-alt"></fa-icon>
         </button>
-        <button class="identity-action-button" mat-raised-button color="warn" (click)="deleteIdentifier(identity.clientId,identity.id,index)">
+        <button class="identity-action-button" mat-raised-button color="warn" (click)="deleteIdentifier(identity.clientId,identity.id,i)">
           <fa-icon icon="times"></fa-icon>
         </button>
             </td>

--- a/src/app/clients/clients.module.ts
+++ b/src/app/clients/clients.module.ts
@@ -22,6 +22,7 @@ import { DocumentsTabComponent } from './clients-view/documents-tab/documents-ta
 import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
 import { MultiRowComponent } from './clients-view/datatable-tab/multi-row/multi-row.component';
 import { SingleRowComponent } from './clients-view/datatable-tab/single-row/single-row.component';
+import { AddressTabComponent } from './clients-view/address-tab/address-tab.component';
 
 
 /**
@@ -49,7 +50,8 @@ import { SingleRowComponent } from './clients-view/datatable-tab/single-row/sing
     DocumentsTabComponent,
     DatatableTabComponent,
     MultiRowComponent,
-    SingleRowComponent
+    SingleRowComponent,
+    AddressTabComponent
   ],
   entryComponents: [
     UploadDocumentDialogComponent,

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -39,6 +39,7 @@ export class ClientsService {
     return this.http.get(`/datatables/${datatableName}/${clientId}`, { params: httpParams });
   }
 
+
   getClientAccountData(clientId: string) {
     return this.http.get(`/clients/${clientId}/accounts`);
   }
@@ -137,5 +138,17 @@ export class ClientsService {
 
   deleteClientNote(clientId: string, noteId: string) {
     return this.http.delete(`/clients/${clientId}/notes/${noteId}`);
+  }
+
+  getAddressFieldConfiguration() {
+    return this.http.get(`/fieldconfiguration/ADDRESS`);
+  }
+
+  getClientAddressData(clientId: string) {
+    return this.http.get(`/client/${clientId}/addresses`);
+  }
+
+  getClientAddressTemplate() {
+    return this.http.get(`/client/addresses/template`);
   }
 }

--- a/src/app/clients/common-resolvers/client-address-fieldconfiguration.resolver.ts
+++ b/src/app/clients/common-resolvers/client-address-fieldconfiguration.resolver.ts
@@ -1,0 +1,30 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { ClientsService } from '../clients.service';
+
+/**
+ * Client Address Field Configuration resolver.
+ */
+@Injectable()
+export class ClientAddressFieldConfigurationResolver implements Resolve<Object> {
+
+    /**
+     * @param {ClientsService} ClientsService Clients service.
+     */
+    constructor(private clientsService: ClientsService) { }
+
+    /**
+     * Returns the Client Address Field Configuration.
+     * @returns {Observable<any>}
+     */
+    resolve(): Observable<any> {
+        return this.clientsService.getAddressFieldConfiguration();
+    }
+
+}

--- a/src/app/clients/common-resolvers/client-address-template.resolver.ts
+++ b/src/app/clients/common-resolvers/client-address-template.resolver.ts
@@ -1,0 +1,30 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { ClientsService } from '../clients.service';
+
+/**
+ * Client Address Field Configuration resolver.
+ */
+@Injectable()
+export class ClientAddressTemplateResolver implements Resolve<Object> {
+
+    /**
+     * @param {ClientsService} ClientsService Clients service.
+     */
+    constructor(private clientsService: ClientsService) { }
+
+    /**
+     * Returns the Client Address Field Configuration.
+     * @returns {Observable<any>}
+     */
+    resolve(): Observable<any> {
+        return this.clientsService.getClientAddressTemplate();
+    }
+
+}

--- a/src/app/clients/common-resolvers/client-address.resolver.ts
+++ b/src/app/clients/common-resolvers/client-address.resolver.ts
@@ -1,0 +1,31 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { ClientsService } from '../clients.service';
+
+/**
+ * Client Address data resolver.
+ */
+@Injectable()
+export class ClientAddressResolver implements Resolve<Object> {
+
+    /**
+     * @param {ClientsService} ClientsService Clients service.
+     */
+    constructor(private clientsService: ClientsService) { }
+
+    /**
+     * Returns the Client Address data.
+     * @returns {Observable<any>}
+     */
+    resolve(route: ActivatedRouteSnapshot): Observable<any> {
+        const clientId = route.parent.paramMap.get('clientId');
+        return this.clientsService.getClientAddressData(clientId);
+    }
+
+}


### PR DESCRIPTION
## Description
- added clients address tab in client-view component

## Related issues and discussion
 #258

## Screenshots, if any
![screencapture-localhost-4200-clients-1-address-2019-07-15-23_26_35](https://user-images.githubusercontent.com/15383669/61238528-71398100-a75a-11e9-8f9a-acb75927afab.png)


## Checklist
- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
