### PR TITLE
Loan product with due and overdue days notification to be sent

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
@@ -473,6 +473,18 @@
     <span fxFlex="60%">{{ loanProduct.disallowExpectedDisbursements ? 'Yes' : 'No' }}</span>
   </div>
 
+  <h3 class="mat-h3" fxFlexFill>Event Settings</h3>
+
+  <div fxFlexFill>
+    <span fxFlex="40%">Due days for repayment event:</span>
+    <span fxFlex="60%">{{ loanProduct.dueDaysForRepaymentEvent | number }}</span>
+  </div>
+
+  <div fxFlexFill>
+    <span fxFlex="40%">OverDue days for repayment event:</span>
+    <span fxFlex="60%">{{ loanProduct.overDueDaysForRepaymentEvent | number }}</span>
+  </div>
+
   <h3 class="mat-h3" fxFlexFill>Configurable Terms and Settings</h3>
 
   <mat-divider fxFlexFill></mat-divider>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -416,6 +416,22 @@
 
     <mat-divider fxFlex="98%"></mat-divider>
 
+    <h3 fxFlex="23%" class="mat-h3">Event Settings</h3>
+    <div fxFlexFill fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
+
+      <mat-form-field fxFlex="48%">
+        <mat-label>Due days for repayment event</mat-label>
+        <input type="number" matInput matTooltip="Specific days when repayment due notification should be sent." formControlName="dueDaysForRepaymentEvent" [min]="0">
+      </mat-form-field>
+
+      <mat-form-field fxFlex="48%">
+        <mat-label>OverDue days for repayment event</mat-label>
+        <input type="number" matInput matTooltip="Specific days when repayment Overdue notification should be sent." formControlName="overDueDaysForRepaymentEvent" [min]="0">
+      </mat-form-field>
+    </div>
+
+    <mat-divider fxFlex="98%"></mat-divider>
+
     <h3 fxFlex="23%" class="mat-h3">Configurable Terms and Settings</h3>
 
     <mat-checkbox fxFlex="73%" labelPosition="before" formControlName="allowAttributeConfiguration" class="margin-b">

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -86,6 +86,8 @@ export class LoanProductSettingsStepComponent implements OnInit {
       'multiDisburseLoan': this.loanProductsTemplate.multiDisburseLoan,
       'maxTrancheCount': this.loanProductsTemplate.maxTrancheCount,
       'outstandingLoanBalance': this.loanProductsTemplate.outstandingLoanBalance,
+      'dueDaysForRepaymentEvent': this.loanProductsTemplate.dueDaysForRepaymentEvent,
+      'overDueDaysForRepaymentEvent': this.loanProductsTemplate.overDueDaysForRepaymentEvent,
     });
 
     if (this.loanProductsTemplate.delinquencyBucket) {
@@ -181,7 +183,9 @@ export class LoanProductSettingsStepComponent implements OnInit {
         'graceOnPrincipalAndInterestPayment': [true],
         'graceOnArrearsAgeing': [true]
       }),
-      'delinquencyBucketId': ['', Validators.required]
+      'delinquencyBucketId': ['', Validators.required],
+      'dueDaysForRepaymentEvent': [''],
+      'overDueDaysForRepaymentEvent': ['']
     });
   }
 

--- a/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.html
+++ b/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.html
@@ -506,6 +506,18 @@
     </div>
   </div>
 
+  <h3 class="mat-h3" fxFlexFill>Event Settings</h3>
+
+  <div fxFlexFill>
+    <span fxFlex="40%">Due days for repayment event:</span>
+    <span fxFlex="60%">{{ loanProduct.dueDaysForRepaymentEvent | number }}</span>
+  </div>
+
+  <div fxFlexFill>
+    <span fxFlex="40%">OverDue days for repayment event:</span>
+    <span fxFlex="60%">{{ loanProduct.overDueDaysForRepaymentEvent | number }}</span>
+  </div>
+
   <h3 class="mat-h3" fxFlexFill>Configurable Terms and Settings</h3>
 
   <mat-divider [inset]="true"></mat-divider>


### PR DESCRIPTION
## Description

As a user I will be able to define product specific days when repayment due and overdue notification should be sent in order to customize loan product.

<img width="1288" alt="Screenshot 2023-06-28 at 23 30 01" src="https://github.com/openMF/web-app/assets/44206706/777ad19c-6813-4ced-9af7-6e41d9761cc6">

## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
