### PR TITLE
fix (keyboard-shortcuts-dialog.component.scss): text not visible in dark mode

### DIFF
--- a/src/app/shared/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.component.scss
+++ b/src/app/shared/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.component.scss
@@ -2,6 +2,7 @@
     border: 1px solid #0000004d;
     padding: 0.3rem;
     background: #f8f8f8;
+    color: #00000086;
     font-weight: bold;
     border-radius: 0.3rem;
 }


### PR DESCRIPTION


## Description
Changed the color in keyboard-shortcuts-dialog.component.scss as it was not visible in drak mode.

## Related issues and discussion
#1307  

## Screenshots, if any
![image](https://user-images.githubusercontent.com/33516757/108152977-3e0e5f00-7100-11eb-9042-26ce60d6a44a.png)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
