### PR TITLE
fix: unable to create a savings account when "balance required for interest calculation" is added

### DIFF
--- a/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.ts
@@ -147,6 +147,7 @@ export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
     const payload = this.savingsAccountTermsForm.getRawValue();
     delete payload.currencyCode;
     delete payload.decimal;
+    delete payload.minBalanceForInterestCalculation; //Backend is not accepting minBalanceForInterestCalculation value
     return payload;
   }
 


### PR DESCRIPTION
Fixes: #1754

## Description
now we can create saving account when balance required for interest calculation value was used while creating saving product, actually backend is not accepting minBalanceForInterestCalculation so I deleted from payload.
## Related issues and discussion
#1754 

## Screenshots, if any

https://github.com/openMF/web-app/assets/76156941/dce685a0-5755-4a46-8058-699d351888f3


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
