### PR TITLE
Client and External Id

### DIFF
--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
@@ -16,7 +16,7 @@
 
     <mat-form-field fxFlex="48%">
       <mat-label>Legal Form</mat-label>
-      <mat-select formControlName="legalFormId">
+      <mat-select required formControlName="legalFormId">
         <mat-option *ngFor="let legalForm of legalFormOptions" [value]="legalForm.id">
           {{ legalForm.value }}
         </mat-option>

--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
@@ -1,6 +1,7 @@
 /** Angular Imports */
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
+import { ClientsService } from 'app/clients/clients.service';
 import { Dates } from 'app/core/utils/dates';
 
 /** Custom Services */
@@ -51,10 +52,12 @@ export class ClientGeneralStepComponent implements OnInit {
    * @param {FormBuilder} formBuilder Form Builder
    * @param {Dates} dateUtils Date Utils
    * @param {SettingsService} settingsService Setting service
+   * @param {ClientsService} clientService Client service
    */
   constructor(private formBuilder: FormBuilder,
               private dateUtils: Dates,
-              private settingsService: SettingsService) {
+              private settingsService: SettingsService,
+              private clientService: ClientsService) {
     this.setClientForm();
   }
 
@@ -71,7 +74,7 @@ export class ClientGeneralStepComponent implements OnInit {
     this.createClientForm = this.formBuilder.group({
       'officeId': ['', Validators.required],
       'staffId': [''],
-      'legalFormId': [''],
+      'legalFormId': ['', Validators.required],
       'isStaff': [false],
       'active': [false],
       'addSavings': [false],
@@ -142,6 +145,11 @@ export class ClientGeneralStepComponent implements OnInit {
       } else {
         this.createClientForm.removeControl('savingsProductId');
       }
+    });
+    this.createClientForm.get('officeId').valueChanges.subscribe((officeId: number) => {
+      this.clientService.getClientWithOfficeTemplate(officeId).subscribe((clientTemplate: any) => {
+        this.staffOptions = clientTemplate.staffOptions;
+      });
     });
   }
 

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -29,20 +29,23 @@
         <mat-card-title>
           <h3>
             <i class="fa fa-stop" [ngClass]="clientViewData.status.code|statusLookup" [matTooltip]="clientViewData.status.value"></i>
-            Client Name : {{clientViewData.displayName}}
+            <b>Client Name :</b> {{clientViewData.displayName}}
           </h3>
         </mat-card-title>
 
         <mat-card-subtitle>
           <p>
-            Client #:{{clientViewData.accountNo}} | External
-            Id: {{clientViewData.externalId}} | Staff:{{clientViewData.staffName || 'Unassigned'}}<br />
-            Activation Date : {{(clientViewData.activationDate) ? (clientViewData.activationDate | dateFormat) :'Not Activated'}}<br />
-            Member Of :
-            <span *ngFor="let group of clientViewData.groups">
-              <a>{{group.name}}</a>&nbsp;
+            <b>Office :</b> {{clientViewData.officeName}}<br />
+            <b>Client :</b> {{clientViewData.accountNo}}<br />
+            <b>External Id:</b> {{clientViewData.externalId}}<br />
+            <span *ngIf="clientViewData.staffName"><b>Staff :</b> {{clientViewData.staffName || 'Unassigned'}}<br /></span>
+            <span *ngIf="clientViewData.activationDate"><b>Activation Date :</b> {{clientViewData.activationDate | dateFormat}}<br /></span>
+            <span *ngIf="clientViewData.groups.length > 0">
+              Member Of :
+              <span *ngFor="let group of clientViewData.groups">
+                <a>{{group.name}}</a>&nbsp;
+              </span>
             </span>
-            <span *ngIf="!clientViewData.groups">Unassigned</span>
             <br/>
           </p>
         </mat-card-subtitle>

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -112,7 +112,6 @@ export class ClientsViewComponent implements OnInit {
     }
   }
 
-
   /**
    * Refetches data for the component
    * TODO: Replace by a custom reload component instead of hard-coded back-routing.

--- a/src/app/clients/clients.component.html
+++ b/src/app/clients/clients.component.html
@@ -34,7 +34,9 @@
       <!-- External ID Column -->
       <ng-container matColumnDef="externalid">
         <th mat-header-cell *matHeaderCellDef mat-sort-header="externalId"> ExternalID </th>
-        <td mat-cell *matCellDef="let row"> {{row.externalId}} </td>
+        <td mat-cell *matCellDef="let row">
+          <mifosx-external-identifier externalId="{{row.externalId}}"></mifosx-external-identifier>
+        </td>
       </ng-container>
 
       <!-- Status Column -->

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -41,6 +41,10 @@ export class ClientsService {
     return this.http.get('/clients/template');
   }
 
+  getClientWithOfficeTemplate(officeId: number): Observable<any> {
+    return this.http.get(`/clients/template?officeId=${officeId}&staffInSelectedOfficeOnly=true`);
+  }
+
   getClientData(clientId: string) {
     return this.http.get(`/clients/${clientId}`);
   }

--- a/src/app/clients/create-client/create-client.component.ts
+++ b/src/app/clients/create-client/create-client.component.ts
@@ -104,11 +104,13 @@ export class CreateClientComponent {
     if (this.legalFormType === 2) {
       legalFormTypeVal = 'entity';
     }
-    this.clientTemplate.datatables.forEach((datatable: any) => {
-      if (datatable.entitySubType.toLowerCase() === legalFormTypeVal) {
-        this.datatables.push(datatable);
-      }
-    });
+    if (this.clientTemplate.datatables) {
+      this.clientTemplate.datatables.forEach((datatable: any) => {
+        if (datatable.entitySubType.toLowerCase() === legalFormTypeVal) {
+          this.datatables.push(datatable);
+        }
+      });
+    }
   }
 
   legalFormChange(eventData: { legalForm: number }) {

--- a/src/app/pipes/external-identifier.pipe.spec.ts
+++ b/src/app/pipes/external-identifier.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { ExternalIdentifierPipe } from './external-identifier.pipe';
+
+describe('ExternalIdentifierPipe', () => {
+  it('create an instance', () => {
+    const pipe = new ExternalIdentifierPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/external-identifier.pipe.ts
+++ b/src/app/pipes/external-identifier.pipe.ts
@@ -1,0 +1,25 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'externalIdentifier'
+})
+export class ExternalIdentifierPipe implements PipeTransform {
+
+  transform(externalId: string): string {
+    const limit = 20;
+    if (!externalId) {
+      return '';
+    } else {
+      const regexExp = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+
+      if (regexExp.test(externalId)) {
+        const values = externalId.split('-');
+        return values[4];
+      } else {
+        const inputLen = externalId.length;
+        return inputLen > limit ? externalId.substring((inputLen - limit), inputLen) : externalId;
+      }
+    }
+  }
+
+}

--- a/src/app/pipes/pipes.module.ts
+++ b/src/app/pipes/pipes.module.ts
@@ -8,13 +8,14 @@ import { FindPipe } from './find.pipe';
 import { UrlToStringPipe } from './url-to-string.pipe';
 import { DateFormatPipe } from './date-format.pipe';
 import { DatetimeFormatPipe } from './datetime-format.pipe';
+import { ExternalIdentifierPipe } from './external-identifier.pipe';
 
 @NgModule({
   imports: [
     CommonModule
   ],
-  declarations: [StatusLookupPipe, AccountsFilterPipe, ChargesFilterPipe, ChargesPenaltyFilterPipe, FindPipe, UrlToStringPipe, DateFormatPipe, DatetimeFormatPipe],
-  providers: [StatusLookupPipe, AccountsFilterPipe, ChargesFilterPipe, ChargesPenaltyFilterPipe, FindPipe, UrlToStringPipe, DateFormatPipe, DatetimeFormatPipe],
-  exports: [StatusLookupPipe, AccountsFilterPipe, ChargesFilterPipe, ChargesPenaltyFilterPipe, FindPipe, UrlToStringPipe, DateFormatPipe, DatetimeFormatPipe]
+  declarations: [StatusLookupPipe, AccountsFilterPipe, ChargesFilterPipe, ChargesPenaltyFilterPipe, FindPipe, UrlToStringPipe, DateFormatPipe, DatetimeFormatPipe, ExternalIdentifierPipe],
+  providers: [StatusLookupPipe, AccountsFilterPipe, ChargesFilterPipe, ChargesPenaltyFilterPipe, FindPipe, UrlToStringPipe, DateFormatPipe, DatetimeFormatPipe, ExternalIdentifierPipe],
+  exports: [StatusLookupPipe, AccountsFilterPipe, ChargesFilterPipe, ChargesPenaltyFilterPipe, FindPipe, UrlToStringPipe, DateFormatPipe, DatetimeFormatPipe, ExternalIdentifierPipe]
 })
 export class PipesModule { }

--- a/src/app/search/search-page/search-page.component.html
+++ b/src/app/search/search-page/search-page.component.html
@@ -23,7 +23,9 @@
 
       <ng-container matColumnDef="externalId">
         <th mat-header-cell *matHeaderCellDef> External Id </th>
-        <td mat-cell *matCellDef="let entity" class="view-details"> {{entity.entityExternalId | externalIdentifier}} </td>
+        <td mat-cell *matCellDef="let entity" class="view-details">
+          <mifosx-external-identifier externalId="{{entity.entityExternalId}}"></mifosx-external-identifier>
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="parentType">

--- a/src/app/shared/external-identifier/external-identifier.component.html
+++ b/src/app/shared/external-identifier/external-identifier.component.html
@@ -1,0 +1,4 @@
+<div>
+  <span *ngIf="isLongValue()"><fa-icon icon="eye" size="sm" [title]="externalId"></fa-icon></span>
+  {{ externalId | externalIdentifier }}
+</div>

--- a/src/app/shared/external-identifier/external-identifier.component.spec.ts
+++ b/src/app/shared/external-identifier/external-identifier.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExternalIdentifierComponent } from './external-identifier.component';
+
+describe('ExternalIdentifierComponent', () => {
+  let component: ExternalIdentifierComponent;
+  let fixture: ComponentFixture<ExternalIdentifierComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ExternalIdentifierComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExternalIdentifierComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/external-identifier/external-identifier.component.ts
+++ b/src/app/shared/external-identifier/external-identifier.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'mifosx-external-identifier',
+  templateUrl: './external-identifier.component.html',
+  styleUrls: ['./external-identifier.component.scss']
+})
+export class ExternalIdentifierComponent implements OnInit {
+  @Input() externalId: string;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  isLongValue(): boolean {
+    if (this.externalId == null) {
+      return false;
+    }
+    return (this.externalId.length > 15);
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -27,6 +27,8 @@ import { TenantSelectorComponent } from './tenant-selector/tenant-selector.compo
 import { IconsModule } from './icons.module';
 import { MaterialModule } from './material.module';
 import { TranslateModule } from '@ngx-translate/core';
+import { ExternalIdentifierComponent } from './external-identifier/external-identifier.component';
+import { PipesModule } from 'app/pipes/pipes.module';
 
 /**
  * Shared Module
@@ -40,6 +42,7 @@ import { TranslateModule } from '@ngx-translate/core';
     MaterialModule,
     ReactiveFormsModule,
     TranslateModule.forRoot(),
+    PipesModule
   ],
   declarations: [
     FormfieldComponent,
@@ -59,7 +62,8 @@ import { TranslateModule } from '@ngx-translate/core';
     NotificationsTrayComponent,
     SearchToolComponent,
     ServerSelectorComponent,
-    TenantSelectorComponent
+    TenantSelectorComponent,
+    ExternalIdentifierComponent
   ],
   exports: [
     FileUploadComponent,
@@ -76,7 +80,8 @@ import { TranslateModule } from '@ngx-translate/core';
     FormsModule,
     ReactiveFormsModule,
     TranslateModule,
-    TenantSelectorComponent
+    TenantSelectorComponent,
+    ExternalIdentifierComponent
   ]
 })
 export class SharedModule { }

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-locked/loan-locked.component.scss
@@ -24,28 +24,6 @@
   }
 }
 
-.alert {
-  background-color: #E8F4FD;
-  padding: 6px 16px;
-  font-size: 0.875rem;
-  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
-  font-weight: 400;
-  line-height: 1.43;
-  border-radius: 4px;
-  letter-spacing: 0.01071em;
-  margin: 10px;
-
-  .message {
-    padding: 8px 0;
-    font-size: 18px;
-  }
-  .alert-check {
-    color:#359FF4;
-    margin-right: 2px;
-    font-size: 1.4rem;
-  }
-}
-
 .error-log {
   color: #ffa726;
 }

--- a/src/assets/styles/_misc.scss
+++ b/src/assets/styles/_misc.scss
@@ -22,3 +22,27 @@ div {
 .nolist {
   list-style: none;
 }
+
+
+.alert {
+  background-color: #E8F4FD;
+  padding: 6px 16px;
+  font-size: 0.875rem;
+  font-family: "Roboto", "Helvetica", "Arial", sans-serif;
+  font-weight: 400;
+  line-height: 1.43;
+  border-radius: 4px;
+  letter-spacing: 0.01071em;
+  margin: 10px;
+
+  .message {
+    padding: 8px 0;
+    font-size: 18px;
+  }
+  .alert-check {
+    color:#359FF4;
+    margin-right: 2px;
+    font-size: 1.4rem;
+  }
+}
+


### PR DESCRIPTION
## Description

In the client creation, we'll have the next scenarios for `externalId`:

- If the `externalId` value is added by the user this value will be used,
- If the `externalId` was not added by the user and the config to auto generate external Id (as UUID) is enabled, then we'll create this value as part of the client creation process, and as part of the response we'll have a new attribute for `resourceExternalId`

<img width="1204" alt="Screenshot 2022-11-30 at 22 56 40" src="https://user-images.githubusercontent.com/44206706/204971007-a9ef8fa6-f346-4f02-a229-30ffa14effbb.png">

- Long External Id value with an eye icon to display the full value
<img width="1301" alt="Screenshot 2022-12-01 at 22 36 27" src="https://user-images.githubusercontent.com/44206706/205217272-402d01c2-0ae6-48ea-9513-e3273f457ba9.png">

- In the client view to show the full value If it's the case
<img width="1305" alt="Screenshot 2022-12-01 at 22 19 24" src="https://user-images.githubusercontent.com/44206706/205217360-4793af6d-05e9-4c53-bbf2-451f13647d2a.png">


## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
