### PR TITLE
fix: journal button on transaction tab in loans account fixed

### DIFF
--- a/src/app/accounting/accounting-routing.module.ts
+++ b/src/app/accounting/accounting-routing.module.ts
@@ -356,6 +356,20 @@ const routes: Routes = [
           ]
         }
       ]
+    },
+    {
+      path:'journal-entry',
+      data:{title:extract('Journal Entries'), breadcrumb:'Journal Entries'},
+      children:[
+        {
+          path: 'view/:id',
+          component: ViewTransactionComponent,
+          data: { title: extract('View Transaction'), routeParamBreadcrumb: 'id' },
+          resolve: {
+            transaction: TransactionResolver
+          }
+        }
+      ]
     }
   ])
 ];

--- a/src/app/accounting/accounting-routing.module.ts
+++ b/src/app/accounting/accounting-routing.module.ts
@@ -358,8 +358,8 @@ const routes: Routes = [
       ]
     },
     {
-      path:'journal-entry',
-      data:{title:extract('Journal Entries'), breadcrumb:'Journal Entries'},
+      path: 'journal-entry',
+      data: {title: extract('Journal Entries'), breadcrumb: 'Journal Entries' },
       children:[
         {
           path: 'view/:id',

--- a/src/app/accounting/accounting-routing.module.ts
+++ b/src/app/accounting/accounting-routing.module.ts
@@ -360,7 +360,7 @@ const routes: Routes = [
     {
       path: 'journal-entry',
       data: {title: extract('Journal Entries'), breadcrumb: 'Journal Entries' },
-      children:[
+      children: [
         {
           path: 'view/:id',
           component: ViewTransactionComponent,

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.html
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.html
@@ -70,7 +70,7 @@
             <i class="fa fa-file-text"></i>
           </button>
           <button class="account-action-button" mat-raised-button color="primary" matTooltip="View Journal Entries" matTooltipPosition="left"
-            (click)="routeEdit($event)" >
+            (click)="routeEdit($event)" [routerLink]="['/','journal-entry', 'view', 'L'+transaction.id ]">
             <i class="fa fa-arrow-circle-right"></i>
           </button>
         </td>


### PR DESCRIPTION
## Description
Added functionality to the journal entry button. Now opening to show journal entries.

## Related issues and discussion
#1443 

## Screenshots, if any
![image](https://user-images.githubusercontent.com/59759301/175059985-f277d4d1-8a70-46b7-bb6f-96dc881c9647.png)

![image](https://user-images.githubusercontent.com/59759301/175059559-03b33138-9705-4ce8-b525-9c93568a0bcc.png)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
