### PR TITLE
Office hierarchy view as tree

### DIFF
--- a/src/app/organization/offices/office-node.model.ts
+++ b/src/app/organization/offices/office-node.model.ts
@@ -1,0 +1,34 @@
+/**
+ * Office Node model.
+ */
+ export class OfficeNode {
+
+  /** Office Node children. */
+  children: OfficeNode[];
+
+  name: string;
+  id: string;
+  parentId: string;
+  hierarchy: string;
+  externalId: string;
+  parentName: string;
+  openingDate: string;
+
+  constructor(name: string,
+              id: string = '',
+              parentId: string = '',
+              hierarchy: string = '',
+              externalId: string = '',
+              parentName: string = '',
+              openingDate: string = '') {
+    this.name = name;
+    this.id = id;
+    this.parentId = parentId;
+    this.hierarchy = hierarchy;
+    this.externalId = externalId;
+    this.parentName = parentName;
+    this.openingDate = openingDate;
+    this.children = [];
+  }
+
+}

--- a/src/app/organization/offices/office-tree-service.service.spec.ts
+++ b/src/app/organization/offices/office-tree-service.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { OfficeTreeServiceService } from './office-tree-service.service';
+
+describe('OfficeTreeServiceService', () => {
+  let service: OfficeTreeServiceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(OfficeTreeServiceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/organization/offices/office-tree-service.service.ts
+++ b/src/app/organization/offices/office-tree-service.service.ts
@@ -1,0 +1,81 @@
+/** Angular Imports */
+import { Injectable } from '@angular/core';
+
+/** rxjs Imports */
+import { BehaviorSubject } from 'rxjs';
+
+/** Custom Components */
+import { OfficeNode } from './office-node.model';
+
+/**
+ * Office tree service.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class OfficeTreeService {
+
+  /** Office data. */
+  officesData: any;
+  /** Offices tree data behavior subject to represent offices tree nodes. */
+  treeDataChange = new BehaviorSubject<OfficeNode[]>([]);
+
+  /**
+   * Gets the offices tree nodes.
+   */
+  get treeData(): OfficeNode[] { return this.treeDataChange.value; }
+
+  constructor() {  }
+
+  /**
+   * Builds the offices tree and emits the value.
+   * @param {any} officesData Offices data.
+   */
+  initialize(officesData: any) {
+    const treeData = this.buildOfficeTree(officesData);
+    this.treeDataChange.next(treeData);
+  }
+
+  /**
+   * Builds and returns the offices tree.
+   * @param {any} officeData Offices data.
+   * @returns {OfficeNode} Offices tree nodes.
+   */
+  buildOfficeTree(officesData: any): OfficeNode[] {
+    const officeTree: OfficeNode[] = [];
+
+    // Header nodes
+    const mainOffice = officesData.find((office: any) => office.hierarchy === '.');
+    officeTree.push(new OfficeNode(mainOffice.name, mainOffice.id));
+
+    // Sort by parent id (so that child nodes can be added properly)
+    officesData.sort((officeOne: any, officeTwo: any) => {
+      if (!officeOne.parentId) {
+        officeOne.parentId = 0;
+      }
+      return officeOne.parentId - officeTwo.parentId;
+    });
+
+    const offices: OfficeNode[] = [];
+
+    // Add offices to any array where index for each is denoted by its id
+    for (const office of officesData) {
+      offices[office.id] =
+        new OfficeNode(office.name, office.id, office.parentId, office.hierarchy, office.externalId, office.parentName, office.openingDate);
+    }
+
+    // Construct offices tree by adding all nodes belonging to headers (with parent id = 0),
+    // and rest as children to respective parent nodes.
+    for (const office of officesData) {
+      if (office.hierarchy !== '.') {
+        if (office.parentId === 1) {
+          officeTree[0].children.push(offices[office.id]);
+        } else {
+          offices[office.parentId].children.push(offices[office.id]);
+        }
+      }
+    }
+    return officeTree;
+  }
+
+}

--- a/src/app/organization/offices/offices.component.html
+++ b/src/app/organization/offices/offices.component.html
@@ -1,15 +1,17 @@
 <div class="container m-b-20" fxLayout="row" fxLayoutAlign="end" fxLayoutGap="20px">
 
-  <div #buttonTreeView class="in-block">
-    <button mat-raised-button color="primary">
-      <fa-icon icon="sitemap"></fa-icon>&nbsp;&nbsp;
-      Tree View
-    </button>
-  </div>
+  <mat-button-toggle-group [formControl]="viewGroup">
+    <mat-button-toggle value="listView">
+      <fa-icon icon="list"></fa-icon>
+    </mat-button-toggle>
+    <mat-button-toggle value="treeView">
+      <fa-icon icon="sitemap"></fa-icon>
+    </mat-button-toggle>
+  </mat-button-toggle-group>
 
   <div #buttonCreateOffice class="in-block">
     <button mat-raised-button color="primary" [routerLink]="['create']" *mifosxHasPermission="'CREATE_OFFICE'">
-      <fa-icon icon="plus"></fa-icon>&nbsp;&nbsp;
+      <fa-icon icon="plus" class="m-r-10"></fa-icon>
       Create Office
     </button>
   </div>
@@ -17,43 +19,44 @@
   <div #buttonImportOffices class="in-block">
     <button mat-raised-button color="primary" *mifosxHasPermission="'CREATE_OFFICE'"
       [routerLink]="['/organization', 'bulk-import', 'Offices']">
-      <fa-icon icon="upload"></fa-icon>&nbsp;&nbsp;
+      <fa-icon icon="upload" class="m-r-10"></fa-icon>
       Import Offices
     </button>
   </div>
 
 </div>
 
-<div class="container">
+<div class="container" [hidden]="viewGroup.value !== 'listView'">
 
-  <div #filter fxLayout="row" fxLayoutGap="20px">
+  <div fxLayout="row" fxLayoutGap="20px">
     <mat-form-field fxFlex>
-      <mat-label>Filter</mat-label>
+      <mat-label>{{ 'Filter'| translate}}</mat-label>
       <input matInput (keyup)="applyFilter($event.target.value)">
     </mat-form-field>
   </div>
 
-  <div #tableOffices class="mat-elevation-z8">
+  <!-- List View -->
+  <div class="mat-elevation-z8">
 
     <table mat-table [dataSource]="dataSource" matSort>
 
       <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header> Office Name </th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{' Office Name '|translate}}</th>
         <td mat-cell *matCellDef="let offices"> {{ offices.name }} </td>
       </ng-container>
 
       <ng-container matColumnDef="externalId">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header> External ID </th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{' External ID '|translate}}</th>
         <td mat-cell *matCellDef="let offices"> {{ offices.externalId }} </td>
       </ng-container>
 
       <ng-container matColumnDef="parentName">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header> Parent Office </th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{' Parent Office '|translate}}</th>
         <td mat-cell *matCellDef="let offices"> {{ offices.parentName }} </td>
       </ng-container>
 
       <ng-container matColumnDef="openingDate">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header> Opened On </th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{' Opened On '|translate}}</th>
         <td mat-cell *matCellDef="let offices"> {{ offices.openingDate | dateFormat }} </td>
       </ng-container>
 
@@ -64,6 +67,129 @@
     </table>
 
     <mat-paginator [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons></mat-paginator>
+
+  </div>
+</div>
+
+<!-- Tree View -->
+<div class="container" [hidden]="viewGroup.value !== 'treeView'">
+
+  <div class="m-b-20" fxLayout="row" fxLayoutAlign="start" fxLayoutGap="20px">
+    <button mat-raised-button (click)="nestedTreeControl.expandAll()">
+      {{'Expand All'|translate}}
+    </button>
+    <button mat-raised-button (click)="nestedTreeControl.collapseAll()">
+      {{'Collapse All'|translate}}
+    </button>
+  </div>
+
+  <div fxLayout="row" fxLayoutGap="4%" fxLayout.lt-md="column">
+
+    <div fxFlex>
+
+      <mat-card>
+
+        <mat-card-content>
+
+          <mat-tree [dataSource]="nestedTreeDataSource" [treeControl]="nestedTreeControl" class="office-tree">
+
+            <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
+              <li class="mat-tree-node">
+                <button mat-icon-button disabled></button>
+                <span (click)="viewOfficeNode(node)" class="m-r-10">
+                  {{ node.name }}
+                </span>
+              </li>
+            </mat-tree-node>
+
+            <mat-nested-tree-node *matTreeNodeDef="let node; when: hasNestedChild">
+              <li>
+                <div class="mat-tree-node">
+                  <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.name">
+                    <fa-icon class="mat-icon-rtl-mirror"
+                      icon="{{ nestedTreeControl.isExpanded(node) ? 'chevron-down' : 'chevron-right' }}"></fa-icon>
+                  </button>
+                  <span (click)="viewOfficeNode(node)" class="m-r-10">
+                    {{ node.name }}
+                  </span>
+                </div>
+                <ul [class.office-tree-invisible]="!nestedTreeControl.isExpanded(node)">
+                  <ng-container matTreeNodeOutlet></ng-container>
+                </ul>
+              </li>
+            </mat-nested-tree-node>
+
+          </mat-tree>
+
+        </mat-card-content>
+
+      </mat-card>
+
+    </div>
+
+    <div fxFlex="48%" *ngIf="office">
+
+      <mat-card>
+
+        <mat-card-content>
+
+          <div fxLayout="row">
+
+            <mat-card-title>
+              {{ office.name }}
+            </mat-card-title>
+
+            <div fxFlex fxLayoutAlign="end">
+              <button mat-icon-button (click)="closeOffice()">
+                <fa-icon icon="times"></fa-icon>
+              </button>
+            </div>
+
+          </div>
+
+          <mat-tab-group>
+
+            <mat-tab label="General">
+
+              <div fxLayout="row wrap" class="content">
+
+                <div fxFlex="50%" class="mat-body-strong" *ngIf="office.parentId">
+                  {{'Parent Office'|translate}}
+                </div>
+
+                <div fxFlex="50%" *ngIf="office.parentId">
+                  {{ office.parentName }}
+                </div>
+
+                <div fxFlex="50%" class="mat-body-strong">
+                 {{' Opened On'|translate}}
+                </div>
+
+                <div fxFlex="50%">
+                  {{ office.openingDate | date }}
+                </div>
+
+                <div fxFlex="50%" class="mat-body-strong" *ngIf="office.externalId">
+                  {{'External ID'|translate}}
+                </div>
+
+                <div fxFlex="50%" *ngIf="office.externalId">
+                  {{ office.externalId }}
+                </div>
+
+              </div>
+
+            </mat-tab>
+
+            <mat-tab *ngFor="let dataTable of dataTablesData" label="{{ dataTable.registeredTableName }}"></mat-tab>
+
+          </mat-tab-group>
+
+        </mat-card-content>
+
+      </mat-card>
+
+    </div>
 
   </div>
 

--- a/src/app/organization/offices/offices.component.scss
+++ b/src/app/organization/offices/offices.component.scss
@@ -5,3 +5,29 @@ table {
     cursor: pointer;
   }
 }
+
+.content {
+  div {
+    margin: 1rem 0;
+    word-wrap: break-word;
+  }
+}
+
+.office-tree {
+  ul,
+  li {
+    margin-top: 0;
+    margin-bottom: 0;
+    list-style-type: none;
+  }
+
+  li {
+    span {
+      cursor: pointer;
+    }
+  }
+
+  .office-tree-invisible {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Description

Currently we have the Organization Office view as List, but now we can have that view as Tree (similar as we have for GL Accounts) 

<img width="1233" alt="Screenshot 2022-11-25 at 14 01 17" src="https://user-images.githubusercontent.com/44206706/204051072-a195ad48-48b9-4a65-974f-b80d9dfc9cbb.png">

Initial Tree view
<img width="1226" alt="Screenshot 2022-11-25 at 14 01 36" src="https://user-images.githubusercontent.com/44206706/204051102-cc99d81f-ebd0-41a5-9fe5-b2cf7b13e149.png">

After select an Office, we can see some details in the right
<img width="1220" alt="Screenshot 2022-11-25 at 14 01 58" src="https://user-images.githubusercontent.com/44206706/204051185-7b8380cb-f437-44c2-aeaf-18cd57440fe9.png">


## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
