### PR TITLE
Display Loan Arrears and Delinquency information using the global con…

### DIFF
--- a/src/app/loans/common-resolvers/loan-arrear-delinquency.resolver.spec.ts
+++ b/src/app/loans/common-resolvers/loan-arrear-delinquency.resolver.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LoanArrearDelinquencyResolver } from './loan-arrear-delinquency.resolver';
+
+describe('LoanArrearDelinquencyResolver', () => {
+  let resolver: LoanArrearDelinquencyResolver;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    resolver = TestBed.inject(LoanArrearDelinquencyResolver);
+  });
+
+  it('should be created', () => {
+    expect(resolver).toBeTruthy();
+  });
+});

--- a/src/app/loans/common-resolvers/loan-arrear-delinquency.resolver.ts
+++ b/src/app/loans/common-resolvers/loan-arrear-delinquency.resolver.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { Resolve, ActivatedRouteSnapshot } from '@angular/router';
+import { SystemService } from 'app/system/system.service';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoanArrearDelinquencyResolver implements Resolve<boolean> {
+
+    /**
+     * @param {SystemService} systemService System service.
+     */
+    constructor(private systemService: SystemService) { }
+
+    /**
+     * Returns the loan-arrears-delinquency-display-data configuration data.
+     * @returns {Observable<any>}
+     */
+    resolve(route: ActivatedRouteSnapshot): Observable<any> {
+      return this.systemService.getConfigurationByName('loan-arrears-delinquency-display-data');
+    }
+}

--- a/src/app/loans/loans-routing.module.ts
+++ b/src/app/loans/loans-routing.module.ts
@@ -56,6 +56,7 @@ import { LoanDelinquencyTagsTabComponent } from './loans-view/loan-delinquency-t
 import { LoanReschedulesResolver } from './common-resolvers/loan-reschedules.resolver';
 import { RescheduleLoanTabComponent } from './loans-view/reschedule-loan-tab/reschedule-loan-tab.component';
 import { AdjustLoanChargeComponent } from './loans-view/loan-account-actions/adjust-loan-charge/adjust-loan-charge.component';
+import { LoanArrearDelinquencyResolver } from './common-resolvers/loan-arrear-delinquency.resolver';
 
 /** Loans Route. */
 const routes: Routes = [
@@ -77,7 +78,8 @@ const routes: Routes = [
         component: LoansViewComponent,
         resolve: {
           loanDetailsData: LoanDetailsResolver,
-          loanDatatables: LoanDatatablesResolver
+          loanDatatables: LoanDatatablesResolver,
+          loanArrearsDelinquencyConfig: LoanArrearDelinquencyResolver
         },
         children: [
           {

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -26,32 +26,36 @@
                 {{entityType}} Name: {{loanDetailsData.clientName ||
                 loanDetailsData.groupName}}<span class="m-l-10">({{loanDetailsData.clientAccountNo}})</span><br />
               </span>
-              <span class="loans-overview" *ngIf="loanDetailsData.delinquencyRange">
-                Loan Account Classification : {{loanDetailsData?.delinquencyRange.classification}}<br />
-              </span>
-              <span class="loans-overview"
-                *ngIf="loanDetailsData.delinquent && loanDetailsData.delinquent.pastDueDays > 0">
-                Past Due Days : {{loanDetailsData?.delinquent.pastDueDays | formatNumber}}<br />
-              </span>
-              <span class="loans-overview" *ngIf="loanDetailsData.delinquent && loanDetailsData.delinquent.delinquentDays > 0
-                && loanDetailsData.delinquent.pastDueDays != loanDetailsData.delinquent.delinquentDays">
-                Delinquent Days : {{loanDetailsData?.delinquent.delinquentDays | formatNumber}}
-              </span>
+              <div *ngIf="loanDisplayArrearsDelinquency != 1">
+                <span class="loans-overview" *ngIf="loanDetailsData.delinquencyRange">
+                  Loan Account Classification : {{loanDetailsData?.delinquencyRange.classification}}<br />
+                </span>
+                <span class="loans-overview"
+                  *ngIf="loanDetailsData.delinquent && loanDetailsData.delinquent.pastDueDays > 0">
+                  Past Due Days : {{loanDetailsData?.delinquent.pastDueDays | formatNumber}}<br />
+                </span>
+                <span class="loans-overview" *ngIf="loanDetailsData.delinquent && loanDetailsData.delinquent.delinquentDays > 0
+                  && loanDetailsData.delinquent.pastDueDays != loanDetailsData.delinquent.delinquentDays">
+                  Delinquent Days : {{loanDetailsData?.delinquent.delinquentDays | formatNumber}}
+                </span>
+              </div>
             </div>
 
             <div *ngIf="loanDetailsData.summary" class="loans-overview mat-typography" fxFlex="40%">
               <h3> Loan Account OverView </h3>
               <span>Current Balance: {{loanDetailsData.currency.displaySymbol}}
                 {{loanDetailsData.summary.totalOutstanding | formatNumber}}</span><br>
-              <span *ngIf="loanDetailsData.inArrears">Arrears By: {{loanDetailsData.summary.totalOverdue | formatNumber}}
+              <div *ngIf="loanDisplayArrearsDelinquency < 2">
+                <span *ngIf="loanDetailsData.inArrears">Arrears By: {{loanDetailsData.summary.totalOverdue | formatNumber}}
                 <span *ngIf="!(loanDetailsData.summary.totalOverdue>=0)">Not Provided</span>
-              </span><br>
-              <span *ngIf="loanDetailsData.inArrears">Arrears Since: {{loanDetailsData.summary.overdueSinceDate |
-                dateFormat}}
-              </span>
-              <span *ngIf="loanDetailsData.totalOverpaid && loanDetailsData.totalOverpaid > 0">
-                Overpaid By: {{loanDetailsData.currency.displaySymbol}} {{loanDetailsData.totalOverpaid | formatNumber}}
-              </span>
+                </span><br>
+                <span *ngIf="loanDetailsData.inArrears">Arrears Since: {{loanDetailsData.summary.overdueSinceDate |
+                  dateFormat}}
+                </span>
+                <span *ngIf="loanDetailsData.totalOverpaid && loanDetailsData.totalOverpaid > 0">
+                  Overpaid By: {{loanDetailsData.currency.displaySymbol}} {{loanDetailsData.totalOverpaid | formatNumber}}
+                </span>
+              </div>
             </div>
 
             <span fxFlex="auto"></span>

--- a/src/app/loans/loans-view/loans-view.component.ts
+++ b/src/app/loans/loans-view/loans-view.component.ts
@@ -27,6 +27,8 @@ export class LoansViewComponent implements OnInit {
   loanDatatables: any;
   /** Recalculate Interest */
   recalculateInterest: any;
+  /** loan Arrears Delinquency config value */
+  loanDisplayArrearsDelinquency: number;
   /** Status */
   status: string;
   entityType: string;
@@ -45,9 +47,10 @@ export class LoansViewComponent implements OnInit {
               private router: Router,
               public loansService: LoansService,
               public dialog: MatDialog) {
-    this.route.data.subscribe((data: { loanDetailsData: any, loanDatatables: any}) => {
+    this.route.data.subscribe((data: { loanDetailsData: any, loanDatatables: any, loanArrearsDelinquencyConfig: any}) => {
       this.loanDetailsData = data.loanDetailsData;
       this.loanDatatables = data.loanDatatables;
+      this.loanDisplayArrearsDelinquency = data.loanArrearsDelinquencyConfig.value || 0;
       this.loanStatus = this.loanDetailsData.status;
     });
     this.loanId = this.route.snapshot.params['loanId'];

--- a/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.ts
+++ b/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.ts
@@ -75,6 +75,9 @@ export class EditConfigurationComponent implements OnInit {
       const payload = {
         ...this.configurationForm.value
       };
+      if (!this.configurationForm.value.stringValue) {
+        delete payload.stringValue;
+      }
       if (this.configurationForm.value.dateValue != null) {
         payload.locale = this.settingsService.language.code;
         payload.dateFormat = this.settingsService.dateFormat;


### PR DESCRIPTION
…figuration

## Description

We will be able to configure the display of overdue calculation based on the old logic and new logic. in order to have an accurate overdue display and calculation for the organization as per their business needs

## Related issues and discussion
#{Issue Number}

## Screenshots, if any
**- Global Configuration**
<img width="1022" alt="Screenshot 2023-03-13 at 22 52 42" src="https://user-images.githubusercontent.com/44206706/225010872-4130af31-fa42-405a-8bd0-934d6bdd11bd.png">

**- Value 0 (zero) Both / Default**
<img width="1373" alt="Screenshot 2023-03-13 at 22 45 30" src="https://user-images.githubusercontent.com/44206706/225010968-2853a3c8-bdca-416c-aab0-fefe9f46fd1f.png">

**- Value 1 Just Arrears**
<img width="1374" alt="Screenshot 2023-03-13 at 22 52 17" src="https://user-images.githubusercontent.com/44206706/225011053-70dd3671-16ff-4249-8293-bd8d463b7661.png">

**- Value 2 Just Delinquency**
<img width="1370" alt="Screenshot 2023-03-13 at 22 54 25" src="https://user-images.githubusercontent.com/44206706/225011185-eea9bcb2-4609-46e3-ab18-02507fc38a76.png">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
