### PR TITLE
fix: unable to create a loan account when floating interest rate is used

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -126,7 +126,8 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
         'graceOnInterestCharged': this.loansAccountTermsData.graceOnInterestCharged,
         'fixedEmiAmount': this.loansAccountTermsData.fixedEmiAmount,
         'maxOutstandingLoanBalance': this.loansAccountTermsData.maxOutstandingLoanBalance,
-        'transactionProcessingStrategyCode': this.loansAccountTermsData.transactionProcessingStrategyCode
+        'transactionProcessingStrategyCode': this.loansAccountTermsData.transactionProcessingStrategyCode,
+        'interestRateDifferential':this.loansAccountTermsData.interestRateDifferential
       });
 
       this.multiDisburseLoan = this.loansAccountTermsData.multiDisburseLoan;
@@ -208,7 +209,8 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
         'graceOnInterestCharged': this.loansAccountTermsData.graceOnInterestCharged,
         'fixedEmiAmount': this.loansAccountTermsData.fixedEmiAmount,
         'maxOutstandingLoanBalance': this.loansAccountTermsData.maxOutstandingLoanBalance,
-        'transactionProcessingStrategyCode': this.loansAccountTermsData.transactionProcessingStrategyCode
+        'transactionProcessingStrategyCode': this.loansAccountTermsData.transactionProcessingStrategyCode,
+        'interestRateDifferential':this.loansAccountTermsData.interestRateDifferential
       });
     }
     this.createloansAccountTermsForm();
@@ -269,6 +271,7 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
       'fixedEmiAmount': [''],
       'isTopup': [''],
       'maxOutstandingLoanBalance': [''],
+      'interestRateDifferential':[''],
       'transactionProcessingStrategyCode': ['', Validators.required]
     });
   }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -38,6 +38,7 @@ export class LoanProductSettingsStepComponent implements OnInit {
       .subscribe((isLinkedToFloatingInterestRates: any) => {
         if (isLinkedToFloatingInterestRates) {
           this.loanProductSettingsForm.get('isInterestRecalculationEnabled').setValue(true);
+          this.loanProductSettingsForm.get('allowPartialPeriodInterestCalcualtion').setValue(true);
         }
       });
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -6,7 +6,10 @@
 
     <mat-form-field fxFlex="31%">
       <mat-label>Minimum</mat-label>
-      <input type="number" matInput formControlName="minPrincipal">
+      <input type="number" matInput formControlName="minPrincipal" [min]="0">
+      <mat-error>
+        Minimum Value must be <strong>greater equal to than 0</strong>
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field fxFlex="31%">
@@ -19,7 +22,10 @@
 
     <mat-form-field fxFlex="31%">
       <mat-label>Maximum</mat-label>
-      <input type="number" matInput formControlName="maxPrincipal">
+      <input type="number" matInput formControlName="maxPrincipal" [min]="0">
+      <mat-error>
+        Maximum Value must be <strong>greater equal to than 0</strong> and must be greater than <strong>Minimum Principal</strong>
+      </mat-error>
     </mat-form-field>
 
     <mat-checkbox fxFlex="31%" labelPosition="before" formControlName="allowApprovedDisbursedAmountsOverApplied">
@@ -44,7 +50,10 @@
 
     <mat-form-field fxFlex="31%">
       <mat-label>Minimum</mat-label>
-      <input type="number" matInput formControlName="minNumberOfRepayments">
+      <input type="number" matInput formControlName="minNumberOfRepayments" [min]="0">
+      <mat-error>
+        Minimum Value must be <strong>greater equal to than 0</strong>
+        </mat-error>
     </mat-form-field>
 
     <mat-form-field fxFlex="31%">
@@ -57,7 +66,10 @@
 
     <mat-form-field fxFlex="31%">
       <mat-label>Maximum</mat-label>
-      <input type="number" matInput formControlName="maxNumberOfRepayments">
+      <input type="number" matInput formControlName="maxNumberOfRepayments" [min]="0">
+      <mat-error>
+        Maximum Value must be <strong>greater equal to than 0</strong> and must be greater than <strong>Minimum Principal</strong>
+      </mat-error>
     </mat-form-field>
 
     <mat-divider fxFlex="98%"></mat-divider>
@@ -74,7 +86,10 @@
 
       <mat-form-field fxFlex="23%">
         <mat-label>Minimum</mat-label>
-        <input type="number" matInput formControlName="minInterestRatePerPeriod">
+        <input type="number" matInput formControlName="minInterestRatePerPeriod" [min]="0.1">
+        <mat-error>
+          Minimum Value must be <strong>greater than 0</strong>
+          </mat-error>
       </mat-form-field>
 
       <mat-form-field fxFlex="23%">
@@ -87,7 +102,10 @@
 
       <mat-form-field fxFlex="23%">
         <mat-label>Maximum</mat-label>
-        <input type="number" matInput formControlName="maxInterestRatePerPeriod">
+        <input type="number" matInput formControlName="maxInterestRatePerPeriod" [min]="0.2">
+        <mat-error>
+          Maximum Value must be <strong>greater equal to than 0</strong> and must be greater than <strong>Minimum Principal</strong>
+        </mat-error>
       </mat-form-field>
 
       <mat-form-field fxFlex="23%">
@@ -134,7 +152,7 @@
 
       <mat-form-field fxFlex="31%">
         <mat-label>Minimum</mat-label>
-        <input type="number" matInput formControlName="minDifferentialLendingRate" required>
+        <input type="number" matInput formControlName="minDifferentialLendingRate" [min]="0" required>
         <mat-error>
           Minimum interest rate is <strong>required</strong>
         </mat-error>


### PR DESCRIPTION
## Description
now we can create loan account when floating interest rate was used.
actually, we needed to make loan product first with floating interest rate, and when floating interest rate will be chosen 
then we needed select interest calculation period as daily or we needed to check partial interest calculation with same as repayment in setting step of loan product  
## Related issues and discussion
#1755 

## Screenshots, if any
Firstly make loan product
https://github.com/openMF/web-app/assets/76156941/2916d525-e893-45f8-83b8-9659c2fcbf33
Then make loan account
https://github.com/openMF/web-app/assets/76156941/16e6bda8-c5ee-42aa-a0f5-cdcaa082eae1
## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
