### PR TITLE
feat: Removing css to ensure dark theme has a lighter logo.

### DIFF
--- a/src/app/core/shell/sidenav/sidenav.component.scss
+++ b/src/app/core/shell/sidenav/sidenav.component.scss
@@ -18,7 +18,9 @@
     text-align: center;
     max-width: 15rem;
     z-index: 9999;
-    color: #444;
+    &:hover {
+      cursor: pointer;
+    }
 
     .app-logo {
       width: auto;
@@ -33,7 +35,9 @@
       font-weight: normal;
     }
   }
-
+  .text-muted-white{
+    color: white;
+  }
   .app-user {
     text-align: center;
     width: 100%;


### PR DESCRIPTION
## Description
Removing css to ensure dark theme has a lighter logo.

## Related issues and discussion
Fixes #747

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
