### PR TITLE
fix: Product Charge Name fix

### DIFF
--- a/src/app/products/charges/view-charge/view-charge.component.html
+++ b/src/app/products/charges/view-charge/view-charge.component.html
@@ -16,6 +16,14 @@
     <mat-card-content>
 
       <div fxLayout="row wrap" class="content">
+        
+        <div fxFlex="50%" class="mat-body-strong">
+          Charge Name
+        </div>
+          
+        <div fxFlex="50%">
+          {{ chargeData.name }}
+        </div>
 
         <div fxFlex="50%" class="mat-body-strong">
           Charge Type


### PR DESCRIPTION
## Description
Issue: When we go to products->charges->and view charge details, the charge details screen doesn't display the charge name
Fix: Now the Charge name is displaying

## Related issues and discussion
#1415 

## Screenshots, if any
![image](https://user-images.githubusercontent.com/59759301/171573881-00230cd6-d2c6-420b-9a06-219b6f7f5c74.png)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
