### PR TITLE
Fix Loan lock COB pagination

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
@@ -23,7 +23,7 @@ import * as _ from 'lodash';
 })
 export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges {
 
-  SELECT_NAME_FIELD:string = 'select';
+  SELECT_NAME_FIELD = 'select';
   /** Data Object */
   @Input() dataObject: any;
   @Input() entityId: string;
@@ -163,7 +163,9 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
         this.selection.selected.forEach((data) => {
           this.systemService.deleteDatatableEntry(this.entityId, data.row[1], this.datatableName).subscribe(() => {
             this.datatableData.forEach((item: any, index: any) => {
-              if (item.row[1] === data.row[1]) delete this.datatableData[index]
+              if (item.row[1] === data.row[1]) {
+                delete this.datatableData[index];
+              }
             });
           });
         });
@@ -192,7 +194,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
   /** Whether the number of selected elements matches the total number of rows. */
   isAllSelected() {
     const numSelected = this.selection.selected;
-    return (this.datatableData.length == numSelected);
+    return (this.datatableData.length === numSelected);
   }
 
   isAnySelected() {

--- a/src/app/system/manage-jobs/cob-workflow/loan-locked/loan-locked.component.html
+++ b/src/app/system/manage-jobs/cob-workflow/loan-locked/loan-locked.component.html
@@ -65,8 +65,8 @@
     </tr>
   </table>
 
-  <mat-paginator [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons [pageSize]="pageSize"
-    [pageIndex]="currentPage" (page)="pageEvent = handlePage($event)">
+  <mat-paginator [hidden]="!showPaginator" [pageSizeOptions]="[100, 500, 1000, 5000]" [pageSize]="pageSize"
+    [pageIndex]="currentPage" showFirstLastButtons (page)="changePaging($event)">
   </mat-paginator>
 
 </div>

--- a/src/app/system/manage-jobs/cob-workflow/loan-locked/loan-locked.component.ts
+++ b/src/app/system/manage-jobs/cob-workflow/loan-locked/loan-locked.component.ts
@@ -26,14 +26,22 @@ export class LoanLockedComponent implements OnInit {
   selection: SelectionModel<any>;
   /** Displayed Columns for loan disbursal data */
   displayedColumns: string[] = ['select', 'loanId', 'lockPlacedOn', 'lockOwner', 'error', 'details'];
+
   /** Paginator for the table */
-  @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
+  @ViewChild(MatPaginator, {static: false})
+  set paginator(value: MatPaginator) {
+    this.dataSource.paginator = value;
+  }
+
   currentPage = 0;
-  pageSize = 10;
+  itemsToRead = 5000;
+  pageSize = 100;
   /** Control for enable/disable button */
   allowRunInlineJob = false;
   /** Const for the jobName */
   jobName: String = 'LOAN_COB';
+
+  showPaginator = false;
 
   /**
    * @param {LoansService} loansService Loans Service
@@ -49,29 +57,27 @@ export class LoanLockedComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.dataSource = new MatTableDataSource(this.loans);
-    this.dataSource.paginator = this.paginator;
-    this.selection = new SelectionModel(true, []);
     this.allowRunInlineJob = false;
-    this.getLoansLocked(this.currentPage);
+    this.getLoansLocked(0);
   }
 
   applyFilter(filterValue: string = '') {
     this.dataSource.filter = filterValue.trim().toLowerCase();
   }
 
-  handlePage(e: any) {
+  changePaging(e: any) {
+    this.pageSize = e.pageSize;
     if (this.currentPage !== e.pageIndex) {
       this.currentPage = e.pageIndex;
-      this.pageSize = e.pageSize;
-      this.getLoansLocked(this.currentPage);
     }
   }
 
   getLoansLocked(page: number) {
-    this.tasksService.getAllLoansLocked(page, this.pageSize).subscribe((data: any) => {
+    this.tasksService.getAllLoansLocked(page, this.itemsToRead).subscribe((data: any) => {
       this.loans = data.content;
       this.dataSource = new MatTableDataSource(this.loans);
+      this.dataSource.paginator = this.paginator;
+      this.showPaginator = (this.loans.length > this.pageSize);
       this.allowRunInlineJob = false;
       this.selection = new SelectionModel(true, []);
     });


### PR DESCRIPTION
## Description

There was a bug in UI where we are retrieving only 10 loans in Manage COB job section. This is hindering our ability to run Inline COB for other accounts. Pagination on this particular page doesn’t work, so we are stuck with the same 10 accounts all the time. We have been missing remediating a few accounts that failed during COB.


https://github.com/openMF/web-app/assets/44206706/80b5f39b-6238-4651-adc1-5fb9157968c3


## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
