### PR TITLE
fix: alignments in migrate opening balances

### DIFF
--- a/src/app/accounting/migrate-opening-balances/migrate-opening-balances.component.html
+++ b/src/app/accounting/migrate-opening-balances/migrate-opening-balances.component.html
@@ -21,7 +21,7 @@
             </mat-error>
           </mat-form-field>
 
-          <button mat-button type="button" color="primary" fxFlex="4%" (click)="retrieveOpeningBalances()">Retrieve</button>
+          <button mat-button type="button" color="primary" fxFlex="8%" (click)="retrieveOpeningBalances()">Retrieve</button>
 
         </div>
 
@@ -80,15 +80,15 @@
 
             <div fxFlexFill fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column" [formGroupName]="i">
 
-              <div fxFlex="8%">
+              <div fxFlex="8%" class="p-t-30">
                 {{ (openingBalancesData.glAccounts[i].glAccountType.value !== openingBalancesData.glAccounts[i-1]?.glAccountType.value) ? openingBalancesData.glAccounts[i].glAccountType.value : '' }}
               </div>
 
-              <div fxFlex="18%">
+              <div fxFlex="18%" class="p-t-30">
                 {{ openingBalancesData.glAccounts[i].glAccountCode }}
               </div>
 
-              <div fxFlex="18%">
+              <div fxFlex="18%" class="p-t-30">
                 {{ openingBalancesData.glAccounts[i].glAccountName }}
               </div>
 


### PR DESCRIPTION
## Description
Fixed retrieve button and form fields alignments in Accounting->Migrate Opening Balances

## Related issues and discussion
#743 

## Screenshots, if any
![webapp1](https://user-images.githubusercontent.com/43112139/81495318-15357f80-92cd-11ea-9ca4-6c802816bec5.gif)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
