### PR TITLE
Fix for dates used in loan reschedule action

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/loan-reschedule/loan-reschedule.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/loan-reschedule/loan-reschedule.component.ts
@@ -72,13 +72,13 @@ export class LoanRescheduleComponent implements OnInit {
     const prevRescheduleFromDate = this.rescheduleLoanForm.value.rescheduleFromDate;
     const prevAdjustedDueDate = this.rescheduleLoanForm.value.adjustedDueDate;
     const prevSubmittedOnDate = this.rescheduleLoanForm.value.submittedOnDate;
-    if (rescheduleLoanFormData.rescheduleFromDate instanceof Date) {
+    if (prevRescheduleFromDate instanceof Date) {
       rescheduleLoanFormData.rescheduleFromDate = this.dateUtils.formatDate(prevRescheduleFromDate, dateFormat);
     }
-    if (rescheduleLoanFormData.rescheduleFromDate instanceof Date) {
+    if (prevAdjustedDueDate instanceof Date) {
       rescheduleLoanFormData.adjustedDueDate = this.dateUtils.formatDate(prevAdjustedDueDate, dateFormat);
     }
-    if (rescheduleLoanFormData.rescheduleFromDate instanceof Date) {
+    if (prevSubmittedOnDate instanceof Date) {
       rescheduleLoanFormData.submittedOnDate = this.dateUtils.formatDate(prevSubmittedOnDate, dateFormat);
     }
     const data = {

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -273,7 +273,7 @@ export class LoansService {
                                       .set('staffInSelectedOfficeOnly', 'true');
     httpParams = productId ? httpParams.set('productId', productId) : httpParams;
     httpParams = isGroup ? httpParams.set('groupId', entityId)
-                                      .set('templateType', 'group') : 
+                                      .set('templateType', 'group') :
                                       httpParams.set('clientId', entityId)
                                       .set('templateType', 'individual');
     return this.http.get('/loans/template', { params: httpParams });


### PR DESCRIPTION
## Description

There was an issue during the Loan reschedule, the UI was sending wrong dates. The format and value were wrong

## Screenshots, if any
- Error detected

![Screenshot 2022-07-15 at 13 05 55](https://user-images.githubusercontent.com/44206706/179647800-084f0907-0196-457d-a38f-4a8ff134d244.png)

- Fixed the issue, format date and date values are passed as expected

<img width="1254" alt="Screen Shot 2022-07-18 at 20 49 40" src="https://user-images.githubusercontent.com/44206706/179647696-b6f05df5-2162-4c81-a73d-4d991235fcde.png">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
