### PR TITLE
refactor: account info in Chart of Accounts tree view

### DIFF
--- a/src/app/accounting/chart-of-accounts/chart-of-accounts.component.html
+++ b/src/app/accounting/chart-of-accounts/chart-of-accounts.component.html
@@ -95,6 +95,41 @@
   </div>
 
   <div fxLayout="row" fxLayoutGap="4%" fxLayout.lt-md="column">
+    
+    <div class="mat-elevation-z8" fxFlex>
+
+      <mat-tree [dataSource]="nestedTreeDataSource" [treeControl]="nestedTreeControl" class="gl-account-tree">
+
+        <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
+          <li class="mat-tree-node">
+            <button mat-icon-button disabled></button>
+            <span (click)="viewGLAccountNode(node)">
+              <span *ngIf="node.glCode">{{ '(' + node.glCode + ')' }}</span>&nbsp;&nbsp;
+              {{ node.name }}
+            </span>
+          </li>
+        </mat-tree-node>
+
+        <mat-nested-tree-node *matTreeNodeDef="let node; when: hasNestedChild">
+          <li>
+            <div class="mat-tree-node">
+              <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.name">
+                <fa-icon class="mat-icon-rtl-mirror" icon="{{ nestedTreeControl.isExpanded(node) ? 'chevron-down' : 'chevron-right' }}"></fa-icon>
+              </button>
+              <span (click)="viewGLAccountNode(node)">
+                <span *ngIf="node.glCode">{{ '(' + node.glCode + ')' }}</span>&nbsp;&nbsp;
+                {{ node.name }}
+              </span>
+            </div>
+            <ul [class.gl-account-tree-invisible]="!nestedTreeControl.isExpanded(node)">
+              <ng-container matTreeNodeOutlet></ng-container>
+            </ul>
+          </li>
+        </mat-nested-tree-node>
+
+      </mat-tree>
+
+    </div>
 
     <div fxFlex="48%" *ngIf="glAccount">
 
@@ -157,41 +192,6 @@
         </mat-card-content>
 
       </mat-card>
-
-    </div>
-
-    <div class="mat-elevation-z8" fxFlex>
-
-      <mat-tree [dataSource]="nestedTreeDataSource" [treeControl]="nestedTreeControl" class="gl-account-tree">
-
-        <mat-tree-node *matTreeNodeDef="let node" matTreeNodeToggle>
-          <li class="mat-tree-node">
-            <button mat-icon-button disabled></button>
-            <span (click)="viewGLAccountNode(node)">
-              <span *ngIf="node.glCode">{{ '(' + node.glCode + ')' }}</span>&nbsp;&nbsp;
-              {{ node.name }}
-            </span>
-          </li>
-        </mat-tree-node>
-
-        <mat-nested-tree-node *matTreeNodeDef="let node; when: hasNestedChild">
-          <li>
-            <div class="mat-tree-node">
-              <button mat-icon-button matTreeNodeToggle [attr.aria-label]="'toggle ' + node.name">
-                <fa-icon class="mat-icon-rtl-mirror" icon="{{ nestedTreeControl.isExpanded(node) ? 'chevron-down' : 'chevron-right' }}"></fa-icon>
-              </button>
-              <span (click)="viewGLAccountNode(node)">
-                <span *ngIf="node.glCode">{{ '(' + node.glCode + ')' }}</span>&nbsp;&nbsp;
-                {{ node.name }}
-              </span>
-            </div>
-            <ul [class.gl-account-tree-invisible]="!nestedTreeControl.isExpanded(node)">
-              <ng-container matTreeNodeOutlet></ng-container>
-            </ul>
-          </li>
-        </mat-nested-tree-node>
-
-      </mat-tree>
 
     </div>
 


### PR DESCRIPTION
## Description
now the account info in chart of accounts appears on the right side instead of left side

## Related issues and discussion
#1714 

## Screenshots, if any

https://user-images.githubusercontent.com/76156941/226539540-0329aaf7-6416-4c84-9dc9-6ba2a85d896e.mov


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
