### PR TITLE
Loan account locked management

### DIFF
--- a/src/app/shared/error-dialog/error-dialog.component.html
+++ b/src/app/shared/error-dialog/error-dialog.component.html
@@ -1,11 +1,10 @@
-<h1 mat-dialog-title> Error Log </h1>
+<h1 mat-dialog-title>{{'Error Log' | translate}}</h1>
 
 <div mat-dialog-content>
-
-    <p> {{ data }}</p>
-
+    <p *ngIf="!showAsCode"> {{ data }}</p>
+    <span *ngIf="showAsCode" [innerHTML]="data"></span>
 </div>
 
 <mat-dialog-actions align="left">
-    <button mat-raised-button mat-dialog-close>Cancel</button>
+    <button mat-raised-button mat-dialog-close>{{'Cancel' | translate}}</button>
 </mat-dialog-actions>

--- a/src/app/shared/error-dialog/error-dialog.component.ts
+++ b/src/app/shared/error-dialog/error-dialog.component.ts
@@ -9,11 +9,14 @@ import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 })
 export class ErrorDialogComponent {
 
+  showAsCode = false;
   /**
    * @param {MatDialogRef} dialogRef Component reference to dialog.
    * @param {any} data Provides any data.
    */
   constructor(public dialogRef: MatDialogRef<ErrorDialogComponent>,
-              @Inject(MAT_DIALOG_DATA) public data: any) { }
+              @Inject(MAT_DIALOG_DATA) public data: string) {
+    this.showAsCode = (data.startsWith('<pre><code>'));
+  }
 
 }

--- a/src/app/system/system.service.ts
+++ b/src/app/system/system.service.ts
@@ -269,6 +269,13 @@ export class SystemService {
   }
 
   /**
+   * @returns {Observable<any>} Updates Jobs.
+   */
+  runInlineCOB(jobName: String, payload: any): Observable<any> {
+    return this.http.post(`/jobs/${jobName}/inline`, payload);
+  }
+
+  /**
    * @returns {Observable<any>} Fetches Steps.
    */
   getAvailablesJobSteps(jobCategory: String): Observable<any> {

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.html
@@ -1,0 +1,81 @@
+<div class="tab-container mat-typography" *ngIf="loans.length > 0">
+
+  <div fxLayout="row" fxLayoutAlign="start center">
+    <div class="search-box" fxFlex="40%">
+      <mat-form-field fxFlex="90%">
+        <input matInput placeholder="Filter by loan Id or error" (keyup)="applyFilter($event.target.value)">
+      </mat-form-field>
+    </div>
+    <div fxFlex="60%" *ngIf="allowRunInlineJob">
+      <button mat-raised-button color="success" *mifosxHasPermission="'EXECUTE_INLINE_JOB'" (click)="runInlineCOB()">
+        <fa-icon icon="play"></fa-icon>&nbsp;&nbsp;{{'Start inline COB' | translate}}
+      </button>
+    </div>
+  </div>
+
+  <table mat-table [dataSource]="dataSource">
+
+    <ng-container matColumnDef="select">
+      <th mat-header-cell *matHeaderCellDef>
+        <mat-checkbox (change)="$event ? masterToggle() : null" [checked]="selection.hasValue() && isAllSelected()"
+          [indeterminate]="selection.hasValue() && !isAllSelected()" [aria-label]="checkboxLabel()">
+        </mat-checkbox>
+      </th>
+      <td mat-cell *matCellDef="let row">
+        <mat-checkbox (click)="$event.stopPropagation()" (change)="$event ? selection.toggle(row) : null"
+          [checked]="selection.isSelected(row)" [aria-label]="checkboxLabel(row)">
+        </mat-checkbox>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="loanId">
+      <th mat-header-cell *matHeaderCellDef> Loan Id </th>
+      <td mat-cell *matCellDef="let loan" class="view-details"> {{loan.loanId}} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="lockPlacedOn">
+      <th mat-header-cell *matHeaderCellDef> Lock Placed On </th>
+      <td mat-cell *matCellDef="let loan" class="view-details"> {{loan.lockPlacedOn | datetimeFormat}} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="lockOwner">
+      <th mat-header-cell *matHeaderCellDef> Lock Owner </th>
+      <td mat-cell *matCellDef="let loan" class="view-details"> {{loan.lockOwner}} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="error">
+      <th mat-header-cell *matHeaderCellDef> Error </th>
+      <td mat-cell *matCellDef="let loan" class="view-details"> {{loan.error}} </td>
+    </ng-container>
+
+    <ng-container matColumnDef="details">
+      <th mat-header-cell *matHeaderCellDef> Details </th>
+      <td mat-cell *matCellDef="let loan" class="view-details">
+        <button mat-icon-button class="error-log" matTooltip="Error details" (click)="showDetails(loan)" matTooltipPosition="left">
+          <fa-icon icon="exclamation-circle" size="lg"></fa-icon>
+        </button>
+        <button mat-icon-button matTooltip="View Loan Account" (click)="viewLoanAccount(loan)" matTooltipPosition="right">
+          <fa-icon icon="eye" size="lg"></fa-icon>
+        </button>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="selection.toggle(row)">
+    </tr>
+  </table>
+
+  <mat-paginator [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons [pageSize]="pageSize"
+    [pageIndex]="currentPage" (page)="pageEvent = handlePage($event)">
+  </mat-paginator>
+
+</div>
+
+<div class="alert" *ngIf="loans.length === 0">
+
+  <div class="message">
+    <i class="fa fa-exclamation-circle alert-check"></i>
+    No loan locked available.
+  </div>
+
+</div>

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.scss
@@ -1,0 +1,29 @@
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+
+  .mat-raised-button.mat-success {
+    color: #fff;
+    background-color: #32cd32;
+  }
+  .mat-raised-button.mat-reject {
+    color: #fff;
+    background-color: #ffa726;
+  }
+  #search-button {
+    height: 2.5rem;
+    margin-top: 1rem;
+  }
+  .view-details{
+    cursor: pointer;
+  }
+  table {
+    tr.select-row:hover {
+      cursor: pointer;
+    }
+  }
+}
+
+.error-log {
+  color: #ffa726;
+}

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.spec.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoanLockedComponent } from './loan-locked.component';
+
+describe('LoanLockedComponent', () => {
+  let component: LoanLockedComponent;
+  let fixture: ComponentFixture<LoanLockedComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LoanLockedComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoanLockedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.ts
@@ -1,0 +1,139 @@
+import { SelectionModel } from '@angular/cdk/collections';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatTableDataSource } from '@angular/material/table';
+import { ActivatedRoute, Router } from '@angular/router';
+import { LoansService } from 'app/loans/loans.service';
+import { ErrorDialogComponent } from 'app/shared/error-dialog/error-dialog.component';
+import { SystemService } from 'app/system/system.service';
+import { TasksService } from 'app/tasks/tasks.service';
+
+@Component({
+  selector: 'mifosx-loan-locked',
+  templateUrl: './loan-locked.component.html',
+  styleUrls: ['./loan-locked.component.scss']
+})
+export class LoanLockedComponent implements OnInit {
+
+  /** Loans Data */
+  loans: any[];
+  /** Batch Requests */
+  batchRequests: any[];
+  /** Datasource for loans disbursal table */
+  dataSource: MatTableDataSource<any>;
+  /** Row Selection */
+  selection: SelectionModel<any>;
+  /** Displayed Columns for loan disbursal data */
+  displayedColumns: string[] = ['select', 'loanId', 'lockPlacedOn', 'lockOwner', 'error', 'details'];
+  /** Paginator for the table */
+  @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
+  currentPage = 0;
+  pageSize = 10;
+  /** Control for enable/disable button */
+  allowRunInlineJob = false;
+  /** Const for the jobName */
+  jobName: String = 'LOAN_COB';
+
+  /**
+   * @param {LoansService} loansService Loans Service
+   * @param {Router} router Router for navigation.
+   * @param {MatDialog} dialog Dialog reference.
+   */
+  constructor(private route: ActivatedRoute,
+    private router: Router,
+    private loansService: LoansService,
+    private systemService: SystemService,
+    private tasksService: TasksService,
+    private dialog: MatDialog) {
+    this.route.data.subscribe((data: { loansData: any }) => {
+      this.loans = data.loansData.content;
+    });
+  }
+
+  ngOnInit(): void {
+    this.dataSource = new MatTableDataSource(this.loans);
+    this.dataSource.paginator = this.paginator;
+    this.selection = new SelectionModel(true, []);
+    this.allowRunInlineJob = false;
+  }
+
+  applyFilter(filterValue: string = '') {
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+  }
+
+  handlePage(e: any) {
+    if (this.currentPage !== e.pageIndex) {
+      this.currentPage = e.pageIndex;
+      this.pageSize = e.pageSize;
+      this.getLoansLocked(this.currentPage);
+    }
+  }
+
+  getLoansLocked(page: number) {
+    this.tasksService.getAllLoansLocked(page, this.pageSize).subscribe((data: any) => {
+      this.loans = data.content;
+      this.allowRunInlineJob = false;
+      this.selection = new SelectionModel(true, []);
+    });
+  }
+
+  /** Whether the number of selected elements matches the total number of rows. */
+  isAllSelected() {
+    const numSelected = this.selection.selected.length;
+    if (numSelected === 0) {
+      this.allowRunInlineJob = false;
+    } else {
+      this.allowRunInlineJob = true;
+    }
+    const numRows = this.dataSource.data.length;
+    return numSelected === numRows;
+  }
+
+  /** Selects all rows if they are not all selected; otherwise clear selection. */
+  masterToggle() {
+    this.isAllSelected() ?
+      this.selection.clear() :
+      this.dataSource.data.forEach((row: any) => this.selection.select(row));
+  }
+
+  /** The label for the checkbox on the passed row */
+  checkboxLabel(row?: any): string {
+    if (!row) {
+      return `${this.isAllSelected() ? 'select' : 'deselect'} all`;
+    }
+    return `${this.selection.isSelected(row) ? 'deselect' : 'select'} row ${row.position + 1}`;
+  }
+
+  showDetails(loan: any) {
+    this.dialog.open(ErrorDialogComponent, {
+      width: '960px',
+      height: '400px',
+      data: '<pre><code>' + loan.stacktrace + '</code></pre>'
+    });
+  }
+
+  viewLoanAccount(loan: any) {
+    const loanId = loan.loanId;
+    this.loansService.getLoanAccountDetails(loanId).subscribe((loanData: any) => {
+      const clientId = loanData.clientId;
+      this.router.navigateByUrl(`/clients/${clientId}/loans-accounts/${loanId}/general`);
+    });
+  }
+
+  runInlineCOB(): void {
+    const loanIds: any = [];
+    this.selection.selected.forEach((row: any) => {
+      loanIds.push(row.loanId);
+    });
+    if (loanIds.length > 0) {
+      const payload = {
+        loanIds: loanIds
+      };
+      this.systemService.runInlineCOB(this.jobName, payload).subscribe((data: any) => {
+        this.getLoansLocked(0);
+      });
+    }
+  }
+
+}

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.resolver.spec.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.resolver.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LoanLockedResolver } from './loan-locked.resolver';
+
+describe('LoanLockedResolver', () => {
+  let resolver: LoanLockedResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    resolver = TestBed.inject(LoanLockedResolver);
+  });
+
+  it('should be created', () => {
+    expect(resolver).toBeTruthy();
+  });
+});

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.resolver.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.resolver.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import {
+  Router, Resolve,
+  RouterStateSnapshot,
+  ActivatedRouteSnapshot
+} from '@angular/router';
+import { TasksService } from 'app/tasks/tasks.service';
+import { Observable, of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoanLockedResolver implements Resolve<boolean> {
+
+    /**
+     * @param {TasksService} tasksService Tasks service.
+     */
+     constructor(private tasksService: TasksService) { }
+
+     /**
+      * Returns all the loans data.
+      * @returns {Observable<any>}
+      */
+     resolve(): Observable<any> {
+         return this.tasksService.getAllLoansLocked(0, 200);
+     }
+}

--- a/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
@@ -25,6 +25,10 @@
           [active]="rescheduleLoan.isActive" *mifosxHasPermission="'RESCHEDULE_LOAN'">
           Reschedule Loan
         </a>
+        <a mat-tab-link [routerLink]="['./loan-locked']" routerLinkActive #loanLocked="routerLinkActive"
+          [active]="loanLocked.isActive">
+          Loan Locked
+        </a>
       </nav>
 
       <router-outlet></router-outlet>

--- a/src/app/tasks/tasks-routing.module.ts
+++ b/src/app/tasks/tasks-routing.module.ts
@@ -25,6 +25,8 @@ import { GetLoans } from './common-resolvers/getLoans.resolver';
 import { GetRescheduleLoans } from './common-resolvers/getRescheduleLoans.resolver';
 import { MakerCheckerTemplate } from './common-resolvers/makerCheckerTemplate.resolver';
 import { GetCheckerInboxDetailResolver } from './common-resolvers/getCheckerInboxDetail.resolver';
+import { LoanLockedComponent } from './checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component';
+import { LoanLockedResolver } from './checker-inbox-and-tasks-tabs/loan-locked/loan-locked.resolver';
 
 /** Tasks Routes */
 const routes: Routes = [
@@ -66,6 +68,14 @@ const routes: Routes = [
           data: { title: extract('Loan Disbursal') },
           resolve: {
             loansData: GetLoans
+          }
+        },
+        {
+          path: 'loan-locked',
+          component: LoanLockedComponent,
+          data: { title: extract('Loan Locked') },
+          resolve: {
+            loansData: LoanLockedResolver
           }
         },
         {

--- a/src/app/tasks/tasks.module.ts
+++ b/src/app/tasks/tasks.module.ts
@@ -14,6 +14,7 @@ import { LoanApprovalComponent } from './checker-inbox-and-tasks-tabs/loan-appro
 import { LoanDisbursalComponent } from './checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component';
 import { RescheduleLoanComponent } from './checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component';
 import { ViewCheckerInboxComponent } from './view-checker-inbox/view-checker-inbox.component';
+import { LoanLockedComponent } from './checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component';
 
 /**
  * Tasks Module
@@ -32,7 +33,8 @@ import { ViewCheckerInboxComponent } from './view-checker-inbox/view-checker-inb
     LoanApprovalComponent,
     LoanDisbursalComponent,
     RescheduleLoanComponent,
-    ViewCheckerInboxComponent
+    ViewCheckerInboxComponent,
+    LoanLockedComponent
   ],
   providers: [ ]
 })

--- a/src/app/tasks/tasks.service.ts
+++ b/src/app/tasks/tasks.service.ts
@@ -69,6 +69,14 @@ export class TasksService {
   }
 
   /**
+   * Get Loans Locked Data using pages and limit
+   */
+  getAllLoansLocked(page: number, limit: number): Observable<any> {
+    const httpParams = new HttpParams().set('page', page).set('limit', limit);
+    return this.http.get('/loans/locked', { params: httpParams });
+  }
+
+  /**
    * Get Pending Rescheduled Loans
    */
   getPendingRescheduleLoans(): Observable<any> {


### PR DESCRIPTION
## Description

We have a new Tab in the screen of _Checker Inbox & Tasks_, so that operators can list which accounts have inconsistencies in their state therefore being unable to execute the Loan COB properly. The main action for this is in the button to kick-off the inline COB

After select some rows, we can click the _Start Inline COB_ to run the COB Job

On each row we have two actions:
- Exclamation in yellow to review the stack trace generated, and
- Eye to view (go to) the account details

## Screenshots, if any
<img width="1212" alt="Screenshot 2022-11-08 at 8 14 57" src="https://user-images.githubusercontent.com/44206706/200587845-10d96cea-8aba-4750-a494-f926a8137f4d.png">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
