### PR TITLE
fix: Close Searchbar when it goes out of focus

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -49,7 +49,7 @@
   <div *ngIf="searchVisible" class="search-bar" fxFlex="auto" fxHide.lt-sm="true" [@fadeInOut]>
     <mat-form-field class="search">
       <mat-label>Search</mat-label>
-      <input matInput type="text">
+      <input matInput type="text" (focusout)="toggleSearchVisibility()">
     </mat-form-field>
   </div>
 


### PR DESCRIPTION
## Description
Searchbar will now close automatically when it goes out of focus.Previously Searchbar would only close when the user clicks the Search button

## Related issues and discussion
#638 

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
