### PR TITLE
Display Loan charge Pay button using chargePayable attribute

### DIFF
--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.html
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.html
@@ -63,7 +63,7 @@
               <i class="fa fa-trash"></i>
             </button>
           </span>
-            <button class="account-action-button" mat-raised-button color="primary" matTooltip="Pay Charge" *ngIf="charge.chargePayable && status=='Active'"
+            <button class="account-action-button" mat-raised-button color="primary" matTooltip="Pay Charge" *ngIf="charge.chargePayable && status === 'Active'"
                (click)="routeEdit($event); payCharge(charge.id)">
               <i class="fa fa-dollar"></i>
             </button>

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
@@ -66,7 +66,7 @@ export class ChargesTabComponent implements OnInit {
     this.status = this.loanDetails.status.value;
     let actionFlag;
     this.chargesData.forEach((element: any) => {
-      if (element.paid || element.waived || element.chargeTimeType.value === 'Disbursement' || this.loanDetails.status.value !== 'Active') {
+      if (element.paid || element.waived || element.chargeTimeType.value === 'Disbursement' || this.status.value !== 'Active') {
         actionFlag = true;
       } else {
         actionFlag = false;

--- a/src/app/loans/loans-view/loans-view.component.ts
+++ b/src/app/loans/loans-view/loans-view.component.ts
@@ -54,7 +54,7 @@ export class LoansViewComponent implements OnInit {
     this.recalculateInterest = this.loanDetailsData.recalculateInterest || true;
     this.status = this.loanDetailsData.status.value;
     if (this.loanDetailsData.status.active && this.loanDetailsData.multiDisburseLoan) {
-      if (this.loanDetailsData) {
+      if (this.loanDetailsData && this.loanDetailsData.transactions) {
         this.loanDetailsData.transactions.forEach((transaction: any) => {
           if (transaction.type.disbursement) {
             this.disburseTransactionNo++;

--- a/src/app/loans/loans-view/view-charge/view-charge.component.ts
+++ b/src/app/loans/loans-view/view-charge/view-charge.component.ts
@@ -32,7 +32,7 @@ export class ViewChargeComponent {
   chargeData: any;
   /** Loans Account Data */
   loansAccountData: any;
-  allowPayCharge = true;
+  allowPayCharge = false;
   allowWaive = true;
 
   /**
@@ -52,7 +52,7 @@ export class ViewChargeComponent {
               private settingsService: SettingsService) {
     this.route.data.subscribe((data: { loansAccountCharge: any, loanDetailsData: any }) => {
       this.chargeData = data.loansAccountCharge;
-      this.allowPayCharge = (this.chargeData.chargeTimeType.code === 'chargeTimeType.instalmentFee');
+      this.allowPayCharge = this.chargeData.chargePayable;
       this.allowWaive = !this.chargeData.chargeTimeType.waived;
       this.loansAccountData = data.loanDetailsData;
     });


### PR DESCRIPTION
## Description

Currently the only way to pay a Loan charge are:
1. Loan repayment process using the repayment strategy, and
2. Savings account transfer funds that works as Loan repayment too

So, we'll display the Pay action button only when the charge is payable

## Screenshots, if any
<img width="1255" alt="Screenshot 2023-01-03 at 6 43 51" src="https://user-images.githubusercontent.com/44206706/210360151-132c611c-33d3-4796-b001-c033391d1c9c.png">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
