### PR TITLE
Enable extra fields for Global Configurations

### DIFF
--- a/src/app/accounting/view-transaction/view-transaction.component.html
+++ b/src/app/accounting/view-transaction/view-transaction.component.html
@@ -81,12 +81,12 @@
 
     <ng-container matColumnDef="debit">
       <th mat-header-cell class="center" *matHeaderCellDef mat-sort-header> Debit </th>
-      <td mat-cell class="r-amount" *matCellDef="let transaction"><span *ngIf="transaction.entryType.value === 'DEBIT'"> {{ (transaction.currency.displaySymbol || transaction.currency.code) }} {{ transaction.amount | number }} </span></td>
+      <td mat-cell *matCellDef="let transaction"><span *ngIf="transaction.entryType.value === 'DEBIT'"> {{ (transaction.currency.displaySymbol || transaction.currency.code) }} {{ transaction.amount | number }} </span></td>
     </ng-container>
 
     <ng-container matColumnDef="credit">
       <th mat-header-cell class="center" *matHeaderCellDef mat-sort-header> Credit </th>
-      <td mat-cell class="r-amount" *matCellDef="let transaction"><span *ngIf="transaction.entryType.value === 'CREDIT'"> {{ (transaction.currency.displaySymbol || transaction.currency.code) }} {{ transaction.amount | number }} </span></td>
+      <td mat-cell *matCellDef="let transaction"><span *ngIf="transaction.entryType.value === 'CREDIT'"> {{ (transaction.currency.displaySymbol || transaction.currency.code) }} {{ transaction.amount | number }} </span></td>
     </ng-container>
 
     <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.html
+++ b/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.html
@@ -14,11 +14,25 @@
           </mat-form-field>
 
           <mat-form-field>
-            <mat-label>Configuration Value</mat-label>
-            <input matInput required type="number" formControlName="value">
-            <mat-error *ngIf="configurationForm.controls.value.hasError('required')">
-              Configuration Value is <strong>required</strong>
-            </mat-error>
+            <mat-label>Description</mat-label>
+            <textarea matInput formControlName="description" cdkTextareaAutosize cdkAutosizeMinRows="2"></textarea>
+          </mat-form-field>
+
+          <mat-form-field>
+            <mat-label>Number Value</mat-label>
+            <input matInput type="number" formControlName="value">
+          </mat-form-field>
+
+          <mat-form-field>
+            <mat-label>String Value</mat-label>
+            <input matInput formControlName="stringValue">
+          </mat-form-field>
+
+          <mat-form-field fxFlex="48%" (click)="configurationDatePicker.open()">
+            <mat-label>Date Value</mat-label>
+            <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="configurationDatePicker" formControlName="dateValue">
+            <mat-datepicker-toggle matSuffix [for]="configurationDatePicker"></mat-datepicker-toggle>
+            <mat-datepicker #configurationDatePicker></mat-datepicker>
           </mat-form-field>
 
         </div>

--- a/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.html
+++ b/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.html
@@ -35,6 +35,16 @@
         <td mat-cell *matCellDef="let configuration"> {{ configuration.value }}</td>
       </ng-container>
 
+      <ng-container matColumnDef="stringValue">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header> String Value </th>
+        <td mat-cell *matCellDef="let configuration"> {{ configuration.stringValue }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="dateValue">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header> Date Value </th>
+        <td mat-cell *matCellDef="let configuration"> {{ configuration.dateValue | dateFormat }}</td>
+      </ng-container>
+
       <ng-container matColumnDef="edit">
         <th mat-header-cell *matHeaderCellDef> Edit </th>
         <td mat-cell *matCellDef="let configuration">

--- a/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.ts
+++ b/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.ts
@@ -22,7 +22,7 @@ export class GlobalConfigurationsTabComponent implements OnInit, AfterViewInit {
   /** Configuration data. */
   configurationData: any;
   /** Columns to be displayed in configurations table. */
-  displayedColumns: string[] = ['name', 'enabled', 'value', 'edit'];
+  displayedColumns: string[] = ['name', 'enabled', 'value', 'stringValue', 'dateValue', 'edit'];
   /** Data source for configurations table. */
   dataSource: MatTableDataSource<any>;
 

--- a/src/app/system/manage-jobs/cob-workflow/cob-workflow.component.ts
+++ b/src/app/system/manage-jobs/cob-workflow/cob-workflow.component.ts
@@ -8,7 +8,7 @@ import { SystemService } from 'app/system/system.service';
 })
 export class CobWorkflowComponent implements OnInit, OnDestroy {
 
-  waitTime: number = 30000;
+  waitTime = 30000;
 
   isCatchUpRunning = false;
   /** Timer to refetch COB Catch-Up status every 5 seconds */
@@ -27,6 +27,9 @@ export class CobWorkflowComponent implements OnInit, OnDestroy {
   getCOBCatchUpStatus(): void {
     this.systemService.getCOBCatchUpStatus().subscribe((response: any) => {
       this.isCatchUpRunning = response.isCatchUpRunning;
+      if (!this.isCatchUpRunning) {
+        this.waitTime = 30000;
+      }
     });
     this.timer = setTimeout(() => { this.getCOBCatchUpStatus(); }, this.waitTime);
   }


### PR DESCRIPTION
## Description

Enable extra fields for Global Configuration like String and/or Date values

## Screenshots, if any
- View Global Configurations
<img width="1357" alt="Screenshot 2023-02-28 at 16 03 48" src="https://user-images.githubusercontent.com/44206706/221994522-d16c06c0-a381-44ca-a0cc-9f20ccd85b54.png">

- Edit Global Configuration
<img width="1055" alt="Screenshot 2023-02-28 at 16 03 26" src="https://user-images.githubusercontent.com/44206706/221994565-f7cc9edc-59e6-4c81-b8ff-b59dab8d619b.png">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
