### PR TITLE
enhance: Replace select with angular material tree in CreateHoliday

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -32,30 +32,36 @@
             ],
             "styles": [
               "src/main.scss",
-              {"inject":false,
+              {
+                "inject": false,
                 "input": "src/theme/deeppurple-amber.scss",
                 "bundleName": "theme/deeppurple-amber"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/indigo-pink.scss",
                 "bundleName": "theme/indigo-pink"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/pink-bluegrey.scss",
                 "bundleName": "theme/pink-bluegrey"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/purple-green.scss",
                 "bundleName": "theme/purple-green"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/custom/denim-yellowgreen.scss",
                 "bundleName": "theme/denim-yellowgreen"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/custom/pictonblue-yellowgreen.scss",
                 "bundleName": "theme/pictonblue-yellowgreen"
-}
+              }
             ],
             "scripts": []
           },
@@ -113,30 +119,36 @@
             "scripts": [],
             "styles": [
               "src/main.scss",
-              {"inject":false,
+              {
+                "inject": false,
                 "input": "src/theme/deeppurple-amber.scss",
                 "bundleName": "theme/deeppurple-amber"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/indigo-pink.scss",
                 "bundleName": "theme/indigo-pink"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/pink-bluegrey.scss",
                 "bundleName": "theme/pink-bluegrey"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/purple-green.scss",
                 "bundleName": "theme/purple-green"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/custom/denim-yellowgreen.scss",
                 "bundleName": "theme/denim-yellowgreen"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/custom/pictonblue-yellowgreen.scss",
                 "bundleName": "theme/pictonblue-yellowgreen"
-}
+              }
             ],
             "assets": [
               "src/favicon.ico",
@@ -190,5 +202,8 @@
       }
     }
   },
-  "defaultProject": "mifosx-web-app"
+  "defaultProject": "mifosx-web-app",
+  "cli": {
+    "analytics": "e8d00692-ba7f-4b47-8b90-2d3fd314372c"
+  }
 }

--- a/src/app/organization/holidays/create-holiday/create-holiday.component.html
+++ b/src/app/organization/holidays/create-holiday/create-holiday.component.html
@@ -62,19 +62,29 @@
             <mat-label>Description</mat-label>
             <input matInput formControlName="description">
           </mat-form-field>   
+
+            <label>Select applicable offices</label>
+
+          <mat-tree [dataSource]="dataSource" [treeControl]="treeControl">
+            <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle matTreeNodePadding>
+              <button mat-icon-button disabled></button>
+              <mat-checkbox class="checklist-leaf-node"
+                            [checked]="checklistSelection.isSelected(node)"
+                            (change)="todoLeafItemSelectionToggle(node);">{{officesDict[node.item].name}}</mat-checkbox>
+            </mat-tree-node>
           
-          <!-- TODO: Replace multi-select by custom angular material tree -->
-          <mat-form-field>
-            <mat-label>Applicable Offices</mat-label>
-            <mat-select required formControlName="offices" multiple>
-              <mat-option *ngFor="let office of officesData" [value]="{ officeId: office.id }">
-                {{ office.name }} 
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="holidayForm.controls.offices.hasError('required')">
-              Offices is <strong>required</strong>
-            </mat-error>
-          </mat-form-field>
+            <mat-tree-node *matTreeNodeDef="let node; when: hasChild" matTreeNodePadding>
+              <button type="button" mat-icon-button matTreeNodeToggle
+                      [attr.aria-label]="'toggle ' + node.filename">
+                <mat-icon class="mat-icon-rtl-mirror">
+                  {{treeControl.isExpanded(node) ? 'expand_more' : 'chevron_right'}}
+                </mat-icon>
+              </button>
+              <mat-checkbox [checked]="descendantsAllSelected(node)"
+                            [indeterminate]="descendantsPartiallySelected(node)"
+                            (change)="todoItemSelectionToggle(node)">{{ officesDict[node.item].name }}</mat-checkbox>
+            </mat-tree-node>
+          </mat-tree>
 
         </div>
 

--- a/src/app/organization/holidays/create-holiday/create-holiday.component.ts
+++ b/src/app/organization/holidays/create-holiday/create-holiday.component.ts
@@ -1,23 +1,81 @@
 /** Angular Imports. */
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { SelectionModel } from '@angular/cdk/collections';
+import { Component, OnInit, ViewChild, Injectable } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DatePipe } from '@angular/common';
+import { MatTreeFlatDataSource, MatTreeFlattener } from '@angular/material/tree';
+import { FlatTreeControl } from '@angular/cdk/tree';
+import { BehaviorSubject } from 'rxjs';
 
 /** Custom Services. */
 import { OrganizationService } from 'app/organization/organization.service';
 
+export class TodoItemNode {
+  children: TodoItemNode[];
+  item: string;
+}
+
+/** Flat office node with expandable and level information */
+export class TodoItemFlatNode {
+  item: string;
+  level: number;
+  expandable: boolean;
+}
+
 /**
- * Create Holiday component.
- * TODO: Develop a custom angular checkbox tree and replace offices select.
+ * Checklist database, it can build a tree structured Json object.
+ * Each node in Json object represents an office.
+ * If a node is a category, it has children items and new items can be added under the category.
  */
+@Injectable()
+export class ChecklistDatabase {
+
+
+  // rxjs functionality to update DOM via subscribe
+  dataChange = new BehaviorSubject<TodoItemNode[]>([]);
+  get data(): TodoItemNode[] {
+    return this.dataChange.value;
+  }
+  TREE_DATA = {};
+
+  constructor() {
+  }
+
+  // called every time the data in route changes
+  initialize(trie: any) {
+    this.TREE_DATA = trie;
+    const data = this.buildFileTree(this.TREE_DATA, 0);
+    this.dataChange.next(data);
+  }
+
+  // builds hierarchical tree of TodoItemNodes
+  buildFileTree(obj: { [key: string]: any }, level: number): TodoItemNode[] {
+    return Object.keys(obj).reduce<TodoItemNode[]>((accumulator, key) => {
+      const value = obj[key];
+      const node = new TodoItemNode();
+      node.item = key;
+
+      if (value != null) {
+        if (typeof value === 'object') {
+          node.children = this.buildFileTree(value, level + 1);
+        } else {
+          node.item = value;
+        }
+      }
+
+      return accumulator.concat(node);
+    }, []);
+  }
+}
+
 @Component({
   selector: 'mifosx-create-holiday',
   templateUrl: './create-holiday.component.html',
-  styleUrls: ['./create-holiday.component.scss']
+  styleUrls: ['./create-holiday.component.scss'],
+  providers: [ChecklistDatabase],
 })
 export class CreateHolidayComponent implements OnInit {
-
   /** Create Holiday form. */
   holidayForm: FormGroup;
   /** Repayment Scheduling data. */
@@ -29,6 +87,36 @@ export class CreateHolidayComponent implements OnInit {
   /** Maximum Date allowed. */
   maxDate = new Date();
 
+  // Stores office data in a trie-like structure
+  officesTrie: any;
+  // Stores office data for access from DOM via Office ID
+  officesDict = {};
+
+  // Angular Material Tree Configuration start ------------
+
+  /** Map from flat node to nested node. This helps us finding the nested node to be modified */
+  flatNodeMap = new Map<TodoItemFlatNode, TodoItemNode>();
+
+  /** Map from nested node to flattened node. This helps us to keep the same object for selection */
+  nestedNodeMap = new Map<TodoItemNode, TodoItemFlatNode>();
+
+  /** A selected parent node to be inserted */
+  selectedParent: TodoItemFlatNode | null = null;
+
+  /** The new item's name */
+  newItemName = '';
+
+  treeControl: FlatTreeControl<TodoItemFlatNode>;
+
+  treeFlattener: MatTreeFlattener<TodoItemNode, TodoItemFlatNode>;
+
+  dataSource: MatTreeFlatDataSource<TodoItemNode, TodoItemFlatNode>;
+
+  /** The selection for checklist */
+  checklistSelection = new SelectionModel<TodoItemFlatNode>(true /* multiple */);
+
+  // Angular Material Tree Configuration end ------------
+
   /**
    * Get offices and holiday template from `Resolver`.
    * @param {FormBuilder} formBuilder Form Builder.
@@ -37,14 +125,30 @@ export class CreateHolidayComponent implements OnInit {
    * @param {OrganizationService} organizationService Organization Service.
    * @param {Router} router Router.
    */
-  constructor(private formBuilder: FormBuilder,
-              private route: ActivatedRoute,
-              private datePipe: DatePipe,
-              private organizationService: OrganizationService,
-              private router: Router ) {
-    this.route.data.subscribe((data: { offices: any, holidayTemplate: any }) => {
+  constructor(
+    private formBuilder: FormBuilder,
+    private route: ActivatedRoute,
+    private datePipe: DatePipe,
+    private organizationService: OrganizationService,
+    private router: Router,
+    private _database: ChecklistDatabase
+  ) {
+    this.treeFlattener = new MatTreeFlattener(this.transformer, this.getLevel, this.isExpandable, this.getChildren);
+    this.treeControl = new FlatTreeControl<TodoItemFlatNode>(this.getLevel, this.isExpandable);
+    this.dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
+
+    // Listens for changes in CheckListDatabase
+    this._database.dataChange.subscribe((data) => {
+      this.dataSource.data = data;
+    });
+
+    this.route.data.subscribe((data: { offices: any; holidayTemplate: any }) => {
       this.officesData = data.offices;
       this.repaymentSchedulingTypes = data.holidayTemplate;
+      // Constructs trie everytime data changes
+      this.constructOfficeHierarchy();
+      // Updates data in the CheckListDatabase
+      _database.initialize(this.officesTrie);
     });
   }
 
@@ -53,17 +157,183 @@ export class CreateHolidayComponent implements OnInit {
     this.buildDependencies();
   }
 
+  setEmptyObjectsToNull(root: any) {
+    Object.keys(root).forEach((key) => {
+      if (Object.keys(root[key]).length === 0) {
+        root[key] = null;
+      } else {
+        this.setEmptyObjectsToNull(root[key]);
+      }
+    });
+  }
+
+  constructOfficeHierarchy() {
+    const trie = {};
+    // Iterates over all the offices
+    this.officesData.forEach((office: any) => {
+      this.officesDict[office.id] = office;
+
+      let hierarchy = office.hierarchy.split('.');
+
+      // Removes empty strings
+      hierarchy = hierarchy.filter((stage: any) => {
+        return stage.length > 0;
+      });
+
+      // Temporary variable to store current object
+
+      let root = trie;
+
+      if (hierarchy.length === 0) {
+        root[office.id] = {};
+      } else {
+        // Sets root as the first object
+        root = trie[Object.keys(trie)[0]];
+        // Construction of hierarchy via Depth First Search
+          hierarchy.forEach((stage: string) => {
+          if (!(stage in root)) {
+            root[stage] = {};
+          }
+          root = root[stage];
+        });
+      }
+    });
+
+    // Sets leaf offices to null as per the requirement of Angular Material
+    this.setEmptyObjectsToNull(trie);
+
+    this.officesTrie = trie;
+  }
+
+  // angular material tree config start ----------------------
+
+  getLevel = (node: TodoItemFlatNode) => node.level;
+
+  isExpandable = (node: TodoItemFlatNode) => node.expandable;
+
+  getChildren = (node: TodoItemNode): TodoItemNode[] => node.children;
+
+  hasChild = (_: number, _nodeData: TodoItemFlatNode) => _nodeData.expandable;
+
+  hasNoContent = (_: number, _nodeData: TodoItemFlatNode) => _nodeData.item === '';
+
+  /**
+   * Transformer to convert nested node to flat node. Record the nodes in maps for later use.
+   */
+  transformer = (node: TodoItemNode, level: number) => {
+    const existingNode = this.nestedNodeMap.get(node);
+    const flatNode = existingNode && existingNode.item === node.item ? existingNode : new TodoItemFlatNode();
+    flatNode.item = node.item;
+    flatNode.level = level;
+    flatNode.expandable = !!node.children?.length;
+    this.flatNodeMap.set(flatNode, node);
+    this.nestedNodeMap.set(node, flatNode);
+    return flatNode;
+  }
+
+  /** Whether all the descendants of the node are selected. */
+  descendantsAllSelected(node: TodoItemFlatNode): boolean {
+    const descendants = this.treeControl.getDescendants(node);
+    const descAllSelected =
+      descendants.length > 0 &&
+      descendants.every((child) => {
+        return this.checklistSelection.isSelected(child);
+      });
+    return descAllSelected;
+  }
+
+  /** Whether part of the descendants are selected */
+  descendantsPartiallySelected(node: TodoItemFlatNode): boolean {
+    const descendants = this.treeControl.getDescendants(node);
+    const result = descendants.some((child) => this.checklistSelection.isSelected(child));
+    return result && !this.descendantsAllSelected(node);
+  }
+
+  setSelectedOffices() {
+    this.holidayForm.patchValue({
+      offices: this.checklistSelection.selected.map((item) => item.item),
+    });
+  }
+
+  /** Toggle the to-do item selection. Select/deselect all the descendants node */
+  todoItemSelectionToggle(node: TodoItemFlatNode): void {
+    this.checklistSelection.toggle(node);
+    const descendants = this.treeControl.getDescendants(node);
+    this.checklistSelection.isSelected(node)
+      ? this.checklistSelection.select(...descendants)
+      : this.checklistSelection.deselect(...descendants);
+
+    // Force update for the parent
+    descendants.forEach((child) => this.checklistSelection.isSelected(child));
+    this.checkAllParentsSelection(node);
+    this.setSelectedOffices();
+  }
+
+  /** Toggle a leaf to-do item selection. Check all the parents to see if they changed */
+  todoLeafItemSelectionToggle(node: TodoItemFlatNode): void {
+    this.checklistSelection.toggle(node);
+    this.checkAllParentsSelection(node);
+    this.setSelectedOffices();
+  }
+
+  /* Checks all the parents when a leaf node is selected/unselected */
+  checkAllParentsSelection(node: TodoItemFlatNode): void {
+    let parent: TodoItemFlatNode | null = this.getParentNode(node);
+    while (parent) {
+      this.checkRootNodeSelection(parent);
+      parent = this.getParentNode(parent);
+    }
+  }
+
+  /** Check root node checked state and change it accordingly */
+  checkRootNodeSelection(node: TodoItemFlatNode): void {
+    const nodeSelected = this.checklistSelection.isSelected(node);
+    const descendants = this.treeControl.getDescendants(node);
+    const descAllSelected =
+      descendants.length > 0 &&
+      descendants.every((child) => {
+        return this.checklistSelection.isSelected(child);
+      });
+    if (nodeSelected && !descAllSelected) {
+      this.checklistSelection.deselect(node);
+    } else if (!nodeSelected && descAllSelected) {
+      this.checklistSelection.select(node);
+    }
+  }
+
+  /* Get the parent node of a node */
+  getParentNode(node: TodoItemFlatNode): TodoItemFlatNode | null {
+    const currentLevel = this.getLevel(node);
+
+    if (currentLevel < 1) {
+      return null;
+    }
+
+    const startIndex = this.treeControl.dataNodes.indexOf(node) - 1;
+
+    for (let i = startIndex; i >= 0; i--) {
+      const currentNode = this.treeControl.dataNodes[i];
+
+      if (this.getLevel(currentNode) < currentLevel) {
+        return currentNode;
+      }
+    }
+    return null;
+  }
+
+  // angular material tree config end ----------------------
+
   /**
    * Sets Holiday Form.
    */
   setHolidayForm() {
     this.holidayForm = this.formBuilder.group({
-      'name': ['', Validators.required],
-      'fromDate': ['', Validators.required],
-      'toDate': ['', Validators.required],
-      'reschedulingType': ['', Validators.required],
-      'description': [''],
-      'offices': ['', Validators.required]
+      name: ['', Validators.required],
+      fromDate: ['', Validators.required],
+      toDate: ['', Validators.required],
+      reschedulingType: ['', Validators.required],
+      description: [''],
+      offices: ['', Validators.required],
     });
   }
 
@@ -87,22 +357,21 @@ export class CreateHolidayComponent implements OnInit {
     const dateFormat = 'yyyy-MM-dd';
     const locale = 'en';
     this.holidayForm.patchValue({
-      'fromDate': this.datePipe.transform(this.holidayForm.value.fromDate, dateFormat),
-      'toDate': this.datePipe.transform(this.holidayForm.value.toDate, dateFormat),
+      fromDate: this.datePipe.transform(this.holidayForm.value.fromDate, dateFormat),
+      toDate: this.datePipe.transform(this.holidayForm.value.toDate, dateFormat),
     });
     if (this.holidayForm.contains('repaymentsRescheduledTo')) {
       this.holidayForm.patchValue({
-        'repaymentsRescheduledTo': this.datePipe.transform(this.holidayForm.value.repaymentsRescheduledTo, dateFormat)
+        repaymentsRescheduledTo: this.datePipe.transform(this.holidayForm.value.repaymentsRescheduledTo, dateFormat),
       });
     }
     const holiday = {
       ...this.holidayForm.value,
       dateFormat,
-      locale
+      locale,
     };
     this.organizationService.createHoliday(holiday).subscribe((response: any) => {
       this.router.navigate(['../', response.resourceId], { relativeTo: this.route });
     });
   }
-
 }


### PR DESCRIPTION
## Description

#### Part 1: Convert the office list into a hierarchical object structure using office.hierarchy string.

I used a method similar to how a trie data structure is created to generate an object as specified in the documentation.

#### Part 2: Reading the Angular Material Checkbox Tree guidelines and sample code.

I went through the link given in description of the issue to understand how Angular Material Tree works.

#### Part 3: Integrating the specified code sections into CreateHoliday component and remove the previous select box.

I removed the select option and added all the required codes.

#### Part 4: Updating offices in HolidayForm object similar to what was being done before.

The format of checkListSelection Angular module is different from what we require, i.e. a simple list of strings (office ids). Therefore I create a function that updates the HolidayForm whenever checklist changes.

## Related issues and discussion
#1231 

## Screenshots, if any

The list generated by the Angular Material Tree comes in the console and I have tested it thoroughly.

![image](https://user-images.githubusercontent.com/28949397/91633120-62b43480-ea03-11ea-8da6-d085fff1a3f2.png)

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
