### PR TITLE
fix: edit charge - tax group is mandatory by backend, but cannot be set on UI

### DIFF
--- a/src/app/products/charges/edit-charge/edit-charge.component.ts
+++ b/src/app/products/charges/edit-charge/edit-charge.component.ts
@@ -123,9 +123,9 @@ export class EditChargeComponent implements OnInit {
       }
     }
     if (this.chargeData.taxGroup) {
-      this.chargeForm.addControl('taxGroupId', this.formBuilder.control({ value: this.chargeData.taxGroup.id }, Validators.required));
+      this.chargeForm.addControl('taxGroupId', this.formBuilder.control({ value: this.chargeData.taxGroup.id, disabled: true }));
     } else {
-      delete this.chargeData.taxGroupId;
+      this.chargeForm.addControl('taxGroupId', this.formBuilder.control({ value: '' }));
     }
   }
 
@@ -150,6 +150,9 @@ export class EditChargeComponent implements OnInit {
     const charges = this.chargeForm.getRawValue();
     charges.locale = this.settingsService.language.code;
     charges.chargePaymentMode = this.chargeData.chargePaymentMode.id;
+    if(charges.taxGroupId.value===''){
+      delete charges.taxGroupId;
+    }
     this.productsService.updateCharge(this.chargeData.id.toString(), charges)
       .subscribe((response: any) => {
         this.router.navigate(['../'], { relativeTo: this.route });


### PR DESCRIPTION
## Description
now no empty tax-group request is sent to backend from edit charge and when empty tax-group charge is filled with some tax-group ,it is sending back the request to backend

## Related issues and discussion
#1722 

## Screenshots, if any

https://user-images.githubusercontent.com/76156941/228804014-c7b22576-6571-441b-9eaa-8500a149ff87.mov


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
