### PR TITLE
feat: add view product mix

### DIFF
--- a/src/app/products/products-mix/products-mix.component.html
+++ b/src/app/products/products-mix/products-mix.component.html
@@ -23,7 +23,7 @@
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;" class="select-row"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;" class="select-row" [routerLink]="[row.productId]"></tr>
 
     </table>
 

--- a/src/app/products/products-mix/view-product-mix/view-product-mix.componenent.spec.ts
+++ b/src/app/products/products-mix/view-product-mix/view-product-mix.componenent.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewProductMixComponent } from './view-product-mix.component';
+
+describe('ViewProductMixComponent', () => {
+  let component: ViewProductMixComponent;
+  let fixture: ComponentFixture<ViewProductMixComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ViewProductMixComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ViewProductMixComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/products/products-mix/view-product-mix/view-product-mix.component.html
+++ b/src/app/products/products-mix/view-product-mix/view-product-mix.component.html
@@ -1,0 +1,47 @@
+<div class="container m-b-20" fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="end" fxLayoutGap="20px">
+  <button mat-raised-button color="primary">
+    <fa-icon icon="edit"></fa-icon>&nbsp;&nbsp;
+    Edit
+  </button>
+  <button mat-raised-button color="warn">
+    <fa-icon icon="trash"></fa-icon>&nbsp;&nbsp;
+    Delete
+  </button>
+</div>
+
+<div class="container">
+  
+    <div class="mat-elevation-z8 inline-table">
+  
+      <table mat-table [dataSource]="allowedProductsDatasource" matSort>
+        
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header [ngClass]="'customWidthClass'"> Allowed Products </th>
+          <td mat-cell *matCellDef="let product" [ngClass]="'customWidthClass'"> {{ product.name }} </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="allowedProductsDisplayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: allowedProductsDisplayedColumns;"></tr>
+      </table>
+
+      <mat-paginator #allowed [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons></mat-paginator>
+  
+    </div>
+
+    <div class="mat-elevation-z8 inline-table">
+        
+      <table mat-table [dataSource]="restrictedProductsDatasource" matSort>
+        
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header> Restricted Products </th>
+          <td mat-cell *matCellDef="let product"> {{ product.name }} </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="restrictedProductsDisplayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: restrictedProductsDisplayedColumns;"></tr>
+      </table>
+  
+      <mat-paginator #restricted [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons></mat-paginator>
+    </div>
+  
+  </div>

--- a/src/app/products/products-mix/view-product-mix/view-product-mix.component.scss
+++ b/src/app/products/products-mix/view-product-mix/view-product-mix.component.scss
@@ -1,0 +1,10 @@
+.container {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-evenly;
+
+  .inline-table {
+    display: inline-block;
+    width: 45%;
+  }
+}

--- a/src/app/products/products-mix/view-product-mix/view-product-mix.component.ts
+++ b/src/app/products/products-mix/view-product-mix/view-product-mix.component.ts
@@ -1,0 +1,71 @@
+/** Angular Imports */
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { MatPaginator, MatSort, MatTableDataSource } from '@angular/material';
+
+/**
+ * View product mix component.
+ */
+@Component({
+  selector: 'mifosx-view-product-mix',
+  templateUrl: './view-product-mix.component.html',
+  styleUrls: ['./view-product-mix.component.scss']
+})
+export class ViewProductMixComponent implements OnInit {
+
+  /** Product mix data. */
+  productMixData: any;
+  /** Allowed products datasource. */
+  allowedProductsDatasource: MatTableDataSource<any>;
+  /** Restricted products datasource. */
+  restrictedProductsDatasource: MatTableDataSource<any>;
+  /** Columns to be displayed in allowed products table. */
+  allowedProductsDisplayedColumns: string[] = ['name'];
+  /** Columns to be displayed in restricted products table. */
+  restrictedProductsDisplayedColumns: string[] = ['name'];
+
+  /** Paginator for allowed products table. */
+  @ViewChild('allowed') allowedPaginator: MatPaginator;
+  /** Paginator for restricted products table. */
+  @ViewChild('restricted') restrictedPaginator: MatPaginator;
+  /** Sorter for allowed products table. */
+  @ViewChild(MatSort) allowedSort: MatSort;
+  /** Sorter for restricted products table. */
+  @ViewChild(MatSort) restrictedSort: MatSort;
+
+  /**
+   * Retrieves the product mix data from `resolve`.
+   * @param {ActivatedRoute} route Activated Route.
+   */
+  constructor(private route: ActivatedRoute) {
+    this.route.data.subscribe((data: { productMix: any }) => {
+      this.productMixData = data.productMix;
+    });
+  }
+
+  /**
+   * Sets the allowed and restricted products tables.
+   */
+  ngOnInit() {
+    this.setAllowedProducts();
+    this.setRestrictedProducts();
+  }
+
+  /**
+   * Initializes the data source, paginator and sorter for the allowed products table.
+   */
+  setAllowedProducts() {
+    this.allowedProductsDatasource = new MatTableDataSource(this.productMixData.allowedProducts);
+    this.allowedProductsDatasource.paginator = this.allowedPaginator;
+    this.allowedProductsDatasource.sort = this.allowedSort;
+  }
+
+  /**
+   * Initializes the data source, paginator and sorter for the restricted products table.
+   */
+  setRestrictedProducts() {
+    this.restrictedProductsDatasource = new MatTableDataSource(this.productMixData.restrictedProducts);
+    this.restrictedProductsDatasource.paginator = this.restrictedPaginator;
+    this.restrictedProductsDatasource.sort = this.restrictedSort;
+  }
+}

--- a/src/app/products/products-mix/view-product-mix/view-product-mix.resolver.ts
+++ b/src/app/products/products-mix/view-product-mix/view-product-mix.resolver.ts
@@ -1,0 +1,30 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { ProductsService } from '../../products.service';
+
+/**
+ * View product mix data resolver.
+ */
+@Injectable()
+export class ViewProductMixResolver implements Resolve<Object> {
+
+  /**
+   * @param {ProductsService} productsService Products service.
+   */
+  constructor(private productsService: ProductsService) {}
+
+  /**
+   * Returns the product mix.
+   * @returns {Observable<any>}
+   */
+  resolve(route: ActivatedRouteSnapshot): Observable<any> {
+    const id = route.paramMap.get('id');
+    return this.productsService.getProductMix(id);
+  }
+}

--- a/src/app/products/products-routing.module.ts
+++ b/src/app/products/products-routing.module.ts
@@ -33,6 +33,7 @@ import { FloatingRatesComponent } from './floating-rates/floating-rates.componen
 import { CreateFloatingRateComponent } from './floating-rates/create-floating-rate/create-floating-rate.component';
 import { ViewFloatingRateComponent } from './floating-rates/view-floating-rate/view-floating-rate.component';
 import { EditFloatingRateComponent } from './floating-rates/edit-floating-rate/edit-floating-rate.component';
+import { ViewProductMixComponent } from './products-mix/view-product-mix/view-product-mix.component';
 import { ManageTaxComponentsComponent } from './manage-tax-components/manage-tax-components.component';
 import { ManageTaxGroupsComponent } from './manage-tax-groups/manage-tax-groups.component';
 import { ViewTaxComponentComponent } from './manage-tax-components/view-tax-component/view-tax-component.component';
@@ -60,6 +61,7 @@ import { FixedDepositProductsTemplateResolver } from './fixed-deposit-products/f
 import { ProductsMixResolver } from './products-mix/products-mix.resolver';
 import { FloatingRatesResolver } from './floating-rates/floating-rates.resolver';
 import { FloatingRateResolver } from './floating-rates/floating-rate.resolver';
+import { ViewProductMixResolver } from './products-mix/view-product-mix/view-product-mix.resolver';
 import { ManageTaxComponentsResolver } from './manage-tax-components/manage-tax-components.resolver';
 import { ManageTaxGroupsResolver } from './manage-tax-groups/manage-tax-groups.resolver';
 import { TaxComponentResolver } from './manage-tax-components/tax-component.resolver';
@@ -295,11 +297,24 @@ const routes: Routes = [
         },
         {
           path: 'products-mix',
-          component: ProductsMixComponent,
-          resolve: {
-                products: ProductsMixResolver
-          },
           data: { title:  extract('Products Mix'), breadcrumb: 'Products Mix' },
+          children: [
+            {
+              path: '',
+              component: ProductsMixComponent,
+              resolve: {
+                    products: ProductsMixResolver
+              }
+            },
+            {
+              path: ':id',
+              component: ViewProductMixComponent,
+              data: { title: extract('View Product Mix'), routeParamBreadcrumb: 'id'},
+              resolve: {
+                productMix: ViewProductMixResolver
+              },
+            }
+          ]
         },
         {
           path: 'floating-rates',
@@ -409,6 +424,7 @@ const routes: Routes = [
     FixedDepositProductsResolver,
     FixedDepositProductsTemplateResolver,
     ProductsMixResolver,
+    ViewProductMixResolver,
     ManageTaxComponentsResolver,
     ManageTaxGroupsResolver,
     TaxComponentResolver,

--- a/src/app/products/products.module.ts
+++ b/src/app/products/products.module.ts
@@ -24,6 +24,7 @@ import { ChargesComponent } from './charges/charges.component';
 import { ViewChargeComponent } from './charges/view-charge/view-charge.component';
 import { FixedDepositProductsComponent } from './fixed-deposit-products/fixed-deposit-products.component';
 import { ProductsMixComponent } from './products-mix/products-mix.component';
+import { ViewProductMixComponent } from './products-mix/view-product-mix/view-product-mix.component';
 import { ManageTaxComponentsComponent } from './manage-tax-components/manage-tax-components.component';
 import { ViewLoanProductComponent } from './loan-products/view-loan-product/view-loan-product.component';
 import { EditLoanProductComponent } from './loan-products/edit-loan-product/edit-loan-product.component';
@@ -107,6 +108,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
     ViewFloatingRateComponent,
     EditFloatingRateComponent,
     FloatingRatePeriodDialogComponent,
+    ViewProductMixComponent,
     ManageTaxComponentsComponent,
     ViewLoanProductComponent,
     EditLoanProductComponent,

--- a/src/app/products/products.service.ts
+++ b/src/app/products/products.service.ts
@@ -234,4 +234,11 @@ export class ProductsService {
     return this.http.put(`/floatingrates/${floatingRateId}`, floatingRate);
   }
 
+  /**
+   * @param {string} productId Id of the product.
+   * @returns {Observable<any>} Product.
+   */
+  getProductMix(productId: string): Observable<any> {
+    return this.http.get(`/loanproducts/${productId}/productmix`);
+  }
 }


### PR DESCRIPTION
Fixes #541

## Description
- The reference application (https://mobile.openmf.org/#/viewproductmix/13) displays the tables next to each other. In that case, there is no pagination used and all of the tables entries are directly shown. To support pagination and improve the UX, the "Restricted Products" table is now displayed below the first one, as shown in the attached images.

## Related issues and discussion
#541 

## Screenshots, if any
![image](https://user-images.githubusercontent.com/9131682/75252369-d8cda980-57dc-11ea-953a-63437ff0ab78.png)
![image](https://user-images.githubusercontent.com/9131682/75252857-c2741d80-57dd-11ea-9c92-977800b86207.png)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
