### PR TITLE
fix: modified css to ensure darker themes have a lighter logo.

### DIFF
--- a/src/app/core/shell/sidenav/sidenav.component.html
+++ b/src/app/core/shell/sidenav/sidenav.component.html
@@ -21,10 +21,10 @@
         {{ username }}
       </span>
       <div class="app-user-controls">
-        <button class="text-muted xs-button" mat-icon-button matTooltip="Settings" [routerLink]="['/settings']">
+        <button class="xs-button" mat-icon-button matTooltip="Settings" [routerLink]="['/settings']">
           <fa-icon icon="cog"></fa-icon>
         </button>
-        <button class="text-muted xs-button" mat-icon-button matTooltip="Sign Out" (click)="logout()">
+        <button class="xs-button" mat-icon-button matTooltip="Sign Out" (click)="logout()">
           <fa-icon icon="sign-out-alt"></fa-icon>
         </button>
       </div>

--- a/src/app/core/shell/sidenav/sidenav.component.scss
+++ b/src/app/core/shell/sidenav/sidenav.component.scss
@@ -18,7 +18,6 @@
     text-align: center;
     max-width: 15rem;
     z-index: 9999;
-    color: #444;
     &:hover {
       cursor: pointer;
     }
@@ -61,7 +60,6 @@
       display: block;
       font-size: 0.875rem;
       font-weight: 300;
-      color: rgba(0, 0, 0, 0.96);
       margin-left: -2px;
     }
 


### PR DESCRIPTION
## Description
Removed css to ensure darker themes have a light logo.

## Related issues and discussion
Fixes #747

## Screenshots, if any
![Screenshot from 2020-09-21 23-27-05](https://user-images.githubusercontent.com/48902681/93803179-18208380-fc62-11ea-8b39-4556c3a18ee6.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
