### PR TITLE
feat: add view loans (overdue charges tab)

### DIFF
--- a/src/app/loans/loans-routing.module.ts
+++ b/src/app/loans/loans-routing.module.ts
@@ -19,6 +19,7 @@ import { LoanDetailsGeneralResolver } from './common-resolvers/loan-details-gene
 import { LoanNotesResolver } from './common-resolvers/loan-notes-resolver';
 import { ChargesTabComponent } from './loans-view/charges-tab/charges-tab.component';
 import { LoanDetailsChargesResolver } from './common-resolvers/loan-details-charges.resolver';
+import { OverdueChargesTabComponent } from './loans-view/overdue-charges-tab/overdue-charges-tab.component';
 
 const routes: Routes = [
   {
@@ -50,6 +51,14 @@ const routes: Routes = [
           }
         },
         {
+          path: 'overdue-charges',
+          component: OverdueChargesTabComponent,
+          data: { title: extract('Overdue Charges'), breadcrumb: 'Overdue Charges', routeParamBreadcrumb: false },
+          resolve: {
+            loanDetailsData: LoanDetailsGeneralResolver
+          }
+        },
+        {
           path: 'charges',
           component: ChargesTabComponent,
           data: { title: extract('Charges'), breadcrumb: 'Charges', routeParamBreadcrumb: false },
@@ -63,7 +72,7 @@ const routes: Routes = [
           data: { title: extract('Notes'), breadcrumb: 'Notes', routeParamBreadcrumb: false },
           resolve: {
             loanNotes: LoanNotesResolver
-          }
+          },
         },
         {
           path: 'add-loan-charge',
@@ -72,7 +81,7 @@ const routes: Routes = [
           resolve: {
             loanChargeTemplate: LoanChargeTemplateResolver
           }
-        }
+        },
       ]
     }]
   }

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
@@ -16,18 +16,18 @@ export class ChargesTabComponent implements OnInit {
   chargesData: any;
   /** Status */
   status: any;
-  /** Columns to be displayed in codes table. */
+  /** Columns to be displayed in charges table. */
   displayedColumns: string[] = ['name', 'feepenalty', 'paymentdueat', 'dueasof', 'calculationtype', 'due', 'paid', 'waived', 'outstanding', 'actions'];
-  /** Data source for codes table. */
+  /** Data source for charges table. */
   dataSource: MatTableDataSource<any>;
 
-  /** Paginator for codes table. */
+  /** Paginator for charges table. */
   @ViewChild(MatPaginator) paginator: MatPaginator;
-  /** Sorter for codes table. */
+  /** Sorter for charges table. */
   @ViewChild(MatSort) sort: MatSort;
 
   /**
-   * Retrieves the codes data from `resolve`.
+   * Retrieves the loans data from `resolve`.
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor(private route: ActivatedRoute) {

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -58,6 +58,11 @@
 	  <a mat-tab-link [routerLink]="['./accountdetail']" routerLinkActive #accountdetail="routerLinkActive" [active]="accountdetail.isActive">
 		Account Details
 	  </a>
+	  <ng-container *ngIf="loanDetailsData.overdueCharges.length > 0">
+		<a mat-tab-link [routerLink]="['./overdue-charges']" routerLinkActive #overduecharges="routerLinkActive" [active]="overduecharges.isActive">
+			Overdue Charges
+		</a>
+	  </ng-container>
 	  <ng-container *ngIf="loanDetailsData.charges">
 		<a mat-tab-link [routerLink]="['./charges']" routerLinkActive #charges="routerLinkActive" [active]="charges.isActive">
 		  Charges

--- a/src/app/loans/loans-view/overdue-charges-tab/overdue-charges-tab.component.html
+++ b/src/app/loans/loans-view/overdue-charges-tab/overdue-charges-tab.component.html
@@ -1,0 +1,31 @@
+<div class="container">
+
+  <table mat-table [dataSource]="dataSource" matSort>
+
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Name </th>
+      <td mat-cell *matCellDef="let charge"> {{ charge.name }},{{ charge.currency.displaySymbol }} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="type">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Type </th>
+      <td mat-cell *matCellDef="let charge"> {{ charge.chargeCalculationType.value }} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="amount">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Amount </th>
+      <td mat-cell *matCellDef="let charge"> {{ charge.amount| number }} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="collectedon">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Collected On </th>
+      <td mat-cell *matCellDef="let charge"> {{ charge.chargeTimeType.value }} </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+
+  <mat-paginator [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons></mat-paginator>
+
+</div>

--- a/src/app/loans/loans-view/overdue-charges-tab/overdue-charges-tab.component.scss
+++ b/src/app/loans/loans-view/overdue-charges-tab/overdue-charges-tab.component.scss
@@ -1,0 +1,4 @@
+table {
+    width: 100%;
+    margin-top: 3%;
+}

--- a/src/app/loans/loans-view/overdue-charges-tab/overdue-charges-tab.component.spec.ts
+++ b/src/app/loans/loans-view/overdue-charges-tab/overdue-charges-tab.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OverdueChargesTabComponent } from './overdue-charges-tab.component';
+
+describe('OverdueChargesTabComponent', () => {
+  let component: OverdueChargesTabComponent;
+  let fixture: ComponentFixture<OverdueChargesTabComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ OverdueChargesTabComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OverdueChargesTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/loans/loans-view/overdue-charges-tab/overdue-charges-tab.component.ts
+++ b/src/app/loans/loans-view/overdue-charges-tab/overdue-charges-tab.component.ts
@@ -1,0 +1,48 @@
+/** Angular Imports */
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { MatTableDataSource, MatPaginator, MatSort } from '@angular/material';
+import { ActivatedRoute } from '@angular/router';
+
+/**
+ * Overdue charges tab component
+ */
+@Component({
+  selector: 'mifosx-overdue-charges-tab',
+  templateUrl: './overdue-charges-tab.component.html',
+  styleUrls: ['./overdue-charges-tab.component.scss']
+})
+export class OverdueChargesTabComponent implements OnInit {
+
+  /** Stores the resolved loan data */
+  loanDetails: any;
+  /** Stores the overdue data */
+  overdueCharges: any;
+
+  /** Columns to be displayed in overdue charges table. */
+  displayedColumns: string[] = ['name', 'type', 'amount', 'collectedon'];
+  /** Data source for codes table. */
+  dataSource: MatTableDataSource<any>;
+
+  /** Paginator for codes table. */
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  /** Sorter for codes table. */
+  @ViewChild(MatSort) sort: MatSort;
+
+  /**
+   * Retrieves the loans data from `resolve`.
+   * @param {ActivatedRoute} route Activated Route.
+   */
+  constructor(private route: ActivatedRoute) {
+    this.route.data.subscribe(( data: { loanDetailsData: any }) => {
+      this.loanDetails = data.loanDetailsData;
+    });
+  }
+
+  ngOnInit() {
+    this.overdueCharges = this.loanDetails.overdueCharges;
+    this.dataSource = new MatTableDataSource(this.overdueCharges);
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
+  }
+
+}

--- a/src/app/loans/loans.module.ts
+++ b/src/app/loans/loans.module.ts
@@ -15,6 +15,7 @@ import { GeneralTabComponent } from './loans-view/general-tab/general-tab.compon
 import { AccountDetailsComponent } from './loans-view/account-details/account-details.component';
 import { NotesTabComponent } from './loans-view/notes-tab/notes-tab.component';
 import { ChargesTabComponent } from './loans-view/charges-tab/charges-tab.component';
+import { OverdueChargesTabComponent } from './loans-view/overdue-charges-tab/overdue-charges-tab.component';
 
 /**
  * Loans Module
@@ -30,6 +31,7 @@ import { ChargesTabComponent } from './loans-view/charges-tab/charges-tab.compon
     AccountDetailsComponent,
     NotesTabComponent,
     ChargesTabComponent,
+    OverdueChargesTabComponent,
   ],
   providers: [DatePipe],
 })


### PR DESCRIPTION
## Description
Add Charges Tab for the view loans

- User can view the overdue charges data, if available

Needs to be merged after PR #820

## Related issues and discussion
#817 

## Screenshots, if any
![Screenshot from 2020-05-31 13-29-19](https://user-images.githubusercontent.com/36980003/83347585-8e137e80-a343-11ea-9303-80d25edb1842.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
