### PR TITLE
feat: add view sms component

### DIFF
--- a/src/app/organization/organization-routing.module.ts
+++ b/src/app/organization/organization-routing.module.ts
@@ -26,6 +26,9 @@ import { EntityDataTableChecksComponent } from './entity-data-table-checks/entit
 import { WorkingDaysComponent } from './working-days/working-days.component';
 import { CreateOfficeComponent } from './offices/create-office/create-office.component';
 import { CreatePaymentTypeComponent } from './payment-types/create-payment-type/create-payment-type.component';
+import { ViewSmsCampaignComponent } from './sms-campaigns/view-sms-campaign/view-sms-campaign.component';
+import { CampaignTabComponent } from './sms-campaigns/view-sms-campaign/campaign-tab/campaign-tab.component';
+import { SmsCampaignTabsComponent } from './sms-campaigns/view-sms-campaign/sms-campaign-tabs/sms-campaign-tabs.component';
 
 /** Custom Resolvers */
 import { LoanProvisioningCriteriaResolver } from './loan-provisioning-criteria/loan-provisioning-criteria.resolver';
@@ -41,6 +44,8 @@ import { PaymentTypesResolver } from './payment-types/payment-types.resolver';
 import { PasswordPreferencesTemplateResolver } from './password-preferences/password-preferences-template.resolver';
 import { EntityDataTableChecksResolver } from './entity-data-table-checks/entity-data-table-checks.resolver';
 import { WorkingDaysResolver } from './working-days/working-days.resolver';
+import { SmsCampaignResolver } from './sms-campaigns/common-resolvers/sms-campaign.resolver';
+import { CampaignResolver } from './sms-campaigns/common-resolvers/campaign.resolver';
 
 /** Organization Routes */
 const routes: Routes = [
@@ -121,11 +126,42 @@ const routes: Routes = [
         },
         {
           path: 'sms-campaigns',
-          component: SmsCampaignsComponent,
           data: { title: extract('SMS Campaigns'), breadcrumb: 'SMS Campaigns' },
-          resolve: {
-            smsCampaigns: SmsCampaignsResolver
-          }
+          children: [
+            {
+              path: '',
+              component: SmsCampaignsComponent,
+              resolve: {
+                smsCampaigns: SmsCampaignsResolver
+              }
+            },
+            {
+              path: ':id',
+              component: ViewSmsCampaignComponent,
+              data: { title: extract('View SMS Campaign'), routeResolveBreadcrumb: ['smsCampaign', 'campaignName'] },
+              resolve: {
+                smsCampaign: SmsCampaignResolver
+              },
+              children : [
+                {
+                  path: 'campaign',
+                  component: CampaignTabComponent,
+                  data: { title: extract('Campaign'), routeParamBreadcrumb: false },
+                  resolve: {
+                  smsCampaign: CampaignResolver
+                  }
+                },
+                {
+                  path: ':tabname',
+                  component: SmsCampaignTabsComponent,
+                  data: { title: extract('Campaign'), routeParamBreadcrumb: false },
+                  resolve: {
+                  smsCampaign: CampaignResolver
+                  }
+                },
+              ]
+            }
+          ]
         },
         {
           path: 'adhoc-query',
@@ -224,7 +260,9 @@ const routes: Routes = [
     PaymentTypesResolver,
     PasswordPreferencesTemplateResolver,
     EntityDataTableChecksResolver,
-    WorkingDaysResolver
+    WorkingDaysResolver,
+    SmsCampaignResolver,
+    CampaignResolver
   ]
 })
 export class OrganizationRoutingModule { }

--- a/src/app/organization/organization.module.ts
+++ b/src/app/organization/organization.module.ts
@@ -24,6 +24,9 @@ import { CreateOfficeComponent } from './offices/create-office/create-office.com
 import { CreateEmployeeComponent } from './employees/create-employee/create-employee.component';
 import { CreatePaymentTypeComponent } from './payment-types/create-payment-type/create-payment-type.component';
 import { ViewEmployeeComponent } from './employees/view-employee/view-employee.component';
+import { ViewSmsCampaignComponent } from './sms-campaigns/view-sms-campaign/view-sms-campaign.component';
+import { CampaignTabComponent } from './sms-campaigns/view-sms-campaign/campaign-tab/campaign-tab.component';
+import { SmsCampaignTabsComponent } from './sms-campaigns/view-sms-campaign/sms-campaign-tabs/sms-campaign-tabs.component';
 
 /**
  * Organization Module
@@ -53,7 +56,10 @@ import { ViewEmployeeComponent } from './employees/view-employee/view-employee.c
     CreateOfficeComponent,
     CreateEmployeeComponent,
     CreatePaymentTypeComponent,
-    ViewEmployeeComponent
+    ViewEmployeeComponent,
+    ViewSmsCampaignComponent,
+    CampaignTabComponent,
+    SmsCampaignTabsComponent
   ]
 })
 export class OrganizationModule { }

--- a/src/app/organization/organization.service.ts
+++ b/src/app/organization/organization.service.ts
@@ -1,3 +1,4 @@
+
 /** Angular Imports */
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
@@ -75,6 +76,31 @@ export class OrganizationService {
    */
   getSmsCampaigns(): Observable<any> {
     return this.http.get('/smscampaigns');
+  }
+
+  /**
+   * @param {string} smsCampaignId SMS Campaign ID of SMS Campaign.
+   * @returns {Observable<any>} SMS Campaign.
+   */
+  getSmsCampaign(smsCampaignId: string): Observable<any> {
+    return this.http.get(`/smscampaigns/${smsCampaignId}`);
+  }
+
+  /**
+   * @param {number} offset Page offset.
+   * @param {number} limit Number of entries within the page.
+   * @returns {Observable<any>} SMS Data by Status data.
+   */
+  getSmsCampaignbyStatus(fetchSMS: any, offset: number = 0, limit: number = -1): Observable<any> {
+    const httpParams = new HttpParams()
+      .set('status', fetchSMS.status)
+      .set('offset', offset.toString())
+      .set('limit', limit.toString())
+      .set('locale', fetchSMS.locale)
+      .set('dateFormat', fetchSMS.dateFormat)
+      .set('fromDate', fetchSMS.fromDate)
+      .set('toDate', fetchSMS.toDate);
+    return this.http.get(`/sms/${fetchSMS.id}/messageByStatus`, { params: httpParams });
   }
 
   /**

--- a/src/app/organization/sms-campaigns/common-resolvers/campaign.resolver.ts
+++ b/src/app/organization/sms-campaigns/common-resolvers/campaign.resolver.ts
@@ -1,0 +1,31 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { OrganizationService } from 'app/organization/organization.service';
+
+/**
+ * SMS Campaign data resolver.
+ */
+@Injectable()
+export class CampaignResolver implements Resolve<Object> {
+
+  /**
+   * @param {OrganizationService} organizationService Organization service.
+   */
+  constructor(private organizationService: OrganizationService) {}
+
+  /**
+   * Returns the SMS Campaign data.
+   * @returns {Observable<any>}
+   */
+  resolve(route: ActivatedRouteSnapshot): Observable<any> {
+    const smsCampaignId  = route.parent.paramMap.get('id');
+    return this.organizationService.getSmsCampaign(smsCampaignId);
+  }
+
+}

--- a/src/app/organization/sms-campaigns/common-resolvers/sms-campaign.resolver.ts
+++ b/src/app/organization/sms-campaigns/common-resolvers/sms-campaign.resolver.ts
@@ -1,0 +1,31 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { OrganizationService } from 'app/organization/organization.service';
+
+/**
+ * SMS Campaign data resolver.
+ */
+@Injectable()
+export class SmsCampaignResolver implements Resolve<Object> {
+
+  /**
+   * @param {OrganizationService} organizationService Organization service.
+   */
+  constructor(private organizationService: OrganizationService) {}
+
+  /**
+   * Returns the SMS Campaign data.
+   * @returns {Observable<any>}
+   */
+  resolve(route: ActivatedRouteSnapshot): Observable<any> {
+    const smsCampaignId  = route.paramMap.get('id');
+    return this.organizationService.getSmsCampaign(smsCampaignId);
+  }
+
+}

--- a/src/app/organization/sms-campaigns/sms-campaigns.component.html
+++ b/src/app/organization/sms-campaigns/sms-campaigns.component.html
@@ -55,7 +55,7 @@
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;" class="select-row"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;" [routerLink]="[row.id, 'campaign']" class="select-row"></tr>
 
     </table>
 

--- a/src/app/organization/sms-campaigns/view-sms-campaign/campaign-tab/campaign-tab.component.html
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/campaign-tab/campaign-tab.component.html
@@ -1,0 +1,94 @@
+<div class="container m-b-20" fxLayout="row" fxLayoutAlign="end" fxLayoutGap="30px">
+    <button mat-raised-button color="primary">
+    <i class="fa fa-remove"></i>
+    &nbsp;&nbsp; Close
+  </button>
+</div>
+
+<div class="container">
+
+  <mat-card>
+
+    <mat-card-content>
+
+      <div fxLayout="row wrap" class="content">
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Campaign Name
+        </div>
+
+        <div fxFlex="50%">
+          {{ smsCampaignData.campaignName }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Report Name
+        </div>
+
+        <div fxFlex="50%">
+          {{ smsCampaignData.reportName }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Status
+        </div>
+
+        <div fxFlex="50%">
+          {{ smsCampaignData.campaignStatus.value }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Trigger Type
+        </div>
+
+        <div fxFlex="50%">
+          {{ smsCampaignData.triggerType.value }}
+        </div>
+
+		    <div fxFlex="50%" class="mat-body-strong">
+          Template Message
+        </div>
+
+        <div fxFlex="50%">
+          {{ smsCampaignData.campaignMessage }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Submitted On
+        </div>
+
+        <div fxFlex="50%">
+          {{ smsCampaignData.smsCampaignTimeLine.submittedOnDate | date }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong" *ngIf="smsCampaignData.recurrence">
+          Recurrence
+        </div>
+        
+        <div fxFlex="50%">
+          {{ smsCampaignData.recurrence }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong" *ngIf="smsCampaignData.triggerEntityType">
+          Trigger Entity Type
+        </div>
+        
+        <div fxFlex="50%">
+          {{ smsCampaignData.triggerEntityType }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong" *ngIf="smsCampaignData.triggerActionType">
+          Trigger Action Type
+        </div>
+        
+        <div fxFlex="50%">
+          {{ smsCampaignData.triggerActionType }}
+        </div>
+
+      </div>
+
+    </mat-card-content>
+
+  </mat-card>
+
+</div>

--- a/src/app/organization/sms-campaigns/view-sms-campaign/campaign-tab/campaign-tab.component.scss
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/campaign-tab/campaign-tab.component.scss
@@ -1,0 +1,11 @@
+.container {
+  max-width: 37rem;
+
+.content {
+  div {
+    margin: 1rem 0;
+    word-wrap: break-word;
+    }
+  }
+}
+

--- a/src/app/organization/sms-campaigns/view-sms-campaign/campaign-tab/campaign-tab.component.spec.ts
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/campaign-tab/campaign-tab.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CampaignTabComponent } from './campaign-tab.component';
+
+describe('CampaignTabComponent', () => {
+  let component: CampaignTabComponent;
+  let fixture: ComponentFixture<CampaignTabComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CampaignTabComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CampaignTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/organization/sms-campaigns/view-sms-campaign/campaign-tab/campaign-tab.component.ts
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/campaign-tab/campaign-tab.component.ts
@@ -1,0 +1,34 @@
+/** Angular Imports */
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { MatTable } from '@angular/material/table';
+import { MatDialog } from '@angular/material';
+
+/**
+ * Campaign tab component.
+ */
+
+@Component({
+  selector: 'mifosx-campaign-tab',
+  templateUrl: './campaign-tab.component.html',
+  styleUrls: ['./campaign-tab.component.scss']
+})
+export class CampaignTabComponent implements OnInit {
+
+  /** SMS Campaign data. */
+  smsCampaignData: any;
+
+  /**
+   * Retrieves the SMS Campaign data from `resolve`.
+   * @param {ActivatedRoute} route Activated Route.
+   */
+  constructor(private route: ActivatedRoute) {
+    this.route.data.subscribe((data: { smsCampaign: any }) => {
+      this.smsCampaignData = data.smsCampaign;
+    });
+  }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/organization/sms-campaigns/view-sms-campaign/sms-campaign-tabs/sms-campaign-tabs.component.html
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/sms-campaign-tabs/sms-campaign-tabs.component.html
@@ -1,0 +1,76 @@
+<div class="container">
+
+  <mat-card>
+
+    <form [formGroup]="fetchSMSForm" (ngSubmit)="submit($event)">
+
+      <mat-card-content>
+
+        <div fxLayout="column">
+
+          <mat-form-field>
+            <mat-label>From Date</mat-label>
+            <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="fromDatePicker" required formControlName="fromDate">
+            <mat-datepicker-toggle matSuffix [for]="fromDatePicker"></mat-datepicker-toggle>
+            <mat-datepicker #fromDatePicker></mat-datepicker>
+            <mat-error *ngIf="fetchSMSForm.controls.fromDate.hasError('required')">
+              From is <strong>required</strong>
+            </mat-error>
+          </mat-form-field>
+
+          <mat-form-field>
+            <mat-label>To Date</mat-label>
+            <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="toDatePicker" required formControlName="toDate">
+            <mat-datepicker-toggle matSuffix [for]="toDatePicker"></mat-datepicker-toggle>
+            <mat-datepicker #toDatePicker></mat-datepicker>
+            <mat-error *ngIf="fetchSMSForm.controls.toDate.hasError('required')">
+              Tp Date is <strong>required</strong>
+            </mat-error>
+          </mat-form-field>
+
+        </div>
+
+      </mat-card-content>
+
+      <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
+        <button mat-raised-button color="primary" [disabled]="!fetchSMSForm.valid">Submit</button>
+      </mat-card-actions>
+
+    </form>
+
+  </mat-card>
+
+</div>
+
+<div class="mat-elevation-z8" *ngIf="smsList.length">
+
+  <table mat-table [dataSource]="smsList" matSort>
+
+    <ng-container matColumnDef="message">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Message </th>
+      <td mat-cell *matCellDef="let sms"> {{ sms.message }} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Status </th>
+      <td mat-cell *matCellDef="let sms"> {{ sms.status.value }} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="mobileNo">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Mobile Number </th>
+      <td mat-cell *matCellDef="let sms"> {{ sms.mobileNo }} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="campaignName">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Campaign Name </th>
+      <td mat-cell *matCellDef="let sms"> {{ smsCampaign.campaignName }} </td>
+    </ng-container>
+   
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;" class="select-row"></tr>
+
+  </table>
+
+  <mat-paginator [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons></mat-paginator>
+
+</div>

--- a/src/app/organization/sms-campaigns/view-sms-campaign/sms-campaign-tabs/sms-campaign-tabs.component.scss
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/sms-campaign-tabs/sms-campaign-tabs.component.scss
@@ -1,0 +1,7 @@
+.container {
+	width: 37rem;
+}
+
+table {
+  width: 100%;
+}

--- a/src/app/organization/sms-campaigns/view-sms-campaign/sms-campaign-tabs/sms-campaign-tabs.component.spec.ts
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/sms-campaign-tabs/sms-campaign-tabs.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PendingSmsTabComponent } from './pending-sms-tab.component';
+
+describe('PendingSmsTabComponent', () => {
+  let component: PendingSmsTabComponent;
+  let fixture: ComponentFixture<PendingSmsTabComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PendingSmsTabComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PendingSmsTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/organization/sms-campaigns/view-sms-campaign/sms-campaign-tabs/sms-campaign-tabs.component.ts
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/sms-campaign-tabs/sms-campaign-tabs.component.ts
@@ -1,0 +1,95 @@
+/** Angular Imports */
+import { Component, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { Router, ActivatedRoute , ActivatedRouteSnapshot} from '@angular/router';
+import { DatePipe } from '@angular/common';
+import { MatTableDataSource } from '@angular/material';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { OrganizationService } from '../../../organization.service';
+
+@Component({
+  selector: 'mifosx-pending-sms-tab',
+  templateUrl: './sms-campaign-tabs.component.html',
+  styleUrls: ['./sms-campaign-tabs.component.scss']
+})
+export class SmsCampaignTabsComponent implements OnInit {
+
+  /** Minimum from/to date allowed. */
+  minDate = new Date(2000, 0, 1);
+  /** Maximum from/to date allowed. */
+  maxDate = new Date();
+  /** fetchSMS form. */
+  fetchSMSForm: FormGroup;
+  /** SMS Campaign data. */
+  smsCampaignData: any;
+  /** SMS List datasource. */
+  smsList = new MatTableDataSource();
+  /** Status of tab. */
+  status: any;
+  /** Displayed Columns */
+  displayedColumns: string[] = ['message', 'status', 'mobileNo', 'campaignName'];
+
+  constructor(private formBuilder: FormBuilder,
+              private organizationService: OrganizationService,
+              private route: ActivatedRoute,
+              private router: Router,
+              private datePipe: DatePipe, ) {
+      this.route.data.subscribe((data: { smsCampaign: any }) => {
+        this.smsCampaignData = data.smsCampaign;
+    });
+    if (this.route.snapshot.params.tabname === 'pendingsms') {
+      this.status = '100';
+    }
+    if (this.route.snapshot.params.tabname === 'waitingfordeliveryreport') {
+      this.status = '150';
+    }
+    if (this.route.snapshot.params.tabname === 'sentsms') {
+      this.status = '200';
+    }
+    if (this.route.snapshot.params.tabname === 'deliveredsms') {
+      this.status = '300';
+    }
+    if (this.route.snapshot.params.tabname === 'failedsms') {
+      this.status = '400';
+    }
+  }
+
+  ngOnInit() {
+    this.createfetchSMSForm();
+  }
+
+  createfetchSMSForm() {
+    this.fetchSMSForm = this.formBuilder.group({
+      'fromDate': ['', Validators.required],
+      'toDate': ['', Validators.required]
+    });
+  }
+
+  submit($event: any) {
+    $event.preventDefault();
+    const prevFromDate: Date = this.fetchSMSForm.value.fromDate;
+    const prevToDate: Date = this.fetchSMSForm.value.toDate;
+    const dateFormat = 'dd-MMMM-yyyy';
+    this.fetchSMSForm.patchValue({
+      fromDate: this.datePipe.transform(prevFromDate, dateFormat),
+      toDate: this.datePipe.transform(prevToDate, dateFormat)
+    });
+    const fetchSMS = this.fetchSMSForm.value;
+    // TODO: Update once language and date settings are setup
+    fetchSMS.locale = 'en';
+    fetchSMS.status = this.status;
+    fetchSMS.id = this.smsCampaignData.id;
+    fetchSMS.dateFormat = dateFormat;
+    this.organizationService.getSmsCampaignbyStatus(fetchSMS).subscribe(
+      (data => {
+          this.smsList = new MatTableDataSource(data.pageItems);
+          console.log(data);
+      })
+    );
+  }
+
+}

--- a/src/app/organization/sms-campaigns/view-sms-campaign/view-sms-campaign.component.html
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/view-sms-campaign.component.html
@@ -1,0 +1,39 @@
+<div class="container">
+
+  <mat-card>
+    
+    <mat-card-content>
+      
+      <nav mat-tab-nav-bar class="navigation-tabs">
+        <a mat-tab-link [routerLink]="['./campaign']" routerLinkActive #campaign="routerLinkActive"
+          [active]="campaign.isActive">
+          Campaign
+        </a>
+        <a mat-tab-link [routerLink]="['./pendingsms']" routerLinkActive #pendingsms="routerLinkActive"
+          [active]="pendingsms.isActive">
+          Pending SMS
+        </a>
+        <a mat-tab-link [routerLink]="['./waitingfordeliveryreport']" routerLinkActive #waitingfordeliveryreport="routerLinkActive"
+          [active]="waitingfordeliveryreport.isActive">
+          Waiting For Delivery Report
+        </a>
+        <a mat-tab-link [routerLink]="['./sentsms']" routerLinkActive #sentsms="routerLinkActive"
+          [active]="sentsms.isActive">
+          Sent SMS
+        </a>
+        <a mat-tab-link [routerLink]="['./deliveredsms']" routerLinkActive #deliveredsms="routerLinkActive"
+          [active]="deliveredsms.isActive">
+          Delivered SMS
+        </a>
+        <a mat-tab-link [routerLink]="['./failedsms']" routerLinkActive #failedsms="routerLinkActive"
+          [active]="failedsms.isActive">
+          Failed SMS
+        </a>
+      </nav>
+      <router-outlet></router-outlet>
+   
+   </mat-card-content>
+   
+  </mat-card>
+
+</div>

--- a/src/app/organization/sms-campaigns/view-sms-campaign/view-sms-campaign.component.scss
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/view-sms-campaign.component.scss
@@ -1,0 +1,3 @@
+.navigation-tabs {
+    overflow: auto;
+  }

--- a/src/app/organization/sms-campaigns/view-sms-campaign/view-sms-campaign.component.spec.ts
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/view-sms-campaign.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewSmsCampaignComponent } from './view-sms-campaigns.component';
+
+describe('ViewSmsCampaignComponent', () => {
+  let component: ViewSmsCampaignComponent;
+  let fixture: ComponentFixture<ViewSmsCampaignComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ViewSmsCampaignComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ViewSmsCampaignComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/organization/sms-campaigns/view-sms-campaign/view-sms-campaign.component.ts
+++ b/src/app/organization/sms-campaigns/view-sms-campaign/view-sms-campaign.component.ts
@@ -1,0 +1,22 @@
+/** Angular Imports */
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+/**
+ * View SMS Campaign component.
+ */
+
+@Component({
+  selector: 'mifosx-view-sms-campaign',
+  templateUrl: './view-sms-campaign.component.html',
+  styleUrls: ['./view-sms-campaign.component.scss']
+})
+export class ViewSmsCampaignComponent implements OnInit {
+
+  constructor() {
+  }
+
+  ngOnInit() {
+  }
+
+}


### PR DESCRIPTION
earlier the view sms campaign component was not available. now, the view sms campaign component have a navbar which contains five options out of the them the campaign option have been implemented successfully.

## Related issues and discussion
#563

## Screenshots, if any
![Screenshot from 2020-01-13 10-22-20](https://user-images.githubusercontent.com/45865775/72233664-ab42ed00-35ee-11ea-9bf0-637a22d533f3.png)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
