### PR TITLE
feat: Create dialog for users to add/remove custom servers

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -32,30 +32,36 @@
             ],
             "styles": [
               "src/main.scss",
-              {"inject":false,
+              {
+                "inject": false,
                 "input": "src/theme/deeppurple-amber.scss",
                 "bundleName": "theme/deeppurple-amber"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/indigo-pink.scss",
                 "bundleName": "theme/indigo-pink"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/pink-bluegrey.scss",
                 "bundleName": "theme/pink-bluegrey"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/purple-green.scss",
                 "bundleName": "theme/purple-green"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/custom/denim-yellowgreen.scss",
                 "bundleName": "theme/denim-yellowgreen"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/custom/pictonblue-yellowgreen.scss",
                 "bundleName": "theme/pictonblue-yellowgreen"
-}
+              }
             ],
             "scripts": []
           },
@@ -113,30 +119,36 @@
             "scripts": [],
             "styles": [
               "src/main.scss",
-              {"inject":false,
+              {
+                "inject": false,
                 "input": "src/theme/deeppurple-amber.scss",
                 "bundleName": "theme/deeppurple-amber"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/indigo-pink.scss",
                 "bundleName": "theme/indigo-pink"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/pink-bluegrey.scss",
                 "bundleName": "theme/pink-bluegrey"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/purple-green.scss",
                 "bundleName": "theme/purple-green"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/custom/denim-yellowgreen.scss",
                 "bundleName": "theme/denim-yellowgreen"
-},
-              {"inject":false,
+              },
+              {
+                "inject": false,
                 "input": "src/theme/custom/pictonblue-yellowgreen.scss",
                 "bundleName": "theme/pictonblue-yellowgreen"
-}
+              }
             ],
             "assets": [
               "src/favicon.ico",

--- a/src/app/login/login-form/login-form.component.ts
+++ b/src/app/login/login-form/login-form.component.ts
@@ -30,7 +30,7 @@ export class LoginFormComponent implements OnInit {
    * @param {AuthenticationService} authenticationService Authentication Service.
    */
   constructor(private formBuilder: FormBuilder,
-              private authenticationService: AuthenticationService) {  }
+              private authenticationService: AuthenticationService) { }
 
   /**
    * Creates login form.

--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.html
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.html
@@ -35,7 +35,7 @@
     <ng-container matColumnDef="amount">
       <th mat-header-cell *matHeaderCellDef> Amount </th>
       <td mat-cell *matCellDef="let charge">
-        {{ charge.amount }} 
+        {{ charge.amount }}
         <button mat-icon-button color="primary" (click)="editChargeAmount(charge)">
           <fa-icon icon="pen"></fa-icon>
         </button>
@@ -58,14 +58,14 @@
         <span *ngIf="charge.chargeTimeType.value === 'Monthly Fee' || charge.chargeTimeType.value === 'Annual Fee'">
           {{(charge.feeOnMonthDay | date) || 'Unassigned'}}
         </span>
-        <span 
+        <span
           *ngIf="!(charge.chargeTimeType.value === 'Monthly Fee' || charge.chargeTimeType.value === 'Annual Fee'
             || charge.chargeTimeType.value === 'Specified due date' || charge.chargeTimeType.value === 'Weekly Fee')">
           N/A
         </span>
         <button mat-icon-button color="primary"
           *ngIf="charge.chargeTimeType.value === 'Weekly Fee' || charge.chargeTimeType.value === 'Annual Fee'
-                  || charge.chargeTimeType.value === 'Specified due date'" 
+                  || charge.chargeTimeType.value === 'Specified due date'"
           (click)="editChargeDate(charge)">
           <fa-icon icon="pen"></fa-icon>
         </button>
@@ -75,8 +75,8 @@
     <ng-container matColumnDef="repaymentsEvery">
       <th mat-header-cell *matHeaderCellDef> Repayments Every </th>
       <td mat-cell *matCellDef="let charge">
-        {{ charge.feeInterval || 'Not Provided' }} 
-        <button mat-icon-button color="primary" 
+        {{ charge.feeInterval || 'Not Provided' }}
+        <button mat-icon-button color="primary"
           *ngIf="charge.chargeTimeType.value === 'Weekly Fee' || charge.chargeTimeType.value === 'Monthly Fee'"
           (click)="editChargeFeeInterval(charge)">
           <fa-icon icon="pen"></fa-icon>

--- a/src/app/shared/server-selector/custom-server/custom-server.component.html
+++ b/src/app/shared/server-selector/custom-server/custom-server.component.html
@@ -1,0 +1,49 @@
+<h3>Select Servers</h3>
+<div fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column" class="mb-7" fxLayoutAlign="center">
+
+  <form [formGroup]="addServerForm" fxFlex="48%">
+    <mat-form-field >
+      <mat-label>Server URL</mat-label>
+      <input matInput #server>
+    </mat-form-field>
+  </form>
+
+  <div fxFlex="48%" fxFlexAlign="center">
+    <button type="button" mat-raised-button color="primary" (click)="addCustomServer(server.value)" [disabled]="!server.value">
+      Add
+    </button>
+  </div>
+
+  <table fxFlex="90%" class="mat-elevation-z1" mat-table [dataSource]="serversDataSource" [hidden]="serversDataSource.length === 0">
+
+    <ng-container matColumnDef="URL">
+      <th mat-header-cell *matHeaderCellDef> Server URL </th>
+      <td mat-cell *matCellDef="let server">
+        {{ server }}
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="action">
+      <th mat-header-cell *matHeaderCellDef> Actions </th>
+      <td mat-cell *matCellDef="let server">
+        <button mat-icon-button color="warn" (click)="deleteCustomServer(server)">
+          <fa-icon icon="trash"></fa-icon>
+        </button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+
+  </table>
+</div>
+
+<div fxLayout="row" class="margin-t" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="2%">
+  <button mat-raised-button (click)="onCancel()">
+    Cancel
+  </button>
+  <button mat-raised-button color="primary" (click)="onConfirm()" [disabled]="serversDataSource.length === 0">
+    Confirm
+  </button>
+</div>
+

--- a/src/app/shared/server-selector/custom-server/custom-server.component.scss
+++ b/src/app/shared/server-selector/custom-server/custom-server.component.scss
@@ -1,0 +1,4 @@
+.mb-7{
+  margin-bottom: 7px;
+}
+

--- a/src/app/shared/server-selector/custom-server/custom-server.component.spec.ts
+++ b/src/app/shared/server-selector/custom-server/custom-server.component.spec.ts
@@ -1,0 +1,26 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CustomServerComponent } from './custom-server.component';
+
+describe('CustomServerComponent', () => {
+  let component: CustomServerComponent;
+  let fixture: ComponentFixture<CustomServerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ CustomServerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CustomServerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+

--- a/src/app/shared/server-selector/custom-server/custom-server.component.ts
+++ b/src/app/shared/server-selector/custom-server/custom-server.component.ts
@@ -1,0 +1,88 @@
+/** Angular Imports */
+import { Component, OnInit, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { FormBuilder } from '@angular/forms';
+
+/** Custom Services */
+import { SettingsService } from 'app/settings/settings.service';
+
+/**
+ * Custom Server Selector Dialog Component
+ */
+@Component({
+  selector: 'mifosx-custom-server',
+  templateUrl: './custom-server.component.html',
+  styleUrls: ['./custom-server.component.scss']
+})
+export class CustomServerComponent implements OnInit {
+
+  /** List of selected custom servers */
+  serversDataSource: string[] = [];
+  /** To identify if data has been changed due to user interaction */
+  pristine = true;
+  /** Column headers to be displayed in table */
+  displayedColumns: string[] = ['URL', 'action'];
+  /** Form to add custom servers */
+  addServerForm: any;
+
+  /**
+   * @param {MatDialogRef} dialogRef Component Reference to dialog
+   * @param {any} data provides any data
+   * @param {FormBuilder} formBuilder helps to create form for adding custom servers
+   * @param {SettingsService} settingsService to add/remove servers in localstorage
+   */
+  constructor(public dialogRef: MatDialogRef<CustomServerComponent>,
+              @Inject(MAT_DIALOG_DATA) public data: any,
+              private formBuilder: FormBuilder,
+              private settingsService: SettingsService) { }
+
+  ngOnInit() {
+    this.serversDataSource = this.settingsService.servers;
+    this.createAddServerForm();
+  }
+
+  /** Add Server Form */
+  createAddServerForm() {
+    this.addServerForm = this.formBuilder.group({
+      'server': [''],
+    });
+  }
+
+  /**
+   * Add selected server to custom servers table
+   * @param server any
+   */
+  addCustomServer(server: any) {
+    this.serversDataSource = this.serversDataSource.concat([server]);
+    this.addServerForm.server = '';
+    this.pristine = false;
+  }
+
+  /**
+   * Delete specific server from custom servers table
+   * @param server any
+   */
+  deleteCustomServer(server: any) {
+    this.serversDataSource.splice(this.serversDataSource.indexOf(server), 1);
+    this.serversDataSource = this.serversDataSource.concat([]);
+    this.pristine = false;
+  }
+
+  onCancel() {
+    this.serversDataSource = [];
+    this.dialogRef.close();
+  }
+
+  onConfirm() {
+    this.dialogRef.close({data: this.serversDataSource});
+  }
+
+  /**
+   * return selected custom servers
+   */
+  get customServers() {
+    return this.serversDataSource;
+  }
+
+}
+

--- a/src/app/shared/server-selector/server-selector.component.html
+++ b/src/app/shared/server-selector/server-selector.component.html
@@ -5,4 +5,7 @@
       {{ server }}
     </mat-option>
   </mat-select>
-</mat-form-field>
+</mat-form-field>&nbsp;&nbsp;
+<button type="button" mat-raised-button color="primary" (click)="customServersDialog()">
+  Customize
+</button>

--- a/src/app/shared/server-selector/server-selector.component.ts
+++ b/src/app/shared/server-selector/server-selector.component.ts
@@ -1,9 +1,17 @@
 /** Angular Imports */
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnChanges, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { FormControl } from '@angular/forms';
 
 /** Custom Services */
 import { SettingsService } from 'app/settings/settings.service';
+
+/** Custom Dialogs */
+import { CustomServerComponent } from 'app/shared/server-selector/custom-server/custom-server.component';
+
+/** Custom Models */
+import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-base';
+import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
 
 /**
  * Server Selector Component
@@ -23,13 +31,24 @@ export class ServerSelectorComponent implements OnInit {
 
   /**
    * @param {SettingsService} settingsService Settings Service
+   * @param {MatDialog} dialog Mat Dialog
    */
-  constructor(private settingsService: SettingsService) { }
+  constructor(public dialog: MatDialog, private settingsService: SettingsService) { }
 
   ngOnInit(): void {
     this.servers = this.settingsService.servers;
     this.serverSelector.patchValue(this.settingsService.server);
     this.buildDependencies();
+  }
+
+  customServersDialog(): void {
+    const editNoteDialogRef = this.dialog.open(CustomServerComponent, {});
+    editNoteDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.data) {
+        this.servers = response.data;
+        this.settingsService.setServers(response.data);
+      }
+    });
   }
 
   /**

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -25,6 +25,7 @@ import { ServerSelectorComponent } from './server-selector/server-selector.compo
 /** Custom Modules */
 import { IconsModule } from './icons.module';
 import { MaterialModule } from './material.module';
+import { CustomServerComponent } from './server-selector/custom-server/custom-server.component';
 
 /**
  * Shared Module
@@ -55,7 +56,8 @@ import { MaterialModule } from './material.module';
     ErrorDialogComponent,
     NotificationsTrayComponent,
     SearchToolComponent,
-    ServerSelectorComponent
+    ServerSelectorComponent,
+    CustomServerComponent
   ],
   exports: [
     FileUploadComponent,
@@ -71,6 +73,6 @@ import { MaterialModule } from './material.module';
     MaterialModule,
     FormsModule,
     ReactiveFormsModule,
-  ]
+  ],
 })
 export class SharedModule { }


### PR DESCRIPTION
Feat: Create dialog for users to add/remove custom servers

## Description
Created a new dialog component "Custom Server Component" under Server Selector component to add custom servers to a table and display the table in the dialog box. Added servers can also be deleted from the table. Selected servers in the table are added to the list of mifosXServers in localstorage using the settings service. This will help users to add and store custom servers to run the web app.

## Related issues and discussion
Fixes #1273 

## Screenshots
New custom server dialog box
![Screenshot 2020-12-26 at 4 30 06 PM](https://user-images.githubusercontent.com/54751139/103150730-b14cc200-479c-11eb-97e5-a170c0ad516d.png)

Added a new custom dummy server "https://mifos.xoxo" to the custom servers table
![Screenshot 2020-12-26 at 4 30 34 PM](https://user-images.githubusercontent.com/54751139/103150763-13a5c280-479d-11eb-8fdc-67fe24825736.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
