### PR TITLE
Use of text area input in client datatable

### DIFF
--- a/src/app/clients/client-stepper/client-datatable-step/client-datatable-step.component.html
+++ b/src/app/clients/client-stepper/client-datatable-step/client-datatable-step.component.html
@@ -19,6 +19,9 @@
         <input matInput *ngIf="isString(datatableInput.columnDisplayType)"
         formControlName="{{datatableInput.controlName}}">
 
+        <textarea matInput *ngIf="isText(datatableInput.columnDisplayType)"
+        formControlName="{{datatableInput.controlName}}"></textarea>
+
         <span *ngIf="isDate(datatableInput.columnDisplayType)" (click)="datePicker.open()">
           <input matInput [matDatepicker]="datePicker" formControlName="{{datatableInput.controlName}}" class="date-picker">
           <mat-datepicker-toggle matSuffix [for]="datePicker"></mat-datepicker-toggle>

--- a/src/app/clients/client-stepper/client-datatable-step/client-datatable-step.component.ts
+++ b/src/app/clients/client-stepper/client-datatable-step/client-datatable-step.component.ts
@@ -67,6 +67,10 @@ export class ClientDatatableStepComponent implements OnInit {
     return this.isColumnType(columnType, 'STRING');
   }
 
+  isText(columnType: string) {
+    return this.isColumnType(columnType, 'TEXT');
+  }
+
   isColumnType(columnType: string, expectedType: string) {
     return (columnType === expectedType);
   }

--- a/src/app/shared/confirmation-dialog/confirmation-dialog.component.ts
+++ b/src/app/shared/confirmation-dialog/confirmation-dialog.component.ts
@@ -30,7 +30,7 @@ export class ConfirmationDialogComponent implements OnInit {
         this.color = 'primary';
         break;
       case 'Mild':
-        this.color = 'accent';
+        this.color = 'primary';
         break;
       case 'Strong':
         this.color = 'warn';


### PR DESCRIPTION
## Description

There was missing the Text (textarea) input field in the client datatable creation step

## Screenshots, if any
<img width="1249" alt="Screenshot 2022-11-23 at 13 45 59" src="https://user-images.githubusercontent.com/44206706/203633826-ca523fd7-aabe-4cda-a57d-df10257db2dd.png">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
