### PR TITLE
feat: add Share Applications submitted/approved page

### DIFF
--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -37,6 +37,8 @@ import { ClientDatatableResolver } from './common-resolvers/client-datatable.res
 import { ClientIdentifierTemplateResolver } from './common-resolvers/client-identifier-template.resolver';
 import { ClientAddressFieldConfigurationResolver } from './common-resolvers/client-address-fieldconfiguration.resolver';
 import { ClientAddressTemplateResolver } from './common-resolvers/client-address-template.resolver';
+import { ViewShareAccountComponent } from './clients-view/view-share-account/view-share-account.component';
+import { ClientViewShareAccountResolver } from './common-resolvers/client-view-share-account.resolver';
 
 const routes: Routes = [
   Route.withShell([{
@@ -67,6 +69,14 @@ const routes: Routes = [
               clientSummary: ClientSummaryResolver
             }
           },
+          {
+            path: 'view-share-account/:accountId',
+            data: { title: extract('Share Account View'), routeParamBreadcrumb: 'accountId' },
+            component: ViewShareAccountComponent,
+            resolve: {
+              shareAccountsData: ClientViewShareAccountResolver,
+            }
+      },
           {
             path: 'address',
             component: AddressTabComponent,
@@ -172,7 +182,8 @@ const routes: Routes = [
     ClientDatatableResolver,
     ClientIdentifierTemplateResolver,
     ClientAddressFieldConfigurationResolver,
-    ClientAddressTemplateResolver
+    ClientAddressTemplateResolver,
+    ClientViewShareAccountResolver
   ]
 })
 export class ClientsRoutingModule { }

--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -318,7 +318,7 @@
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="openSharesColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: openSharesColumns;"></tr>
+    <tr mat-row *matRowDef="let row; columns: openSharesColumns;"  [routerLink]="['../view-share-account/'+ row.id]" class="select-row"></tr>
   </table>
   <!-- Closed Share Accounts -->
   <table *ngIf="showClosedShareAccounts" mat-table [dataSource]="shareAccounts|accountsFilter:'share':'closed'">
@@ -350,7 +350,7 @@
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="closedSharesColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: closedSharesColumns;"></tr>
+    <tr mat-row *matRowDef="let row; columns: closedSharesColumns;"  [routerLink]="['../view-share-account/'+ row.id]" class="select-row"></tr>
   </table>
 
 </div>

--- a/src/app/clients/clients-view/general-tab/general-tab.component.scss
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.scss
@@ -18,5 +18,8 @@
       margin: 4px;
       line-height: 25px;
     }
+    .select-row:hover {
+      cursor: pointer;
+    }
   }
 }

--- a/src/app/clients/clients-view/view-share-account/view-share-account.component.html
+++ b/src/app/clients/clients-view/view-share-account/view-share-account.component.html
@@ -1,0 +1,151 @@
+<mat-card>
+<mat-card-title>
+      <div class="share-account-header">
+        <h4>
+          <i class="fa fa-stop" [ngClass]="shareAccount?.status?.code|statusLookup"></i>
+          {{shareAccount.productName}}({{shareAccount.accountNo}})
+        </h4>
+        <button mat-raised-button color="primary"><i class="fa fa-pencil front-icons"></i>Modify Application</button>
+        <button mat-raised-button color="primary"><i class="fa fa-check front-icons"></i>Approve</button>
+        <button mat-raised-button color="primary" [matMenuTriggerFor]="More">More<i class="fa fa-caret-down rear-icons"></i></button>
+        <mat-menu #More="matMenu">
+          <button mat-menu-item>Reject</button>
+          <button mat-menu-item>Delete</button>
+        </mat-menu>
+      </div>
+</mat-card-title>
+<mat-card-content>
+  <div class="share-account-tables">
+    <table>
+      <tbody>
+        <tr>
+          <td >Activated On</td>
+              <td>
+                <span *ngIf = "shareAccount.status.value === 'Active'">{{shareAccount.timeline.activatedDate | date}}</span>
+                <span *ngIf = "shareAccount.status.value !== 'Active'">Not Activated</span>
+              </td>
+        </tr>
+        <tr>
+          <td >Currency</td>
+          <td >{{shareAccount.currency.name}}</td>
+        </tr>
+        <tr>
+          <td >External Id</td>
+          <td></td>
+          <!-- <td >{{shareAccount.externalId}}</td> -->
+        </tr>
+        <tr>
+          <td >Linked Savings Account(Dividend Posting)</td>
+          <td >{{shareAccount.savingsAccountNumber}}</td>
+        </tr>
+      </tbody>
+    </table>
+    <table id="right-table">
+      <tbody>
+        <tr>
+            <td >Approved Shares</td>
+            <td >{{shareAccount.summary.totalApprovedShares}}</td>
+        </tr>
+        <tr>
+            <td >Pending for Approval Shares</td>
+            <td >{{shareAccount.summary.totalPendingForApprovalShares}}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <mat-tab-group>
+    <mat-tab label="Transactions Overview">
+      <table mat-table [dataSource]="shareAccount.purchasedShares">
+        <ng-container matColumnDef="Transaction Date">
+          <th mat-header-cell *matHeaderCellDef> Transaction Date </th>
+          <td mat-cell *matCellDef="let elem"> {{elem.purchasedDate|date}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Transaction Type">
+          <th mat-header-cell *matHeaderCellDef> Transaction Type</th>
+          <td mat-cell *matCellDef="let elem"> {{elem.type.value}}({{elem.status.value}}) </td>
+        </ng-container>
+        <ng-container matColumnDef="Total Shares">
+          <th mat-header-cell *matHeaderCellDef>Total Shares</th>
+          <td mat-cell *matCellDef="let elem"> {{elem.numberOfShares}}</td>
+        </ng-container>
+        <ng-container matColumnDef="Purchased/Redeemed Price">
+          <th mat-header-cell *matHeaderCellDef> Purchased/Redeemed Price</th>
+          <td mat-cell *matCellDef="let elem">{{shareAccount.currency.displaySymbol}}{{elem.purchasedPrice}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Charge Amount">
+          <th mat-header-cell *matHeaderCellDef> Charge Amount</th>
+          <td mat-cell *matCellDef="let elem">{{shareAccount.currency.displaySymbol}}{{elem.chargeAmount}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Amount Received/Returned">
+          <th mat-header-cell *matHeaderCellDef> Amount Received/Returned</th>
+          <td mat-cell *matCellDef="let elem">{{shareAccount.currency.displaySymbol}}{{elem.amountPaid}} </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="transactionColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: transactionColumns"></tr>
+      </table>
+    </mat-tab>
+    <mat-tab label="Charges">
+      <table mat-table [dataSource]="shareAccount.charges">
+        <ng-container matColumnDef="Name">
+          <th mat-header-cell *matHeaderCellDef> Name </th>
+          <td mat-cell *matCellDef="let elem"> {{elem.name}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Fee/Penalty">
+          <th mat-header-cell *matHeaderCellDef> Fee/Penalty</th>
+          <td mat-cell *matCellDef="let elem"> {{elem.penalty ? 'Penalty' : 'Fee'}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Payment due at">
+          <th mat-header-cell *matHeaderCellDef> Payment due at </th>
+          <td mat-cell *matCellDef="let elem"> {{elem.chargeTimeType.value}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Calculation Type">
+          <th mat-header-cell *matHeaderCellDef> Calculation Type </th>
+          <td mat-cell *matCellDef="let elem"> {{elem.chargeCalculationType.value}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Due">
+          <th mat-header-cell *matHeaderCellDef> Due </th>
+          <td mat-cell *matCellDef="let elem"> {{elem.currency.displaySymbol}}{{elem.amount}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Paid">
+          <th mat-header-cell *matHeaderCellDef> Paid </th>
+          <td mat-cell *matCellDef="let elem"> {{elem.currency.displaySymbol}}{{elem.amountPaid}}  </td>
+        </ng-container>
+        <ng-container matColumnDef="Waived">
+          <th mat-header-cell *matHeaderCellDef> Waived </th>
+          <td mat-cell *matCellDef="let elem"> {{elem.currency.displaySymbol}}{{elem.amountWaived}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Outstanding">
+          <th mat-header-cell *matHeaderCellDef> Outstanding </th>
+          <td mat-cell *matCellDef="let elem"> {{elem.currency.displaySymbol}}{{elem.amountOutstanding}}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="chargesColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: chargesColumns"></tr>
+      </table>
+    </mat-tab>
+    <mat-tab label="Dividends">
+      <table mat-table [dataSource]="shareAccount.dividends">
+        <ng-container matColumnDef="Transaction Date">
+          <th mat-header-cell *matHeaderCellDef> Transaction Date </th>
+          <td mat-cell *matCellDef="let elem"> {{elem.postedDate|date}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Amount">
+          <th mat-header-cell *matHeaderCellDef> Amount</th>
+          <td mat-cell *matCellDef="let elem">{{shareAccount.currency.displaySymbol}}{{elem.amount}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Transaction Reference">
+          <th mat-header-cell *matHeaderCellDef> Transaction Reference </th>
+          <td mat-cell *matCellDef="let elem"> {{elem.savingsTransactionId}} </td>
+        </ng-container>
+        <ng-container matColumnDef="Status">
+          <th mat-header-cell *matHeaderCellDef>Status</th>
+          <td mat-cell *matCellDef="let elem"> {{elem.status.value}} </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="dividendColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: dividendColumns"></tr>
+      </table>
+    </mat-tab>
+  </mat-tab-group>
+
+
+</mat-card-content>
+</mat-card>

--- a/src/app/clients/clients-view/view-share-account/view-share-account.component.html
+++ b/src/app/clients/clients-view/view-share-account/view-share-account.component.html
@@ -32,7 +32,7 @@
         <tr>
           <td >External Id</td>
           <td></td>
-          <!-- <td >{{shareAccount.externalId}}</td> -->
+          <td >{{shareAccount?.externalId}}</td>
         </tr>
         <tr>
           <td >Linked Savings Account(Dividend Posting)</td>
@@ -145,7 +145,5 @@
       </table>
     </mat-tab>
   </mat-tab-group>
-
-
 </mat-card-content>
 </mat-card>

--- a/src/app/clients/clients-view/view-share-account/view-share-account.component.scss
+++ b/src/app/clients/clients-view/view-share-account/view-share-account.component.scss
@@ -1,0 +1,24 @@
+.share-account-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    .front-icons {
+        margin-right: 0.5rem;
+    }
+    .rear-icons {
+        margin-left: 0.25rem;
+    }
+    h4 {
+        flex: 2;
+    }
+    button {
+        margin-right: 1rem;
+    }
+}
+.share-account-tables {
+    display: flex;
+    justify-content: space-between;
+    #right-table {
+        margin-left: 1rem;
+    }
+}

--- a/src/app/clients/clients-view/view-share-account/view-share-account.component.spec.ts
+++ b/src/app/clients/clients-view/view-share-account/view-share-account.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewShareAccountComponent } from './view-share-account.component';
+
+describe('ViewShareAccountComponent', () => {
+  let component: ViewShareAccountComponent;
+  let fixture: ComponentFixture<ViewShareAccountComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ViewShareAccountComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ViewShareAccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/clients/clients-view/view-share-account/view-share-account.component.ts
+++ b/src/app/clients/clients-view/view-share-account/view-share-account.component.ts
@@ -7,20 +7,23 @@ import { ActivatedRoute } from '@angular/router';
   styleUrls: ['./view-share-account.component.scss']
 })
 export class ViewShareAccountComponent implements OnInit {
+  // Charges tab Columns Labels
   chargesColumns: string[] = ['Name', 'Fee/Penalty', 'Payment due at', 'Calculation Type', 'Due', 'Paid', 'Waived', 'Outstanding'];
+  // Transaction Overview tab Column Labels
   transactionColumns: string[] = ['Transaction Date', 'Transaction Type',	'Total Shares', 'Purchased/Redeemed Price', 'Charge Amount', 'Amount Received/Returned'];
+  // Dividend Tab Column Labels
   dividendColumns: string[] = ['Transaction Date', 'Amount', 'Transaction Reference', 'Status'];
+  // Client share-account data variable
   shareAccount: any;
 
   constructor(
     private route: ActivatedRoute,
-  ) {
-    this.route.data.subscribe((data: {shareAccountsData: any}) => {
-      this.shareAccount = data.shareAccountsData;
-    });
-   }
+  ) {}
 
   ngOnInit() {
+    this.route.data.subscribe((data: {shareAccountsData: any, }) => {
+      this.shareAccount = data.shareAccountsData;
+    });
   }
 
 }

--- a/src/app/clients/clients-view/view-share-account/view-share-account.component.ts
+++ b/src/app/clients/clients-view/view-share-account/view-share-account.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'mifosx-view-share-account',
+  templateUrl: './view-share-account.component.html',
+  styleUrls: ['./view-share-account.component.scss']
+})
+export class ViewShareAccountComponent implements OnInit {
+  chargesColumns: string[] = ['Name', 'Fee/Penalty', 'Payment due at', 'Calculation Type', 'Due', 'Paid', 'Waived', 'Outstanding'];
+  transactionColumns: string[] = ['Transaction Date', 'Transaction Type',	'Total Shares', 'Purchased/Redeemed Price', 'Charge Amount', 'Amount Received/Returned'];
+  dividendColumns: string[] = ['Transaction Date', 'Amount', 'Transaction Reference', 'Status'];
+  shareAccount: any;
+
+  constructor(
+    private route: ActivatedRoute,
+  ) {
+    this.route.data.subscribe((data: {shareAccountsData: any}) => {
+      this.shareAccount = data.shareAccountsData;
+    });
+   }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/clients/clients.module.ts
+++ b/src/app/clients/clients.module.ts
@@ -23,6 +23,7 @@ import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-ta
 import { MultiRowComponent } from './clients-view/datatable-tab/multi-row/multi-row.component';
 import { SingleRowComponent } from './clients-view/datatable-tab/single-row/single-row.component';
 import { AddressTabComponent } from './clients-view/address-tab/address-tab.component';
+import { ViewShareAccountComponent } from './clients-view/view-share-account/view-share-account.component';
 
 
 /**
@@ -51,7 +52,8 @@ import { AddressTabComponent } from './clients-view/address-tab/address-tab.comp
     DatatableTabComponent,
     MultiRowComponent,
     SingleRowComponent,
-    AddressTabComponent
+    AddressTabComponent,
+    ViewShareAccountComponent
   ],
   entryComponents: [
     UploadDocumentDialogComponent,

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -177,4 +177,7 @@ export class ClientsService {
   editClientAddress(clientId: string, addressTypeId: string, addressData: any) {
     return this.http.put(`/client/${clientId}/addresses?type=${addressTypeId}`, addressData);
   }
+  getClientShareAccount(accountId: string) {
+    return this.http.get(`/accounts/share/${accountId}`);
+  }
 }

--- a/src/app/clients/common-resolvers/client-view-share-account.resolver.ts
+++ b/src/app/clients/common-resolvers/client-view-share-account.resolver.ts
@@ -1,0 +1,31 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { ClientsService } from '../clients.service';
+
+/**
+ * Client View Share Account data resolver.
+ */
+@Injectable()
+export class ClientViewShareAccountResolver implements Resolve<Object> {
+
+    /**
+     * @param {ClientsService} ClientsService Clients service.
+     */
+    constructor(private clientsService: ClientsService) { }
+
+    /**
+     * Returns the Client Account data.
+     * @returns {Observable<any>}
+     */
+    resolve(route: ActivatedRouteSnapshot): Observable<any> {
+        const accountId = route.params.accountId;
+        return this.clientsService.getClientShareAccount(accountId);
+    }
+
+}


### PR DESCRIPTION
## Description
**Goal:** Able to view share application which is in the submitted/approved state. 

Add a view-share-account component to display the share product details for a share account if there is one. To go to the share product detail page, click on Institution -> Clients -> client-entry -> share-product-entry under the share-accounts tab.

No extra dependencies are required.

## Related issues and discussion
#231 

## Screenshots, if any
![Screen Shot 2020-03-31 at 10 52 28 PM](https://user-images.githubusercontent.com/48222473/78056225-65eabc00-73a2-11ea-950d-6dac8ae09d07.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
