### PR TITLE
fix: modified link to create loan application from member listing under group #1352

### DIFF
--- a/src/app/groups/groups-view/general-tab/general-tab.component.html
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.html
@@ -56,7 +56,7 @@
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="clientMemberColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: clientMemberColumns;" [routerLink]="['/clients', row.id, 'general']" class="select-row"></tr>
+      <tr mat-row *matRowDef="let row; columns: clientMemberColumns;" [routerLink]="['/clients', row.id, 'loans-accounts', 'create']" class="select-row"></tr>
 
     </table>
 


### PR DESCRIPTION
## Description
Changed the routerlink params in the clients listed under the general tab of groups so that the user can be redirected to a new loan application instead of the client profile.
## Related issues and discussion
#1352 

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ X] If you have multiple commits please combine them into one commit by squashing them.

- [ X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
