### PR TITLE
load defaults in terms step of savings account creation

### DIFF
--- a/src/app/savings/savings-account-stepper/savings-account-details-step/savings-account-details-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-details-step/savings-account-details-step.component.ts
@@ -54,6 +54,10 @@ export class SavingsAccountDetailsStepComponent implements OnInit {
           'submittedOnDate': this.savingsAccountTemplate.timeline.submittedOnDate && new Date(this.savingsAccountTemplate.timeline.submittedOnDate),
           'externalId': this.savingsAccountTemplate.externalId
         });
+      } else {
+        this.savingsAccountDetailsForm.patchValue({
+          'submittedOnDate': new Date()
+        })
       }
     }
   }

--- a/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.ts
@@ -48,7 +48,19 @@ export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
         'currencyCode': this.savingsAccountProductTemplate.currency.code,
         'decimal': this.savingsAccountProductTemplate.currency.decimalPlaces,
         'currencyMultiple': this.savingsAccountProductTemplate.currency.inMultiplesOf,
-        'minBalanceForInterestCalculation': this.savingsAccountProductTemplate.minBalanceForInterestCalculation
+        'minBalanceForInterestCalculation': this.savingsAccountProductTemplate.minBalanceForInterestCalculation,
+        'nominalAnnualInterestRate': this.savingsAccountProductTemplate.nominalAnnualInterestRate,
+        'interestCompoundingPeriodType': this.savingsAccountProductTemplate.interestCompoundingPeriodType.id,
+        'interestPostingPeriodType': this.savingsAccountProductTemplate.interestPostingPeriodType.id,
+        'interestCalculationType': this.savingsAccountProductTemplate.interestCalculationType.id,
+        'interestCalculationDaysInYearType': this.savingsAccountProductTemplate.interestCalculationDaysInYearType.id,
+        'minRequiredOpeningBalance': this.savingsAccountProductTemplate.minRequiredOpeningBalance,
+        'withdrawalFeeForTransfers': this.savingsAccountProductTemplate.withdrawalFeeForTransfers,
+        'lockinPeriodFrequency': this.savingsAccountProductTemplate.lockinPeriodFrequency,
+        'lockinPeriodFrequencyType': this.savingsAccountProductTemplate.lockinPeriodFrequencyType && this.savingsAccountTemplate.lockinPeriodFrequencyType.id,
+        'allowOverdraft': this.savingsAccountProductTemplate.allowOverdraft,
+        'enforceMinRequiredBalance': this.savingsAccountProductTemplate.enforceMinRequiredBalance,
+        'minRequiredBalance': this.savingsAccountProductTemplate.minRequiredBalance,
       });
       this.setOptions();
     }


### PR DESCRIPTION
## Description
As its requested in the related issue, this PR implements the loading of defaults in the terms step of savings account creation. Also in the details step the current date is loaded as default when creating a new account.

## Related issues and discussion
#1278 

## Screenshots
![loading defaults in savings account creation](https://user-images.githubusercontent.com/39027928/103755455-de6a6180-5033-11eb-8fa9-8008afa29bbb.gif)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

Please share feedback and suggestions.
