### PR TITLE
fix: make report run frequency value displayed

### DIFF
--- a/src/app/organization/adhoc-query/view-adhoc-query/view-adhoc-query.component.html
+++ b/src/app/organization/adhoc-query/view-adhoc-query/view-adhoc-query.component.html
@@ -46,7 +46,7 @@
         </div>
 
         <div fxFlex="50%" *ngIf="adhocQueryData.reportRunFrequency">
-          {{ adhocQueryData.reportRunFrequency }}
+          {{ reportRunFrequency }}
         </div>
 
         <div fxFlex="50%" class="mat-body-strong">

--- a/src/app/organization/adhoc-query/view-adhoc-query/view-adhoc-query.component.ts
+++ b/src/app/organization/adhoc-query/view-adhoc-query/view-adhoc-query.component.ts
@@ -42,6 +42,18 @@ export class ViewAdhocQueryComponent implements OnInit {
   }
 
   /**
+   * Retrieves the report run frequency value from id
+   * @returns {string} Report run frequency value.
+   */
+  get reportRunFrequency(): string {
+    for (const reportRunFrequency of this.adhocQueryData.reportRunFrequencies) {
+      if (reportRunFrequency.id === this.adhocQueryData.reportRunFrequency) {
+        return reportRunFrequency.value;
+      }
+    }
+  }
+
+  /**
    * Deletes the adhoc query and redirects to adhoc queries.
    */
   deleteAdhocQuery() {


### PR DESCRIPTION
## Description
- Make report run frequency value displayed rather than the id in View Adhoc Query

I understand that I have another PR up, but I saw this while solving merge issues and just thought that I could push forward a quick fix.

## Related issues and discussion
#555

## Screenshots, if any
<img width="923" alt="Screenshot 2020-01-07 at 12 18 06" src="https://user-images.githubusercontent.com/28529491/71895014-cf628200-3147-11ea-908a-4fc9189a9219.png">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
