### PR TITLE
Fix for displaying dates with right month

### DIFF
--- a/src/app/pipes/date-format.pipe.ts
+++ b/src/app/pipes/date-format.pipe.ts
@@ -7,18 +7,24 @@ import * as moment from 'moment';
 })
 export class DateFormatPipe implements PipeTransform {
 
-  defaultDateFormat: string;
-
   constructor(private settingsService: SettingsService) {
-    this.defaultDateFormat = this.settingsService.dateFormat;
-    this.defaultDateFormat = this.defaultDateFormat.replace('dd', 'DD');
   }
 
-  transform(value: Date | moment.Moment, dateFormat: string): any {
-    if (dateFormat == null) {
-      return moment(value).format(this.defaultDateFormat);
+  transform(value: any, dateFormat: string): any {
+    const defaultDateFormat = this.settingsService.dateFormat.replace('dd', 'DD');
+    if (typeof value === 'undefined') {
+      return '';
     }
-    return moment(value).format(dateFormat);
+    let dateVal;
+    if (value instanceof Array) {
+      dateVal = moment(value.join('-'), 'YYYY-MM-DD');
+    } else {
+      dateVal = moment(value);
+    }
+    if (dateFormat == null) {
+      return dateVal.format(defaultDateFormat);
+    }
+    return dateVal.format(dateFormat);
   }
 
 }


### PR DESCRIPTION
## Description

On the UI the dates are 1 month later than the date which was given (first image)
Plus the dates that are undefined will be displayed as empty value (second image)

## Screenshots, if any
<img width="1039" alt="Screen Shot 2022-06-29 at 11 46 40" src="https://user-images.githubusercontent.com/44206706/176505140-db474a0c-f189-4826-81d8-b3a2aa70f141.png">

Dates that are undefined will be displayed as empty values (Loan Pending for Approval)
<img width="932" alt="Screen Shot 2022-06-29 at 13 07 51" src="https://user-images.githubusercontent.com/44206706/176506027-f93d81f7-6fb1-4588-92ae-00ca3fbd6df5.png">



## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
