### PR TITLE
Fix for Loan summary principal writtenoff value

### DIFF
--- a/src/app/loans/loans-view/general-tab/general-tab.component.ts
+++ b/src/app/loans/loans-view/general-tab/general-tab.component.ts
@@ -53,8 +53,8 @@ export class GeneralTabComponent implements OnInit {
         'property': 'Principal',
         'original': this.loanDetails.summary.principalDisbursed,
         'paid': this.loanDetails.summary.principalPaid,
-        'waived': this.loanDetails.summary.principalWrittenOff,
-        'writtenOff': this.loanDetails.summary.principalOutstanding,
+        'waived': this.loanDetails.summary.principalWaived || 0,
+        'writtenOff': this.loanDetails.summary.principalWrittenOff,
         'outstanding': this.loanDetails.summary.principalOutstanding,
         'overdue': this.loanDetails.summary.principalOverdue,
 


### PR DESCRIPTION
## Description

There was an error in the Loan summary principal `writtenoff` amount because It was taking the value of outstanding 

## Screenshots, if any

<img width="1333" alt="Screen Shot 2022-08-18 at 10 28 55" src="https://user-images.githubusercontent.com/44206706/185435784-a6bda07c-22b8-4692-bb1b-dc7c22569329.png">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
