### PR TITLE
feat: add groups view page (datatable-tabs)

### DIFF
--- a/src/app/groups/common-resolvers/group-datatable.resolver.ts
+++ b/src/app/groups/common-resolvers/group-datatable.resolver.ts
@@ -1,0 +1,32 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { GroupsService } from '../groups.service';
+
+/**
+ * Group Datatable data resolver.
+ */
+@Injectable()
+export class GroupDatatableResolver implements Resolve<Object> {
+
+  /**
+   * @param {GroupsService} GroupsService Groups service.
+   */
+  constructor(private groupsService: GroupsService) { }
+
+  /**
+   * Returns the Group's Datatable data.
+   * @returns {Observable<any>}
+   */
+  resolve(route: ActivatedRouteSnapshot): Observable<any> {
+    const groupId = route.parent.parent.paramMap.get('groupId');
+    const datatableName = route.paramMap.get('datatableName');
+    return this.groupsService.getGroupDatatable(groupId, datatableName);
+  }
+
+}

--- a/src/app/groups/common-resolvers/group-datatables.resolver.ts
+++ b/src/app/groups/common-resolvers/group-datatables.resolver.ts
@@ -1,0 +1,30 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { GroupsService } from '../groups.service';
+
+/**
+ * Group Datatables data resolver.
+ */
+@Injectable()
+export class GroupDatatablesResolver implements Resolve<Object> {
+
+  /**
+   * @param {GroupsService} GroupsService Groups service.
+   */
+  constructor(private groupsService: GroupsService) { }
+
+  /**
+   * Returns the Group's Datatables data.
+   * @returns {Observable<any>}
+   */
+  resolve(): Observable<any> {
+    return this.groupsService.getGroupDatatables();
+  }
+
+}

--- a/src/app/groups/groups-routing.module.ts
+++ b/src/app/groups/groups-routing.module.ts
@@ -15,6 +15,7 @@ import { GeneralTabComponent } from './groups-view/general-tab/general-tab.compo
 import { NotesTabComponent } from './groups-view/notes-tab/notes-tab.component';
 import { CommitteeTabComponent } from './groups-view/committee-tab/committee-tab.component';
 import { CreateGroupComponent } from './create-group/create-group.component';
+import { DatatableTabsComponent } from './groups-view/datatable-tabs/datatable-tabs.component';
 
 /** Custom Resolvers */
 import { GroupViewResolver } from './common-resolvers/group-view.resolver';
@@ -22,6 +23,8 @@ import { GroupAccountsResolver } from './common-resolvers/group-account.resolver
 import { GroupSummaryResolver } from './common-resolvers/group-summary.resolver';
 import { GroupNotesResolver } from './common-resolvers/group-notes.resolver';
 import { OfficesResolver } from 'app/accounting/common-resolvers/offices.resolver';
+import { GroupDatatablesResolver } from './common-resolvers/group-datatables.resolver';
+import { GroupDatatableResolver } from './common-resolvers/group-datatable.resolver';
 
 /** Groups Routes */
 const routes: Routes = [
@@ -47,7 +50,8 @@ const routes: Routes = [
           component: GroupsViewComponent,
           data: { title: extract('View Group'), routeParamBreadcrumb: 'groupId' },
           resolve: {
-            groupViewData: GroupViewResolver
+            groupViewData: GroupViewResolver,
+            groupDatatables: GroupDatatablesResolver
           },
           children: [
             {
@@ -71,6 +75,19 @@ const routes: Routes = [
               path: 'committee',
               component: CommitteeTabComponent,
               data: { title: extract('Committee'), breadcrumb: 'Committee', routeParamBreadcrumb: false }
+            },
+            {
+              path: 'datatables',
+              children: [
+                {
+                  path: ':datatableName',
+                  component: DatatableTabsComponent,
+                  data: { title: extract('View Data Table'), routeParamBreadcrumb: 'datatableName' },
+                  resolve: {
+                    groupDatatable: GroupDatatableResolver
+                  }
+                }
+              ]
             }
           ]
         }
@@ -90,6 +107,8 @@ const routes: Routes = [
   providers: [GroupViewResolver,
               GroupAccountsResolver,
               GroupSummaryResolver,
-              GroupNotesResolver]
+              GroupNotesResolver,
+              GroupDatatablesResolver,
+              GroupDatatableResolver]
 })
 export class GroupsRoutingModule { }

--- a/src/app/groups/groups-view/committee-tab/committee-tab.component.html
+++ b/src/app/groups/groups-view/committee-tab/committee-tab.component.html
@@ -1,6 +1,6 @@
 <div class="tab-container mat-typography">
   
-  <div fxLayout="row" fxLayoutAlign="start" class="table-header">
+  <div fxLayout="row" fxLayoutAlign="start">
     <div class="m-b-10">
       <h3>Client Members</h3>
     </div>
@@ -11,39 +11,43 @@
     </div>
   </div>
 
-  <table mat-table [dataSource]="groupRolesData"
-    class="mat-elevation-z1">
+  <div *ngIf="groupRolesData">
+    
+    <table mat-table [dataSource]="groupRolesData"
+      class="mat-elevation-z1 m-b-25">
 
-    <ng-container matColumnDef="Name">
-      <th mat-header-cell *matHeaderCellDef> Name </th>
-      <td mat-cell *matCellDef="let element"> {{element.clientName}} </td>
-    </ng-container>
+      <ng-container matColumnDef="Name">
+        <th mat-header-cell *matHeaderCellDef> Name </th>
+        <td mat-cell *matCellDef="let element"> {{element.clientName}} </td>
+      </ng-container>
 
-    <ng-container matColumnDef="Role">
-      <th mat-header-cell *matHeaderCellDef> Role </th>
-      <td mat-cell *matCellDef="let element"> {{element.role.name}} </td>
-    </ng-container>
+      <ng-container matColumnDef="Role">
+        <th mat-header-cell *matHeaderCellDef> Role </th>
+        <td mat-cell *matCellDef="let element"> {{element.role.name}} </td>
+      </ng-container>
 
-    <ng-container matColumnDef="Client Id">
-      <th mat-header-cell *matHeaderCellDef> Client Id </th>
-      <td mat-cell *matCellDef="let element"> {{element.clientId}} </td>
-    </ng-container>
+      <ng-container matColumnDef="Client Id">
+        <th mat-header-cell *matHeaderCellDef> Client Id </th>
+        <td mat-cell *matCellDef="let element"> {{element.clientId}} </td>
+      </ng-container>
 
-    <ng-container matColumnDef="Actions">
-      <th mat-header-cell *matHeaderCellDef> Actions </th>
-      <td mat-cell *matCellDef="let element">
-        <span *ngIf="groupStatus !== 'Closed'">
-          <button class="account-action-button" mat-raised-button color="primary"
-          *mifosxHasPermission="'UNASSIGNROLE_GROUP'">
-          <i class="fa fa-ban" matTooltip="Unassign"></i>
-          </button>
-        </span>
-      </td>
-    </ng-container>
+      <ng-container matColumnDef="Actions">
+        <th mat-header-cell *matHeaderCellDef> Actions </th>
+        <td mat-cell *matCellDef="let element">
+          <span *ngIf="groupStatus !== 'Closed'">
+            <button class="account-action-button" mat-raised-button color="primary"
+            *mifosxHasPermission="'UNASSIGNROLE_GROUP'">
+            <i class="fa fa-ban" matTooltip="Unassign"></i>
+            </button>
+          </span>
+        </td>
+      </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="groupRolesColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: groupRolesColumns;"></tr>
+      <tr mat-header-row *matHeaderRowDef="groupRolesColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: groupRolesColumns;"></tr>
 
-  </table>
+    </table>
+
+  </div>
 
 </div>

--- a/src/app/groups/groups-view/committee-tab/committee-tab.component.scss
+++ b/src/app/groups/groups-view/committee-tab/committee-tab.component.scss
@@ -4,14 +4,11 @@
   h3 {
     margin:1% auto;
   }
-  .table-header {
-    .action-button{
+  .action-button {
       margin-left: auto;
-    }
   }
   table {
     width: 100%;
-    margin-bottom: 30px;
     .account-action-button{
       min-width: 26px;
       padding: 0 6px;

--- a/src/app/groups/groups-view/datatable-tabs/datatable-tabs.component.html
+++ b/src/app/groups/groups-view/datatable-tabs/datatable-tabs.component.html
@@ -1,0 +1,4 @@
+<div>
+  <mifosx-multi-row *ngIf="multiRowDatatableFlag" [dataObject]="groupDatatable"></mifosx-multi-row>
+  <mifosx-single-row *ngIf="!multiRowDatatableFlag" [dataObject]="groupDatatable"></mifosx-single-row>
+</div>

--- a/src/app/groups/groups-view/datatable-tabs/datatable-tabs.component.spec.ts
+++ b/src/app/groups/groups-view/datatable-tabs/datatable-tabs.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DatatableTabsComponent } from './datatable-tabs.component';
+
+describe('DatatableTabsComponent', () => {
+  let component: DatatableTabsComponent;
+  let fixture: ComponentFixture<DatatableTabsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DatatableTabsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DatatableTabsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/groups/groups-view/datatable-tabs/datatable-tabs.component.ts
+++ b/src/app/groups/groups-view/datatable-tabs/datatable-tabs.component.ts
@@ -1,0 +1,31 @@
+/** Angular Imports */
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+
+/**
+ * Groups Datatable Tabs Component
+ */
+@Component({
+  selector: 'mifosx-datatable-tabs',
+  templateUrl: './datatable-tabs.component.html',
+  styleUrls: ['./datatable-tabs.component.scss']
+})
+export class DatatableTabsComponent {
+
+  /** Group Datatable */
+  groupDatatable: any;
+  /** Multi Row Datatable Flag */
+  multiRowDatatableFlag: boolean;
+
+  /**
+   * Fetches data table data from `resolve`
+   * @param {ActivatedRoute} route Activated Route.
+   */
+  constructor(private route: ActivatedRoute) {
+    this.route.data.subscribe((data: { groupDatatable: any }) => {
+      this.groupDatatable = data.groupDatatable;
+      this.multiRowDatatableFlag = this.groupDatatable.columnHeaders[0].columnName === 'id' ? true : false;
+    });
+  }
+
+}

--- a/src/app/groups/groups-view/datatable-tabs/multi-row/multi-row.component.html
+++ b/src/app/groups/groups-view/datatable-tabs/multi-row/multi-row.component.html
@@ -1,0 +1,33 @@
+<div class="tab-container mat-typography">
+
+  <div fxLayout="row" fxLayoutAlign="start">
+    <div class="m-b-10">
+      <h3>{{datatableName}}</h3>
+    </div>
+    <div class="action-button m-b-5" fxLayoutGap="10px">
+      <span *mifosxHasPermission="'CREATE_' + datatableName">
+        <button mat-raised-button color="primary" (click)="add()">
+          <fa-icon icon="plus"></fa-icon>&nbsp;&nbsp;Add
+        </button>
+      </span>
+      <span *mifosxHasPermission="'DELETE_' + datatableName">
+        <button class="delete-button" mat-raised-button color="warn" (click)="delete()" *ngIf="showDeleteBotton">
+          <fa-icon icon="trash"></fa-icon>&nbsp;&nbsp;Delete All
+        </button>
+      </span>
+    </div>
+  </div>
+
+  <table #dataTable mat-table [hidden]="!datatableData[0]" [dataSource]="datatableData" class="mat-elevation-z1 m-b-25">
+
+    <ng-container *ngFor="let datatableColumn of datatableColumns;let i = index" [matColumnDef]="datatableColumn">
+      <th mat-header-cell *matHeaderCellDef> {{datatableColumn}} </th>
+      <td mat-cell *matCellDef="let data"> {{data.row[i]}} </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="datatableColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: datatableColumns;"></tr>
+
+  </table>
+
+</div>

--- a/src/app/groups/groups-view/datatable-tabs/multi-row/multi-row.component.scss
+++ b/src/app/groups/groups-view/datatable-tabs/multi-row/multi-row.component.scss
@@ -1,0 +1,10 @@
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+  .action-button{
+    margin-left: auto;
+  }
+  table {
+    width: 100%;
+  }
+}

--- a/src/app/groups/groups-view/datatable-tabs/multi-row/multi-row.component.spec.ts
+++ b/src/app/groups/groups-view/datatable-tabs/multi-row/multi-row.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MultiRowComponent } from './multi-row.component';
+
+describe('MultiRowComponent', () => {
+  let component: MultiRowComponent;
+  let fixture: ComponentFixture<MultiRowComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ MultiRowComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MultiRowComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/groups/groups-view/datatable-tabs/multi-row/multi-row.component.ts
+++ b/src/app/groups/groups-view/datatable-tabs/multi-row/multi-row.component.ts
@@ -1,0 +1,184 @@
+/** Angular Imports */
+import { Component, OnChanges, OnInit, Input, ViewChild } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { MatTable } from '@angular/material/table';
+import { MatDialog } from '@angular/material';
+import { DatePipe } from '@angular/common';
+
+/** Custom Dialogs */
+import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
+import { DeleteDialogComponent } from '../../../../shared/delete-dialog/delete-dialog.component';
+
+/** Custom Models */
+import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-base';
+import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
+import { SelectBase } from 'app/shared/form-dialog/formfield/model/select-base';
+import { CheckboxBase } from 'app/shared/form-dialog/formfield/model/checkbox-base';
+import { DatepickerBase } from 'app/shared/form-dialog/formfield/model/datepicker-base';
+
+/** Custom Services */
+import { GroupsService } from '../../../groups.service';
+
+/**
+ * Group Multi Row Data Tables
+ */
+@Component({
+  selector: 'mifosx-multi-row',
+  templateUrl: './multi-row.component.html',
+  styleUrls: ['./multi-row.component.scss']
+})
+export class MultiRowComponent implements OnInit, OnChanges {
+
+  /** Data Object */
+  @Input() dataObject: any;
+
+  /** Data Table Name */
+  datatableName: string;
+  /** Data Table Columns */
+  datatableColumns: string[] = [];
+  /** Data Table Data */
+  datatableData: any;
+  /** Group Id */
+  groupId: string;
+  /** Toggle button visibility */
+  showDeleteBotton: boolean;
+
+  /** Data Table Reference */
+  @ViewChild('dataTable') dataTableRef: MatTable<Element>;
+
+  /**
+   * Fetches group Id from parent route params.
+   * @param {ActivatedRoute} route Activated Route.
+   * @param {DatePipe} datePipe Date Pipe.
+   * @param {GroupsService} groupsService Groups Service.
+   * @param {MatDialog} dialog Mat Dialog.
+   */
+  constructor(private route: ActivatedRoute,
+              private datePipe: DatePipe,
+              private groupsService: GroupsService,
+              private dialog: MatDialog) {
+    this.groupId = this.route.parent.parent.snapshot.paramMap.get('groupId');
+  }
+
+  /**
+   * Updates related variables on changes to dataObject.
+   */
+  ngOnChanges() {
+    this.datatableColumns = this.dataObject.columnHeaders.map((columnHeader: any) => {
+      return columnHeader.columnName;
+    });
+    this.datatableData = this.dataObject.data;
+    this.showDeleteBotton = this.datatableData[0] ? true : false;
+  }
+
+  /**
+   * Fetches data table name from route params.
+   * subscription is required due to asynchronicity.
+   */
+  ngOnInit() {
+    this.route.params.subscribe((routeParams: any) => {
+      this.datatableName = routeParams.datatableName;
+    });
+  }
+
+  /**
+   * Adds a new row to the given multi row data table.
+   */
+  add() {
+    let dataTableEntryObject: any = { locale: 'en' };
+    const dateTransformColumns: string[] = [];
+    const columns = this.dataObject.columnHeaders.filter((column: any) => {
+      return ((column.columnName !== 'id') && (column.columnName !== 'group_id'));
+    });
+    const formfields: FormfieldBase[] = columns.map((column: any) => {
+      switch (column.columnDisplayType) {
+        case 'INTEGER':
+        case 'STRING':
+        case 'DECIMAL':
+        case 'TEXT': return new InputBase({
+          controlName: column.columnName,
+          label: column.columnName,
+          value: '',
+          type: (column.columnDisplayType === 'INTEGER' || column.columnDisplayType === 'DECIMAL') ? 'number' : 'text',
+          required: (column.isColumnNullable) ? false : true
+        });
+        case 'BOOLEAN': return new CheckboxBase({
+          controlName: column.columnName,
+          label: column.columnName,
+          value: '',
+          type: 'checkbox',
+          required: (column.isColumnNullable) ? false : true
+        });
+        case 'CODELOOKUP': return new SelectBase({
+          controlName: column.columnName,
+          label: column.columnName,
+          value: '',
+          options: { label: 'value', value: 'id', data: column.columnValues },
+          required: (column.isColumnNullable) ? false : true
+        });
+        case 'DATE': {
+          dateTransformColumns.push(column.columnName);
+          dataTableEntryObject.dateFormat = 'yyyy-MM-dd';
+          return new DatepickerBase({
+            controlName: column.columnName,
+            label: column.columnName,
+            value: '',
+            type: 'date',
+            required: (column.isColumnNullable) ? false : true
+          });
+        }
+        case 'DATETIME': {
+          dateTransformColumns.push(column.columnName);
+          dataTableEntryObject.dateFormat = 'yyyy-MM-dd HH:mm';
+          return new DatepickerBase({
+            controlName: column.columnName,
+            label: column.columnName,
+            value: '',
+            type: 'datetime-local',
+            required: (column.isColumnNullable) ? false : true
+          });
+        }
+      }
+    });
+    const data = {
+      title: 'Add ' + this.datatableName,
+      formfields: formfields
+    };
+    const addDialogRef = this.dialog.open(FormDialogComponent, { data });
+    addDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.data) {
+        dateTransformColumns.forEach((column) => {
+          response.data.value[column] = this.datePipe.transform(response.data.value[column], dataTableEntryObject.dateFormat);
+        });
+        dataTableEntryObject = { ...response.data.value, ...dataTableEntryObject };
+        this.groupsService.addGroupDatatableEntry(this.groupId, this.datatableName, dataTableEntryObject).subscribe(() => {
+          this.groupsService.getGroupDatatable(this.groupId, this.datatableName).subscribe((dataObject: any) => {
+            this.datatableData = dataObject.data;
+            this.dataTableRef.renderRows();
+          });
+        });
+      }
+    });
+  }
+
+  /**
+   * Deletes all rows of the given multi row data table.
+   */
+  delete() {
+    const deleteDataTableDialogRef = this.dialog.open(DeleteDialogComponent, {
+      data: { deleteContext: `the contents of ${this.datatableName}` }
+    });
+    deleteDataTableDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.delete) {
+        this.groupsService.deleteDatatableContent(this.groupId, this.datatableName).subscribe(() => {
+          this.groupsService.getGroupDatatable(this.groupId, this.datatableName).subscribe((dataObject: any) => {
+            this.datatableData = dataObject.data;
+            this.showDeleteBotton = false;
+            this.dataTableRef.renderRows();
+           });
+        });
+      }
+    });
+  }
+
+}

--- a/src/app/groups/groups-view/datatable-tabs/single-row/single-row.component.html
+++ b/src/app/groups/groups-view/datatable-tabs/single-row/single-row.component.html
@@ -1,0 +1,29 @@
+<div class="tab-container mat-typography">
+
+  <h3>{{datatableName}}</h3>
+
+  <div fxLayout="row" fxLayoutAlign="flex-end">
+    <span *mifosxHasPermission="'CREATE_' + datatableName">
+      <button mat-raised-button color="primary" (click)="add()" *ngIf="!dataObject.data[0]">
+        <fa-icon icon="plus"></fa-icon>&nbsp;&nbsp;Add
+      </button>
+    </span>
+    <span *mifosxHasPermission="'UPDATE_' + datatableName">
+      <button mat-raised-button color="primary" (click)="edit()" *ngIf="dataObject.data[0]">
+        <fa-icon icon="edit"></fa-icon>&nbsp;&nbsp;Edit
+      </button>
+    </span>
+    <span *mifosxHasPermission="'DELETE_' + datatableName" class="delete-button">
+      <button mat-raised-button color="warn" (click)="delete()" *ngIf="dataObject.data[0]">
+        <fa-icon icon="trash"></fa-icon>&nbsp;&nbsp;Delete
+      </button>
+    </span>
+  </div>
+
+  <mat-list role="list" *ngIf="dataObject.data[0]">
+    <mat-list-item role="listitem" *ngFor="let columnHeader of dataObject.columnHeaders;let i = index">
+      {{columnHeader.columnName}} : {{dataObject.data[0].row[i]}}
+    </mat-list-item>
+  </mat-list>
+
+</div>

--- a/src/app/groups/groups-view/datatable-tabs/single-row/single-row.component.scss
+++ b/src/app/groups/groups-view/datatable-tabs/single-row/single-row.component.scss
@@ -1,0 +1,7 @@
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+  .delete-button {
+    margin-left: 1%;
+  }
+}

--- a/src/app/groups/groups-view/datatable-tabs/single-row/single-row.component.spec.ts
+++ b/src/app/groups/groups-view/datatable-tabs/single-row/single-row.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SingleRowComponent } from './single-row.component';
+
+describe('SingleRowComponent', () => {
+  let component: SingleRowComponent;
+  let fixture: ComponentFixture<SingleRowComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SingleRowComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SingleRowComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/groups/groups-view/datatable-tabs/single-row/single-row.component.ts
+++ b/src/app/groups/groups-view/datatable-tabs/single-row/single-row.component.ts
@@ -1,0 +1,207 @@
+/** Angular Imports */
+import { Component, Input, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material';
+import { DatePipe } from '@angular/common';
+
+/** Custom Components */
+import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
+import { DeleteDialogComponent } from '../../../../shared/delete-dialog/delete-dialog.component';
+
+/** Custom Models */
+import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-base';
+import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
+import { DatepickerBase } from 'app/shared/form-dialog/formfield/model/datepicker-base';
+import { SelectBase } from 'app/shared/form-dialog/formfield/model/select-base';
+import { CheckboxBase } from 'app/shared/form-dialog/formfield/model/checkbox-base';
+
+/** Custom Services */
+import { GroupsService } from '../../../groups.service';
+
+
+/**
+ * Groups Single Row Data Tables
+ */
+@Component({
+  selector: 'mifosx-single-row',
+  templateUrl: './single-row.component.html',
+  styleUrls: ['./single-row.component.scss']
+})
+export class SingleRowComponent implements OnInit {
+
+  /** Data Object */
+  @Input() dataObject: any;
+
+  /** Data Table Name */
+  datatableName: string;
+  /** Group Id */
+  groupId: string;
+
+  /**
+   * Fetches group Id from parent route params.
+   * @param {ActivatedRoute} route Activated Route.
+   * @param {DatePipe} datePipe Date Pipe.
+   * @param {GroupsService} groupsService Groups Service.
+   * @param {MatDialog} dialog Mat Dialog.
+   */
+  constructor(private route: ActivatedRoute,
+              private datePipe: DatePipe,
+              private dialog: MatDialog,
+              private groupsService: GroupsService) {
+    this.groupId = this.route.parent.parent.snapshot.paramMap.get('groupId');
+  }
+
+  /**
+   * Fetches data table name from route params.
+   * subscription is required due to asynchronicity.
+   */
+  ngOnInit() {
+    this.route.params.subscribe((routeParams: any) => {
+      this.datatableName = routeParams.datatableName;
+    });
+  }
+
+  /**
+   * Creates a new instance of the given single row data table.
+   */
+  add() {
+    let dataTableEntryObject: any = { locale: 'en' };
+    const dateTransformColumns: string[] = [];
+    const columns = this.dataObject.columnHeaders.filter((column: any) => {
+      return ((column.columnName !== 'id') && (column.columnName !== 'group_id'));
+    });
+    const formfields: FormfieldBase[] = this.getFormfields(columns, dateTransformColumns, dataTableEntryObject);
+    const data = {
+      title: 'Add ' + this.datatableName,
+      formfields: formfields
+    };
+    const addDialogRef = this.dialog.open(FormDialogComponent, { data });
+    addDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.data) {
+        dateTransformColumns.forEach((column) => {
+          response.data.value[column] = this.datePipe.transform(response.data.value[column], dataTableEntryObject.dateFormat);
+        });
+        dataTableEntryObject = { ...response.data.value, ...dataTableEntryObject };
+        this.groupsService.addGroupDatatableEntry(this.groupId, this.datatableName, dataTableEntryObject).subscribe(() => {
+          this.groupsService.getGroupDatatable(this.groupId, this.datatableName).subscribe((dataObject: any) => {
+            this.dataObject = dataObject;
+          });
+        });
+      }
+    });
+  }
+
+  /**
+   * Edits the current instance of single row data table.
+   */
+  edit() {
+    let dataTableEntryObject: any = { locale: 'en' };
+    const dateTransformColumns: string[] = [];
+    const columns = this.dataObject.columnHeaders.filter((column: any) => {
+      return ((column.columnName !== 'id') && (column.columnName !== 'group_id'));
+    });
+    let formfields: FormfieldBase[] = this.getFormfields(columns, dateTransformColumns, dataTableEntryObject);
+    formfields = formfields.map((formfield: FormfieldBase, index: number) => {
+      formfield.value = (this.dataObject.data[0].row[index + 1]) ? this.dataObject.data[0].row[index + 1] : '';
+      return formfield;
+    });
+    const data = {
+      title: 'Edit ' + this.datatableName,
+      layout: { addButtonText: 'Confirm' },
+      formfields: formfields
+    };
+    const editDialogRef = this.dialog.open(FormDialogComponent, { data });
+    editDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.data) {
+        dateTransformColumns.forEach((column) => {
+          response.data.value[column] = this.datePipe.transform(response.data.value[column], dataTableEntryObject.dateFormat);
+        });
+        dataTableEntryObject = { ...response.data.value, ...dataTableEntryObject };
+        this.groupsService.editGroupDatatableEntry(this.groupId, this.datatableName, dataTableEntryObject).subscribe(() => {
+          this.groupsService.getGroupDatatable(this.groupId, this.datatableName).subscribe((dataObject: any) => {
+            this.dataObject = dataObject;
+          });
+        });
+      }
+    });
+  }
+
+  /**
+   * Deletes the current instance of single row data table.
+   */
+  delete() {
+    const deleteDataTableDialogRef = this.dialog.open(DeleteDialogComponent, {
+      data: { deleteContext: `the contents of ${this.datatableName}` }
+    });
+    deleteDataTableDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.delete) {
+        this.groupsService.deleteDatatableContent(this.groupId, this.datatableName)
+          .subscribe(() => {
+            this.groupsService.getGroupDatatable(this.groupId, this.datatableName).subscribe((dataObject: any) => {
+              this.dataObject = dataObject;
+            });
+          });
+      }
+    });
+  }
+
+  /**
+   * Maps API response to data table form fields.
+   * @param {any} columns Data Table Columns.
+   * @param {string[]} dateTransformColumns Columns transformed with date pipe.
+   * @param {any} dataTableEntryObject Additional data table details.
+   */
+  getFormfields(columns: any, dateTransformColumns: string[], dataTableEntryObject: any) {
+    return columns.map((column: any) => {
+      switch (column.columnDisplayType) {
+        case 'INTEGER':
+        case 'STRING':
+        case 'DECIMAL':
+        case 'TEXT': return new InputBase({
+          controlName: column.columnName,
+          label: column.columnName,
+          value: '',
+          type: (column.columnDisplayType === 'INTEGER' || column.columnDisplayType === 'DECIMAL') ? 'number' : 'text',
+          required: (column.isColumnNullable) ? false : true
+        });
+        case 'BOOLEAN': return new CheckboxBase({
+          controlName: column.columnName,
+          label: column.columnName,
+          value: '',
+          type: 'checkbox',
+          required: (column.isColumnNullable) ? false : true
+        });
+        case 'CODELOOKUP': return new SelectBase({
+          controlName: column.columnName,
+          label: column.columnName,
+          value: '',
+          options: { label: 'value', value: 'id', data: column.columnValues },
+          required: (column.isColumnNullable) ? false : true
+        });
+        case 'DATE': {
+          dateTransformColumns.push(column.columnName);
+          dataTableEntryObject.dateFormat = 'yyyy-MM-dd';
+          return new DatepickerBase({
+            controlName: column.columnName,
+            label: column.columnName,
+            value: '',
+            type: 'date',
+            required: (column.isColumnNullable) ? false : true
+          });
+        }
+        case 'DATETIME': {
+          dateTransformColumns.push(column.columnName);
+          dataTableEntryObject.dateFormat = 'yyyy-MM-dd HH:mm';
+          return new DatepickerBase({
+            controlName: column.columnName,
+            label: column.columnName,
+            value: '',
+            type: 'datetime-local',
+            required: (column.isColumnNullable) ? false : true
+          });
+        }
+      }
+    });
+  }
+
+}

--- a/src/app/groups/groups-view/general-tab/general-tab.component.html
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.html
@@ -2,7 +2,7 @@
 
   <h3>Group Details</h3>
 
-  <div fxLayout="row" fxLayoutGap="32px" class="group-details-container">
+  <div fxLayout="row" fxLayoutGap="32px" class="group-details-container m-b-30">
     <p>
       Active Client Loans: {{groupSummary?.activeClientLoans}}<br/>
       Active Client Borrowers: {{groupSummary?.activeClientBorrowers}}<br/>
@@ -24,7 +24,7 @@
     <h3>Client Members</h3>
 
     <table mat-table [dataSource]="groupClientMembers"
-      class="mat-elevation-z1">
+      class="mat-elevation-z1 m-b-30">
 
       <ng-container matColumnDef="Name">
         <th mat-header-cell *matHeaderCellDef> Name </th>
@@ -68,7 +68,7 @@
       <div class="m-b-10">
         <h3>Loan Accounts</h3>
       </div>
-      <div *ngIf="(loanAccounts|accountsFilter:'loan':'closed').length" class="action-button m-b-10" fxLayoutGap="25px">
+      <div *ngIf="(loanAccounts|accountsFilter:'loan':'closed').length" class="action-button m-b-10">
         <button mat-raised-button class="f-right" color="primary"
       (click)="toggleLoanAccountsOverview()">{{showClosedLoanAccounts?'View Active Accounts':'View Closed Accounts'}}</button>
       </div>
@@ -76,7 +76,7 @@
 
     <!-- Open Loan Accounts Table -->
     <table *ngIf="!showClosedLoanAccounts" mat-table [dataSource]="loanAccounts|accountsFilter:'loan'"
-      class="mat-elevation-z1">
+      class="mat-elevation-z1 m-b-30">
 
       <ng-container matColumnDef="Account No">
         <th mat-header-cell *matHeaderCellDef> Account No. </th>
@@ -142,7 +142,7 @@
 
     <!-- Closed Loan Accounts Table-->
     <table *ngIf="showClosedLoanAccounts" mat-table [dataSource]="loanAccounts|accountsFilter:'loan':'closed'"
-      class="mat-elevation-z1">
+      class="mat-elevation-z1 m-b-30">
 
       <ng-container matColumnDef="Account No">
         <th mat-header-cell *matHeaderCellDef> Account No. </th>
@@ -199,7 +199,7 @@
       <div class="m-b-10">
         <h3>Saving Accounts</h3>
       </div>
-      <div class="action-button m-b-10" fxLayoutGap="25px">
+      <div class="action-button m-b-10">
         <button *ngIf="(savingAccounts|accountsFilter:'saving':'closed').length" mat-raised-button class="f-right" color="primary"
         (click)="toggleSavingAccountsOverview()">{{showClosedSavingAccounts?'View Active Accounts':'View Closed Accounts'}}</button>
       </div>
@@ -207,7 +207,7 @@
 
     <!-- Open Savings Accounts Table -->
     <table *ngIf="!showClosedSavingAccounts" mat-table [dataSource]="savingAccounts|accountsFilter:'saving'"
-      class="mat-elevation-z1">
+      class="mat-elevation-z1 m-b-30">
 
       <ng-container matColumnDef="Account No">
         <th mat-header-cell *matHeaderCellDef> Account No. </th>
@@ -261,7 +261,7 @@
 
     <!-- Closed Saving Accounts Table -->
     <table *ngIf="showClosedSavingAccounts" mat-table [dataSource]="savingAccounts|accountsFilter:'saving':'closed'"
-      class="mat-elevation-z1">
+      class="mat-elevation-z1 m-b-30">
 
       <ng-container matColumnDef="Account No">
         <th mat-header-cell *matHeaderCellDef> Account No. </th>

--- a/src/app/groups/groups-view/general-tab/general-tab.component.scss
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.scss
@@ -7,12 +7,9 @@
   .group-details-container {
     border: 1px solid;
     padding: 1%;
-    margin-bottom: 30px;
   }
-  .table-header {
-    .action-button{
-      margin-left: auto;
-    }
+  .action-button{
+    margin-left: auto;
   }
   table {
     width: 100%;
@@ -25,7 +22,6 @@
     tr.select-row:hover {
       cursor: pointer;
     }
-    margin-bottom: 30px;
   }
   i:hover {
     cursor: pointer;

--- a/src/app/groups/groups-view/groups-view.component.html
+++ b/src/app/groups/groups-view/groups-view.component.html
@@ -108,6 +108,13 @@
       [active]="committee.isActive">
         Committee
       </a>
+      <span *ngFor="let groupDatatable of groupDatatables">
+        <a mat-tab-link *mifosxHasPermission="'READ_' + groupDatatable.registeredTableName"
+          [routerLink]="['./datatables',groupDatatable.registeredTableName]"
+          routerLinkActive #datatable="routerLinkActive" [active]="datatable.isActive">
+          {{groupDatatable.registeredTableName}}
+        </a>
+      </span>
     </nav>
 
     <router-outlet></router-outlet>

--- a/src/app/groups/groups-view/groups-view.component.ts
+++ b/src/app/groups/groups-view/groups-view.component.ts
@@ -14,14 +14,17 @@ export class GroupsViewComponent {
 
   /** Group view data */
   groupViewData: any;
+  /** Group datatables data */
+  groupDatatables: any;
 
   /**
    * Fetches group data from `resolve`
    * @param {ActivatedRoute} route Activated Route
    */
   constructor(private route: ActivatedRoute) {
-    this.route.data.subscribe((data: { groupViewData: any }) => {
+    this.route.data.subscribe((data: { groupViewData: any, groupDatatables: any }) => {
       this.groupViewData = data.groupViewData;
+      this.groupDatatables = data.groupDatatables;
     });
   }
 

--- a/src/app/groups/groups.module.ts
+++ b/src/app/groups/groups.module.ts
@@ -15,6 +15,9 @@ import { GeneralTabComponent } from './groups-view/general-tab/general-tab.compo
 import { NotesTabComponent } from './groups-view/notes-tab/notes-tab.component';
 import { CommitteeTabComponent } from './groups-view/committee-tab/committee-tab.component';
 import { CreateGroupComponent } from './create-group/create-group.component';
+import { DatatableTabsComponent } from './groups-view/datatable-tabs/datatable-tabs.component';
+import { SingleRowComponent } from './groups-view/datatable-tabs/single-row/single-row.component';
+import { MultiRowComponent } from './groups-view/datatable-tabs/multi-row/multi-row.component';
 
 /**
  * Groups Module
@@ -34,7 +37,10 @@ import { CreateGroupComponent } from './create-group/create-group.component';
     GeneralTabComponent,
     NotesTabComponent,
     CommitteeTabComponent,
-    CreateGroupComponent
+    CreateGroupComponent,
+    DatatableTabsComponent,
+    SingleRowComponent,
+    MultiRowComponent
   ],
   providers: [DatePipe]
 })

--- a/src/app/groups/groups.service.ts
+++ b/src/app/groups/groups.service.ts
@@ -100,28 +100,80 @@ export class GroupsService {
      * @param groupId Group Id of group to edit note for.
      * @param noteId Note Id
      * @param noteData Note Data
+     * @returns {Observable<any>}
      */
-    editGroupNote(groupId: string, noteId: string, noteData: any) {
+    editGroupNote(groupId: string, noteId: string, noteData: any): Observable<any> {
       return this.http.put(`/groups/${groupId}/notes/${noteId}`, noteData);
     }
 
     /**
      * @param groupId Group Id of group to delete note for.
      * @param noteId Note Id
+     * @returns {Observable<any>}
      */
-    deleteGroupNote(groupId: string, noteId: string) {
+    deleteGroupNote(groupId: string, noteId: string): Observable<any> {
       return this.http.delete(`/groups/${groupId}/notes/${noteId}`);
+    }
+
+    /**
+     * @returns {Observable<any>}
+     */
+    getGroupDatatables(): Observable<any> {
+      const httpParams = new HttpParams().set('apptable', 'm_group');
+      return this.http.get(`/datatables`, { params: httpParams });
+    }
+
+    /**
+     * @param groupId Group Id of group to get datatable for.
+     * @param datatableName Data table name.
+     * @returns {Observable<any>}
+     */
+    getGroupDatatable(groupId: string, datatableName: string): Observable<any> {
+      const httpParams = new HttpParams().set('genericResultSet', 'true');
+      return this.http.get(`/datatables/${datatableName}/${groupId}`, { params: httpParams });
+    }
+
+    /**
+     * @param groupId Group Id of group to get add datatable entry for.
+     * @param datatableName Data Table name.
+     * @param data Data.
+     * @returns {Observable<any>}
+     */
+    addGroupDatatableEntry(groupId: string, datatableName: string, data: any): Observable<any> {
+      const httpParams = new HttpParams().set('genericResultSet', 'true');
+      return this.http.post(`/datatables/${datatableName}/${groupId}`, data, { params: httpParams });
+    }
+
+    /**
+     * @param groupId Group Id of group to get add datatable entry for.
+     * @param datatableName Data Table name.
+     * @param data Data.
+     * @returns {Observable<any>}
+     */
+    editGroupDatatableEntry(groupId: string, datatableName: string, data: any): Observable<any> {
+      const httpParams = new HttpParams().set('genericResultSet', 'true');
+      return this.http.put(`/datatables/${datatableName}/${groupId}`, data, { params: httpParams });
+    }
+
+    /**
+     * @param groupId Group Id of group to get add datatable entry for.
+     * @param datatableName Data Table name.
+     * @returns {Observable<any>}
+     */
+    deleteDatatableContent(groupId: string, datatableName: string): Observable<any> {
+      const httpParams = new HttpParams().set('genericResultSet', 'true');
+      return this.http.delete(`/datatables/${datatableName}/${groupId}`, { params: httpParams });
     }
 
     /**
      * @param {number} officeId Office Id of office to get staff for.
      * @returns {Observable<any>}
      */
-    getStaff(id: number) {
-        const httpParams = new HttpParams()
-            .set('officeId', id.toString())
-            .set('staffInSelectedOfficeOnly', 'true');
-        return this.http.get('/groups/template', { params: httpParams });
+    getStaff(id: number): Observable<any> {
+      const httpParams = new HttpParams()
+          .set('officeId', id.toString())
+          .set('staffInSelectedOfficeOnly', 'true');
+      return this.http.get('/groups/template', { params: httpParams });
     }
 
     /**
@@ -131,5 +183,6 @@ export class GroupsService {
     createGroup(group: any): Observable<any> {
         return this.http.post('/groups', group);
     }
+
 
 }


### PR DESCRIPTION
## Description
- Developed single-row and multi-row Data Tables taking reference from clients view page.
- Enforced Permission using has permission directive
- Refactored HTML and SCSS.

## Related issues and discussion
#776, #777, #791 

## Screenshots, if any

**Single Row Data Table View**

![Screenshot from 2020-05-21 20-59-07](https://user-images.githubusercontent.com/54709463/82582660-03e35180-9bb0-11ea-89ae-0ef04f7e0e0c.png)

**Multi Row Data Table View**

![Screenshot from 2020-05-21 20-57-21](https://user-images.githubusercontent.com/54709463/82582761-1f4e5c80-9bb0-11ea-8fd8-155200c15805.png)

**Single Row Data Table Edit**

![Screenshot from 2020-05-21 21-02-12](https://user-images.githubusercontent.com/54709463/82582783-2bd2b500-9bb0-11ea-9179-b20d65d8d4a1.png)

**Multi Row Data Table Add**

![Screenshot from 2020-05-21 20-59-41](https://user-images.githubusercontent.com/54709463/82582818-3c832b00-9bb0-11ea-8786-b7ffed65dbd6.png)






## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
