### PR TITLE
feat: add view loan (standing instructions tab)

### DIFF
--- a/src/app/loans/loans-routing.module.ts
+++ b/src/app/loans/loans-routing.module.ts
@@ -23,6 +23,7 @@ import { LoanTrancheDetailsComponent } from './loans-view/loan-tranche-details/l
 import { LoanCollateralTabComponent } from './loans-view/loan-collateral-tab/loan-collateral-tab.component';
 import { CreateLoansAccountComponent } from './create-loans-account/create-loans-account.component';
 import { LoanDocumentsTabComponent } from './loans-view/loan-documents-tab/loan-documents-tab.component';
+import { StandingInstructionsTabComponent } from 'app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component';
 
 /** Custom Resolvers */
 import { LoanChargeTemplateResolver } from './common-resolvers/loan-charge-template.resolver';
@@ -155,6 +156,14 @@ const routes: Routes = [
           data: { title: extract('Notes'), breadcrumb: 'Notes', routeParamBreadcrumb: false },
           resolve: {
             loanNotes: LoanNotesResolver
+          },
+        },
+        {
+          path: 'standing-instruction',
+          component: StandingInstructionsTabComponent,
+          data: { title: extract('Standing Instructions'), breadcrumb: 'Standing Instructions', routeParamBreadcrumb: false },
+          resolve: {
+            loanDetailsData: LoanDetailsGeneralResolver
           },
         },
         {

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -103,6 +103,12 @@
 	  <a mat-tab-link *mifosxHasPermission="'READ_LOANNOTE'" [routerLink]="['./notes']" routerLinkActive #notes="routerLinkActive" [active]="notes.isActive">
 		Notes
 	  </a>
+	<ng-container *ngIf="loanDetailsData.clientId">
+		<a mat-tab-link [routerLink]="['./standing-instruction']" routerLinkActive #standingInstruction="routerLinkActive"
+			[active]="standingInstruction.isActive">
+			Standing Instruction
+		</a>
+	</ng-container>
 	  <ng-container *ngFor="let loanDatatable of loanDatatables">
         <a mat-tab-link *mifosxHasPermission="'READ_' + loanDatatable.registeredTableName" [routerLink]="['./datatables',loanDatatable.registeredTableName]"
           routerLinkActive #datatable="routerLinkActive" [active]="datatable.isActive">

--- a/src/app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component.html
+++ b/src/app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component.html
@@ -1,0 +1,77 @@
+<div class="tab-container mat-typography">
+
+  <div class="m-b-10">
+    <h3>All Standing Instructions</h3>
+  </div>
+
+  <div class="mat-elevation-z1 m-b-25">
+
+    <table mat-table #instructionsTable [dataSource]="dataSource">
+
+      <ng-container matColumnDef="client">
+        <th mat-header-cell *matHeaderCellDef> Client </th>
+        <td mat-cell *matCellDef="let instruction">{{instruction.fromClient.displayName}}-{{instruction.fromClient.id}}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="fromAccount">
+        <th mat-header-cell *matHeaderCellDef> From Account </th>
+        <td mat-cell *matCellDef="let instruction">{{instruction.fromAccount.accountNo}}
+          ({{instruction.fromAccountType.value}})</td>
+      </ng-container>
+
+      <ng-container matColumnDef="beneficiary">
+        <th mat-header-cell *matHeaderCellDef> Beneficiary </th>
+        <td mat-cell *matCellDef="let instruction">
+          <span *ngIf="instruction.fromClient.id != instruction.toClient.id"> {{instruction.toClient.displayName}} </span>
+          <span *ngIf="instruction.fromClient.id == instruction.toClient.id">Own Account</span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="toAccount">
+        <th mat-header-cell *matHeaderCellDef> To Account </th>
+        <td mat-cell *matCellDef="let instruction">{{instruction.toAccount.accountNo}}
+          ({{instruction.toAccountType.value}})</td>
+      </ng-container>
+
+      <ng-container matColumnDef="amount">
+        <th mat-header-cell *matHeaderCellDef> Amount </th>
+        <td mat-cell *matCellDef="let instruction">{{instruction.instructionType.value}}/{{instruction.amount}}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="validity">
+        <th mat-header-cell *matHeaderCellDef> Validity </th>
+        <td mat-cell *matCellDef="let instruction">{{instruction.validFrom | date}} to {{instruction.validTill | date}}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef> Actions </th>
+        <td mat-cell *matCellDef="let instruction">
+          <span *ngIf="instruction.status.value!=='Deleted'">
+            <button class="account-action-button" mat-raised-button color="primary"
+              matTooltip="Edit Standing Instruction" *mifosxHasPermission="'UPDATE_STANDINGINSTRUCTION'">
+              <i class="fa fa-edit"></i>
+            </button>
+          </span>
+          <span *ngIf="instruction.status.value!=='Deleted'">
+            <button class="account-action-button" mat-raised-button color="warn"
+              matTooltip="Delete Standing Instruction" *mifosxHasPermission="'DELETE_STANDINGINSTRUCTION'">
+              <i class="fa fa-times"></i>
+            </button>
+          </span>
+          <button class="account-action-button" mat-raised-button color="primary" matTooltip="View Standing Instruction"
+            *mifosxHasPermission="'READ_STANDINGINSTRUCTION'">
+            <i class="fa fa-eye"></i>
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+
+    </table>
+
+  </div>
+
+</div>

--- a/src/app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component.scss
+++ b/src/app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component.scss
@@ -1,0 +1,19 @@
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+  h3 {
+    margin:1% auto;
+  }
+  .action-button {
+      margin-left: auto;
+  }
+  table {
+    width: 100%;
+    .account-action-button{
+      min-width: 26px;
+      padding: 0 6px;
+      margin: 4px;
+      line-height: 25px;
+    }
+  }
+}

--- a/src/app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component.spec.ts
+++ b/src/app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StandingInstructionsTabComponent } from './standing-instructions-tab.component';
+
+describe('StandingInstructionsTabComponent', () => {
+  let component: StandingInstructionsTabComponent;
+  let fixture: ComponentFixture<StandingInstructionsTabComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ StandingInstructionsTabComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StandingInstructionsTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component.ts
+++ b/src/app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component.ts
@@ -1,0 +1,62 @@
+/** Angular Imports */
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { MatTableDataSource, MatTable } from '@angular/material';
+import { ActivatedRoute } from '@angular/router';
+
+/** Custom Services */
+import { LoansService } from 'app/loans/loans.service';
+
+/**
+ * Loans Standing Instructions Tab
+ */
+@Component({
+  selector: 'mifosx-standing-instructions-tab',
+  templateUrl: './standing-instructions-tab.component.html',
+  styleUrls: ['./standing-instructions-tab.component.scss']
+})
+export class StandingInstructionsTabComponent implements OnInit {
+
+  /** Loans Data */
+  loanDetailsData: any;
+  /** Instructions Data */
+  instructionsData: any[];
+  /** Data source for instructions table. */
+  dataSource = new MatTableDataSource();
+  /** Columns to be displayed in instructions table. */
+  displayedColumns: string[] = ['client', 'fromAccount', 'beneficiary', 'toAccount', 'amount', 'validity', 'actions'];
+
+  /** Instruction Table Reference */
+  @ViewChild('instructionsTable') instructionTableRef: MatTable<Element>;
+
+  /**
+   * Retrieves Loans Account Data from `resolve`.
+   * @param {ActivatedRoute} route Activated Route.
+   */
+  constructor(private route: ActivatedRoute,
+    private loansService: LoansService) {
+    this.route.parent.data.subscribe((data: { loanDetailsData: any }) => {
+      this.loanDetailsData = data.loanDetailsData;
+    });
+  }
+
+  ngOnInit() {
+    this.getStandingInstructions();
+  }
+
+  /**
+   * Retrieves standing instructions and initializes instructions table.
+   */
+  getStandingInstructions() {
+    const clientId = this.loanDetailsData.clientId;
+    const clientName = this.loanDetailsData.clientName;
+    const accountId = this.loanDetailsData.id;
+    const locale = 'en';
+    const dateFormat = 'dd MMMM yyyy';
+    this.loansService.getStandingInstructions(clientId, clientName, accountId, locale, dateFormat).subscribe((response: any) => {
+      this.instructionsData = response.pageItems;
+      this.dataSource.data = this.instructionsData;
+      this.instructionTableRef.renderRows();
+    });
+  }
+
+}

--- a/src/app/loans/loans.module.ts
+++ b/src/app/loans/loans.module.ts
@@ -57,6 +57,7 @@ import { LoansAccountViewGuarantorDetailsDialogComponent } from './custom-dialog
 import { LoansAccountAddCollateralDialogComponent } from './custom-dialog/loans-account-add-collateral-dialog/loans-account-add-collateral-dialog.component';
 import { LoansConfirmationDialogBoxComponent } from './custom-dialog/loans-confirmation-dialog-box/loans-confirmation-dialog-box.component';
 import { LoanAccountLoadDocumentsDialogComponent } from './custom-dialog/loan-account-load-documents-dialog/loan-account-load-documents-dialog.component';
+import { StandingInstructionsTabComponent } from './loans-view/standing-instructions-tab/standing-instructions-tab.component';
 
 /**
  * Loans Module
@@ -112,6 +113,7 @@ import { LoanAccountLoadDocumentsDialogComponent } from './custom-dialog/loan-ac
     UndoDisbursalComponent,
     LoanDocumentsTabComponent,
     LoanAccountLoadDocumentsDialogComponent,
+    StandingInstructionsTabComponent,
   ],
   entryComponents: [
     LoansAccountAddCollateralDialogComponent,

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -297,4 +297,27 @@ export class LoansService {
     return this.http.post(`/loans/${loanId}/documents`, data);
   }
 
+  /**
+   * @param clientId Client Id
+   * @param clientName Client Name
+   * @param fromAccountId Account Id
+   * @param locale Locale
+   * @param dateFormat Date Format
+   * @returns {Observable<any>} Standing Instructions
+   */
+  getStandingInstructions(
+    clientId: string, clientName: string, fromAccountId: string,
+    locale: string, dateFormat: string): Observable<any> {
+    const httpParams = new HttpParams()
+      .set('clientId', clientId)
+      .set('clientName', clientName)
+      .set('fromAccountId', fromAccountId)
+      .set('fromAccountType', '1')
+      .set('locale', locale)
+      .set('dateFormat', dateFormat)
+      .set('limit', '14')
+      .set('offset', '0');
+    return this.http.get(`/standinginstructions`, { params: httpParams });
+  }
+
 }


### PR DESCRIPTION
## Description
 - Add standing instructions tab in the view loan account

## Related issues and discussion
#1127 

## Screenshots, if any
![Screenshot from 2020-07-17 21-15-58](https://user-images.githubusercontent.com/36980003/87807031-63d73b00-c875-11ea-95cd-66d997679e25.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
