### PR TITLE
Display Submitted On Date in Loan Charge views

### DIFF
--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.html
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.html
@@ -20,6 +20,11 @@
       <td mat-cell *matCellDef="let charge"> {{ charge.chargeTimeType.value }} </td>
     </ng-container>
 
+    <ng-container matColumnDef="submittedDate">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Submitted On </th>
+      <td mat-cell *matCellDef="let charge"> {{ charge.submittedOnDate | dateFormat }} </td>
+    </ng-container>
+
     <ng-container matColumnDef="dueDate">
       <th mat-header-cell *matHeaderCellDef mat-sort-header> Due as of </th>
       <td mat-cell *matCellDef="let charge"> {{ charge.dueDate | dateFormat }} </td>
@@ -55,7 +60,7 @@
     </ng-container>
 
     <ng-container matColumnDef="actions">
-      <th mat-header-cell class="center" *matHeaderCellDef mat-sort-header> Actions </th>
+      <th mat-header-cell class="r-amount" *matHeaderCellDef mat-sort-header> Actions </th>
       <td mat-cell class="center" *matCellDef="let charge">
         <span *ngIf="status === 'Submitted and pending approval'">
           <button class="account-action-button" mat-raised-button color="primary" matTooltip="Edit Charge"

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
@@ -35,7 +35,7 @@ export class ChargesTabComponent implements OnInit {
   /** Status */
   status: any;
   /** Columns to be displayed in charges table. */
-  displayedColumns: string[] = ['name', 'feepenalty', 'paymentdueat', 'dueDate', 'calculationtype', 'due', 'paid', 'waived', 'outstanding', 'actions'];
+  displayedColumns: string[] = ['name', 'feepenalty', 'paymentdueat', 'submittedDate', 'dueDate', 'calculationtype', 'due', 'paid', 'waived', 'outstanding', 'actions'];
   /** Data source for charges table. */
   dataSource: MatTableDataSource<any>;
 

--- a/src/app/loans/loans-view/view-charge/view-charge.component.html
+++ b/src/app/loans/loans-view/view-charge/view-charge.component.html
@@ -128,6 +128,14 @@
           {{ chargeData.amountOutstanding | formatNumber }}
         </div>
 
+        <div fxFlex="50%" class="mat-body-strong">
+          Submitted On Date
+        </div>
+
+        <div fxFlex="50%">
+          {{ chargeData.submittedOnDate | dateFormat }}
+        </div>
+
       </div>
 
       <div fxLayout="row" fxLayoutAlign="center" fxLayoutGap="2%" fxLayout.lt-md="column">


### PR DESCRIPTION
## Description

Display Submitted On Date in Loan Charge views

- Loan Charge tab
<img width="1361" alt="Screenshot 2023-06-30 at 19 38 52" src="https://github.com/openMF/web-app/assets/44206706/06fd098c-9446-4824-892a-3f812abbbef3">

- Loan Charge detail view
<img width="1007" alt="Screenshot 2023-06-30 at 19 39 03" src="https://github.com/openMF/web-app/assets/44206706/561ceee5-5e65-4a8d-84e8-7fd4d9b3833c">


## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
