### PR TITLE
Fix to display ExternalId complete value

### DIFF
--- a/src/app/shared/external-identifier/external-identifier.component.html
+++ b/src/app/shared/external-identifier/external-identifier.component.html
@@ -1,4 +1,5 @@
 <div>
-  <span *ngIf="isLongValue()"><fa-icon icon="eye" size="sm" [title]="externalId"></fa-icon></span>
+  <span matTooltip="{{externalId}}" (mouseenter)="$event.stopImmediatePropagation()" (mouseleave)="$event.stopImmediatePropagation()" #tooltip="matTooltip"></span>
+  <span *ngIf="isLongValue()" (click)="tooltip.toggle()"><fa-icon icon="eye" size="sm" [title]="externalId"></fa-icon></span>
   {{ externalId | externalIdentifier }}
 </div>


### PR DESCRIPTION
## Description

Fix to display ExternalId complete value, when the ExternalId is generated is a long value then It is displayed by default in a short way with an eye icon behind this. When you click the eye icon, will be displayed a tooltip with the full ExternalId value.

**Search** 
<img width="1354" alt="Screenshot 2023-06-25 at 21 33 11" src="https://github.com/openMF/web-app/assets/44206706/7fd0b0ff-ba60-4209-b0cc-9fa2cfb81c68">


**Client List**
<img width="1373" alt="Screenshot 2023-06-25 at 21 37 06" src="https://github.com/openMF/web-app/assets/44206706/f5cdcd2f-b3bb-466b-bb4b-1203fcc184f5">


## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
