### PR TITLE
feat: add font selection feature

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -46,6 +46,8 @@
   <mifosx-language-selector class="ml-1 language" fxHide.lt-md></mifosx-language-selector>
 
   <mifosx-theme-picker fxHide.lt-md></mifosx-theme-picker>
+  
+  <mifosx-font-picker fxHide.lt-md></mifosx-font-picker>
 
   <mifosx-notifications-tray fxHide.lt-md></mifosx-notifications-tray>
 

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -91,14 +91,17 @@
         <span class="header">Theme</span>
         <mifosx-theme-picker></mifosx-theme-picker>
 
-        <mat-form-field>
+        <!-- <mat-form-field>
           <mat-label>Default Font</mat-label>
           <mat-select>
             <mat-option *ngFor="let font of fonts" [value]="font">
               {{ font }}
             </mat-option>
           </mat-select>
-        </mat-form-field>
+        </mat-form-field> -->
+
+        <span class="header">Fonts</span>
+        <mifosx-font-picker></mifosx-font-picker>
 
       </div>
 

--- a/src/app/shared/font-picker/font-picker.component.html
+++ b/src/app/shared/font-picker/font-picker.component.html
@@ -1,0 +1,9 @@
+<button mat-icon-button [matMenuTriggerFor]="fontMenu" matTooltip="Font Styles">
+  <h2>Aa</h2>
+</button>
+
+<mat-menu #fontMenu="matMenu" x-position="before">
+  <div *ngFor="let font of fonts">
+    <mat-option (click)="onFontChange(font)" value=font>{{font}}</mat-option>
+  </div>
+</mat-menu>

--- a/src/app/shared/font-picker/font-picker.component.spec.ts
+++ b/src/app/shared/font-picker/font-picker.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FontPickerComponent } from './font-picker.component';
+
+describe('FontPickerComponent', () => {
+  let component: FontPickerComponent;
+  let fixture: ComponentFixture<FontPickerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FontPickerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FontPickerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/font-picker/font-picker.component.ts
+++ b/src/app/shared/font-picker/font-picker.component.ts
@@ -1,0 +1,34 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'mifosx-font-picker',
+  templateUrl: './font-picker.component.html',
+  styleUrls: ['./font-picker.component.scss']
+})
+export class FontPickerComponent implements OnInit {
+
+  currentFont = 'roboto';
+
+  fonts = [
+    'roboto',
+    'monospace',
+    'anton'
+  ];
+
+  constructor() { }
+  ngOnInit() {
+    this.currentFont = localStorage.getItem('mifosXfont');
+    document.body.classList.add(this.currentFont);
+  }
+
+
+  /**
+   * For changing the currentfont to the new font.
+   */
+  onFontChange(font: string) {
+    document.body.classList.remove(this.currentFont);
+    document.body.classList.add(font);
+    localStorage.setItem('mifosXfont', font);
+    this.currentFont = font;
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -25,6 +25,7 @@ import { ServerSelectorComponent } from './server-selector/server-selector.compo
 /** Custom Modules */
 import { IconsModule } from './icons.module';
 import { MaterialModule } from './material.module';
+import { FontPickerComponent } from './font-picker/font-picker.component';
 
 /**
  * Shared Module
@@ -47,6 +48,7 @@ import { MaterialModule } from './material.module';
     FooterComponent,
     LanguageSelectorComponent,
     ThemePickerComponent,
+    FontPickerComponent,
     ChangePasswordDialogComponent,
     EnableDialogComponent,
     DisableDialogComponent,
@@ -63,6 +65,7 @@ import { MaterialModule } from './material.module';
     LanguageSelectorComponent,
     ServerSelectorComponent,
     ThemePickerComponent,
+    FontPickerComponent,
     NotificationsTrayComponent,
     SearchToolComponent,
     ErrorDialogComponent,

--- a/src/fonts/Anton.scss
+++ b/src/fonts/Anton.scss
@@ -1,0 +1,12 @@
+@import '~@angular/material/theming';
+
+/** Created style for secondaryFont*/
+$typo2: mat-typography-config(
+  $font-family: 'Anton',
+  $headline: mat-typography-level(32px, 48px, 700),
+  $body-1: mat-typography-level(16px, 24px, 500)
+);
+
+.anton {
+    @include mat-core($typo2);
+}

--- a/src/fonts/Monospace.scss
+++ b/src/fonts/Monospace.scss
@@ -1,0 +1,12 @@
+@import '~@angular/material/theming';
+
+/** Created style for the primaryFont*/
+$typo1: mat-typography-config(
+  $font-family: 'monospace',
+  $headline: mat-typography-level(32px, 48px, 700),
+  $body-1: mat-typography-level(16px, 24px, 500)
+);
+
+.monospace {
+    @include mat-core($typo1);
+}

--- a/src/fonts/Roboto.scss
+++ b/src/fonts/Roboto.scss
@@ -1,0 +1,12 @@
+@import '~@angular/material/theming';
+
+/** Created style for tertiaryFont*/
+$typo3: mat-typography-config(
+  $font-family: 'Roboto',
+  $headline: mat-typography-level(32px, 48px, 700),
+  $body-1: mat-typography-level(16px, 24px, 500)
+);
+
+.roboto {
+  @include mat-core($typo3);
+}

--- a/src/main.scss
+++ b/src/main.scss
@@ -14,3 +14,8 @@
 // 3rd party libraries
 $fa-font-path: "../node_modules/font-awesome/fonts";
 @import "../node_modules/font-awesome/scss/font-awesome.scss";
+
+// import Default Font for MifosX
+@import "./fonts/Roboto";
+@import "./fonts/Anton";
+@import "./fonts/Monospace";


### PR DESCRIPTION
Font selection isn't there in the app, so using local storage to apply
the fonts. Currently showing three fonts may add other if required

Fixes:#472

## Description
Add font selection feature with currently three fonts 'anton', 'monospace' and 'roboto

## Related issues and discussion
#472 

## Screenshots, if any
![image](https://user-images.githubusercontent.com/59651136/104104984-48ebfd80-52d1-11eb-95ab-3b737a1faf65.png)
![image](https://user-images.githubusercontent.com/59651136/104104996-52756580-52d1-11eb-95ad-07dfa0f84a1c.png)

##Note
I tried to make this as theme component but the can't get the code of how themes is applied to all, if you can share any resource it might be helpful for me and I can make the font-picker component as same as theme. Thanks!

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
