### PR TITLE
Fix client address according to enable address system setting

### DIFF
--- a/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.html
+++ b/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.html
@@ -162,7 +162,7 @@
 
   </div>
 
-  <div fxFlexFill *ngIf="client.address.length" fxLayout="row wrap" fxLayout.lt-md="column">
+  <div fxFlexFill *ngIf="clientTemplate.isAddressEnabled && client.address.length" fxLayout="row wrap" fxLayout.lt-md="column">
 
     <h3 class="mat-h3" fxFlexFill>Address</h3>
 

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -120,7 +120,7 @@
         General
       </a>
       <a mat-tab-link [routerLink]="['./address']" routerLinkActive #address="routerLinkActive"
-        [active]="address.isActive" *ngIf="clientTemplateData.isAddressEnabled">
+        [active]="address.isActive">
         Address
       </a>
       <a mat-tab-link [routerLink]="['./family-members']" routerLinkActive #familyMembers="routerLinkActive"

--- a/src/app/clients/create-client/create-client.component.html
+++ b/src/app/clients/create-client/create-client.component.html
@@ -38,11 +38,11 @@
 
     </mat-step>
 
-    <mat-step>
+    <mat-step *ngIf="clientTemplate.isAddressEnabled">
 
       <ng-template matStepLabel>ADDRESS</ng-template>
 
-      <mifosx-client-address-step 
+      <mifosx-client-address-step
         [clientTemplate]="clientTemplate"
         [clientAddressFieldConfig]="clientAddressFieldConfig"
       >

--- a/src/app/clients/create-client/create-client.component.ts
+++ b/src/app/clients/create-client/create-client.component.ts
@@ -44,9 +44,9 @@ export class CreateClientComponent {
    * @param {SettingsService} settingsService Setting service
    */
   constructor(private route: ActivatedRoute,
-              private router: Router,
-              private clientsService: ClientsService,
-              private settingsService: SettingsService) {
+    private router: Router,
+    private clientsService: ClientsService,
+    private settingsService: SettingsService) {
     this.route.data.subscribe((data: { clientTemplate: any, clientAddressFieldConfig: any }) => {
       this.clientTemplate = data.clientTemplate;
       this.clientAddressFieldConfig = data.clientAddressFieldConfig;
@@ -64,11 +64,18 @@ export class CreateClientComponent {
    * Retrieves the client object
    */
   get client() {
-    return {
-      ...this.clientGeneralStep.clientGeneralDetails,
-      ...this.clientFamilyMembersStep.familyMembers,
-      ...this.clientAddressStep.address
-    };
+    if (this.clientTemplate.isAddressEnabled) {
+      return {
+        ...this.clientGeneralStep.clientGeneralDetails,
+        ...this.clientFamilyMembersStep.familyMembers,
+        ...this.clientAddressStep.address
+      };
+    } else {
+      return {
+        ...this.clientGeneralStep.clientGeneralDetails,
+        ...this.clientFamilyMembersStep.familyMembers
+      };
+    }
   }
   /**
    * Submits the create client form.


### PR DESCRIPTION
## Description

Fix client address according to enable address system setting. There was an issue in the client creation view because always was displaying the Address step to register this info independently of the `enable-address` system setting status 

## Screenshots, if any
`enable-address` system setting disabled
<img width="1485" alt="Screen Shot 2022-06-24 at 18 45 43" src="https://user-images.githubusercontent.com/44206706/175749357-0ac2ad4f-f34d-4043-ab13-d0c56daf64d4.png">

Enabling the `enable-address` system setting
<img width="1188" alt="Screen Shot 2022-06-24 at 18 46 22" src="https://user-images.githubusercontent.com/44206706/175749350-ab7caa70-ff40-43a1-aa83-98eb2bf3075e.png">

`enable-address` system setting enabled
<img width="1465" alt="Screen Shot 2022-06-24 at 18 46 40" src="https://user-images.githubusercontent.com/44206706/175749342-8d8579ed-f56b-45a1-b9d6-92fe5e823682.png">


Client view displaying always the Address tab
<img width="1149" alt="Screen Shot 2022-06-24 at 18 47 02" src="https://user-images.githubusercontent.com/44206706/175749320-1e009412-f53e-4429-9b0a-59a30f4c0bc9.png">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
