### PR TITLE
Fix to set the business date as today

### DIFF
--- a/src/app/system/configurations/business-date-tab/business-date-tab.component.html
+++ b/src/app/system/configurations/business-date-tab/business-date-tab.component.html
@@ -44,7 +44,7 @@
                     Submit
                   </button>
                 </span>
-                <button mat-button *ngIf="isEditInProgress" (click)="editInProgressToggle(0)">
+                <button mat-button *ngIf="isEditInProgress && (dateIndex == 0)" (click)="editInProgressToggle(0)">
                   Cancel
                 </button>
                 <button type="button" color="primary" *ngIf="!isEditInProgress" mat-icon-button matTooltip="Edit the Business Date"
@@ -80,7 +80,7 @@
                     Submit
                   </button>
                 </span>
-                <button mat-button *ngIf="isEditInProgress" (click)="editInProgressToggle(1)">
+                <button mat-button *ngIf="isEditInProgress && (dateIndex == 1)" (click)="editInProgressToggle(1)">
                   Cancel
                 </button>
                 <button type="button" color="primary" *ngIf="!isEditInProgress" mat-icon-button matTooltip="Edit the COB Date"

--- a/src/app/system/configurations/business-date-tab/business-date-tab.component.ts
+++ b/src/app/system/configurations/business-date-tab/business-date-tab.component.ts
@@ -88,8 +88,14 @@ export class BusinessDateTabComponent implements OnInit {
       businessDateData.forEach((data: any) => {
         if (data.type === SettingsService.businessDateType) {
           this.businessDate = new Date(data.date);
+          this.businessDateForm.patchValue({
+            businessDate: this.businessDate
+          });
         } else {
           this.cobDate = new Date(data.date);
+          this.businessDateForm.patchValue({
+            cobDate: this.cobDate
+          });
         }
       });
     });


### PR DESCRIPTION
## Description

There was an issue in the Business date value set in the date picker control, as Today, so the form the form was not detecting any change then the Submit button was not activated

## Related issues and discussion
#{Issue Number}

## Screenshots, if any
- First Business date value
<img width="854" alt="Screen Shot 2022-09-07 at 11 43 40" src="https://user-images.githubusercontent.com/44206706/188935063-48ffa65b-e5f1-4b90-9507-16a79eec970c.png">

- Edit the Business date, now with the actual Business date value
- 
<img width="826" alt="Screen Shot 2022-09-07 at 11 43 49" src="https://user-images.githubusercontent.com/44206706/188935016-73e7700e-7259-41b0-b1aa-6eec42798fa5.png">

- Change the Business date to today, then the form is changed
 
<img width="836" alt="Screen Shot 2022-09-07 at 11 44 00" src="https://user-images.githubusercontent.com/44206706/188934982-9ba131ee-501c-46a1-9b65-ffafae436862.png">



## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
