### PR TITLE
feat: add Loan 'Make Repayment' Page

### DIFF
--- a/src/app/clients/clients-accounts/clients-accounts.component.html
+++ b/src/app/clients/clients-accounts/clients-accounts.component.html
@@ -1,0 +1,3 @@
+<p>
+  clients-accounts works!
+</p>

--- a/src/app/clients/clients-accounts/clients-accounts.component.spec.ts
+++ b/src/app/clients/clients-accounts/clients-accounts.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClientsAccountsComponent } from './clients-accounts.component';
+
+describe('ClientsAccountsComponent', () => {
+  let component: ClientsAccountsComponent;
+  let fixture: ComponentFixture<ClientsAccountsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ClientsAccountsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ClientsAccountsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/clients/clients-accounts/clients-accounts.component.ts
+++ b/src/app/clients/clients-accounts/clients-accounts.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'mifosx-clients-accounts',
+  templateUrl: './clients-accounts.component.html',
+  styleUrls: ['./clients-accounts.component.scss']
+})
+export class ClientsAccountsComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/clients/clients-accounts/view-loan-account/loan-repayments/loan-repayments.component.html
+++ b/src/app/clients/clients-accounts/view-loan-account/loan-repayments/loan-repayments.component.html
@@ -1,0 +1,71 @@
+<form [formGroup]="makeRepaymentForm" (ngSubmit)="submit()">
+  <mat-card class="repayment-form-container">
+    <mat-card-title>Loan Repayments</mat-card-title>
+    <mat-card-content class="main-section-container">
+      <!-- main-section start -->
+      <mat-form-field class="full-width" appearance="outline">
+        <mat-label>Transaction date</mat-label>
+        <input matInput [matDatepicker]="transactionDatepicker" [min]="minDate" [max]="maxDate" formControlName="transactionDate" required>
+        <mat-datepicker-toggle matSuffix [for]="transactionDatepicker"></mat-datepicker-toggle>
+        <mat-datepicker #transactionDatepicker ></mat-datepicker>
+        <mat-error *ngIf="makeRepaymentForm.controls.transactionDate.hasError('required')">
+          Transaction Date is <strong>required</strong>
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field class="full-width" appearance="outline">
+        <mat-label>Transaction amount</mat-label>
+        <input type="number" matInput formControlName="transactionAmount" required>
+        <mat-error *ngIf="makeRepaymentForm.controls.transactionAmount.hasError('required')">
+          Transaction Amount is <strong>required</strong>
+        </mat-error>
+      </mat-form-field>
+      <mat-form-field class="full-width" appearance="outline">
+        <mat-label>Payment type</mat-label>
+        <mat-select formControlName = "paymentTypeId">
+          <mat-option *ngFor="let type of loanAccountData.paymentTypeOptions" [value]="type.id">
+            {{type.name}}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+      <div class="payment-details-section">
+        <label>Show Payment Details</label>
+        <button type="button"  mat-raised-button color="primary" (click) = "isExpanded = !isExpanded">
+          <i [ngClass] = "{'fa-plus':!isExpanded,'fa-minus': isExpanded}" class="fa"></i>
+        </button>
+      </div>
+      <!-- expanded-section start -->
+      <div class="expanded-section" *ngIf = "isExpanded">
+        <mat-form-field class="full-width" appearance="outline">
+          <mat-label>Account#</mat-label>
+          <input type="number" matInput  formControlName="accountNumber">
+        </mat-form-field>
+        <mat-form-field class="full-width" appearance="outline">
+          <mat-label>Cheque#</mat-label>
+          <input type="number" matInput  formControlName="checkNumber">
+        </mat-form-field>
+        <mat-form-field class="full-width" appearance="outline">
+          <mat-label>Routing code</mat-label>
+          <input type="number" matInput  formControlName="routingCode">
+        </mat-form-field>
+        <mat-form-field class="full-width" appearance="outline">
+          <mat-label>Receipt#</mat-label>
+          <input type="number" matInput  formControlName="receiptNumber">
+        </mat-form-field>
+        <mat-form-field class="full-width" appearance="outline">
+          <mat-label>Bank#</mat-label>
+          <input type="number" matInput  formControlName="bankNumber">
+        </mat-form-field>
+      </div>
+      <!-- expanded-section end -->
+      <mat-form-field class="full-width" appearance="outline">
+        <mat-label>Note</mat-label>
+        <textarea  formControlName = "note" matInput></textarea>
+      </mat-form-field>
+      <!-- main-section end -->
+    </mat-card-content>
+    <mat-card-footer class="footer-container">
+      <button type="button" id="cancel-btn" mat-raised-button [routerLink]="['../']">Cancel</button>
+      <button type="submit" mat-raised-button color="primary" [disabled]="makeRepaymentForm.pristine||!makeRepaymentForm.valid">Submit</button>
+    </mat-card-footer>
+  </mat-card>
+</form>

--- a/src/app/clients/clients-accounts/view-loan-account/loan-repayments/loan-repayments.component.scss
+++ b/src/app/clients/clients-accounts/view-loan-account/loan-repayments/loan-repayments.component.scss
@@ -1,0 +1,29 @@
+.repayment-form-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    .main-section-container {
+        min-width: 150px;
+        max-width: 500px;
+        width: 100%;
+        .full-width {
+            width: 100%;
+        }
+        .payment-details-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 1rem;
+        }
+    }
+    .footer-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-bottom: 0.5rem;
+        #cancel-btn {
+            margin-right: 0.5rem;
+        }
+    }
+}

--- a/src/app/clients/clients-accounts/view-loan-account/loan-repayments/loan-repayments.component.spec.ts
+++ b/src/app/clients/clients-accounts/view-loan-account/loan-repayments/loan-repayments.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoanRepaymentsComponent } from './loan-repayments.component';
+
+describe('LoanRepaymentsComponent', () => {
+  let component: LoanRepaymentsComponent;
+  let fixture: ComponentFixture<LoanRepaymentsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LoanRepaymentsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoanRepaymentsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/clients/clients-accounts/view-loan-account/loan-repayments/loan-repayments.component.ts
+++ b/src/app/clients/clients-accounts/view-loan-account/loan-repayments/loan-repayments.component.ts
@@ -1,0 +1,71 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { DatePipe } from '@angular/common';
+import { ClientsService } from 'app/clients/clients.service';
+
+@Component({
+  selector: 'mifosx-loan-repayments',
+  templateUrl: './loan-repayments.component.html',
+  styleUrls: ['./loan-repayments.component.scss']
+})
+export class LoanRepaymentsComponent implements OnInit {
+  /** Minimum Due Date allowed. */
+  minDate = new Date(2000, 0, 1);
+  /** Maximum Due Date allowed. */
+  maxDate = new Date();
+  /** Repayment Form. */
+  makeRepaymentForm: FormGroup;
+  /** Loan Transaction Template Data. */
+  loanAccountData: any;
+  /** Boolean indicates if Payment Detail section is expanded or not. */
+  isExpanded: boolean = false;
+
+  constructor(private route: ActivatedRoute,
+    private datePipe: DatePipe,
+    private formBuilder: FormBuilder,
+    private clientsService: ClientsService,
+    private router: Router
+    ) { }
+
+  ngOnInit() {
+    /** GET loan account data and initialize repayment form */
+    this.route.data.subscribe((data: { loanTransactionTemplate: any}) => {
+      this.loanAccountData = data.loanTransactionTemplate;
+      this.createMakeRepaymentForm(this.loanAccountData);
+    });
+  }
+  createMakeRepaymentForm(loanAccountData: any) {
+    this.makeRepaymentForm = this.formBuilder.group({
+      'transactionDate': [this.datePipe.transform(loanAccountData.date,'yyyy-MM-dd'), Validators.required],
+      'transactionAmount': [loanAccountData.amount, Validators.required],
+      'paymentTypeId': [loanAccountData.paymentTypeOptions[0].id],
+      'accountNumber': [''],
+      //TODO: Replace check with cheque once spelling is fixed at Server End of API
+      'checkNumber': [''],
+      'routingCode': [''],
+      'receiptNumber': [''],
+      'bankNumber': [''],
+      'note': [''],
+    });
+  }
+  submit() {
+    /** Date format and locale as mentioned in API doc */
+    const dateFormat = 'dd MMMM yyyy';
+    const locale = 'en';
+    /** Format date selected using datePicker */
+    const unformattedDate = this.makeRepaymentForm.value.transactionDate;
+    this.makeRepaymentForm.patchValue({
+      transactionDate: this.datePipe.transform(unformattedDate, dateFormat)
+    });
+    /** Set final payload data */
+    const makeRepaymentData = this.makeRepaymentForm.value;
+    const loanId = this.route.snapshot.params.loanId;
+    makeRepaymentData.locale = locale;
+    makeRepaymentData.dateFormat = dateFormat;
+    /** POST repayment data  and redirect to previous page on success */
+    this.clientsService.makeRepayment(loanId, makeRepaymentData).subscribe(res => {
+    this.router.navigate(['../'], { relativeTo: this.route });
+  });
+  }
+}

--- a/src/app/clients/clients-accounts/view-loan-account/view-loan-account.component.html
+++ b/src/app/clients/clients-accounts/view-loan-account/view-loan-account.component.html
@@ -1,0 +1,7 @@
+<div class="main-container">
+  <p>
+    This is the temporary view-loan account page to test make repayments feature.
+    <a [routerLink] = "['repayment']">Click here to go to make repayments Page</a>
+  </p>
+</div>
+

--- a/src/app/clients/clients-accounts/view-loan-account/view-loan-account.component.scss
+++ b/src/app/clients/clients-accounts/view-loan-account/view-loan-account.component.scss
@@ -1,0 +1,8 @@
+.main-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    a {
+        margin-left: 0.5rem;
+    }
+}

--- a/src/app/clients/clients-accounts/view-loan-account/view-loan-account.component.spec.ts
+++ b/src/app/clients/clients-accounts/view-loan-account/view-loan-account.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewLoanAccountComponent } from './view-loan-account.component';
+
+describe('ViewLoanAccountComponent', () => {
+  let component: ViewLoanAccountComponent;
+  let fixture: ComponentFixture<ViewLoanAccountComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ViewLoanAccountComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ViewLoanAccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/clients/clients-accounts/view-loan-account/view-loan-account.component.ts
+++ b/src/app/clients/clients-accounts/view-loan-account/view-loan-account.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'mifosx-view-loan-account',
+  templateUrl: './view-loan-account.component.html',
+  styleUrls: ['./view-loan-account.component.scss']
+})
+export class ViewLoanAccountComponent implements OnInit {
+  loanId: string;
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -37,6 +37,9 @@ import { ClientDatatableResolver } from './common-resolvers/client-datatable.res
 import { ClientIdentifierTemplateResolver } from './common-resolvers/client-identifier-template.resolver';
 import { ClientAddressFieldConfigurationResolver } from './common-resolvers/client-address-fieldconfiguration.resolver';
 import { ClientAddressTemplateResolver } from './common-resolvers/client-address-template.resolver';
+import { ViewLoanAccountComponent } from './clients-accounts/view-loan-account/view-loan-account.component';
+import { LoanRepaymentsComponent } from './clients-accounts/view-loan-account/loan-repayments/loan-repayments.component';
+import { LoanTransactionTemplateResolver } from './common-resolvers/loan-transaction-template.resolver';
 
 const routes: Routes = [
   Route.withShell([{
@@ -142,9 +145,31 @@ const routes: Routes = [
               component: DatatableTabComponent,
               data: { title: extract('Data Table View'), routeParamBreadcrumb: 'datatableName' },
               resolve: {
-                clientDatatable: ClientDatatableResolver
+                clientDatatable: ClientDatatableResolver,
               }
             }]
+          }
+        ]
+      }
+    ]
+  }, {
+    path:'clients/accounts',
+    children: [
+      {
+        path: 'view-loan-account/:loanId',
+        data: { title: extract('Loan Account View'), breadcrumb: 'ViewLoanAccount'},
+        children: [
+          {
+            path: '',
+            component: ViewLoanAccountComponent,
+          },
+          {
+            path: 'repayment',
+            data: { title: extract('Repayment'), breadcrumb: 'Repayment', routeParamBreadcrumb: false },
+            component: LoanRepaymentsComponent,
+            resolve: {
+              loanTransactionTemplate: LoanTransactionTemplateResolver,
+            }
           }
         ]
       }
@@ -172,7 +197,8 @@ const routes: Routes = [
     ClientDatatableResolver,
     ClientIdentifierTemplateResolver,
     ClientAddressFieldConfigurationResolver,
-    ClientAddressTemplateResolver
+    ClientAddressTemplateResolver,
+    LoanTransactionTemplateResolver
   ]
 })
 export class ClientsRoutingModule { }

--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -133,7 +133,7 @@
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="openLoansColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: openLoansColumns;"></tr>
+    <tr mat-row *matRowDef="let row; columns: openLoansColumns;" [routerLink] = "['../../accounts/view-loan-account/' + row.id]" class="select-row"></tr>
   </table>
 
   <!-- Closed Loan Accounts -->

--- a/src/app/clients/clients-view/general-tab/general-tab.component.scss
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.scss
@@ -18,5 +18,8 @@
       margin: 4px;
       line-height: 25px;
     }
+    .select-row:hover {
+      cursor: pointer;
+    }
   }
 }

--- a/src/app/clients/clients.module.ts
+++ b/src/app/clients/clients.module.ts
@@ -23,6 +23,9 @@ import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-ta
 import { MultiRowComponent } from './clients-view/datatable-tab/multi-row/multi-row.component';
 import { SingleRowComponent } from './clients-view/datatable-tab/single-row/single-row.component';
 import { AddressTabComponent } from './clients-view/address-tab/address-tab.component';
+import { ClientsAccountsComponent } from './clients-accounts/clients-accounts.component';
+import { LoanRepaymentsComponent } from './clients-accounts/view-loan-account/loan-repayments/loan-repayments.component';
+import { ViewLoanAccountComponent } from './clients-accounts/view-loan-account/view-loan-account.component';
 
 
 /**
@@ -51,7 +54,10 @@ import { AddressTabComponent } from './clients-view/address-tab/address-tab.comp
     DatatableTabComponent,
     MultiRowComponent,
     SingleRowComponent,
-    AddressTabComponent
+    AddressTabComponent,
+    ClientsAccountsComponent,
+    ViewLoanAccountComponent,
+    LoanRepaymentsComponent,
   ],
   entryComponents: [
     UploadDocumentDialogComponent,

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -177,4 +177,10 @@ export class ClientsService {
   editClientAddress(clientId: string, addressTypeId: string, addressData: any) {
     return this.http.put(`/client/${clientId}/addresses?type=${addressTypeId}`, addressData);
   }
+  getLoanTransactionTemplate(loanId: string, command:string) {
+    return this.http.get(`/loans/${loanId}/transactions/template?command=${command}`);
+  }
+  makeRepayment(loanId: string, loanTransactionData: any) {
+    return this.http.post(`/loans/${loanId}/transactions?command=repayment`, loanTransactionData);
+  }
 }

--- a/src/app/clients/common-resolvers/loan-transaction-template.resolver.ts
+++ b/src/app/clients/common-resolvers/loan-transaction-template.resolver.ts
@@ -1,0 +1,32 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot, ActivatedRoute, RouterEvent } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { ClientsService } from '../clients.service';
+
+/**
+ *  Loan Transaction Template resolver.
+ */
+@Injectable()
+export class LoanTransactionTemplateResolver implements Resolve<Object> {
+
+    /**
+     * @param {ClientsService} ClientsService Clients service.
+     */
+    constructor(private clientsService: ClientsService) { }
+
+    /**
+     * Returns the Loan Repayment data.
+     * @returns {Observable<any>}
+     */
+    resolve(route: ActivatedRouteSnapshot): Observable<any> {
+        const loanId = route.paramMap.get('loanId');
+        const command = route.routeConfig.path;
+        return this.clientsService.getLoanTransactionTemplate(loanId, command);
+    }
+
+}


### PR DESCRIPTION
## Description

Make repayment page is for any user having a loan account in an active state (green indicator) to input transaction date, amount, payment method and few other optional details. The date is handled using mat-datepicker and checked by validators along with transaction amount. To go to make repayment page click on Institutions -> Clients -> Any Specific Client -> Active loan account entry under loan accounts in general tab (green box indicator).
To test functionality, client-account and view-loan-account components are also added.
## Related issues and discussion
#242 

## Screenshots, if any

![make-repayment-page(unexpanded)](https://user-images.githubusercontent.com/48222473/78935824-19525f80-7acb-11ea-8013-ba3dc4e5feba.png)

![make-repayment-page(expanded)](https://user-images.githubusercontent.com/48222473/78935816-15bed880-7acb-11ea-85a0-ccfcdc821a0d.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
