### PR TITLE
Allow to set over amount setting for approval and disbursement

### DIFF
--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
@@ -116,5 +116,4 @@ export class EditLoanProductComponent implements OnInit {
       });
   }
 
-
 }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
@@ -72,6 +72,17 @@
   </div>
 
   <div fxFlexFill>
+    <span fxFlex="40%">Allow Approved / Disbursed Amounts Over Applied:</span>
+    <span fxFlex="60%">{{ loanProduct.allowApprovedDisbursedAmountsOverApplied ? 'Yes' : 'No' }}</span>
+  </div>
+
+  <div fxFlexFill *ngIf="loanProduct.allowApprovedDisbursedAmountsOverApplied">
+    <span fxFlex="40%">Over Applied:</span>
+    <span fxFlex="60%" *ngIf="loanProduct.overAppliedCalculationType === 'percentage'">{{ loanProduct.overAppliedNumber }} %</span>
+    <span fxFlex="60%" *ngIf="loanProduct.overAppliedCalculationType === 'flat'">{{ loanProduct.overAppliedNumber }} {{ loanProduct.currencyCode }}</span>
+</div>
+
+  <div fxFlexFill>
     <span fxFlex="40%">Number of Repayments:</span>
     <span fxFlex="60%">{{ loanProduct.numberOfRepayments + ' (Min: ' + (loanProduct.minNumberOfRepayments ? loanProduct.minNumberOfRepayments : loanProduct.numberOfRepayments) + ', Max: ' + (loanProduct.maxNumberOfRepayments ? loanProduct.maxNumberOfRepayments : loanProduct.numberOfRepayments) + ')' }}</span>
   </div>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -22,6 +22,24 @@
       <input type="number" matInput formControlName="maxPrincipal">
     </mat-form-field>
 
+    <mat-checkbox fxFlex="31%" labelPosition="before" formControlName="allowApprovedDisbursedAmountsOverApplied">
+      Allow approval / disbursal above loan applied amount?
+    </mat-checkbox>
+
+    <mat-form-field fxFlex="31%" *ngIf="loanProductTermsForm.value.allowApprovedDisbursedAmountsOverApplied">
+      <mat-label>Over Amount Calculation Type</mat-label>
+      <mat-select formControlName="overAppliedCalculationType" required>
+        <mat-option *ngFor="let overAppliedCalculationType of overAppliedCalculationTypeData" [value]="overAppliedCalculationType.id">
+          {{ overAppliedCalculationType.value }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field fxFlex="31%" *ngIf="loanProductTermsForm.value.allowApprovedDisbursedAmountsOverApplied">
+      <mat-label>Over Amount</mat-label>
+      <input type="number" matInput formControlName="overAppliedNumber" required>
+    </mat-form-field>
+
     <h4 fxFlex="98%" class="mat-h4">Number of repayments</h4>
 
     <mat-form-field fxFlex="31%">

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -23,6 +23,7 @@ export class LoanProductTermsStepComponent implements OnInit {
   valueConditionTypeData: any;
   floatingRateData: any;
   interestRateFrequencyTypeData: any;
+  overAppliedCalculationTypeData: any;
   repaymentFrequencyTypeData: any;
 
   displayedColumns: string[] = ['valueConditionType', 'borrowerCycleNumber', 'minValue', 'defaultValue', 'maxValue', 'actions'];
@@ -38,6 +39,7 @@ export class LoanProductTermsStepComponent implements OnInit {
     this.floatingRateData = this.loanProductsTemplate.floatingRateOptions;
     this.interestRateFrequencyTypeData = this.loanProductsTemplate.interestRateFrequencyTypeOptions;
     this.repaymentFrequencyTypeData = this.loanProductsTemplate.repaymentFrequencyTypeOptions;
+    this.overAppliedCalculationTypeData = [{id: 'percentage', value: 'Percentage'}, {id: 'flat', value: 'Fixed Amount'}];
 
     this.loanProductTermsForm.patchValue({
       'minPrincipal': this.loanProductsTemplate.minPrincipal,
@@ -54,6 +56,7 @@ export class LoanProductTermsStepComponent implements OnInit {
       'floatingRatesId': this.loanProductsTemplate.floatingRateId,
       'interestRateDifferential': this.loanProductsTemplate.interestRateDifferential,
       'isFloatingInterestRateCalculationAllowed': this.loanProductsTemplate.isFloatingInterestRateCalculationAllowed,
+      'allowApprovedDisbursedAmountsOverApplied': this.loanProductsTemplate.allowApprovedDisbursedAmountsOverApplied,
       'minDifferentialLendingRate': this.loanProductsTemplate.minDifferentialLendingRate,
       'defaultDifferentialLendingRate': this.loanProductsTemplate.defaultDifferentialLendingRate,
       'maxDifferentialLendingRate': this.loanProductsTemplate.maxDifferentialLendingRate,
@@ -62,6 +65,13 @@ export class LoanProductTermsStepComponent implements OnInit {
       'repaymentFrequencyType': this.loanProductsTemplate.repaymentFrequencyType.id,
       'minimumDaysBetweenDisbursalAndFirstRepayment': this.loanProductsTemplate.minimumDaysBetweenDisbursalAndFirstRepayment
     });
+
+    if (this.loanProductsTemplate.allowApprovedDisbursedAmountsOverApplied) {
+      this.loanProductTermsForm.patchValue({
+        'overAppliedCalculationType': this.loanProductsTemplate.overAppliedCalculationType,
+        'overAppliedNumber': this.loanProductsTemplate.overAppliedNumber,
+      });
+    }
 
     this.loanProductTermsForm.setControl('principalVariationsForBorrowerCycle',
       this.formBuilder.array(this.loanProductsTemplate.principalVariationsForBorrowerCycle.map((variation: any) => ({ ...variation, valueConditionType: variation.valueConditionType.id }))));
@@ -81,6 +91,7 @@ export class LoanProductTermsStepComponent implements OnInit {
       'numberOfRepayments': ['', Validators.required],
       'maxNumberOfRepayments': [''],
       'isLinkedToFloatingInterestRates': [false],
+      'allowApprovedDisbursedAmountsOverApplied': [false],
       'minInterestRatePerPeriod': [''],
       'interestRatePerPeriod': ['', Validators.required],
       'maxInterestRatePerPeriod': [''],
@@ -92,6 +103,20 @@ export class LoanProductTermsStepComponent implements OnInit {
   }
 
   setConditionalControls() {
+    this.loanProductTermsForm.get('allowApprovedDisbursedAmountsOverApplied').valueChanges
+      .subscribe(allowApprovedDisbursedAmountsOverApplied => {
+        if (allowApprovedDisbursedAmountsOverApplied) {
+          this.loanProductTermsForm.addControl('overAppliedCalculationType', new FormControl(''));
+          this.loanProductTermsForm.addControl('overAppliedNumber', new FormControl(''));
+          this.loanProductTermsForm.addControl('disallowExpectedDisbursements', new FormControl('true'));
+        } else {
+          this.loanProductTermsForm.removeControl('overAppliedCalculationType');
+          this.loanProductTermsForm.removeControl('overAppliedNumber');
+          this.loanProductTermsForm.removeControl('disallowExpectedDisbursements');
+        }
+      }
+    );
+
     this.loanProductTermsForm.get('isLinkedToFloatingInterestRates').valueChanges
       .subscribe(isLinkedToFloatingInterestRates => {
         if (isLinkedToFloatingInterestRates) {

--- a/src/app/products/loan-products/view-loan-product/view-loan-product.component.html
+++ b/src/app/products/loan-products/view-loan-product/view-loan-product.component.html
@@ -85,6 +85,17 @@
         </div>
 
         <div fxFlexFill>
+          <span fxFlex="40%">Allow Approved / Disbursed Amounts Over Applied:</span>
+          <span fxFlex="60%">{{ loanProduct.allowApprovedDisbursedAmountsOverApplied ? 'Yes' : 'No' }}</span>
+        </div>
+
+        <div fxFlexFill *ngIf="loanProduct.allowApprovedDisbursedAmountsOverApplied">
+          <span fxFlex="40%">Over Applied Amount:</span>
+          <span fxFlex="60%" *ngIf="loanProduct.overAppliedCalculationType === 'percentage'">{{ loanProduct.overAppliedNumber }} %</span>
+          <span fxFlex="60%" *ngIf="loanProduct.overAppliedCalculationType === 'flat'">{{ loanProduct.overAppliedNumber }} {{ loanProduct.currencyCode }}</span>
+        </div>
+
+        <div fxFlexFill>
           <span fxFlex="40%">Number of Repayments:</span>
           <span fxFlex="60%">{{ loanProduct.numberOfRepayments + ' (Min: ' + (loanProduct.minNumberOfRepayments ? loanProduct.minNumberOfRepayments : loanProduct.numberOfRepayments) + ', Max: ' + (loanProduct.maxNumberOfRepayments ? loanProduct.maxNumberOfRepayments : loanProduct.numberOfRepayments) + ')' }}</span>
         </div>


### PR DESCRIPTION
## Description

Currently, Approval Amount cannot be higher than Applied amount and Disbursal Amount cannot be higher than Approved Amount. 

There are new settings (at Loan Product level) to allow approval and disbursal up to a certain percentage or fixed amount (flat) over the amount for which the loan is applied for.

## Screenshots, if any

- Allow approval / disbursal above “loan applied amount” flag
<img width="1280" alt="Screen Shot 2022-07-25 at 17 09 33" src="https://user-images.githubusercontent.com/44206706/180901872-18ee8296-f33b-4ed3-bd02-76a43c29613d.png">

Once that the flag is checked appears the other two settings:
<img width="1229" alt="Screen Shot 2022-07-25 at 17 09 46" src="https://user-images.githubusercontent.com/44206706/180902365-43848d29-1de0-4e8f-9a24-364a98bd4c51.png">

- View Loan Product
<img width="1216" alt="Screen Shot 2022-07-25 at 19 23 33" src="https://user-images.githubusercontent.com/44206706/180902496-45e64f63-4c05-48cc-b6bb-a2096eaba01f.png">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
