### PR TITLE
fix: create-holiday-component.ts maxDate to address issue #1314

### DIFF
--- a/src/app/organization/holidays/create-holiday/create-holiday.component.ts
+++ b/src/app/organization/holidays/create-holiday/create-holiday.component.ts
@@ -28,7 +28,7 @@ export class CreateHolidayComponent implements OnInit {
   /** Minimum Date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum Date allowed. */
-  maxDate = new Date();
+  maxDate = new Date(2100, 0, 1);
 
   /**
    * Get offices and holiday template from `Resolver`.


### PR DESCRIPTION
change create-holiday.component.ts from maxDate = new Date(); to maxDate = new Date(2100, 0, 1); to allow users to create holidays in the future

Fixes: #1314