### PR TITLE
Fix to input datatable datetime fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@angular-devkit/schematics": "^14.0.4",
-        "@angular-material-components/datetime-picker": "^7.0.1",
+        "@angular-material-components/datetime-picker": "^7.0.0",
         "@angular/animations": "^13.3.12",
         "@angular/cdk": "13.3.9",
         "@angular/common": "13.3.12",
@@ -24,20 +24,15 @@
         "@angular/platform-browser": "13.3.12",
         "@angular/platform-browser-dynamic": "13.3.12",
         "@angular/router": "13.3.12",
-        "@angular/service-worker": "13.3.12",
         "@ckeditor/ckeditor5-angular": "1.2.3",
         "@ckeditor/ckeditor5-build-classic": "21.0.0",
         "@fortawesome/angular-fontawesome": "^0.10.2",
-        "@fortawesome/fontawesome-svg-core": "^1.2.32",
         "@fortawesome/free-solid-svg-icons": "5.8.2",
         "@ngx-translate/core": "13.0.0",
         "@ngx-translate/http-loader": "^6.0.0",
         "@swimlane/ngx-graph": "^8.0.2",
         "chart.js": "3.0.0-alpha",
-        "core-js": "2.5.0",
         "d3": "^7.6.1",
-        "dagre": "^0.8.5",
-        "font-awesome": "^4.7.0",
         "install": "^0.13.0",
         "lodash": "4.17.21",
         "moment": "^2.29.4",
@@ -488,9 +483,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@angular-material-components/datetime-picker": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-material-components/datetime-picker/-/datetime-picker-7.0.1.tgz",
-      "integrity": "sha512-ukNFdmab++bPF35+56SXFkzWz7F2If3s/rRae37Yq3g7QWWh3kmS7KEbvtSIz000yj3/wGHDV1v9ChGiqsNsgA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-material-components/datetime-picker/-/datetime-picker-7.0.0.tgz",
+      "integrity": "sha512-2Egsr2q+z5PW9CHuvwEu7wTQzvGoqJ8Z+VhvNpCtO82lz7Z5oW6/+Zgg2Fude8Zy9AWB6Rv2hVZkdnUFLVoC0Q==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -965,6 +960,9 @@
       "version": "13.3.12",
       "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-13.3.12.tgz",
       "integrity": "sha512-kZAoUkcTgw37eAyxE6y/XFxzn/94hD1oIT7LQtwe7eDxN/loMeVF7eTPCy2y8u662CMDe9FJ3rIMTasinNyIHA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -3104,6 +3102,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
       "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
       },
@@ -6267,12 +6266,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/core-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha512-mAPLSnIVZAwVEf8OZtnNcF2BL1d6DHV3EvIWj46UDBYNAqLxx7mLLpQxe8/1vtrkzt1KIyjmOqOG3pa+bZf7Fw==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js."
     },
     "node_modules/core-js-compat": {
       "version": "3.26.1",
@@ -9496,6 +9489,7 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
       "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.3"
       }
@@ -21473,9 +21467,9 @@
       }
     },
     "@angular-material-components/datetime-picker": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-material-components/datetime-picker/-/datetime-picker-7.0.1.tgz",
-      "integrity": "sha512-ukNFdmab++bPF35+56SXFkzWz7F2If3s/rRae37Yq3g7QWWh3kmS7KEbvtSIz000yj3/wGHDV1v9ChGiqsNsgA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-material-components/datetime-picker/-/datetime-picker-7.0.0.tgz",
+      "integrity": "sha512-2Egsr2q+z5PW9CHuvwEu7wTQzvGoqJ8Z+VhvNpCtO82lz7Z5oW6/+Zgg2Fude8Zy9AWB6Rv2hVZkdnUFLVoC0Q==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -21781,6 +21775,9 @@
       "version": "13.3.12",
       "resolved": "https://registry.npmjs.org/@angular/service-worker/-/service-worker-13.3.12.tgz",
       "integrity": "sha512-kZAoUkcTgw37eAyxE6y/XFxzn/94hD1oIT7LQtwe7eDxN/loMeVF7eTPCy2y8u662CMDe9FJ3rIMTasinNyIHA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -23311,6 +23308,7 @@
       "version": "1.2.36",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
       "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "peer": true,
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
       }
@@ -25846,11 +25844,6 @@
         }
       }
     },
-    "core-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha512-mAPLSnIVZAwVEf8OZtnNcF2BL1d6DHV3EvIWj46UDBYNAqLxx7mLLpQxe8/1vtrkzt1KIyjmOqOG3pa+bZf7Fw=="
-    },
     "core-js-compat": {
       "version": "3.26.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.26.1.tgz",
@@ -28317,7 +28310,8 @@
     "font-awesome": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg=="
+      "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@angular-devkit/schematics": "^14.0.4",
+    "@angular-material-components/datetime-picker": "^7.0.0",
     "@angular/animations": "^13.3.12",
     "@angular/cdk": "13.3.9",
     "@angular/common": "13.3.12",

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -36,6 +36,7 @@ import { EntityDatatableTabComponent } from './tabs/entity-datatable-tab/entity-
 import { DatatableSingleRowComponent } from './tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component';
 import { DatatableMultiRowComponent } from './tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component';
 import { SvgIconComponent } from './svg-icon/svg-icon.component';
+import { NgxMatDatetimePickerModule, NgxMatNativeDateModule } from '@angular-material-components/datetime-picker';
 
 /**
  * Shared Module
@@ -50,7 +51,9 @@ import { SvgIconComponent } from './svg-icon/svg-icon.component';
     ReactiveFormsModule,
     TranslateModule.forRoot(),
     PipesModule,
-    DirectivesModule
+    DirectivesModule,
+    NgxMatDatetimePickerModule,
+    NgxMatNativeDateModule
   ],
   declarations: [
     FormfieldComponent,


### PR DESCRIPTION
## Description

There was an issue when the `datatable` has `datetime` fileds we were not able to input the date and time value because the datetime picker control was not working

Datetime picker input control displayed 
<img width="1382" alt="Screenshot 2023-05-15 at 11 36 42" src="https://github.com/openMF/web-app/assets/44206706/b62ba62d-da6c-407f-ae2f-c8c9f7abb51c">

Datetime value added 
<img width="1333" alt="Screenshot 2023-05-15 at 11 36 56" src="https://github.com/openMF/web-app/assets/44206706/c01fa728-1c33-45a8-8603-7dad810e6ff2">


## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
