### PR TITLE
fix: edit charge - tax group is mandatory by backend, but cannot be set on UI

### DIFF
--- a/src/app/products/charges/edit-charge/edit-charge.component.html
+++ b/src/app/products/charges/edit-charge/edit-charge.component.html
@@ -101,15 +101,15 @@
 
           <mat-form-field fxFlex="48%">
             <mat-label>Tax Group</mat-label>
-            <mat-select *ngIf="chargeData.taxGroup" required formControlName="taxGroupId">
+            <mat-select *ngIf="chargeData.taxGroup" formControlName="taxGroupId">
               <mat-option *ngFor="let taxGroup of chargeData.taxGroupOptions" [value]="taxGroup.id">
                 {{ taxGroup.name }}
               </mat-option>
             </mat-select>
 
-            <mat-select *ngIf="!chargeData.taxGroup" required formControlName="taxGroupId">
-              <mat-option value="?">
-                Select Option
+            <mat-select *ngIf="!chargeData.taxGroup" formControlName="taxGroupId">
+              <mat-option *ngFor="let taxGroup of chargeData.taxGroupOptions" [value]="taxGroup.id">
+                {{ taxGroup.name }}
               </mat-option>
             </mat-select>
           </mat-form-field>

--- a/src/app/products/charges/edit-charge/edit-charge.component.ts
+++ b/src/app/products/charges/edit-charge/edit-charge.component.ts
@@ -125,7 +125,7 @@ export class EditChargeComponent implements OnInit {
     if (this.chargeData.taxGroup) {
       this.chargeForm.addControl('taxGroupId', this.formBuilder.control({ value: this.chargeData.taxGroup.id }, Validators.required));
     } else {
-      this.chargeForm.addControl('taxGroupId', this.formBuilder.control({ value: '' }));
+      delete this.chargeData.taxGroupId;
     }
   }
 


### PR DESCRIPTION
## Description
- selecting tax group when creating a charge is not mandatory
- selecting tax group when modify a charge is not mandatory
- if we selected a tax group for a charge while creating, it cannot be modified anymore
- if tax group is not selected the UI should not send taxGroupId in the request with empty string while editing(now it is solved)
## Related issues and discussion
#1722 

## Screenshots, if any

https://user-images.githubusercontent.com/76156941/228528297-ebeed79c-5e1d-4129-8f66-f0de49961b89.mov


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
