### PR TITLE
Set a fix date format to run reports

### DIFF
--- a/src/app/reports/run-report/run-report.component.ts
+++ b/src/app/reports/run-report/run-report.component.ts
@@ -195,7 +195,7 @@ export class RunReportComponent implements OnInit {
           formattedResponse[newKey] = value['id'];
           break;
         case 'date':
-          const dateFormat = this.settingsService.dateFormat;
+          const dateFormat = 'yyyy-MM-dd';
           formattedResponse[newKey] = this.dateUtils.formatDate(value, dateFormat);
           this.reportUsesDates = true;
           break;

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.scss
@@ -24,6 +24,28 @@
   }
 }
 
+.alert {
+  background-color: #E8F4FD;
+  padding: 6px 16px;
+  font-size: 0.875rem;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  font-weight: 400;
+  line-height: 1.43;
+  border-radius: 4px;
+  letter-spacing: 0.01071em;
+  margin: 10px;
+
+  .message {
+    padding: 8px 0;
+    font-size: 18px;
+  }
+  .alert-check {
+    color:#359FF4;
+    margin-right: 2px;
+    font-size: 1.4rem;
+  }
+}
+
 .error-log {
   color: #ffa726;
 }


### PR DESCRIPTION
## Description

Small fix to set a constant date format value `yyyy-MM-dd` in the run reports and decouple this value from the local user setting because not all the date formats are supported by the database manager systems

## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
