### PR TITLE
arrow of language select was not aligned now fixed

### DIFF
--- a/src/app/shared/language-selector/language-selector.component.scss
+++ b/src/app/shared/language-selector/language-selector.component.scss
@@ -1,3 +1,9 @@
 #language-selector {
   max-width: 4rem;
 }
+
+::ng-deep .mat-select-arrow {
+  color: rgb(10, 73, 99);
+  position: relative!important;
+  top: 8px!important;
+}


### PR DESCRIPTION
In Reference to  #612. 

I have fixed the wrong alignment of the arrow in the mifox-language-selector.