### PR TITLE
Allow accounting mappings for fund source asset or liability

### DIFF
--- a/src/app/accounting/chart-of-accounts/create-gl-account/create-gl-account.component.html
+++ b/src/app/accounting/chart-of-accounts/create-gl-account/create-gl-account.component.html
@@ -52,7 +52,7 @@
             <mat-label>Parent</mat-label>
             <mat-select formControlName="parentId">
               <mat-option *ngFor="let parent of parentData" [value]="parent.id">
-                {{ parent.name }}
+                ({{ parent.glCode }}) {{ parent.name }}
               </mat-option>
             </mat-select>
           </mat-form-field>

--- a/src/app/accounting/chart-of-accounts/edit-gl-account/edit-gl-account.component.html
+++ b/src/app/accounting/chart-of-accounts/edit-gl-account/edit-gl-account.component.html
@@ -52,7 +52,7 @@
             <mat-label>Parent</mat-label>
             <mat-select formControlName="parentId">
               <mat-option *ngFor="let parent of parentData" [value]="parent.id">
-                {{ parent.name }}
+                ({{ parent.glCode }}) {{ parent.name }}
               </mat-option>
             </mat-select>
           </mat-form-field>

--- a/src/app/accounting/chart-of-accounts/gl-account-tree.service.ts
+++ b/src/app/accounting/chart-of-accounts/gl-account-tree.service.ts
@@ -84,7 +84,9 @@ export class GlAccountTreeService {
           glAccountTree[0].children[4].children.push(glAccounts[glAccount.id]);
         }
       } else {
-        glAccounts[glAccount.parentId].children.push(glAccounts[glAccount.id]);
+        if (glAccounts[glAccount.parentId]) {
+          glAccounts[glAccount.parentId].children.push(glAccounts[glAccount.id]);
+        }
       }
     }
 

--- a/src/app/accounting/chart-of-accounts/view-gl-account/view-gl-account.component.html
+++ b/src/app/accounting/chart-of-accounts/view-gl-account/view-gl-account.component.html
@@ -58,7 +58,9 @@
         </div>
 
         <div fxFlex="50%" *ngIf="glAccount.parent">
-          {{ glAccount.parent.name }}
+          <a class="tab-link" [routerLink]="['/accounting/chart-of-accounts/gl-accounts/view/' + glAccount.parent.id]">
+            ({{ glAccount.parent.glCode }}) {{ glAccount.parent.name }}
+          </a>
         </div>
 
         <div fxFlex="50%" class="header" *ngIf="glAccount.tagId.id">
@@ -82,7 +84,7 @@
         </div>
 
         <div fxFlex="50%">
-          {{ glAccount.manualEntriesAllowed }}
+          {{ glAccount.manualEntriesAllowed ? 'Yes' : 'No' }}
         </div>
 
         <div fxFlex="50%" class="header" *ngIf="glAccount.description">

--- a/src/app/loans/loans-view/loan-tranche-details/loan-tranche-details.component.html
+++ b/src/app/loans/loans-view/loan-tranche-details/loan-tranche-details.component.html
@@ -5,7 +5,7 @@
     <span fxFlex="60%">{{ loanDetails.maxOutstandingLoanBalance | number }}</span>
   </div>
 
-  <h3> Loan Tranche Details</h3>
+  <h3>Loan Tranche Details</h3>
 
   <div fxLayout="row" fxLayoutAlign="flex-end">
       <button mat-raised-button color="primary" *ngIf="showAddDeleteTrancheButtons('adddisbursedetails')">
@@ -65,16 +65,16 @@
         <th mat-header-cell *matHeaderCellDef> Applicable From Date </th>
         <td mat-cell *matCellDef="let ele"> {{ ele.termVariationApplicableFrom  | dateFormat}} </td>
       </ng-container>
-  
+
       <ng-container matColumnDef="fixed emi amount">
         <th mat-header-cell *matHeaderCellDef> Installment Amount </th>
         <td mat-cell *matCellDef="let ele"> {{ ele.termValue }} </td>
       </ng-container>
-  
+
       <tr mat-header-row *matHeaderRowDef="emivariationColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: emivariationColumns;"></tr>
     </table>
   </div>
-  
+
 
 </div>

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
@@ -44,6 +44,9 @@ export class CreateLoanProductComponent implements OnInit {
               private router: Router) {
     this.route.data.subscribe((data: { loanProductsTemplate: any }) => {
       this.loanProductsTemplate = data.loanProductsTemplate;
+      const assetAccountData = this.loanProductsTemplate.accountingMappingOptions.assetAccountOptions || [];
+      const liabilityAccountData = this.loanProductsTemplate.accountingMappingOptions.liabilityAccountOptions || [];
+      this.loanProductsTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions = assetAccountData.concat(liabilityAccountData);
     });
   }
 

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
@@ -44,6 +44,9 @@ export class EditLoanProductComponent implements OnInit {
               private router: Router) {
     this.route.data.subscribe((data: { loanProductAndTemplate: any }) => {
       this.loanProductAndTemplate = data.loanProductAndTemplate;
+      const assetAccountData = this.loanProductAndTemplate.accountingMappingOptions.assetAccountOptions || [];
+      const liabilityAccountData = this.loanProductAndTemplate.accountingMappingOptions.liabilityAccountOptions || [];
+      this.loanProductAndTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions = assetAccountData.concat(liabilityAccountData);
     });
   }
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
@@ -12,13 +12,13 @@
 
     <div *ngIf="loanProductAccountingForm.value.accountingRule >= 2 && loanProductAccountingForm.value.accountingRule <= 4" fxFlexFill fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
 
-      <h4 fxFlex="98%" class="mat-h4">Assets</h4>
+      <h4 fxFlex="98%" class="mat-h4">Assets / Liability</h4>
 
       <mat-form-field fxFlex="48%">
         <mat-label>Fund source</mat-label>
         <mat-select formControlName="fundSourceAccountId" required>
-          <mat-option *ngFor="let assetAccount of assetAccountData" [value]="assetAccount.id">
-            {{ assetAccount.name }}
+          <mat-option *ngFor="let assetAndLiabilityAccount of assetAndLiabilityAccountData" [value]="assetAndLiabilityAccount.id">
+            ({{ assetAndLiabilityAccount.glCode }}) {{ assetAndLiabilityAccount.name }}
           </mat-option>
         </mat-select>
         <mat-error>
@@ -26,11 +26,13 @@
         </mat-error>
       </mat-form-field>
 
+      <h4 fxFlex="98%" class="mat-h4">Assets</h4>
+
       <mat-form-field fxFlex="48%">
         <mat-label>Loan portfolio</mat-label>
         <mat-select formControlName="loanPortfolioAccountId" required>
           <mat-option *ngFor="let assetAccount of assetAccountData" [value]="assetAccount.id">
-            {{ assetAccount.name }}
+            ({{ assetAccount.glCode }}) {{ assetAccount.name }}
           </mat-option>
         </mat-select>
         <mat-error>
@@ -44,7 +46,7 @@
           <mat-label>Interest Receivable</mat-label>
           <mat-select formControlName="receivableInterestAccountId" required>
             <mat-option *ngFor="let assetAccount of assetAccountData" [value]="assetAccount.id">
-              {{ assetAccount.name }}
+              ({{ assetAccount.glCode }}) {{ assetAccount.name }}
             </mat-option>
           </mat-select>
           <mat-error>
@@ -56,7 +58,7 @@
           <mat-label>Fees Receivable</mat-label>
           <mat-select formControlName="receivableFeeAccountId" required>
             <mat-option *ngFor="let assetAccount of assetAccountData" [value]="assetAccount.id">
-              {{ assetAccount.name }}
+              ({{ assetAccount.glCode }}) {{ assetAccount.name }}
             </mat-option>
           </mat-select>
           <mat-error>
@@ -68,7 +70,7 @@
           <mat-label>Penalties Receivable</mat-label>
           <mat-select formControlName="receivablePenaltyAccountId" required>
             <mat-option *ngFor="let assetAccount of assetAccountData" [value]="assetAccount.id">
-              {{ assetAccount.name }}
+              ({{ assetAccount.glCode }}) {{ assetAccount.name }}
             </mat-option>
           </mat-select>
           <mat-error>
@@ -82,7 +84,7 @@
         <mat-label>Transfer in suspense</mat-label>
         <mat-select formControlName="transfersInSuspenseAccountId" required>
           <mat-option *ngFor="let assetAccount of assetAccountData" [value]="assetAccount.id">
-            {{ assetAccount.name }}
+            ({{ assetAccount.glCode }}) {{ assetAccount.name }}
           </mat-option>
         </mat-select>
         <mat-error>
@@ -98,7 +100,7 @@
         <mat-label>Income from Interest</mat-label>
         <mat-select formControlName="interestOnLoanAccountId" required>
           <mat-option *ngFor="let incomeAccount of incomeAccountData" [value]="incomeAccount.id">
-            {{ incomeAccount.name }}
+            ({{ incomeAccount.glCode }}) {{ incomeAccount.name }}
           </mat-option>
         </mat-select>
         <mat-error>
@@ -110,7 +112,7 @@
         <mat-label>Income from fees</mat-label>
         <mat-select formControlName="incomeFromFeeAccountId" required>
           <mat-option *ngFor="let incomeAccount of incomeAccountData" [value]="incomeAccount.id">
-            {{ incomeAccount.name }}
+            ({{ incomeAccount.glCode }}) {{ incomeAccount.name }}
           </mat-option>
         </mat-select>
         <mat-error>
@@ -122,7 +124,7 @@
         <mat-label>Income from penalties</mat-label>
         <mat-select formControlName="incomeFromPenaltyAccountId" required>
           <mat-option *ngFor="let incomeAccount of incomeAccountData" [value]="incomeAccount.id">
-            {{ incomeAccount.name }}
+            ({{ incomeAccount.glCode }}) {{ incomeAccount.name }}
           </mat-option>
         </mat-select>
         <mat-error>
@@ -134,7 +136,7 @@
         <mat-label>Income from Recovery Repayments</mat-label>
         <mat-select formControlName="incomeFromRecoveryAccountId" required>
           <mat-option *ngFor="let incomeAccount of incomeAccountData" [value]="incomeAccount.id">
-            {{ incomeAccount.name }}
+            ({{ incomeAccount.glCode }}) {{ incomeAccount.name }}
           </mat-option>
         </mat-select>
         <mat-error>
@@ -150,11 +152,23 @@
         <mat-label>Losses written off</mat-label>
         <mat-select formControlName="writeOffAccountId" required>
           <mat-option *ngFor="let expenseAccount of expenseAccountData" [value]="expenseAccount.id">
-            {{ expenseAccount.name }}
+            ({{ expenseAccount.glCode }}) {{ expenseAccount.name }}
           </mat-option>
         </mat-select>
         <mat-error>
           Losses written off is <strong>required</strong>
+        </mat-error>
+      </mat-form-field>
+
+      <mat-form-field fxFlex="48%">
+        <mat-label>Goodwill credit</mat-label>
+        <mat-select formControlName="goodwillCreditAccountId" required>
+          <mat-option *ngFor="let expenseAccount of expenseAccountData" [value]="expenseAccount.id">
+            ({{ expenseAccount.glCode }}) {{ expenseAccount.name }}
+          </mat-option>
+        </mat-select>
+        <mat-error>
+          Goodwill credit is <strong>required</strong>
         </mat-error>
       </mat-form-field>
 
@@ -166,7 +180,7 @@
         <mat-label>Over payment liability</mat-label>
         <mat-select formControlName="overpaymentLiabilityAccountId" required>
           <mat-option *ngFor="let liabilityAccount of liabilityAccountData" [value]="liabilityAccount.id">
-            {{ liabilityAccount.name }}
+            ({{ liabilityAccount.glCode }}) {{ liabilityAccount.name }}
           </mat-option>
         </mat-select>
         <mat-error>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -29,6 +29,7 @@ export class LoanProductAccountingStepComponent implements OnInit {
   expenseAccountData: any;
   liabilityAccountData: any;
   incomeAndLiabilityAccountData: any;
+  assetAndLiabilityAccountData: any;
 
   paymentFundSourceDisplayedColumns: string[] = ['paymentTypeId', 'fundSourceAccountId', 'actions'];
   feesPenaltyIncomeDisplayedColumns: string[] = ['chargeId', 'incomeAccountId', 'actions'];
@@ -48,6 +49,7 @@ export class LoanProductAccountingStepComponent implements OnInit {
     this.expenseAccountData = this.loanProductsTemplate.accountingMappingOptions.expenseAccountOptions || [];
     this.liabilityAccountData = this.loanProductsTemplate.accountingMappingOptions.liabilityAccountOptions || [];
     this.incomeAndLiabilityAccountData = this.incomeAccountData.concat(this.liabilityAccountData);
+    this.assetAndLiabilityAccountData = this.loanProductsTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions || [];
 
     this.loanProductAccountingForm.patchValue({
       'accountingRule': this.loanProductsTemplate.accountingRule.id
@@ -72,6 +74,7 @@ export class LoanProductAccountingStepComponent implements OnInit {
           'incomeFromPenaltyAccountId': this.loanProductsTemplate.accountingMappings.incomeFromPenaltyAccount.id,
           'incomeFromRecoveryAccountId': this.loanProductsTemplate.accountingMappings.incomeFromRecoveryAccount.id,
           'writeOffAccountId': this.loanProductsTemplate.accountingMappings.writeOffAccount.id,
+          'goodwillCreditAccountId': this.loanProductsTemplate.accountingMappings.goodwillCreditAccount.id,
           'overpaymentLiabilityAccountId': this.loanProductsTemplate.accountingMappings.overpaymentLiabilityAccount.id,
           'advancedAccountingRules': (this.loanProductsTemplate.paymentChannelToFundSourceMappings || this.loanProductsTemplate.feeToIncomeAccountMappings || this.loanProductsTemplate.penaltyToIncomeAccountMappings) ? true : false
         });
@@ -106,6 +109,7 @@ export class LoanProductAccountingStepComponent implements OnInit {
           this.loanProductAccountingForm.addControl('incomeFromPenaltyAccountId', new FormControl('', Validators.required));
           this.loanProductAccountingForm.addControl('incomeFromRecoveryAccountId', new FormControl('', Validators.required));
           this.loanProductAccountingForm.addControl('writeOffAccountId', new FormControl('', Validators.required));
+          this.loanProductAccountingForm.addControl('goodwillCreditAccountId', new FormControl('', Validators.required));
           this.loanProductAccountingForm.addControl('overpaymentLiabilityAccountId', new FormControl('', Validators.required));
           this.loanProductAccountingForm.addControl('advancedAccountingRules', new FormControl(false));
 
@@ -130,6 +134,7 @@ export class LoanProductAccountingStepComponent implements OnInit {
           this.loanProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
           this.loanProductAccountingForm.removeControl('incomeFromRecoveryAccountId');
           this.loanProductAccountingForm.removeControl('writeOffAccountId');
+          this.loanProductAccountingForm.removeControl('goodwillCreditAccountId');
           this.loanProductAccountingForm.removeControl('overpaymentLiabilityAccountId');
           this.loanProductAccountingForm.removeControl('advancedAccountingRules');
         }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
@@ -589,11 +589,16 @@
 
   <div fxFlexFill *ngIf="loanProduct.accountingRule >= 2 && loanProduct.accountingRule <= 4" fxLayout="row wrap" fxLayout.lt-md="column">
 
-    <h4 fxFlexFill class="mat-h4">Assets</h4>
+    <h4 fxFlexFill class="mat-h4">Assets / Liabilities</h4>
 
     <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
       <span fxFlex="40%">Fund source:</span>
-      <span fxFlex="60%">{{ loanProduct.fundSourceAccountId | find:loanProductsTemplate.accountingMappingOptions.assetAccountOptions:'id':'name' }}</span>
+      <span fxFlex="60%">{{ loanProduct.fundSourceAccountId | find:loanProductsTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions:'id':'name' }}</span>
+    </div>
+
+    <h4 fxFlexFill class="mat-h4">Assets</h4>
+
+    <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
       <span fxFlex="40%">Loan portfolio:</span>
       <span fxFlex="60%">{{ loanProduct.loanPortfolioAccountId | find:loanProductsTemplate.accountingMappingOptions.assetAccountOptions:'id':'name' }}</span>
       <div fxFlexFill *ngIf="loanProduct.accountingRule === 3 || loanProduct.accountingRule === 4" fxLayout="row wrap" fxLayout.lt-md="column">
@@ -623,9 +628,11 @@
 
     <h4 fxFlexFill class="mat-h4">Expenses</h4>
 
-    <div fxFlexFill>
+    <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
       <span fxFlex="40%">Losses written off:</span>
       <span fxFlex="60%">{{ loanProduct.writeOffAccountId | find:loanProductsTemplate.accountingMappingOptions.expenseAccountOptions:'id':'name' }}</span>
+      <span fxFlex="40%">Goodwill credit:</span>
+      <span fxFlex="60%">{{ loanProduct.goodwillCreditAccountId | find:loanProductsTemplate.accountingMappingOptions.expenseAccountOptions:'id':'name' }}</span>
     </div>
 
     <h4 fxFlexFill class="mat-h4">Liabilities</h4>

--- a/src/app/products/loan-products/view-loan-product/view-loan-product.component.html
+++ b/src/app/products/loan-products/view-loan-product/view-loan-product.component.html
@@ -601,50 +601,57 @@
 
         <div fxFlexFill *ngIf="loanProduct.accountingRule.id >= 2 && loanProduct.accountingRule.id <= 4" fxLayout="row wrap" fxLayout.lt-md="column">
 
-          <h4 fxFlexFill class="mat-h4">Assets</h4>
+          <h4 fxFlexFill class="mat-h4">Assets / Liabilities</h4>
 
           <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
             <span fxFlex="40%">Fund source:</span>
-            <span fxFlex="60%">{{ loanProduct.accountingMappings.fundSourceAccount.name }}</span>
+            <span fxFlex="60%">({{loanProduct.accountingMappings.fundSourceAccount.glCode}}) {{ loanProduct.accountingMappings.fundSourceAccount.name }}</span>
+          </div>
+
+          <h4 fxFlexFill class="mat-h4">Assets</h4>
+
+          <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
             <span fxFlex="40%">Loan portfolio:</span>
-            <span fxFlex="60%">{{ loanProduct.accountingMappings.loanPortfolioAccount.name }}</span>
+            <span fxFlex="60%">({{loanProduct.accountingMappings.loanPortfolioAccount.glCode}}) {{ loanProduct.accountingMappings.loanPortfolioAccount.name }}</span>
             <div fxFlexFill *ngIf="loanProduct.accountingRule.id === 3 || loanProduct.accountingRule.id === 4" fxLayout="row wrap" fxLayout.lt-md="column">
               <span fxFlex="40%">Interest Receivable:</span>
-              <span fxFlex="60%">{{ loanProduct.accountingMappings.receivableInterestAccount.name }}</span>
+              <span fxFlex="60%">({{loanProduct.accountingMappings.receivableInterestAccount.glCode}}) {{ loanProduct.accountingMappings.receivableInterestAccount.name }}</span>
               <span fxFlex="40%">Fees Receivable:</span>
-              <span fxFlex="60%">{{ loanProduct.accountingMappings.receivableInterestAccount.name }}</span>
+              <span fxFlex="60%">({{loanProduct.accountingMappings.receivableInterestAccount.glCode}}) {{ loanProduct.accountingMappings.receivableInterestAccount.name }}</span>
               <span fxFlex="40%">Penalties Receivable:</span>
-              <span fxFlex="60%">{{ loanProduct.accountingMappings.receivablePenaltyAccount.name }}</span>
+              <span fxFlex="60%">({{loanProduct.accountingMappings.receivablePenaltyAccount.glCode}}) {{ loanProduct.accountingMappings.receivablePenaltyAccount.name }}</span>
             </div>
             <span fxFlex="40%">Transfer in suspense:</span>
-            <span fxFlex="60%">{{ loanProduct.accountingMappings.transfersInSuspenseAccount.name }}</span>
+            <span fxFlex="60%">({{loanProduct.accountingMappings.transfersInSuspenseAccount.glCode}}) {{ loanProduct.accountingMappings.transfersInSuspenseAccount.name }}</span>
           </div>
 
           <h4 fxFlexFill class="mat-h4">Income</h4>
 
           <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
             <span fxFlex="40%">Income from Interest:</span>
-            <span fxFlex="60%">{{ loanProduct.accountingMappings.interestOnLoanAccount.name }}</span>
+            <span fxFlex="60%">({{loanProduct.accountingMappings.interestOnLoanAccount.glCode}}) {{ loanProduct.accountingMappings.interestOnLoanAccount.name }}</span>
             <span fxFlex="40%">Income from fees:</span>
-            <span fxFlex="60%">{{ loanProduct.accountingMappings.incomeFromFeeAccount.name }}</span>
+            <span fxFlex="60%">({{loanProduct.accountingMappings.incomeFromFeeAccount.glCode}}) {{ loanProduct.accountingMappings.incomeFromFeeAccount.name }}</span>
             <span fxFlex="40%">Income from penalties:</span>
-            <span fxFlex="60%">{{ loanProduct.accountingMappings.incomeFromPenaltyAccount.name }}</span>
+            <span fxFlex="60%">({{loanProduct.accountingMappings.incomeFromPenaltyAccount.glCode}}) {{ loanProduct.accountingMappings.incomeFromPenaltyAccount.name }}</span>
             <span fxFlex="40%">Income from Recovery Repayments:</span>
-            <span fxFlex="60%">{{ loanProduct.accountingMappings.incomeFromRecoveryAccount.name }}</span>
+            <span fxFlex="60%">({{loanProduct.accountingMappings.incomeFromRecoveryAccount.glCode}}) {{ loanProduct.accountingMappings.incomeFromRecoveryAccount.name }}</span>
           </div>
 
           <h4 fxFlexFill class="mat-h4">Expenses</h4>
 
-          <div fxFlexFill>
+          <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
             <span fxFlex="40%">Losses written off:</span>
-            <span fxFlex="60%">{{ loanProduct.accountingMappings.writeOffAccount.name }}</span>
+            <span fxFlex="60%">({{loanProduct.accountingMappings.writeOffAccount.glCode}}) {{ loanProduct.accountingMappings.writeOffAccount.name }}</span>
+            <span fxFlex="40%">Goodwill credit:</span>
+            <span fxFlex="60%">({{loanProduct.accountingMappings.goodwillCreditAccount.glCode}}) {{ loanProduct.accountingMappings.goodwillCreditAccount.name }}</span>
           </div>
 
           <h4 fxFlexFill class="mat-h4">Liabilities</h4>
 
-          <div fxFlexFill>
+          <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
             <span fxFlex="40%">Over payment liability:</span>
-            <span fxFlex="60%">{{ loanProduct.accountingMappings.overpaymentLiabilityAccount.name }}</span>
+            <span fxFlex="60%">({{loanProduct.accountingMappings.overpaymentLiabilityAccount.glCode}}) {{ loanProduct.accountingMappings.overpaymentLiabilityAccount.name }}</span>
           </div>
 
           <div *ngIf="loanProduct.paymentChannelToFundSourceMappings?.length || loanProduct.feeToIncomeAccountMappings?.length || loanProduct.penaltyToIncomeAccountMappings?.length" fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">


### PR DESCRIPTION
## Description

There are a couple of Loan product GL mapping changes for Loan products:

Support Fund source GL Account as Asset or Liability type,

Add the Goodwill credit as Expense GL account type for all the Accounting types used, Cash, Accrual Upfront or Accrual Periodic

## Screenshots, if any
<img width="1227" alt="Screen Shot 2022-08-01 at 13 34 39" src="https://user-images.githubusercontent.com/44206706/182256162-0bda0f36-b8fb-4ca0-8cb2-14b15f27a844.png">

<img width="1227" alt="Screen Shot 2022-08-01 at 14 01 13" src="https://user-images.githubusercontent.com/44206706/182256181-18983570-77c9-4f85-909b-c416286e8917.png">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
