### PR TITLE
Fix in the accounting module

### DIFF
--- a/src/app/accounting/chart-of-accounts/gl-account-and-chart-of-accounts-template.resolver.ts
+++ b/src/app/accounting/chart-of-accounts/gl-account-and-chart-of-accounts-template.resolver.ts
@@ -42,9 +42,11 @@ export class GlAccountAndChartOfAccountsTemplateResolver implements Resolve<Obje
           case 'LIABILITY': accountOptions = glAccountData.liabilityHeaderAccountOptions;
           break;
         }
-        glAccountData.parent = accountOptions.find((accountOption: any) => {
-          return accountOption.id === glAccountData.parentId;
-        });
+        if (glAccountData.parentId) {
+          glAccountData.parent = accountOptions.find((accountOption: any) => {
+            return accountOption.id === glAccountData.parentId;
+          });
+        }
         return glAccountData;
       })
     );

--- a/src/app/accounting/closing-entries/create-closure/create-closure.component.ts
+++ b/src/app/accounting/closing-entries/create-closure/create-closure.component.ts
@@ -6,6 +6,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 /** Custom Services */
 import { AccountingService } from '../../accounting.service';
 import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
 /**
  * Create closure component.
  */
@@ -36,6 +37,7 @@ export class CreateClosureComponent implements OnInit {
   constructor(private formBuilder: FormBuilder,
               private accountingService: AccountingService,
               private settingsService: SettingsService,
+              private dateUtils: Dates,
               private route: ActivatedRoute,
               private router: Router) {
     this.route.data.subscribe((data: { offices: any }) => {
@@ -70,17 +72,8 @@ export class CreateClosureComponent implements OnInit {
     // TODO: Update once language and date settings are setup
     accountingClosure.locale = this.settingsService.language.code;
     accountingClosure.dateFormat = this.settingsService.dateFormat;
-    if (accountingClosure.closingDate instanceof Date) {
-      let day = accountingClosure.closingDate.getDate();
-      let month = accountingClosure.closingDate.getMonth() + 1;
-      const year = accountingClosure.closingDate.getFullYear();
-      if (day < 10) {
-        day = `0${day}`;
-      }
-      if (month < 10) {
-        month = `0${month}`;
-      }
-      accountingClosure.closingDate = `${year}-${month}-${day}`;
+    if (accountingClosure.closingDate) {
+      accountingClosure.closingDate = this.dateUtils.getDate(accountingClosure.closingDate);
     }
     this.accountingService.createAccountingClosure(accountingClosure).subscribe((response: any) => {
       this.router.navigate(['../view', response.resourceId], { relativeTo: this.route });

--- a/src/app/accounting/create-journal-entry/create-journal-entry.component.ts
+++ b/src/app/accounting/create-journal-entry/create-journal-entry.component.ts
@@ -6,6 +6,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 /** Custom Services */
 import { AccountingService } from '../accounting.service';
 import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
 /**
  * Create Journal Entry component.
  */
@@ -42,6 +43,7 @@ export class CreateJournalEntryComponent implements OnInit {
   constructor(private formBuilder: FormBuilder,
               private accountingService: AccountingService,
               private settingsService: SettingsService,
+              private dateUtils: Dates,
               private route: ActivatedRoute,
               private router: Router) {
     this.route.data.subscribe((data: {
@@ -138,17 +140,8 @@ export class CreateJournalEntryComponent implements OnInit {
     // TODO: Update once language and date settings are setup
     journalEntry.locale = this.settingsService.language.code;
     journalEntry.dateFormat = this.settingsService.dateFormat;
-    if (journalEntry.transactionDate instanceof Date) {
-      let day = journalEntry.transactionDate.getDate();
-      let month = journalEntry.transactionDate.getMonth() + 1;
-      const year = journalEntry.transactionDate.getFullYear();
-      if (day < 10) {
-        day = `0${day}`;
-      }
-      if (month < 10) {
-        month = `0${month}`;
-      }
-      journalEntry.transactionDate = `${year}-${month}-${day}`;
+    if (journalEntry.transactionDate) {
+      journalEntry.transactionDate = this.dateUtils.getDate(journalEntry.transactionDate);
     }
     this.accountingService.createJournalEntry(journalEntry).subscribe(response => {
       this.router.navigate(['../transactions/view', response.transactionId], { relativeTo: this.route });

--- a/src/app/accounting/frequent-postings/frequent-postings.component.ts
+++ b/src/app/accounting/frequent-postings/frequent-postings.component.ts
@@ -6,6 +6,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 /** Custom Services */
 import { AccountingService } from '../accounting.service';
 import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
 /**
  * Frequent Postings component.
  */
@@ -50,6 +51,7 @@ export class FrequentPostingsComponent implements OnInit {
   constructor(private formBuilder: FormBuilder,
               private accountingService: AccountingService,
               private settingsService: SettingsService,
+              private dateUtils: Dates,
               private route: ActivatedRoute,
               private router: Router) {
     this.route.data.subscribe((data: {
@@ -170,16 +172,7 @@ export class FrequentPostingsComponent implements OnInit {
     journalEntry.locale = this.settingsService.language.code;
     journalEntry.dateFormat = this.settingsService.dateFormat;
     if (journalEntry.transactionDate instanceof Date) {
-      let day = journalEntry.transactionDate.getDate();
-      let month = journalEntry.transactionDate.getMonth() + 1;
-      const year = journalEntry.transactionDate.getFullYear();
-      if (day < 10) {
-        day = `0${day}`;
-      }
-      if (month < 10) {
-        month = `0${month}`;
-      }
-      journalEntry.transactionDate = `${year}-${month}-${day}`;
+      journalEntry.transactionDate = this.dateUtils.getDate(journalEntry.transactionDate);
     }
     this.accountingService.createJournalEntry(journalEntry).subscribe(response => {
       this.router.navigate(['../transactions/view', response.transactionId], { relativeTo: this.route });

--- a/src/app/accounting/migrate-opening-balances/migrate-opening-balances.component.ts
+++ b/src/app/accounting/migrate-opening-balances/migrate-opening-balances.component.ts
@@ -8,6 +8,7 @@ import { AccountingService } from '../accounting.service';
 import { SettingsService } from 'app/settings/settings.service';
 /** Custom Validators */
 import { onlyOneOfTheFieldsIsRequiredValidator } from './only-one-of-the-fields-is-required.validator';
+import { Dates } from 'app/core/utils/dates';
 
 /**
  * Migrate opening balances component.
@@ -47,6 +48,7 @@ export class MigrateOpeningBalancesComponent implements OnInit {
   constructor(private formBuilder: FormBuilder,
               private accountingService: AccountingService,
               private settingsService: SettingsService,
+              private dateUtils: Dates,
               private route: ActivatedRoute,
               private router: Router) {
     this.route.data.subscribe((data: {
@@ -139,16 +141,7 @@ export class MigrateOpeningBalancesComponent implements OnInit {
     openingBalances.locale = this.settingsService.language.code;
     openingBalances.dateFormat = this.settingsService.dateFormat;
     if (openingBalances.transactionDate instanceof Date) {
-      let day = openingBalances.transactionDate.getDate();
-      let month = openingBalances.transactionDate.getMonth() + 1;
-      const year = openingBalances.transactionDate.getFullYear();
-      if (day < 10) {
-        day = `0${day}`;
-      }
-      if (month < 10) {
-        month = `0${month}`;
-      }
-      openingBalances.transactionDate = `${year}-${month}-${day}`;
+      openingBalances.transactionDate = this.dateUtils.getDate(openingBalances.transactionDate);
     }
     openingBalances.debits = [];
     openingBalances.credits = [];

--- a/src/app/accounting/periodic-accruals/periodic-accruals.component.ts
+++ b/src/app/accounting/periodic-accruals/periodic-accruals.component.ts
@@ -6,6 +6,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 /** Custom Services */
 import { AccountingService } from '../accounting.service';
 import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
 /**
  * Periodic accruals component.
  */
@@ -33,6 +34,7 @@ export class PeriodicAccrualsComponent implements OnInit {
   constructor(private formBuilder: FormBuilder,
               private accountingService: AccountingService,
               private settingsService: SettingsService,
+              private dateUtils: Dates,
               private route: ActivatedRoute,
               private router: Router) { }
 
@@ -62,16 +64,7 @@ export class PeriodicAccrualsComponent implements OnInit {
     periodicAccruals.locale = this.settingsService.language.code;
     periodicAccruals.dateFormat = this.settingsService.dateFormat;
     if (periodicAccruals.tillDate instanceof Date) {
-      let day = periodicAccruals.tillDate.getDate();
-      let month = periodicAccruals.tillDate.getMonth() + 1;
-      const year = periodicAccruals.tillDate.getFullYear();
-      if (day < 10) {
-        day = `0${day}`;
-      }
-      if (month < 10) {
-        month = `0${month}`;
-      }
-      periodicAccruals.tillDate = `${year}-${month}-${day}`;
+      periodicAccruals.tillDate = this.dateUtils.getDate(periodicAccruals.tillDate);
     }
     this.accountingService.executePeriodicAccruals(periodicAccruals).subscribe(() => {
       this.router.navigate(['../'], { relativeTo: this.route });

--- a/src/app/accounting/provisioning-entries/create-provisioning-entry/create-provisioning-entry.component.ts
+++ b/src/app/accounting/provisioning-entries/create-provisioning-entry/create-provisioning-entry.component.ts
@@ -6,6 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 /** Custom Services */
 import { AccountingService } from '../../accounting.service';
 import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
 /**
  * Create provisioning entry component.
  */
@@ -33,6 +34,7 @@ export class CreateProvisioningEntryComponent implements OnInit {
   constructor(private formBuilder: FormBuilder,
               private accountingService: AccountingService,
               private settingsService: SettingsService,
+              private dateUtils: Dates,
               private route: ActivatedRoute,
               private router: Router) { }
 
@@ -63,16 +65,7 @@ export class CreateProvisioningEntryComponent implements OnInit {
     provisioningEntry.locale = this.settingsService.language.code;
     provisioningEntry.dateFormat = this.settingsService.dateFormat;
     if (provisioningEntry.date instanceof Date) {
-      let day = provisioningEntry.date.getDate();
-      let month = provisioningEntry.date.getMonth() + 1;
-      const year = provisioningEntry.date.getFullYear();
-      if (day < 10) {
-        day = `0${day}`;
-      }
-      if (month < 10) {
-        month = `0${month}`;
-      }
-      provisioningEntry.date = `${year}-${month}-${day}`;
+      provisioningEntry.date = this.dateUtils.getDate(provisioningEntry.date);
     }
     this.accountingService.createProvisioningEntry(provisioningEntry)
       .subscribe((response: any) => {

--- a/src/app/accounting/search-journal-entry/search-journal-entry.component.ts
+++ b/src/app/accounting/search-journal-entry/search-journal-entry.component.ts
@@ -14,6 +14,7 @@ import { AccountingService } from '../accounting.service';
 import { SettingsService } from 'app/settings/settings.service';
 /** Custom Data Source */
 import { JournalEntriesDataSource } from './journal-entry.datasource';
+import { Dates } from 'app/core/utils/dates';
 
 /**
  * Search journal entry component.
@@ -88,11 +89,11 @@ export class SearchJournalEntryComponent implements OnInit, AfterViewInit {
     },
     {
       type: 'fromDate',
-      value: this.getDate(new Date(new Date().setMonth(new Date().getMonth() - 1)))
+      value: this.dateUtils.getDate(new Date(new Date().setMonth(new Date().getMonth() - 1)))
     },
     {
       type: 'toDate',
-      value: this.getDate(new Date())
+      value: this.dateUtils.getDate(new Date())
     },
     {
       type: 'dateFormat',
@@ -117,6 +118,7 @@ export class SearchJournalEntryComponent implements OnInit, AfterViewInit {
    */
   constructor(private accountingService: AccountingService,
               private settingsService: SettingsService,
+              private dateUtils: Dates,
               private route: ActivatedRoute) {
     this.route.data.subscribe((data: {
         offices: any,
@@ -179,7 +181,7 @@ export class SearchJournalEntryComponent implements OnInit, AfterViewInit {
         debounceTime(500),
         distinctUntilChanged(),
         tap((filterValue) => {
-          this.applyFilter(this.getDate(filterValue), 'fromDate');
+          this.applyFilter(this.dateUtils.getDate(filterValue), 'fromDate');
         })
       )
       .subscribe();
@@ -189,7 +191,7 @@ export class SearchJournalEntryComponent implements OnInit, AfterViewInit {
         debounceTime(500),
         distinctUntilChanged(),
         tap((filterValue) => {
-          this.applyFilter(this.getDate(filterValue), 'toDate');
+          this.applyFilter(this.dateUtils.getDate(filterValue), 'toDate');
         })
       )
       .subscribe();
@@ -292,25 +294,4 @@ export class SearchJournalEntryComponent implements OnInit, AfterViewInit {
     this.dataSource = new JournalEntriesDataSource(this.accountingService);
     this.dataSource.getJournalEntries(this.filterJournalEntriesBy, this.sort.active, this.sort.direction, this.paginator.pageIndex, this.paginator.pageSize);
   }
-
-  /**
-   * Gets the date from the passed timestamp.
-   *
-   * TODO: Update once language and date settings are setup.
-   *
-   * @param {any} timestamp Timestam from which date is to be extracted.
-   */
-  private getDate(timestamp: any) {
-    let day = timestamp.getDate();
-    let month = timestamp.getMonth() + 1;
-    const year = timestamp.getFullYear();
-    if (day < 10) {
-      day = `0${day}`;
-    }
-    if (month < 10) {
-      month = `0${month}`;
-    }
-    return `${year}-${month}-${day}`;
-  }
-
 }

--- a/src/app/core/utils/dates.ts
+++ b/src/app/core/utils/dates.ts
@@ -1,0 +1,23 @@
+import { DatePipe } from '@angular/common';
+import { Injectable } from '@angular/core';
+import { SettingsService } from 'app/settings/settings.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class Dates {
+
+  constructor(private settingsService: SettingsService,
+      private datePipe: DatePipe) {}
+
+  public getDate(timestamp: any) {
+    const dateFormat = this.settingsService.dateFormat;
+    return this.datePipe.transform(timestamp, dateFormat);
+  }
+
+  public formatDate(timestamp: any, dateFormat: string) {
+    return this.datePipe.transform(timestamp, dateFormat);
+  }
+
+}
+


### PR DESCRIPTION
## Description

In general all the accounting module, there was a common error in the FrontEnd because It was sending the dates in format YYYY-MM-DD and the value of dateFormat parameter with a different value, so Fineract can’t parse the date fields

If the date format selected in the front is equal as the format used in the API call YYYY-MM-DD there is not error, but we don’t need just this format

## Related issues and discussion
#{Issue Number}

- https://github.com/openMF/web-app/issues/1397
- https://github.com/openMF/web-app/issues/1395

## Screenshots, if any
Backend error due the different date format and the date value
<img width="1749" alt="Screen Shot 2022-05-25 at 19 15 13" src="https://user-images.githubusercontent.com/44206706/170395934-6c82d880-4ecd-4c9a-9d97-d8a8d01c5bde.png">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
