### PR TITLE
fix : pop over issue in home screen tour

### DIFF
--- a/src/app/core/shell/sidenav/sidenav.component.html
+++ b/src/app/core/shell/sidenav/sidenav.component.html
@@ -165,7 +165,7 @@
   <div fxLayout="row" fxLayoutAlign="end" fxLayoutGap="2%" fxLayout.lt-md="column">
     <button mat-raised-button color="warn" (click)="popover.close();configurationWizardService.closeConfigWizard()">Close</button>
     <button mat-raised-button color="primary" (click)="popover.close();showPopover(templateDashboard,dashboard,'bottom', true);">Back</button>
-    <button mat-raised-button color="primary" (click)="popover.close();showPopover(templateFrequentPostings,frequentPostings,'bottom', true);">Next</button>
+    <button mat-raised-button color="primary" (click)="popover.close();showPopover(templateFrequentPostings,frequentPostings,'top', true);">Next</button>
   </div>
 </ng-template>
 
@@ -184,7 +184,7 @@
   <p class="mw300">Shortcut to the create journal entry screen.</p>
   <div fxLayout="row" fxLayoutAlign="end" fxLayoutGap="2%" fxLayout.lt-md="column">
     <button mat-raised-button color="warn" (click)="popover.close();configurationWizardService.closeConfigWizard()">Close</button>
-    <button mat-raised-button color="primary" (click)="popover.close();showPopover(templateFrequentPostings,frequentPostings,'bottom', true);">Back</button>
+    <button mat-raised-button color="primary" (click)="popover.close();showPopover(templateFrequentPostings,frequentPostings,'top', true);">Back</button>
     <button mat-raised-button color="primary" (click)="popover.close();showPopover(templateChartOfAccounts,chartOfAccounts,'top', true);">Next</button>
   </div>
 </ng-template>


### PR DESCRIPTION
## Description
The pop over of frequent postings was not visible in Google Chrome browser in Mac Os Ventura, it was coming below the screen and we couldn't able to complete the home screen tour, we had to reload the page . So, I fixed that bug and now it's working fine.

## Related issues and discussion
#1609

## Screenshots, if any
<img width="1440" alt="Screenshot 2023-01-10 at 10 08 17 AM" src="https://user-images.githubusercontent.com/76156941/211463802-91e5a28e-50c0-425d-aeaf-5f9e519fed28.png">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
