### PR TITLE
Add Auto Repayment flag for Loan product Down Payment settings

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -434,6 +434,11 @@
           Disbursed Amount Percentage Down Payment is out <strong>percentage range</strong>
         </mat-error>
       </mat-form-field>
+
+      <mat-checkbox fxFlex="48%" labelPosition="before" formControlName="enableAutoRepaymentForDownPayment" matTooltip="nable or disable  the auto repayment of down-payment.
+      When “auto repayment for the down-payments“ is enabled,  the disbursements will trigger an auto down payment transaction for the down payment amount" class="margin-b">
+        Enable Auto Repayment for Down Payment
+      </mat-checkbox>
     </div>
 
     <mat-divider fxFlex="98%"></mat-divider>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -102,7 +102,8 @@ export class LoanProductSettingsStepComponent implements OnInit {
 
     if (this.loanProductsTemplate.enableDownPayment) {
       this.loanProductSettingsForm.patchValue({
-        'disbursedAmountPercentageForDownPayment': this.loanProductsTemplate.disbursedAmountPercentageForDownPayment || 0
+        'disbursedAmountPercentageForDownPayment': this.loanProductsTemplate.disbursedAmountPercentageForDownPayment || 0,
+        'enableAutoRepaymentForDownPayment': this.loanProductsTemplate.enableAutoRepaymentForDownPayment || false
       });
     }
 
@@ -345,8 +346,10 @@ export class LoanProductSettingsStepComponent implements OnInit {
       .subscribe(enableDownPayment => {
         if (enableDownPayment) {
           this.loanProductSettingsForm.addControl('disbursedAmountPercentageForDownPayment', new FormControl(0, [Validators.required, rangeValidator(0, 100) ]));
+          this.loanProductSettingsForm.addControl('enableAutoRepaymentForDownPayment', new FormControl(false, []));
         } else {
           this.loanProductSettingsForm.removeControl('disbursedAmountPercentageForDownPayment');
+          this.loanProductSettingsForm.removeControl('enableAutoRepaymentForDownPayment');
         }
       });
 


### PR DESCRIPTION
## Description

Add Auto Repayment flag for Loan product Down Payment settings. Now with the Down Payment setting at Loan Product level, I will able to enable or disable  the auto repayment of down payment at the loan product level in order to enable auto repayment only for the products required

## Related issues and discussion
#{Issue Number}

## Screenshots, if any
<img width="1210" alt="Screenshot 2023-08-10 at 22 49 25" src="https://github.com/openMF/web-app/assets/44206706/7f036083-ef26-4a83-ab42-e676c310dc74">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
