### PR TITLE
fix: Loan Account Creation Fix

### DIFF
--- a/src/app/loans/create-loans-account/create-loans-account.component.ts
+++ b/src/app/loans/create-loans-account/create-loans-account.component.ts
@@ -132,8 +132,8 @@ export class CreateLoansAccountComponent implements OnInit {
       loansAccountData.recalculationRestFrequencyDate = this.datePipe.transform(this.loansAccount.recalculationRestFrequencyDate, dateFormat);
     }
 
-    if (loansAccountData.recalculationCompoundingFrequencyDate) {
-      loansAccountData.recalculationCompoundingFrequencyDate = this.datePipe.transform(this.loansAccount.recalculationCompoundingFrequencyDate, dateFormat);
+    if (!loansAccountData.recalculationCompoundingFrequencyDate) {
+      delete loansAccountData.recalculationCompoundingFrequencyDate;
     }
 
     if (loansAccountData.interestCalculationPeriodType === 0) {

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -92,6 +92,29 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
         });
       }
     }
+    this.createloansAccountTermsForm();
+    this.setCustomValidators();
+  }
+
+  /** Custom Validators for the form */
+  setCustomValidators() {
+    const repaymentFrequencyNthDayType = this.loansAccountTermsForm.get('repaymentFrequencyNthDayType');
+    const repaymentFrequencyDayOfWeekType = this.loansAccountTermsForm.get('repaymentFrequencyDayOfWeekType');
+
+    this.loansAccountTermsForm.get('repaymentFrequencyType').valueChanges
+      .subscribe(repaymentFrequencyType => {
+
+        if (repaymentFrequencyType === 2) {
+          repaymentFrequencyNthDayType.setValidators([Validators.required]);
+          repaymentFrequencyDayOfWeekType.setValidators([Validators.required]);
+        }else{
+          repaymentFrequencyNthDayType.setValidators(null);
+          repaymentFrequencyDayOfWeekType.setValidators(null);
+        }
+
+        repaymentFrequencyNthDayType.updateValueAndValidity();
+        repaymentFrequencyDayOfWeekType.updateValueAndValidity();
+      });
   }
 
   /** Create Loans Account Terms Form */


### PR DESCRIPTION
## Description
Set the Custom Validators for the Loan Account Creation Form and removed the _recalculationCompoundingFrequencyDate_ field in the payload in the API request while creating an account. Now able to create Loan Account.

## Related issues and discussion
#{1400}


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ x ] If you have multiple commits please combine them into one commit by squashing them.

- [ x ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
