### PR TITLE
Datatable create and update fields

### DIFF
--- a/src/app/centers/centers-view/datatable-tab/multi-row/multi-row.component.ts
+++ b/src/app/centers/centers-view/datatable-tab/multi-row/multi-row.component.ts
@@ -91,7 +91,7 @@ export class MultiRowComponent implements OnInit, OnChanges {
     let dataTableEntryObject: any = { locale: this.settingsService.language.code };
     const dateTransformColumns: string[] = [];
     const columns = this.dataObject.columnHeaders.filter((column: any) => {
-      return ((column.columnName !== 'id') && (column.columnName !== 'center_id'));
+      return ((column.columnName !== 'id') && (column.columnName !== 'center_id') && (column.columnName !== 'created_at') && (column.columnName !== 'updated_at'));
     });
     const formfields: FormfieldBase[] = columns.map((column: any) => {
       switch (column.columnDisplayType) {

--- a/src/app/centers/centers-view/datatable-tab/single-row/single-row.component.html
+++ b/src/app/centers/centers-view/datatable-tab/single-row/single-row.component.html
@@ -27,7 +27,7 @@
     </div>
 
   </div>
-  
+
   <mat-divider></mat-divider>
 
   <div>

--- a/src/app/centers/centers-view/datatable-tab/single-row/single-row.component.ts
+++ b/src/app/centers/centers-view/datatable-tab/single-row/single-row.component.ts
@@ -70,7 +70,7 @@ export class SingleRowComponent implements OnInit {
     let dataTableEntryObject: any = { locale: this.settingsService.language.code };
     const dateTransformColumns: string[] = [];
     const columns = this.dataObject.columnHeaders.filter((column: any) => {
-      return ((column.columnName !== 'id') && (column.columnName !== 'center_id'));
+      return ((column.columnName !== 'id') && (column.columnName !== 'center_id') && (column.columnName !== 'created_at') && (column.columnName !== 'updated_at'));
     });
     const formfields: FormfieldBase[] = this.getFormfields(columns, dateTransformColumns, dataTableEntryObject);
     const data = {

--- a/src/app/clients/clients-view/datatable-tab/multi-row/multi-row.component.ts
+++ b/src/app/clients/clients-view/datatable-tab/multi-row/multi-row.component.ts
@@ -57,7 +57,7 @@ export class MultiRowComponent implements OnInit, OnChanges {
     };
     const dateTransformColumns: string[] = [];
     const columns = this.dataObject.columnHeaders.filter((column: any) => {
-      return ((column.columnName !== 'id') && (column.columnName !== 'client_id'));
+      return ((column.columnName !== 'id') && (column.columnName !== 'client_id') && (column.columnName !== 'created_at') && (column.columnName !== 'updated_at'));
     });
     const formfields: FormfieldBase[] = columns.map((column: any) => {
       switch (column.columnDisplayType) {

--- a/src/app/clients/clients-view/datatable-tab/single-row/single-row.component.ts
+++ b/src/app/clients/clients-view/datatable-tab/single-row/single-row.component.ts
@@ -47,7 +47,7 @@ export class SingleRowComponent implements OnInit {
     };
     const dateTransformColumns: string[] = [];
     const columns = this.dataObject.columnHeaders.filter((column: any) => {
-      return ((column.columnName !== 'id') && (column.columnName !== 'client_id'));
+      return ((column.columnName !== 'id') && (column.columnName !== 'client_id') && (column.columnName !== 'created_at') && (column.columnName !== 'updated_at'));
     });
     const formfields: FormfieldBase[] = this.getFormfields(columns, dateTransformColumns, dataTableEntryObject);
     const data = {
@@ -77,7 +77,7 @@ export class SingleRowComponent implements OnInit {
     };
     const dateTransformColumns: string[] = [];
     const columns = this.dataObject.columnHeaders.filter((column: any) => {
-      return ((column.columnName !== 'id') && (column.columnName !== 'client_id'));
+      return ((column.columnName !== 'id') && (column.columnName !== 'client_id') && (column.columnName !== 'created_at') && (column.columnName !== 'updated_at'));
     });
     let formfields: FormfieldBase[] = this.getFormfields(columns, dateTransformColumns, dataTableEntryObject);
     formfields = formfields.map((formfield: FormfieldBase, index: number) => {

--- a/src/app/loans/loans-view/datatable-tab/multi-row/multi-row.component.ts
+++ b/src/app/loans/loans-view/datatable-tab/multi-row/multi-row.component.ts
@@ -91,7 +91,7 @@ export class MultiRowComponent implements OnInit, OnChanges {
     let dataTableEntryObject: any = { locale: 'en' };
     const dateTransformColumns: string[] = [];
     const columns = this.dataObject.columnHeaders.filter((column: any) => {
-      return ((column.columnName !== 'id') && (column.columnName !== 'loan_id'));
+      return ((column.columnName !== 'id') && (column.columnName !== 'loan_id') && (column.columnName !== 'created_at') && (column.columnName !== 'updated_at'));
     });
     const formfields: FormfieldBase[] = columns.map((column: any) => {
       switch (column.columnDisplayType) {

--- a/src/app/loans/loans-view/datatable-tab/single-row/single-row.component.ts
+++ b/src/app/loans/loans-view/datatable-tab/single-row/single-row.component.ts
@@ -68,7 +68,7 @@ export class SingleRowComponent implements OnInit {
     let dataTableEntryObject: any = { locale: this.settingsService.language.code };
     const dateTransformColumns: string[] = [];
     const columns = this.dataObject.columnHeaders.filter((column: any) => {
-      return ((column.columnName !== 'id') && (column.columnName !== 'loan_id'));
+      return ((column.columnName !== 'id') && (column.columnName !== 'loan_id') && (column.columnName !== 'created_at') && (column.columnName !== 'updated_at'));
     });
     const formfields: FormfieldBase[] = this.getFormfields(columns, dateTransformColumns, dataTableEntryObject);
     const data = {
@@ -98,7 +98,7 @@ export class SingleRowComponent implements OnInit {
     let dataTableEntryObject: any = { locale: this.settingsService.language.code };
     const dateTransformColumns: string[] = [];
     const columns = this.dataObject.columnHeaders.filter((column: any) => {
-      return ((column.columnName !== 'id') && (column.columnName !== 'loan_id'));
+      return ((column.columnName !== 'id') && (column.columnName !== 'loan_id') && (column.columnName !== 'created_at') && (column.columnName !== 'updated_at'));
     });
     let formfields: FormfieldBase[] = this.getFormfields(columns, dateTransformColumns, dataTableEntryObject);
     formfields = formfields.map((formfield: FormfieldBase, index: number) => {

--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -27,6 +27,7 @@ export class SettingsService {
    * @param {any} language Language.
    */
   setLanguage(language: { name: string, code: string }) {
+    console.log("Language: " + language);
     localStorage.setItem('mifosXLanguage', JSON.stringify(language));
   }
 
@@ -57,7 +58,7 @@ export class SettingsService {
    * Returns language setting
    */
   get language() {
-    return JSON.parse(localStorage.getItem('mifosXLanguage'));
+    return { code: localStorage.getItem('mifosXLanguage') };
   }
 
   /**

--- a/src/app/system/manage-data-tables/app-table-data.ts
+++ b/src/app/system/manage-data-tables/app-table-data.ts
@@ -8,3 +8,8 @@ export const appTableData: { displayValue: string, value: string }[] = [
     { displayValue: 'Product Loan', value: 'm_product_loan' },
     { displayValue: 'Savings Product', value: 'm_savings_product' }
   ];
+
+export const entitySubTypeData: { displayValue: string, value: string }[] = [
+  { displayValue: 'Person', value: 'Person' },
+  { displayValue: 'Entity', value: 'Entity' },
+];

--- a/src/app/system/manage-data-tables/create-data-table/create-data-table.component.html
+++ b/src/app/system/manage-data-tables/create-data-table/create-data-table.component.html
@@ -16,8 +16,8 @@
             </mat-error>
           </mat-form-field>
 
-          <mat-form-field fxFlex="40%">
-            <mat-label>Application Table Name</mat-label>
+          <mat-form-field fxFlex="20%">
+            <mat-label>Entity Type</mat-label>
             <mat-select required formControlName="apptableName">
               <mat-option *ngFor="let appTable of appTableData" [value]="appTable.value">
                 {{ appTable.displayValue }}
@@ -26,6 +26,15 @@
             <mat-error *ngIf="dataTableForm.controls.apptableName.hasError('required')">
               Application Table Name is <strong>required</strong>
             </mat-error>
+          </mat-form-field>
+
+          <mat-form-field fxFlex="20%" *ngIf="showEntitySubType">
+            <mat-label>Entity SubType</mat-label>
+            <mat-select formControlName="entitySubType">
+              <mat-option *ngFor="let entitySubType of entitySubTypeData" [value]="entitySubType.value">
+                {{ entitySubType.displayValue }}
+              </mat-option>
+            </mat-select>
           </mat-form-field>
 
           <div fxFlex="14%" class="multi-row-wrapper">

--- a/src/app/system/manage-data-tables/create-data-table/create-data-table.component.ts
+++ b/src/app/system/manage-data-tables/create-data-table/create-data-table.component.ts
@@ -11,7 +11,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { SystemService } from '../../system.service';
 
 /** Data Imports */
-import { appTableData } from '../app-table-data';
+import { appTableData, entitySubTypeData } from '../app-table-data';
 
 /** Custom Components */
 import { ColumnDialogComponent } from '../column-dialog/column-dialog.component';
@@ -31,6 +31,10 @@ export class CreateDataTableComponent implements OnInit {
   dataTableForm: FormGroup;
   /** Application Table Data */
   appTableData = appTableData;
+  entitySubTypeData = entitySubTypeData;
+
+  showEntitySubType: boolean;
+
   /** Column Data */
   columnData: any[] = [];
   /** Data passed to dialog. */
@@ -84,6 +88,10 @@ export class CreateDataTableComponent implements OnInit {
   ngOnInit() {
     this.createDataTableForm();
     this.setColumns();
+
+    this.dataTableForm.controls.apptableName.valueChanges.subscribe((value: any) => {
+      this.showEntitySubType = (value === 'm_client');
+    });
   }
 
   /**
@@ -102,7 +110,8 @@ export class CreateDataTableComponent implements OnInit {
     this.dataTableForm = this.formBuilder.group({
       'datatableName': ['', Validators.required],
       'apptableName': ['', Validators.required],
-      'multiRow': ['']
+      'multiRow': [false],
+      'entitySubType': ['']
     });
   }
 


### PR DESCRIPTION
## Description
Process automatic fields (created_at and updated_at) for Datatables 
https://mifosforge.jira.com/browse/PERF-228

## Related issues and discussion
#{Issue Number}

## Screenshots, if any
Before
<img width="979" alt="Screen Shot 2022-03-30 at 18 41 08" src="https://user-images.githubusercontent.com/44206706/160982160-dde7a01e-9d8e-406b-85c8-ef8b4e9d5b67.png">

After
<img width="1251" alt="Screen Shot 2022-03-30 at 18 54 50" src="https://user-images.githubusercontent.com/44206706/160982197-88c69569-b6c7-4adf-9ff4-2e96bb13909f.png">

View Datatable data
<img width="801" alt="Screen Shot 2022-03-30 at 18 55 28" src="https://user-images.githubusercontent.com/44206706/160982230-46bc34ac-db02-4cee-a0a4-c01dc48fbecd.png">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
