### PR TITLE
Add locale and dateFormat in runreport APi call

### DIFF
--- a/src/app/reports/run-report/run-report.component.ts
+++ b/src/app/reports/run-report/run-report.component.ts
@@ -51,6 +51,8 @@ export class RunReportComponent implements OnInit {
   hideChart = true;
    /** Toggles Pentaho output */
   hidePentaho = true;
+  /** Report uses dates */
+  reportUsesDates = false;
 
   /**
    * Fetches report specifications from route params and retrieves report parameters data from `resolve`.
@@ -194,6 +196,7 @@ export class RunReportComponent implements OnInit {
         case 'date':
           const dateFormat = this.settingsService.dateFormat;
           formattedResponse[newKey] = this.dateUtils.formatDate(value, dateFormat);
+          this.reportUsesDates = true;
           break;
         case 'none':
           formattedResponse[newKey] = value;
@@ -208,9 +211,19 @@ export class RunReportComponent implements OnInit {
    */
   run() {
     this.isCollapsed = true;
-    const userResponse = this.formatUserResponse(this.reportForm.value);
+    const userResponseValues = this.formatUserResponse(this.reportForm.value);
+    let formData = {
+      ...userResponseValues,
+    };
+    if (this.reportUsesDates) {
+      formData = {
+        ...userResponseValues,
+        locale: this.settingsService.language.code,
+        dateFormat: this.settingsService.dateFormat
+      };
+    }
     this.dataObject = {
-      formData: userResponse,
+      formData: formData,
       report: this.report,
       decimalChoice: this.decimalChoice.value
     };


### PR DESCRIPTION
## Description

Some dates parameters (`locale` and `dateFormat`) in the `runreport` API call were missing when executing reports where data is filtered by dates. For instance: “GeneralLedgerReport Table” report

## Screenshots, if any
- Using the `locale` and `dateFormat` defined in the User Settings
<img width="1762" alt="Screen Shot 2022-07-25 at 23 26 54" src="https://user-images.githubusercontent.com/44206706/180924106-8f8cb9ac-62c1-4b1f-89be-ea3a760a19a1.png">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
