### PR TITLE
Remove the field recalculationCompountFrequenceyDate from loan produc…

### DIFF
--- a/src/app/loans/create-loans-account/create-loans-account.component.ts
+++ b/src/app/loans/create-loans-account/create-loans-account.component.ts
@@ -148,14 +148,6 @@ export class CreateLoansAccountComponent implements OnInit {
       loansAccountData.recalculationRestFrequencyDate = this.dateUtils.formatDate(this.loansAccount.recalculationRestFrequencyDate, dateFormat);
     }
 
-    if (this.loansAccountProductTemplate.isInterestRecalculationEnabled) {
-      if (loansAccountData.recalculationCompoundingFrequencyDate !== null) {
-        loansAccountData.recalculationCompoundingFrequencyDate = this.dateUtils.formatDate(this.loansAccount.recalculationCompoundingFrequencyDate, dateFormat);
-      }
-    } else {
-      delete loansAccountData.recalculationCompoundingFrequencyDate;
-    }
-
     if (loansAccountData.interestCalculationPeriodType === 0) {
       loansAccountData.allowPartialPeriodInterestCalcualtion = false;
     }

--- a/src/app/loans/edit-loans-account/edit-loans-account.component.ts
+++ b/src/app/loans/edit-loans-account/edit-loans-account.component.ts
@@ -135,14 +135,6 @@ export class EditLoansAccountComponent implements OnInit {
       loansAccountData.recalculationRestFrequencyDate = this.dateUtils.formatDate(this.loansAccount.recalculationRestFrequencyDate, dateFormat);
     }
 
-    if (this.loansAccountProductTemplate.isInterestRecalculationEnabled) {
-      if (loansAccountData.recalculationCompoundingFrequencyDate !== null) {
-        loansAccountData.recalculationCompoundingFrequencyDate = this.dateUtils.formatDate(this.loansAccount.recalculationCompoundingFrequencyDate, dateFormat);
-      }
-    } else {
-      delete loansAccountData.recalculationCompoundingFrequencyDate;
-    }
-
     if (loansAccountData.interestCalculationPeriodType === 0) {
       loansAccountData.allowPartialPeriodInterestCalcualtion = false;
     }

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
@@ -253,18 +253,6 @@
         </mat-select>
       </mat-form-field>
 
-      <mat-form-field fxFlex="48%" (click)="recalculationCompoundingFrequencyDatePicker.open()"
-        *ngIf="loansAccountProductTemplate.isInterestRecalculationEnabled && loansAccountProductTemplate.interestRecalculationData.interestRecalculationCompoundingType.id != 0 && loansAccountProductTemplate.interestRecalculationData.recalculationCompoundingFrequencyType.id != 1">
-        <mat-label>Frequency Date for recalculation</mat-label>
-        <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="recalculationCompoundingFrequencyDatePicker"
-          formControlName="recalculationCompoundingFrequencyDate">
-        <mat-datepicker-toggle matSuffix [for]="recalculationCompoundingFrequencyDatePicker"></mat-datepicker-toggle>
-        <mat-datepicker #recalculationCompoundingFrequencyDatePicker></mat-datepicker>
-        <mat-error *ngIf="loansAccountTermsForm.controls.recalculationCompoundingFrequencyDate.hasError('required')">
-          Frequency Data for recalculation is <strong>required</strong>
-        </mat-error>
-      </mat-form-field>
-
     </ng-container>
 
     <mat-divider fxFlex="98%"></mat-divider>

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -93,12 +93,6 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
           'repaymentsStartingFromDate': this.loansAccountTemplate.expectedFirstRepaymentOnDate && new Date(this.loansAccountTemplate.expectedFirstRepaymentOnDate)
         });
       }
-
-      if (this.loansAccountTemplate.isInterestRecalculationEnabled) {
-        this.loansAccountTermsForm.patchValue({
-          'recalculationCompoundingFrequencyDate': ''
-        });
-      }
     }
     this.createloansAccountTermsForm();
     this.setCustomValidators();

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -273,7 +273,7 @@ export class LoansService {
                                       .set('staffInSelectedOfficeOnly', 'true');
     httpParams = productId ? httpParams.set('productId', productId) : httpParams;
     httpParams = isGroup ? httpParams.set('groupId', entityId)
-                                      .set('templateType', 'group') : 
+                                      .set('templateType', 'group') :
                                       httpParams.set('clientId', entityId)
                                       .set('templateType', 'individual');
     return this.http.get('/loans/template', { params: httpParams });

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-charges-step/loan-product-charges-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-charges-step/loan-product-charges-step.component.ts
@@ -28,7 +28,9 @@ export class LoanProductChargesStepComponent implements OnInit {
 
   ngOnInit() {
     this.chargeData = this.loanProductsTemplate.chargeOptions;
-    this.overdueChargeData = this.loanProductsTemplate.penaltyOptions.filter((penalty: any) => penalty.chargeTimeType.code === 'chargeTimeType.overdueInstallment');
+    this.overdueChargeData = this.loanProductsTemplate.penaltyOptions ?
+      this.loanProductsTemplate.penaltyOptions.filter((penalty: any) => penalty.chargeTimeType.code === 'chargeTimeType.overdueInstallment') :
+      [];
 
     this.chargesDataSource = this.loanProductsTemplate.charges || [];
     this.pristine = true;

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
@@ -387,10 +387,6 @@
       <div fxFlexFill *ngIf="loanProduct.recalculationCompoundingFrequencyType !== 1" fxLayout="row wrap" fxLayout.lt-md="column">
         <span fxFlex="40%">Frequency Interval for compounding:</span>
         <span fxFlex="60%">{{ loanProduct.recalculationCompoundingFrequencyInterval }}</span>
-        <div fxFlexFill *ngIf="loanProduct.recalculationCompoundingFrequencyDate">
-          <span fxFlex="40%">Compounding Frequency Date:</span>
-          <span fxFlex="60%">{{ loanProduct.recalculationCompoundingFrequencyDate }}</span>
-        </div>
       </div>
     </div>
     <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">

--- a/src/app/products/loan-products/view-loan-product/view-loan-product.component.html
+++ b/src/app/products/loan-products/view-loan-product/view-loan-product.component.html
@@ -400,10 +400,6 @@
             <div fxFlexFill *ngIf="loanProduct.interestRecalculationData.recalculationCompoundingFrequencyType.id !== 1" fxLayout="row wrap" fxLayout.lt-md="column">
               <span fxFlex="40%">Frequency Interval for compounding:</span>
               <span fxFlex="60%">{{ loanProduct.interestRecalculationData.recalculationCompoundingFrequencyInterval }}</span>
-              <div fxFlexFill *ngIf="loanProduct.recalculationCompoundingFrequencyDate">
-                <span fxFlex="40%">Compounding Frequency Date:</span>
-                <span fxFlex="60%">{{ loanProduct.interestRecalculationData.recalculationCompoundingFrequencyDate }}</span>
-              </div>
             </div>
           </div>
           <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">


### PR DESCRIPTION
…t request

## Description

Remove the field `recalculationCompountFrequenceyDate` from loan product when Interest Recalculation is enabled. It is not supported yet in Fineract

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
