### PR TITLE
Savings account transaction with datatables

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -69,7 +69,7 @@
   <button mat-menu-item routerLink="/clients">{{ 'labels.menus.Clients' | translate }}</button>
   <button mat-menu-item routerLink="/groups">{{ 'labels.menus.Groups' | translate }}</button>
   <button mat-menu-item routerLink="/centers">{{ 'labels.menus.Centers' | translate }}</button>
-  <span fxHide.lt-lg="true">
+  <span fxHide.lt>
     <button mat-menu-item [routerLink]="['/accounting']">{{ 'labels.menus.Accounting' | translate }}</button>
     <button mat-menu-item [matMenuTriggerFor]="reportsMenu">{{ 'labels.menus.Reports' | translate }}</button>
     <button mat-menu-item [matMenuTriggerFor]="adminMenu">{{ 'labels.menus.Admin' | translate }}</button>

--- a/src/app/core/utils/datatables.ts
+++ b/src/app/core/utils/datatables.ts
@@ -14,7 +14,7 @@ export class Datatables {
 
   systemFields: string[] = ['id', 'created_at', 'updated_at'];
 
-  entitiesIdFields: string[] = ['client_id', 'savings_account_id',
+  entitiesIdFields: string[] = ['client_id', 'savings_account_id', 'savings_transaction_id',
     'loan_id', 'group_id', 'center_id', 'office_id', 'product_loan_id', 'savings_product_id', 'share_product_id'];
 
   constructor(private dateUtils: Dates,

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.html
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.html
@@ -118,60 +118,9 @@
           </table>
         </div>
 
-        <mat-divider *ngIf="transactionData.paymentDetailData" [inset]="true"></mat-divider>
-
-        <ng-container *ngIf="transactionData.paymentDetailData">
-
-          <div *ngIf="transactionData.paymentDetailData.paymentType" fxFlex="50%" class="mat-body-strong">
-            {{ 'Payment Type' | translate }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.paymentType" fxFlex="50%">
-            {{ transactionData.paymentDetailData.paymentType.name }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.accountNumber" fxFlex="50%" class="mat-body-strong">
-            {{ 'Account No.' | translate }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.accountNumber" fxFlex="50%">
-            {{ transactionData.paymentDetailData.accountNumber }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.checkNumber" fxFlex="50%" class="mat-body-strong">
-            {{ 'Cheque Number' | translate }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.checkNumber" fxFlex="50%">
-            {{ transactionData.paymentDetailData.checkNumber }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.routingCode" fxFlex="50%" class="mat-body-strong">
-            {{ 'Routing Code' | translate }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.routingCode" fxFlex="50%">
-            {{ transactionData.paymentDetailData.routingCode }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.receiptNumber" fxFlex="50%" class="mat-body-strong">
-            {{ 'Receipt No.' | translate }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.receiptNumber" fxFlex="50%">
-            {{ transactionData.paymentDetailData.receiptNumber }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.bankNumber" fxFlex="50%" class="mat-body-strong">
-            {{ 'Bank No.' | translate }}
-          </div>
-
-          <div *ngIf="transactionData.paymentDetailData.bankNumber" fxFlex="50%">
-            {{ transactionData.paymentDetailData.bankNumber }}
-          </div>
-
-        </ng-container>
-
+        <mifosx-transaction-payment-detail *ngIf="transactionData.paymentDetailData"
+          [paymentDetailData]="transactionData.paymentDetailData">
+        </mifosx-transaction-payment-detail>
       </div>
 
       <div fxLayout="row" fxLayoutAlign="center" fxLayoutGap="2%" fxLayout.lt-md="column">

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.scss
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.scss
@@ -7,6 +7,11 @@
       margin: 1rem 0;
       word-wrap: break-word;
     }
+
+    mifosx-transaction-payment-detail {
+      width: 100%;
+      margin-bottom: 20px;
+    }
   }
 }
 

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
@@ -46,7 +46,7 @@
 
       </mat-step>
 
-      <mat-step [stepControl]="loanProductSettingsForm">
+      <mat-step [stepControl]="loanProductSettingsForm" completed>
 
         <ng-template matStepLabel>SETTINGS</ng-template>
 
@@ -59,7 +59,7 @@
 
       </mat-step>
 
-      <mat-step *ngIf="isAdvancedPaymentStrategy">
+      <mat-step *ngIf="isAdvancedPaymentStrategy" completed>
 
         <ng-template matStepLabel>PAYMENT ALLOCATION</ng-template>
 

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
@@ -127,6 +127,8 @@ export class EditLoanProductComponent implements OnInit {
       ...this.loanProductChargesStep.loanProductCharges,
       ...this.loanProductAccountingStep.loanProductAccounting
     };
+    // Default empty array
+    loanProduct['paymentAllocation'] = [];
     if (this.isAdvancedPaymentStrategy) {
       loanProduct['paymentAllocation'] = this.paymentAllocation;
     }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
@@ -346,14 +346,14 @@
           <table>
             <thead>
               <tr>
-                <th>Order</th>
                 <th>Payment Allocation Rule</th>
+                <th>Order</th>
               </tr>
             </thead>
             <tbody>
               <tr *ngFor="let paymentAllocation of paymentAllocation.paymentAllocationOrder; let idx = index;">
-                <td>{{ (idx + 1) }}</td>
                 <td>{{ paymentAllocation.paymentAllocationRule }}</td>
+                <td>{{ (idx + 1) }}</td>
               </tr>
             </tbody>
           </table>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -10,6 +10,7 @@ import { rangeValidator } from 'app/shared/validators/percentage.validator';
 })
 export class LoanProductSettingsStepComponent implements OnInit {
 
+  @Input() toEdit: boolean;
   @Input() loanProductsTemplate: any;
   @Input() isLinkedToFloatingInterestRates: UntypedFormControl;
   @Output() advancePaymentStrategy = new EventEmitter<string>();

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -28,12 +28,12 @@
       </mat-error>
     </mat-form-field>
 
-    <div fxFlex="98%">
-      <mat-checkbox fxFlex="31%" labelPosition="before" formControlName="allowApprovedDisbursedAmountsOverApplied">
-        Allow approval / disbursal above loan applied amount?
-      </mat-checkbox>
+    <mat-checkbox fxFlex="96%" labelPosition="before" formControlName="allowApprovedDisbursedAmountsOverApplied">
+      Allow approval / disbursal above loan applied amount?
+    </mat-checkbox>
 
-      <mat-form-field fxFlex="31%" *ngIf="loanProductTermsForm.value.allowApprovedDisbursedAmountsOverApplied">
+    <div fxFlex="98%" fxLayoutGap="2%" fxLayout="row wrap" fxLayout.lt-md="column">
+      <mat-form-field fxFlex="32%" *ngIf="loanProductTermsForm.value.allowApprovedDisbursedAmountsOverApplied">
         <mat-label>Over Amount Calculation Type</mat-label>
         <mat-select formControlName="overAppliedCalculationType" required>
           <mat-option *ngFor="let overAppliedCalculationType of overAppliedCalculationTypeData" [value]="overAppliedCalculationType.id">
@@ -42,7 +42,7 @@
         </mat-select>
       </mat-form-field>
 
-      <mat-form-field fxFlex="31%" *ngIf="loanProductTermsForm.value.allowApprovedDisbursedAmountsOverApplied">
+      <mat-form-field fxFlex="32%" *ngIf="loanProductTermsForm.value.allowApprovedDisbursedAmountsOverApplied">
         <mat-label>Over Amount</mat-label>
         <input type="number" matInput formControlName="overAppliedNumber" required>
       </mat-form-field>
@@ -61,7 +61,7 @@
 
     <mat-form-field fxFlex="31%">
       <mat-label>Minimum</mat-label>
-      <input type="number" matInput formControlName="minNumberOfRepayments" [min]="0">
+      <input type="number" matInput formControlName="minNumberOfRepayments" [min]="1">
       <mat-error>
         Minimum Value must be <strong>greater equal to than 0</strong>
         </mat-error>
@@ -113,7 +113,7 @@
 
       <mat-form-field fxFlex="23%">
         <mat-label>Maximum</mat-label>
-        <input type="number" matInput formControlName="maxInterestRatePerPeriod" [min]="0.2">
+        <input type="number" matInput formControlName="maxInterestRatePerPeriod" [min]="0">
         <mat-error>
           Maximum Value must be <strong>greater equal to than 0</strong> and must be greater than <strong>Minimum Principal</strong>
         </mat-error>

--- a/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.html
+++ b/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.html
@@ -349,14 +349,14 @@
           <table>
             <thead>
               <tr>
-                <th>Order</th>
                 <th>Payment Allocation Rule</th>
+                <th>Order</th>
               </tr>
             </thead>
             <tbody>
               <tr *ngFor="let paymentAllocation of paymentAllocation.paymentAllocationOrder; let idx = index;">
-                <td>{{ (idx + 1) }}</td>
                 <td>{{ paymentAllocation.paymentAllocationRule }}</td>
+                <td>{{ (idx + 1) }}</td>
               </tr>
             </tbody>
           </table>

--- a/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.scss
+++ b/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.scss
@@ -3,6 +3,10 @@
 .tab-container {
   padding: 1%;
   margin: 1%;
+
+  div: {
+    margin-top: 3px;
+  }
 }
 
 .mat-h3 {

--- a/src/app/products/saving-products/view-saving-product/saving-product-general-tab/saving-product-general-tab.component.html
+++ b/src/app/products/saving-products/view-saving-product/saving-product-general-tab/saving-product-general-tab.component.html
@@ -1,353 +1,363 @@
-
 <div fxLayout="row" fxLayoutAlign="end" fxLayoutGap="2%" fxLayout.lt-md="column" class="container m-b-20">
   <button mat-raised-button color="primary" [routerLink]="['../edit']" *mifosxHasPermission="'UPDATE_SAVINGSPRODUCT'">
     <fa-icon icon="edit" class="m-r-10"></fa-icon>Edit
   </button>
 </div>
 
-<div class="container">
+<div class="tab-container mat-typography">
 
-  <mat-card>
 
-    <mat-card-content>
+  <div fxLayout="row wrap" fxLayout.lt-md="column">
 
-      <div fxLayout="row wrap" fxLayout.lt-md="column">
+    <h2 class="mat-h2" fxFlexFill>{{ savingProduct.name }}</h2>
 
-        <h2 class="mat-h2" fxFlexFill>{{ savingProduct.name }}</h2>
+    <mat-divider [inset]="true"></mat-divider>
+
+    <h3 class="mat-h3" fxFlexFill>Details</h3>
+
+    <mat-divider [inset]="true"></mat-divider>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Short Name:</span>
+      <span fxFlex="60%">{{ savingProduct.shortName }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.description">
+      <span fxFlex="40%">Description:</span>
+      <span fxFlex="60%">{{ savingProduct.description }}</span>
+    </div>
+
+    <h3 class="mat-h3" fxFlexFill>Currency</h3>
+
+    <mat-divider [inset]="true"></mat-divider>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Currency:</span>
+      <span fxFlex="60%">{{ savingProduct.currency.name }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Decimal Places:</span>
+      <span fxFlex="60%">{{ savingProduct.currency.decimalPlaces }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Currency in multiples of:</span>
+      <span fxFlex="60%">{{ savingProduct.currency.inMultiplesOf }}</span>
+    </div>
+
+    <h3 class="mat-h3" fxFlexFill>Terms</h3>
+
+    <mat-divider [inset]="true"></mat-divider>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Nominal Annual Interest Rate:</span>
+      <span fxFlex="60%">{{ savingProduct.nominalAnnualInterestRate }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Interest Compounding Period:</span>
+      <span fxFlex="60%">{{ savingProduct.interestCompoundingPeriodType.value }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Interest Posting Period:</span>
+      <span fxFlex="60%">{{ savingProduct.interestPostingPeriodType.value }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Interest Calculated using:</span>
+      <span fxFlex="60%">{{ savingProduct.interestCalculationType.value }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Days in Year:</span>
+      <span fxFlex="60%">{{ savingProduct.interestCalculationDaysInYearType.value }}</span>
+    </div>
+
+    <h3 class="mat-h3" fxFlexFill>Settings</h3>
+
+    <mat-divider [inset]="true"></mat-divider>
+
+    <div fxFlexFill *ngIf="savingProduct.minRequiredOpeningBalance">
+      <span fxFlex="40%">Minimum Opening Balance:</span>
+      <span fxFlex="60%">{{ savingProduct.minRequiredOpeningBalance }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.lockinPeriodFrequency">
+      <span fxFlex="40%">Lock-in Period:</span>
+      <span fxFlex="60%">{{ savingProduct.lockinPeriodFrequency + ' ' + savingProduct.lockinPeriodFrequencyType.value
+        }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Apply Withdrawal Fee for Transfers:</span>
+      <span fxFlex="60%">{{ savingProduct.withdrawalFeeForTransfers ? 'Yes' : 'No' }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.minBalanceForInterestCalculation">
+      <span fxFlex="40%">Balance Required for Interest Calculation:</span>
+      <span fxFlex="60%">{{ savingProduct.minBalanceForInterestCalculation }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Enforce Minimum Balance:</span>
+      <span fxFlex="60%">{{ savingProduct.enforceMinRequiredBalance ? 'Yes' : 'No' }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.minRequiredBalance">
+      <span fxFlex="40%">Minimum Balance:</span>
+      <span fxFlex="60%">{{ savingProduct.minRequiredBalance }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Withhold Tax is Applicable:</span>
+      <span fxFlex="60%">{{ savingProduct.withHoldTax ? 'Yes' : 'No' }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.withHoldTax">
+      <span fxFlex="40%">Tax Group:</span>
+      <span fxFlex="60%">{{ savingProduct.taxGroup.name }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Is Overdraft Allowed:</span>
+      <span fxFlex="60%">{{ savingProduct.allowOverdraft ? 'Yes' : 'No' }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.minOverdraftForInterestCalculation">
+      <span fxFlex="40%">Minimum Overdraft Required for Interest Calculation:</span>
+      <span fxFlex="60%">{{ savingProduct.minOverdraftForInterestCalculation }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.nominalAnnualInterestRateOverdraft">
+      <span fxFlex="40%">Nominal Annual Interest for Overdraft:</span>
+      <span fxFlex="60%">{{ savingProduct.nominalAnnualInterestRateOverdraft }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.overdraftLimit">
+      <span fxFlex="40%">Maximum Overdraft Amount Limit:</span>
+      <span fxFlex="60%">{{ savingProduct.overdraftLimit }}</span>
+    </div>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Enable Dormancy Tracking:</span>
+      <span fxFlex="60%">{{ savingProduct.isDormancyTrackingActive ? 'Yes' : 'No' }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.isDormancyTrackingActive" fxLayout="row wrap" fxLayout.lt-md="column">
+      <span fxFlex="40%">Number of Days to Inactive sub-status:</span>
+      <span fxFlex="60%">{{ savingProduct.daysToInactive }}</span>
+      <span fxFlex="40%">Number of Days to Dormant sub-status:</span>
+      <span fxFlex="60%">{{ savingProduct.daysToDormancy }}</span>
+      <span fxFlex="40%">Number of Days to Escheat:</span>
+      <span fxFlex="60%">{{ savingProduct.daysToEscheat }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.charges.length" fxLayout="row wrap" fxLayout.lt-md="column">
+
+      <h3 class="mat-h3" fxFlexFill>Charges</h3>
+
+      <mat-divider [inset]="true"></mat-divider>
+
+      <table fxFlexFill class="mat-elevation-z1" mat-table [dataSource]="savingProduct.charges">
+
+        <ng-container matColumnDef="name">
+          <th mat-header-cell *matHeaderCellDef> Name </th>
+          <td mat-cell *matCellDef="let charge">
+            {{ charge.name + ', ' + charge.currency.displaySymbol }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="chargeCalculationType">
+          <th mat-header-cell *matHeaderCellDef> Type </th>
+          <td mat-cell *matCellDef="let charge">
+            {{ charge.chargeCalculationType.value }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="amount">
+          <th mat-header-cell *matHeaderCellDef> Amount </th>
+          <td mat-cell *matCellDef="let charge">
+            {{ charge.amount }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="chargeTimeType">
+          <th mat-header-cell *matHeaderCellDef> Collected On </th>
+          <td mat-cell *matCellDef="let charge">
+            {{ charge.chargeTimeType.value }}
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="chargesDisplayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: chargesDisplayedColumns;"></tr>
+
+      </table>
+
+    </div>
+
+    <h3 class="mat-h3" fxFlexFill>Accounting</h3>
+
+    <mat-divider [inset]="true"></mat-divider>
+
+    <div fxFlexFill>
+      <span fxFlex="40%">Type:</span>
+      <span fxFlex="60%">{{ savingProduct.accountingRule.value }}</span>
+    </div>
+
+    <div fxFlexFill *ngIf="savingProduct.accountingRule.id === 2" fxLayout="row wrap" fxLayout.lt-md="column">
+
+      <h4 fxFlexFill class="mat-h4">Assets</h4>
+
+      <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
+        <span fxFlex="40%">Saving reference:</span>
+        <span fxFlex="60%">({{ savingProduct.accountingMappings.savingsReferenceAccount.glCode }}) {{
+          savingProduct.accountingMappings.savingsReferenceAccount.name }}</span>
+        <span fxFlex="40%">Overdraft portfolio:</span>
+        <span fxFlex="60%">({{ savingProduct.accountingMappings.overdraftPortfolioControl.glCode }}) {{
+          savingProduct.accountingMappings.overdraftPortfolioControl.name }}</span>
+      </div>
+
+      <h4 fxFlexFill class="mat-h4">Liabilities</h4>
+
+      <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
+        <span fxFlex="40%">Saving control:</span>
+        <span fxFlex="60%">({{ savingProduct.accountingMappings.savingsControlAccount.glCode }}) {{
+          savingProduct.accountingMappings.savingsControlAccount.name }}</span>
+        <span fxFlex="40%">Savings transfers in suspense:</span>
+        <span fxFlex="60%">({{ savingProduct.accountingMappings.transfersInSuspenseAccount.glCode }}) {{
+          savingProduct.accountingMappings.transfersInSuspenseAccount.name }}</span>
+        <div fxFlexFill *ngIf="savingProduct.isDormancyTrackingActive">
+          <span fxFlex="40%">Escheat liability:</span>
+          <span fxFlex="60%">({{ savingProduct.accountingMappings.escheatLiabilityAccount.glCode }}) {{
+            savingProduct.accountingMappings.escheatLiabilityAccount.name }}</span>
+        </div>
+      </div>
+
+      <h4 fxFlexFill class="mat-h4">Expenses</h4>
+
+      <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
+        <span fxFlex="40%">Interest on savings:</span>
+        <span fxFlex="60%">({{ savingProduct.accountingMappings.interestOnSavingsAccount.glCode }}) {{
+          savingProduct.accountingMappings.interestOnSavingsAccount.name }}</span>
+        <span fxFlex="40%">Write-off:</span>
+        <span fxFlex="60%">({{ savingProduct.accountingMappings.writeOffAccount.glCode }}) {{
+          savingProduct.accountingMappings.writeOffAccount.name }}</span>
+      </div>
+
+      <h4 fxFlexFill class="mat-h4">Income</h4>
+
+      <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
+        <span fxFlex="40%">Income from fees:</span>
+        <span fxFlex="60%">({{ savingProduct.accountingMappings.incomeFromFeeAccount.glCode }}) {{
+          savingProduct.accountingMappings.incomeFromFeeAccount.name }}</span>
+        <span fxFlex="40%">Income from penalties:</span>
+        <span fxFlex="60%">({{ savingProduct.accountingMappings.incomeFromPenaltyAccount.glCode }}) {{
+          savingProduct.accountingMappings.incomeFromPenaltyAccount.name }}</span>
+        <span fxFlex="40%">Overdraft Interest Income:</span>
+        <span fxFlex="60%">({{ savingProduct.accountingMappings.incomeFromInterest.glCode }}) {{
+          savingProduct.accountingMappings.incomeFromInterest.name }}</span>
+      </div>
+
+      <div
+        *ngIf="savingProduct.paymentChannelToFundSourceMappings?.length || savingProduct.feeToIncomeAccountMappings?.length || savingProduct.penaltyToIncomeAccountMappings?.length"
+        fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
+
+        <h3 class="mat-h3" fxFlexFill>Advanced Accounting Rules</h3>
 
         <mat-divider [inset]="true"></mat-divider>
 
-        <h3 class="mat-h3" fxFlexFill>Details</h3>
+        <div *ngIf="savingProduct.paymentChannelToFundSourceMappings?.length" fxFlexFill fxLayout="row wrap"
+          fxLayout.lt-md="column">
 
-        <mat-divider [inset]="true"></mat-divider>
+          <h4 class="mat-h4" fxFlexFill>Fund Sources for Payment Channels</h4>
 
-        <div fxFlexFill>
-          <span fxFlex="40%">Short Name:</span>
-          <span fxFlex="60%">{{ savingProduct.shortName }}</span>
-        </div>
+          <table fxFlexFill class="mat-elevation-z1" mat-table
+            [dataSource]="savingProduct.paymentChannelToFundSourceMappings">
 
-        <div fxFlexFill *ngIf="savingProduct.description">
-          <span fxFlex="40%">Description:</span>
-          <span fxFlex="60%">{{ savingProduct.description }}</span>
-        </div>
-
-        <h3 class="mat-h3" fxFlexFill>Currency</h3>
-
-        <mat-divider [inset]="true"></mat-divider>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Currency:</span>
-          <span fxFlex="60%">{{ savingProduct.currency.name }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Decimal Places:</span>
-          <span fxFlex="60%">{{ savingProduct.currency.decimalPlaces }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Currency in multiples of:</span>
-          <span fxFlex="60%">{{ savingProduct.currency.inMultiplesOf }}</span>
-        </div>
-
-        <h3 class="mat-h3" fxFlexFill>Terms</h3>
-
-        <mat-divider [inset]="true"></mat-divider>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Nominal Annual Interest Rate:</span>
-          <span fxFlex="60%">{{ savingProduct.nominalAnnualInterestRate }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Interest Compounding Period:</span>
-          <span fxFlex="60%">{{ savingProduct.interestCompoundingPeriodType.value }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Interest Posting Period:</span>
-          <span fxFlex="60%">{{ savingProduct.interestPostingPeriodType.value }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Interest Calculated using:</span>
-          <span fxFlex="60%">{{ savingProduct.interestCalculationType.value }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Days in Year:</span>
-          <span fxFlex="60%">{{ savingProduct.interestCalculationDaysInYearType.value }}</span>
-        </div>
-
-        <h3 class="mat-h3" fxFlexFill>Settings</h3>
-
-        <mat-divider [inset]="true"></mat-divider>
-
-        <div fxFlexFill *ngIf="savingProduct.minRequiredOpeningBalance">
-          <span fxFlex="40%">Minimum Opening Balance:</span>
-          <span fxFlex="60%">{{ savingProduct.minRequiredOpeningBalance }}</span>
-        </div>
-
-        <div fxFlexFill *ngIf="savingProduct.lockinPeriodFrequency">
-          <span fxFlex="40%">Lock-in Period:</span>
-          <span fxFlex="60%">{{ savingProduct.lockinPeriodFrequency + ' ' + savingProduct.lockinPeriodFrequencyType.value }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Apply Withdrawal Fee for Transfers:</span>
-          <span fxFlex="60%">{{ savingProduct.withdrawalFeeForTransfers ? 'Yes' : 'No' }}</span>
-        </div>
-
-        <div fxFlexFill *ngIf="savingProduct.minBalanceForInterestCalculation">
-          <span fxFlex="40%">Balance Required for Interest Calculation:</span>
-          <span fxFlex="60%">{{ savingProduct.minBalanceForInterestCalculation }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Enforce Minimum Balance:</span>
-          <span fxFlex="60%">{{ savingProduct.enforceMinRequiredBalance ? 'Yes' : 'No' }}</span>
-        </div>
-
-        <div fxFlexFill *ngIf="savingProduct.minRequiredBalance">
-          <span fxFlex="40%">Minimum Balance:</span>
-          <span fxFlex="60%">{{ savingProduct.minRequiredBalance }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Withhold Tax is Applicable:</span>
-          <span fxFlex="60%">{{ savingProduct.withHoldTax ? 'Yes' : 'No' }}</span>
-        </div>
-
-        <div fxFlexFill *ngIf="savingProduct.withHoldTax">
-          <span fxFlex="40%">Tax Group:</span>
-          <span fxFlex="60%">{{ savingProduct.taxGroup.name }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Is Overdraft Allowed:</span>
-          <span fxFlex="60%">{{ savingProduct.allowOverdraft ? 'Yes' : 'No' }}</span>
-        </div>
-
-        <div fxFlexFill *ngIf="savingProduct.minOverdraftForInterestCalculation">
-          <span fxFlex="40%">Minimum Overdraft Required for Interest Calculation:</span>
-          <span fxFlex="60%">{{ savingProduct.minOverdraftForInterestCalculation }}</span>
-        </div>
-
-        <div fxFlexFill *ngIf="savingProduct.nominalAnnualInterestRateOverdraft">
-          <span fxFlex="40%">Nominal Annual Interest for Overdraft:</span>
-          <span fxFlex="60%">{{ savingProduct.nominalAnnualInterestRateOverdraft }}</span>
-        </div>
-
-        <div fxFlexFill *ngIf="savingProduct.overdraftLimit">
-          <span fxFlex="40%">Maximum Overdraft Amount Limit:</span>
-          <span fxFlex="60%">{{ savingProduct.overdraftLimit }}</span>
-        </div>
-
-        <div fxFlexFill>
-          <span fxFlex="40%">Enable Dormancy Tracking:</span>
-          <span fxFlex="60%">{{ savingProduct.isDormancyTrackingActive ? 'Yes' : 'No' }}</span>
-        </div>
-
-        <div fxFlexFill *ngIf="savingProduct.isDormancyTrackingActive" fxLayout="row wrap" fxLayout.lt-md="column">
-          <span fxFlex="40%">Number of Days to Inactive sub-status:</span>
-          <span fxFlex="60%">{{ savingProduct.daysToInactive }}</span>
-          <span fxFlex="40%">Number of Days to Dormant sub-status:</span>
-          <span fxFlex="60%">{{ savingProduct.daysToDormancy }}</span>
-          <span fxFlex="40%">Number of Days to Escheat:</span>
-          <span fxFlex="60%">{{ savingProduct.daysToEscheat }}</span>
-        </div>
-
-        <div fxFlexFill *ngIf="savingProduct.charges.length" fxLayout="row wrap" fxLayout.lt-md="column">
-
-          <h3 class="mat-h3" fxFlexFill>Charges</h3>
-
-          <mat-divider [inset]="true"></mat-divider>
-
-          <table fxFlexFill class="mat-elevation-z1" mat-table [dataSource]="savingProduct.charges">
-
-            <ng-container matColumnDef="name">
-              <th mat-header-cell *matHeaderCellDef> Name </th>
-              <td mat-cell *matCellDef="let charge">
-                {{ charge.name + ', ' + charge.currency.displaySymbol }}
+            <ng-container matColumnDef="paymentTypeId">
+              <th mat-header-cell *matHeaderCellDef> Payment Type </th>
+              <td mat-cell *matCellDef="let paymentFundSource">
+                {{ paymentFundSource.paymentType.name }}
               </td>
             </ng-container>
 
-            <ng-container matColumnDef="chargeCalculationType">
-              <th mat-header-cell *matHeaderCellDef> Type </th>
-              <td mat-cell *matCellDef="let charge">
-                {{ charge.chargeCalculationType.value }}
+            <ng-container matColumnDef="fundSourceAccountId">
+              <th mat-header-cell *matHeaderCellDef> Fund Source </th>
+              <td mat-cell *matCellDef="let paymentFundSource">
+                ({{ paymentFundSource.fundSourceAccount.glCode }}) {{ paymentFundSource.fundSourceAccount.name }}
               </td>
             </ng-container>
 
-            <ng-container matColumnDef="amount">
-              <th mat-header-cell *matHeaderCellDef> Amount </th>
-              <td mat-cell *matCellDef="let charge">
-                {{ charge.amount  }}
-              </td>
-            </ng-container>
-
-            <ng-container matColumnDef="chargeTimeType">
-              <th mat-header-cell *matHeaderCellDef> Collected On </th>
-              <td mat-cell *matCellDef="let charge">
-                {{ charge.chargeTimeType.value }}
-              </td>
-            </ng-container>
-
-            <tr mat-header-row *matHeaderRowDef="chargesDisplayedColumns"></tr>
-            <tr mat-row *matRowDef="let row; columns: chargesDisplayedColumns;"></tr>
+            <tr mat-header-row *matHeaderRowDef="paymentFundSourceDisplayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: paymentFundSourceDisplayedColumns;"></tr>
 
           </table>
 
         </div>
 
-        <h3 class="mat-h3" fxFlexFill>Accounting</h3>
+        <div *ngIf="savingProduct.feeToIncomeAccountMappings?.length" fxFlexFill fxLayout="row wrap"
+          fxLayout.lt-md="column">
 
-        <mat-divider [inset]="true"></mat-divider>
+          <h4 class="mat-h4" fxFlexFill>Fees to Specific Income Accounts</h4>
 
-        <div fxFlexFill>
-          <span fxFlex="40%">Type:</span>
-          <span fxFlex="60%">{{ savingProduct.accountingRule.value }}</span>
+          <table fxFlexFill class="mat-elevation-z1" mat-table [dataSource]="savingProduct.feeToIncomeAccountMappings">
+
+            <ng-container matColumnDef="chargeId">
+              <th mat-header-cell *matHeaderCellDef> Fees </th>
+              <td mat-cell *matCellDef="let feesIncome">
+                {{ feesIncome.charge.name }}
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="incomeAccountId">
+              <th mat-header-cell *matHeaderCellDef> Income Account </th>
+              <td mat-cell *matCellDef="let feesIncome">
+                ({{ feesIncome.incomeAccount.glCode }}) {{ feesIncome.incomeAccount.name }}
+              </td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns;"></tr>
+
+          </table>
+
         </div>
 
-        <div fxFlexFill *ngIf="savingProduct.accountingRule.id === 2" fxLayout="row wrap" fxLayout.lt-md="column">
+        <div *ngIf="savingProduct.penaltyToIncomeAccountMappings?.length" fxFlexFill fxLayout="row wrap"
+          fxLayout.lt-md="column">
 
-          <h4 fxFlexFill class="mat-h4">Assets</h4>
+          <h4 class="mat-h4" fxFlexFill>Penalties to Specific Income Accounts</h4>
 
-          <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
-            <span fxFlex="40%">Saving reference:</span>
-            <span fxFlex="60%">({{ savingProduct.accountingMappings.savingsReferenceAccount.glCode }}) {{ savingProduct.accountingMappings.savingsReferenceAccount.name }}</span>
-            <span fxFlex="40%">Overdraft portfolio:</span>
-            <span fxFlex="60%">({{ savingProduct.accountingMappings.overdraftPortfolioControl.glCode }}) {{ savingProduct.accountingMappings.overdraftPortfolioControl.name }}</span>
-          </div>
+          <table fxFlexFill class="mat-elevation-z1" mat-table
+            [dataSource]="savingProduct.penaltyToIncomeAccountMappings">
 
-          <h4 fxFlexFill class="mat-h4">Liabilities</h4>
+            <ng-container matColumnDef="chargeId">
+              <th mat-header-cell *matHeaderCellDef> Penalty </th>
+              <td mat-cell *matCellDef="let penaltyIncome">
+                {{ penaltyIncome.charge.name }}
+              </td>
+            </ng-container>
 
-          <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
-            <span fxFlex="40%">Saving control:</span>
-            <span fxFlex="60%">({{ savingProduct.accountingMappings.savingsControlAccount.glCode }}) {{ savingProduct.accountingMappings.savingsControlAccount.name }}</span>
-            <span fxFlex="40%">Savings transfers in suspense:</span>
-            <span fxFlex="60%">({{ savingProduct.accountingMappings.transfersInSuspenseAccount.glCode }}) {{ savingProduct.accountingMappings.transfersInSuspenseAccount.name }}</span>
-            <div fxFlexFill *ngIf="savingProduct.isDormancyTrackingActive">
-              <span fxFlex="40%">Escheat liability:</span>
-              <span fxFlex="60%">({{ savingProduct.accountingMappings.escheatLiabilityAccount.glCode }}) {{ savingProduct.accountingMappings.escheatLiabilityAccount.name }}</span>
-            </div>
-          </div>
+            <ng-container matColumnDef="incomeAccountId">
+              <th mat-header-cell *matHeaderCellDef> Income Account </th>
+              <td mat-cell *matCellDef="let penaltyIncome">
+                ({{ penaltyIncome.incomeAccount.glCode }}) {{ penaltyIncome.incomeAccount.name }}
+              </td>
+            </ng-container>
 
-          <h4 fxFlexFill class="mat-h4">Expenses</h4>
+            <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns;"></tr>
 
-          <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
-            <span fxFlex="40%">Interest on savings:</span>
-            <span fxFlex="60%">({{ savingProduct.accountingMappings.interestOnSavingsAccount.glCode }}) {{ savingProduct.accountingMappings.interestOnSavingsAccount.name }}</span>
-            <span fxFlex="40%">Write-off:</span>
-            <span fxFlex="60%">({{ savingProduct.accountingMappings.writeOffAccount.glCode }}) {{ savingProduct.accountingMappings.writeOffAccount.name }}</span>
-          </div>
-
-          <h4 fxFlexFill class="mat-h4">Income</h4>
-
-          <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
-            <span fxFlex="40%">Income from fees:</span>
-            <span fxFlex="60%">({{ savingProduct.accountingMappings.incomeFromFeeAccount.glCode }}) {{ savingProduct.accountingMappings.incomeFromFeeAccount.name }}</span>
-            <span fxFlex="40%">Income from penalties:</span>
-            <span fxFlex="60%">({{ savingProduct.accountingMappings.incomeFromPenaltyAccount.glCode }}) {{ savingProduct.accountingMappings.incomeFromPenaltyAccount.name }}</span>
-            <span fxFlex="40%">Overdraft Interest Income:</span>
-            <span fxFlex="60%">({{ savingProduct.accountingMappings.incomeFromInterest.glCode }}) {{ savingProduct.accountingMappings.incomeFromInterest.name }}</span>
-          </div>
-
-          <div *ngIf="savingProduct.paymentChannelToFundSourceMappings?.length || savingProduct.feeToIncomeAccountMappings?.length || savingProduct.penaltyToIncomeAccountMappings?.length" fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
-
-            <h3 class="mat-h3" fxFlexFill>Advanced Accounting Rules</h3>
-
-            <mat-divider [inset]="true"></mat-divider>
-
-            <div *ngIf="savingProduct.paymentChannelToFundSourceMappings?.length" fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
-
-              <h4 class="mat-h4" fxFlexFill>Fund Sources for Payment Channels</h4>
-
-              <table fxFlexFill class="mat-elevation-z1" mat-table [dataSource]="savingProduct.paymentChannelToFundSourceMappings">
-
-                <ng-container matColumnDef="paymentTypeId">
-                  <th mat-header-cell *matHeaderCellDef> Payment Type </th>
-                  <td mat-cell *matCellDef="let paymentFundSource">
-                    {{ paymentFundSource.paymentType.name }}
-                  </td>
-                </ng-container>
-
-                <ng-container matColumnDef="fundSourceAccountId">
-                  <th mat-header-cell *matHeaderCellDef> Fund Source </th>
-                  <td mat-cell *matCellDef="let paymentFundSource">
-                    ({{ paymentFundSource.fundSourceAccount.glCode }}) {{ paymentFundSource.fundSourceAccount.name }}
-                  </td>
-                </ng-container>
-
-                <tr mat-header-row *matHeaderRowDef="paymentFundSourceDisplayedColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: paymentFundSourceDisplayedColumns;"></tr>
-
-              </table>
-
-            </div>
-
-            <div *ngIf="savingProduct.feeToIncomeAccountMappings?.length" fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
-
-              <h4 class="mat-h4" fxFlexFill>Fees to Specific Income Accounts</h4>
-
-              <table fxFlexFill class="mat-elevation-z1" mat-table [dataSource]="savingProduct.feeToIncomeAccountMappings">
-
-                <ng-container matColumnDef="chargeId">
-                  <th mat-header-cell *matHeaderCellDef> Fees </th>
-                  <td mat-cell *matCellDef="let feesIncome">
-                    {{ feesIncome.charge.name }}
-                  </td>
-                </ng-container>
-
-                <ng-container matColumnDef="incomeAccountId">
-                  <th mat-header-cell *matHeaderCellDef> Income Account </th>
-                  <td mat-cell *matCellDef="let feesIncome">
-                    ({{ feesIncome.incomeAccount.glCode }}) {{ feesIncome.incomeAccount.name }}
-                  </td>
-                </ng-container>
-
-                <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns;"></tr>
-
-              </table>
-
-            </div>
-
-            <div *ngIf="savingProduct.penaltyToIncomeAccountMappings?.length" fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
-
-              <h4 class="mat-h4" fxFlexFill>Penalties to Specific Income Accounts</h4>
-
-              <table fxFlexFill class="mat-elevation-z1" mat-table [dataSource]="savingProduct.penaltyToIncomeAccountMappings">
-
-                <ng-container matColumnDef="chargeId">
-                  <th mat-header-cell *matHeaderCellDef> Penalty </th>
-                  <td mat-cell *matCellDef="let penaltyIncome">
-                    {{ penaltyIncome.charge.name }}
-                  </td>
-                </ng-container>
-
-                <ng-container matColumnDef="incomeAccountId">
-                  <th mat-header-cell *matHeaderCellDef> Income Account </th>
-                  <td mat-cell *matCellDef="let penaltyIncome">
-                    ({{ penaltyIncome.incomeAccount.glCode }}) {{ penaltyIncome.incomeAccount.name }}
-                  </td>
-                </ng-container>
-
-                <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns;"></tr>
-
-              </table>
-
-            </div>
-
-          </div>
+          </table>
 
         </div>
 
       </div>
 
-    </mat-card-content>
+    </div>
 
-  </mat-card>
+  </div>
 
 </div>

--- a/src/app/products/saving-products/view-saving-product/saving-product-general-tab/saving-product-general-tab.component.scss
+++ b/src/app/products/saving-products/view-saving-product/saving-product-general-tab/saving-product-general-tab.component.scss
@@ -3,6 +3,10 @@
 .tab-container {
   padding: 1%;
   margin: 1%;
+
+  div: {
+    margin-top: 3px;
+  }
 }
 
 .mat-h3 {

--- a/src/app/savings/common-resolvers/savings-account-transaction.resolver.ts
+++ b/src/app/savings/common-resolvers/savings-account-transaction.resolver.ts
@@ -26,7 +26,7 @@ export class SavingsAccountTransactionResolver implements Resolve<Object> {
    */
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
     const savingAccountId = route.parent.paramMap.get('savingAccountId');
-    const transactionId = route.paramMap.get('id');
+    const transactionId = route.parent.paramMap.get('id');
     return this.savingsService.getSavingsAccountTransaction(savingAccountId, transactionId);
   }
 

--- a/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.html
+++ b/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.html
@@ -44,12 +44,17 @@
         <td mat-cell class="r-amount" *matCellDef="let transaction"> {{ transaction.runningBalance | formatNumber }} </td>
       </ng-container>
 
-      <ng-container matColumnDef="viewReciept">
-        <th mat-header-cell class="center" *matHeaderCellDef> View Reciept </th>
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell class="center" *matHeaderCellDef> Actions </th>
         <td mat-cell class="center" *matCellDef="let transaction">
           <button class="account-action-button" mat-raised-button color="primary" (click)="routeEdit($event)" [routerLink]="[transaction.id, 'reciept']">
             <i class="fa fa-file" matTooltip="View Reciept"></i>
           </button>
+          <button class="account-action-button" mat-raised-button color="primary" matTooltip="View Journal Entries"
+          matTooltipPosition="left" (click)="routeEdit($event)"
+          [routerLink]="['/','journal-entry', 'view', 'S'+transaction.id ]">
+          <i class="fa fa-arrow-circle-right"></i>
+        </button>
         </td>
       </ng-container>
 

--- a/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.ts
@@ -20,7 +20,7 @@ export class TransactionsTabComponent implements OnInit {
   /** Transactions Data */
   transactionsData: any;
   /** Columns to be displayed in transactions table. */
-  displayedColumns: string[] = ['id', 'date', 'transactionType', 'debit', 'credit', 'balance', 'viewReciept'];
+  displayedColumns: string[] = ['id', 'date', 'transactionType', 'debit', 'credit', 'balance', 'actions'];
   /** Data source for transactions table. */
   dataSource: MatTableDataSource<any>;
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
@@ -75,7 +75,7 @@ export class TransactionsTabComponent implements OnInit {
     if (transactionsData.transfer) {
       this.router.navigate([`account-transfers/account-transfers/${transactionsData.transfer.id}`], { relativeTo: this.route });
     } else {
-      this.router.navigate([transactionsData.id], { relativeTo: this.route });
+      this.router.navigate([transactionsData.id, 'general'], { relativeTo: this.route });
     }
   }
 

--- a/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-datatable-tab/savings-transaction-datatable-tab.component.html
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-datatable-tab/savings-transaction-datatable-tab.component.html
@@ -1,0 +1,1 @@
+<p>savings-transaction-datatable-tab works!</p>

--- a/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-datatable-tab/savings-transaction-datatable-tab.component.spec.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-datatable-tab/savings-transaction-datatable-tab.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SavingsTransactionDatatableTabComponent } from './savings-transaction-datatable-tab.component';
+
+describe('SavingsTransactionDatatableTabComponent', () => {
+  let component: SavingsTransactionDatatableTabComponent;
+  let fixture: ComponentFixture<SavingsTransactionDatatableTabComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SavingsTransactionDatatableTabComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SavingsTransactionDatatableTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-datatable-tab/savings-transaction-datatable-tab.component.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-datatable-tab/savings-transaction-datatable-tab.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'mifosx-savings-transaction-datatable-tab',
+  templateUrl: './savings-transaction-datatable-tab.component.html',
+  styleUrls: ['./savings-transaction-datatable-tab.component.scss']
+})
+export class SavingsTransactionDatatableTabComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.html
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.html
@@ -1,0 +1,90 @@
+<div fxLayoutAlign="end" class="container m-b-20" fxLayoutGap="2%"
+  *ngIf="!(transactionData.interestedPostedAsOn === false && (transactionData.transactionType.id === 17 || transactionData.transactionType.id === 3))">
+  <span *mifosxHasPermission="'ADJUSTTRANSACTION_SAVINGSACCOUNT'">
+    <button mat-raised-button color="primary" *ngIf="transactionData.transactionType.value == 'Transfer' || transactionData.reversed == 'true'
+        || transactionData.transactionType.id==3 || transactionData.transactionType.id==17" [routerLink]="'edit'">
+      <fa-icon icon="edit" class="m-r-10"></fa-icon>Edit
+    </button>
+  </span>
+  <span *ngIf="!transactionData.reversed && transactionData.transactionType.amountHold">
+    <button mat-raised-button color="primary" *mifosxHasPermission="'RELEASEAMOUNT_SAVINGSACCOUNT'"
+      (click)="releaseAmount()">
+      <fa-icon icon="lock-open" class="m-r-10"></fa-icon>Release Amount
+    </button>
+  </span>
+  <button mat-raised-button color="warn" *mifosxHasPermission="'UNDOTRANSACTION_SAVINGSACCOUNT'"
+    (click)="undoTransaction()" [disabled]="transactionData.reversed">
+    <fa-icon icon="undo" class="m-r-10"></fa-icon>Undo
+  </button>
+</div>
+
+<div class="container">
+
+  <mat-card>
+
+    <mat-card-content>
+
+      <div fxLayout="row wrap" class="content">
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Transaction Id
+        </div>
+
+        <div fxFlex="50%">
+          {{ transactionData.id }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Type
+        </div>
+
+        <div fxFlex="50%">
+          {{ transactionData.transactionType.value }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Transaction Date
+        </div>
+
+        <div fxFlex="50%">
+          {{ transactionData.date | dateFormat }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Currency
+        </div>
+
+        <div fxFlex="50%">
+          {{ transactionData.currency.name }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Amount
+        </div>
+
+        <div fxFlex="50%">
+          {{ transactionData.amount | currency }} {{ transactionData.currency.code }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong">
+          Note
+        </div>
+
+        <div fxFlex="50%">
+          {{ transactionData.note }}
+        </div>
+
+        <mifosx-transaction-payment-detail *ngIf="transactionData.paymentDetailData"
+          [paymentDetailData]="transactionData.paymentDetailData">
+        </mifosx-transaction-payment-detail>
+
+      </div>
+
+      <div fxLayout="row" fxLayoutAlign="center" fxLayoutGap="2%" fxLayout.lt-md="column">
+        <button type="button" mat-raised-button color="primary" [routerLink]="['../']">{{ 'Back' | translate }}</button>
+      </div>
+    </mat-card-content>
+
+  </mat-card>
+
+</div>

--- a/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.scss
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.scss
@@ -5,5 +5,10 @@
       margin: 1rem 0;
       word-wrap: break-word;
     }
+
+    mifosx-transaction-payment-detail {
+      width: 100%;
+      margin-bottom: 20px;
+    }
   }
 }

--- a/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.spec.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SavingsTransactionGeneralTabComponent } from './savings-transaction-general-tab.component';
+
+describe('SavingsTransactionGeneralTabComponent', () => {
+  let component: SavingsTransactionGeneralTabComponent;
+  let fixture: ComponentFixture<SavingsTransactionGeneralTabComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SavingsTransactionGeneralTabComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SavingsTransactionGeneralTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.ts
@@ -1,0 +1,67 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Dates } from 'app/core/utils/dates';
+import { ReleaseAmountDialogComponent } from 'app/savings/savings-account-view/custom-dialogs/release-amount-dialog/release-amount-dialog.component';
+import { UndoTransactionDialogComponent } from 'app/savings/savings-account-view/custom-dialogs/undo-transaction-dialog/undo-transaction-dialog.component';
+import { SavingsService } from 'app/savings/savings.service';
+import { SettingsService } from 'app/settings/settings.service';
+
+@Component({
+  selector: 'mifosx-savings-transaction-general-tab',
+  templateUrl: './savings-transaction-general-tab.component.html',
+  styleUrls: ['./savings-transaction-general-tab.component.scss']
+})
+export class SavingsTransactionGeneralTabComponent implements OnInit {
+
+  accountId: string;
+  transactionId: string;
+  transactionData: any;
+
+  constructor(private savingsService: SavingsService,
+    private route: ActivatedRoute,
+    private dateUtils: Dates,
+    private router: Router,
+    public dialog: MatDialog,
+    private settingsService: SettingsService) {
+      this.route.data.subscribe((data: { savingsAccountTransaction: any }) => {
+        this.accountId = this.route.parent.snapshot.params['savingAccountId'];
+        this.transactionData = data.savingsAccountTransaction;
+      });
+    }
+
+  ngOnInit(): void {
+  }
+
+  releaseAmount(): void {
+    const releaseAmountDialogRef = this.dialog.open(ReleaseAmountDialogComponent);
+    releaseAmountDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.confirm) {
+        const data = {};
+        this.savingsService.executeSavingsAccountTransactionsCommand(this.accountId, 'releaseAmount', data, this.transactionData.id).subscribe(() => {
+          this.router.navigate(['../..'], { relativeTo: this.route });
+        });
+      }
+    });
+  }
+
+  undoTransaction(): void {
+    const undoTransactionAccountDialogRef = this.dialog.open(UndoTransactionDialogComponent);
+    undoTransactionAccountDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.confirm) {
+        const locale = this.settingsService.language.code;
+        const dateFormat = this.settingsService.dateFormat;
+        const data = {
+          transactionDate: this.dateUtils.formatDate(this.transactionData.date && new Date(this.transactionData.date), dateFormat),
+          transactionAmount: 0,
+          dateFormat,
+          locale
+        };
+        this.savingsService.executeSavingsAccountTransactionsCommand(this.accountId, 'undo', data, this.transactionData.id).subscribe(() => {
+          this.router.navigate(['../'], { relativeTo: this.route });
+        });
+      }
+    });
+  }
+
+}

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.html
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.html
@@ -1,110 +1,18 @@
-<mat-card class="savings-account-card">
-  <!-- Header -->
-  <mat-card-header fxLayout="column" class="header">
-    <mat-card-title-group class="header-title-group">
-      <div class="profile-image-container">
-        <div>
-          <img mat-card-md-image class="profile-image" matTooltip="Savings Account"
-            [src]="'assets/images/savings_account_placeholder.png'">
-        </div>
-      </div>
+<div class="container">
+  <nav mat-tab-nav-bar class="navigation-tabs">
+    <a mat-tab-link [routerLink]="['./general']" routerLinkActive #general="routerLinkActive"
+      [active]="general.isActive">
+      General
+    </a>
+    <ng-container *ngFor="let entityDatatable of entityDatatables">
+      <a mat-tab-link [routerLink]="['./datatables',entityDatatable.registeredTableName]" routerLinkActive
+        #datatable="routerLinkActive" [active]="datatable.isActive"
+        *mifosxHasPermission="'READ_' + entityDatatable.registeredTableName">
+        {{entityDatatable.registeredTableName}}
+      </a>
+    </ng-container>
+  </nav>
 
-      <div class="mat-typography account-card-title">
-        <mat-card-title fxLayout="row" fxLayout.lt-md="column">
-          <h3 fxFlex="95%">
-            Transaction Id : {{transactionData.id}}<span class="m-l-10">
-              <mifosx-account-number accountNo="{{transactionData.id}}"></mifosx-account-number>
-            </span>
-          </h3>
-          <div fxFlex="15%">
-            <button mat-raised-button color="warn" *mifosxHasPermission="'UNDOTRANSACTION_SAVINGSACCOUNT'"
-              (click)="undoTransaction()" [disabled]="transactionData.reversed">
-              <fa-icon icon="undo" class="m-r-10"></fa-icon>Undo
-            </button>
-          </div>
-          <span *mifosxHasPermission="'ADJUSTTRANSACTION_SAVINGSACCOUNT'">
-            <button mat-raised-button color="primary" *ngIf="transactionData.transactionType.value === 'Transfer' || transactionData.reversed === 'true'
-                || transactionData.transactionType.id===3 || transactionData.transactionType.id===17" [routerLink]="'edit'">
-              <fa-icon icon="edit" class="m-r-10"></fa-icon>Edit
-            </button>
-          </span>
-          <span *ngIf="!transactionData.reversed && transactionData.transactionType.amountHold">
-            <button mat-raised-button color="primary" *mifosxHasPermission="'RELEASEAMOUNT_SAVINGSACCOUNT'"
-              (click)="releaseAmount()">
-              <fa-icon icon="lock-open" class="m-r-10"></fa-icon>Release Amount
-            </button>
-          </span>
-        </mat-card-title>
-      </div>
+  <router-outlet></router-outlet>
 
-    </mat-card-title-group>
-  </mat-card-header>
-
-  <!-- Content -->
-  <mat-card-content class="content">
-    <div class="savings-account-tables" fxLayout="row" fxLayoutGap="2%">
-      <div fxFlex="96%">
-        <h4 class="table-headers">Transaction Summary</h4>
-        <table>
-          <tbody>
-            <tr *ngIf="transactionData.transactionType.value">
-              <td>Transaction Type</td>
-              <td>{{transactionData.transactionType.value}}</td>
-            </tr>
-            <tr *ngIf="transactionData.date">
-              <td>Transaction Date</td>
-              <td>{{transactionData.date | dateFormat}}</td>
-            </tr>
-            <tr *ngIf="transactionData.currency.name">
-              <td>Currency</td>
-              <td>{{transactionData.currency.name}}</td>
-            </tr>
-            <tr *ngIf="transactionData.amount">
-              <td>Amount</td>
-              <td>{{transactionData.amount | currency}}</td>
-            </tr>
-            <tr *ngIf="transactionData.note">
-              <td>Note</td>
-              <td>{{transactionData.note}}</td>
-            </tr>
-            <tr *ngIf="transactionData.paymentDetailData.paymentType">
-              <td>{{ 'Payment Type' | translate }}</td>
-              <td>{{transactionData.paymentDetailData.paymentType.name}}</td>
-            </tr>
-            <tr *ngIf="transactionData.paymentDetailData.accountNumber">
-              <td>{{ 'Account Number' | translate }}</td>
-              <td>{{transactionData.paymentDetailData.accountNumber}}</td>
-            </tr>
-            <tr *ngIf="transactionData.paymentDetailData.checkNumber">
-              <td>{{ 'Cheque Number' | translate }}</td>
-              <td>{{transactionData.paymentDetailData.checkNumber}}</td>
-            </tr>
-            <tr *ngIf="transactionData.paymentDetailData.routingCode">
-              <td>{{ 'Routing Code' | translate }}</td>
-              <td>{{transactionData.paymentDetailData.routingCode}}</td>
-            </tr>
-            <tr *ngIf="transactionData.paymentDetailData.receiptNumber">
-              <td>{{ 'Receipt Number' | translate }}</td>
-              <td>{{transactionData.paymentDetailData.receiptNumber}}</td>
-            </tr>
-            <tr *ngIf="transactionData.paymentDetailData.bankNumber">
-              <td>{{ 'Bank Number' | translate }}</td>
-              <td>{{transactionData.paymentDetailData.bankNumber}}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-    <nav mat-tab-nav-bar class="navigation-tabs">
-      <ng-container *ngFor="let transactionDatatable of entityDatatable">
-        <a mat-tab-link *mifosxHasPermission="'READ_' + transactionDatatable.registeredTableName"
-        [routerLink]="['./datatables',transactionDatatable.registeredTableName]" routerLinkActive #datatable="routerLinkActive"
-         [active]="datatable.isActive">
-          {{transactionDatatable.registeredTableName}}
-        </a>
-      </ng-container>
-    </nav>
-    <router-outlet></router-outlet>
-  </mat-card-content>
-</mat-card>
+</div>

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.ts
@@ -1,21 +1,8 @@
 /** Angular Imports */
 import { Component } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
-/** Custom Services */
-import { SavingsService } from 'app/savings/savings.service';
-import { SettingsService } from 'app/settings/settings.service';
-
-/** Custom Dialogs */
-import { UndoTransactionDialogComponent } from '../../custom-dialogs/undo-transaction-dialog/undo-transaction-dialog.component';
-import { Dates } from 'app/core/utils/dates';
-import { ReleaseAmountDialogComponent } from '../../custom-dialogs/release-amount-dialog/release-amount-dialog.component';
-
-/**
- * View Transaction Component.
- * TODO: Add support for account transfers.
- */
 @Component({
   selector: 'mifosx-view-transaction',
   templateUrl: './view-transaction.component.html',
@@ -28,65 +15,17 @@ export class ViewTransactionComponent {
 
   accountId: any;
   /** Transaction Data Tables */
-  entityDatatable: any;
-  /** Multi Row Datatable Flag */
-  multiRowDatatableFlag: boolean;
-  isActive: false;
+  entityDatatables: any;
 
   /**
-   * Retrieves the Transaction data from `resolve`.
-   * @param {SavingsService} savingsService Savings Service
-   * @param {ActivatedRoute} route Activated Route.
    * @param {Router} router Router for navigation.
    * @param {MatDialog} dialog Dialog reference.
-   * @param {Dates} dateUtils Date Utils.
-   * @param {SettingsService} settingsService Setting service
    */
-  constructor(private savingsService: SavingsService,
-              private route: ActivatedRoute,
-              private dateUtils: Dates,
-              private router: Router,
-              public dialog: MatDialog,
-              private settingsService: SettingsService) {
-            this.route.data.subscribe((data: { savingsAccountTransaction: any, transactionDatatables: any}) => {
+  constructor(private route: ActivatedRoute,
+              public dialog: MatDialog) {
+            this.route.data.subscribe((data: { transactionDatatables: any}) => {
                   this.accountId = this.route.snapshot.params['savingAccountId'];
-                  this.transactionData = data.savingsAccountTransaction;
-                  this.entityDatatable = data.transactionDatatables;
+                  this.entityDatatables = data.transactionDatatables;
                 });
   }
-
-  /**
-   * Undo the savings transaction
-   */
-  undoTransaction() {
-    const undoTransactionAccountDialogRef = this.dialog.open(UndoTransactionDialogComponent);
-    undoTransactionAccountDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
-        const locale = this.settingsService.language.code;
-        const dateFormat = this.settingsService.dateFormat;
-        const data = {
-          transactionDate: this.dateUtils.formatDate(this.transactionData.date && new Date(this.transactionData.date), dateFormat),
-          transactionAmount: 0,
-          dateFormat,
-          locale
-        };
-        this.savingsService.executeSavingsAccountTransactionsCommand(this.accountId, 'undo', data, this.transactionData.id).subscribe(() => {
-          this.router.navigate(['../'], { relativeTo: this.route });
-        });
-      }
-    });
-  }
-
-  releaseAmount() {
-    const releaseAmountDialogRef = this.dialog.open(ReleaseAmountDialogComponent);
-    releaseAmountDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
-        const data = { };
-        this.savingsService.executeSavingsAccountTransactionsCommand(this.accountId, 'releaseAmount', data, this.transactionData.id).subscribe(() => {
-          this.router.navigate(['../'], { relativeTo: this.route });
-        });
-      }
-    });
-  }
-
 }

--- a/src/app/savings/savings-routing.module.ts
+++ b/src/app/savings/savings-routing.module.ts
@@ -44,6 +44,7 @@ import { SavingsDocumentsTabComponent } from './savings-account-view/savings-doc
 import { NotesTabComponent } from './savings-account-view/notes-tab/notes-tab.component';
 import { SavingNotesResolver } from './common-resolvers/saving-notes.resolver';
 import { SavingDocumentsResolver } from './common-resolvers/saving-documents.resolver';
+import { SavingsTransactionGeneralTabComponent } from './savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component';
 
 /** Savings Routes */
 const routes: Routes = [
@@ -144,22 +145,33 @@ const routes: Routes = [
             path: '',
             component: ViewTransactionComponent,
             resolve: {
-              savingsAccountTransaction: SavingsAccountTransactionResolver,
               transactionDatatables: TransactionDatatablesResolver
             },
             children: [
               {
-                path: 'datatables',
-                children: [{
-                  path: ':datatableName',
-                  component: DatatableTransactionTabComponent,
-                  data: { title: extract('View Data table'), routeParamBreadcrumb: 'datatableName' },
-                  resolve: {
-                    transactionDatatable: TransactionDatatableResolver
-                  }
+                path: '',
+                redirectTo: 'general',
+                pathMatch: 'full'
+              },
+              {
+                path: 'general',
+                component: SavingsTransactionGeneralTabComponent,
+                resolve: {
+                  savingsAccountTransaction: SavingsAccountTransactionResolver,
                 }
+              },
+              {
+                path: 'datatables',
+                children: [
+                  {
+                    path: ':datatableName',
+                    component: DatatableTransactionTabComponent,
+                    data: { title: extract('View Data table'), routeParamBreadcrumb: 'datatableName' },
+                    resolve: {
+                      transactionDatatable: TransactionDatatableResolver
+                    }
+                  }
                 ]
-
               }
             ]
           },

--- a/src/app/savings/savings.module.ts
+++ b/src/app/savings/savings.module.ts
@@ -50,6 +50,8 @@ import { ReleaseAmountDialogComponent } from './savings-account-view/custom-dial
 import { SavingsDocumentsTabComponent } from './savings-account-view/savings-documents-tab/savings-documents-tab.component';
 import { NotesTabComponent } from './savings-account-view/notes-tab/notes-tab.component';
 import { DatatableTransactionTabComponent } from './savings-account-view/transactions/view-transaction/datatable-transaction-tab/datatable-transaction-tab.component';
+import { SavingsTransactionGeneralTabComponent } from './savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component';
+import { SavingsTransactionDatatableTabComponent } from './savings-account-view/transactions/view-transaction/savings-transaction-datatable-tab/savings-transaction-datatable-tab.component';
 
 
 /**
@@ -106,7 +108,9 @@ import { DatatableTransactionTabComponent } from './savings-account-view/transac
     ReleaseAmountDialogComponent,
     SavingsDocumentsTabComponent,
     NotesTabComponent,
-    DatatableTransactionTabComponent
+    DatatableTransactionTabComponent,
+    SavingsTransactionGeneralTabComponent,
+    SavingsTransactionDatatableTabComponent
   ],
   providers: [ ]
 })

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -41,6 +41,7 @@ import { ViewJournalEntryComponent } from './accounting/view-journal-entry/view-
 import { ViewJournalEntryTransactionComponent } from './accounting/view-journal-entry-transaction/view-journal-entry-transaction.component';
 import { AccountNumberComponent } from './account-number/account-number.component';
 import { EntityNameComponent } from './entity-name/entity-name.component';
+import { TransactionPaymentDetailComponent } from './transaction-payment-detail/transaction-payment-detail.component';
 
 /**
  * Shared Module
@@ -88,7 +89,8 @@ import { EntityNameComponent } from './entity-name/entity-name.component';
     ViewJournalEntryComponent,
     ViewJournalEntryTransactionComponent,
     AccountNumberComponent,
-    EntityNameComponent
+    EntityNameComponent,
+    TransactionPaymentDetailComponent
   ],
   exports: [
     FileUploadComponent,
@@ -114,7 +116,8 @@ import { EntityNameComponent } from './entity-name/entity-name.component';
     ViewJournalEntryComponent,
     ViewJournalEntryTransactionComponent,
     SvgIconComponent,
-    EntityNameComponent
+    EntityNameComponent,
+    TransactionPaymentDetailComponent
   ]
 })
 export class SharedModule { }

--- a/src/app/shared/transaction-payment-detail/payment-detail-model.ts
+++ b/src/app/shared/transaction-payment-detail/payment-detail-model.ts
@@ -1,0 +1,16 @@
+export interface PaymentType {
+  id: number;
+  isSystemDefined: boolean;
+  name: string;
+}
+
+export interface PaymentDetail {
+  paymentType: PaymentType;
+  accountNumber: string;
+  checkNumber: string;
+  routingCode: string;
+  receiptNumber: string;
+  bankNumber: string;
+}
+
+

--- a/src/app/shared/transaction-payment-detail/transaction-payment-detail.component.html
+++ b/src/app/shared/transaction-payment-detail/transaction-payment-detail.component.html
@@ -1,0 +1,49 @@
+<ng-container class="content">
+  <div *ngIf="paymentDetailData.paymentType" fxFlex="50%" class="attribute">
+    {{ 'Payment Type' | translate }}
+  </div>
+
+  <div *ngIf="paymentDetailData.paymentType" fxFlex="50%">
+    {{ paymentDetailData.paymentType.name }}
+  </div>
+
+  <div *ngIf="paymentDetailData.accountNumber" fxFlex="50%" class="attribute">
+    {{ 'Account No.' | translate }}
+  </div>
+
+  <div *ngIf="paymentDetailData.accountNumber" fxFlex="50%">
+    {{ paymentDetailData.accountNumber }}
+  </div>
+
+  <div *ngIf="paymentDetailData.checkNumber" fxFlex="50%" class="attribute">
+    {{ 'Cheque Number' | translate }}
+  </div>
+
+  <div *ngIf="paymentDetailData.checkNumber" fxFlex="50%">
+    {{ paymentDetailData.checkNumber }}
+  </div>
+
+  <div *ngIf="paymentDetailData.routingCode" fxFlex="50%" class="attribute">
+    {{ 'Routing Code' | translate }}
+  </div>
+
+  <div *ngIf="paymentDetailData.routingCode" fxFlex="50%">
+    {{ paymentDetailData.routingCode }}
+  </div>
+
+  <div *ngIf="paymentDetailData.receiptNumber" fxFlex="50%" class="attribute">
+    {{ 'Receipt No.' | translate }}
+  </div>
+
+  <div *ngIf="paymentDetailData.receiptNumber" fxFlex="50%">
+    {{ paymentDetailData.receiptNumber }}
+  </div>
+
+  <div *ngIf="paymentDetailData.bankNumber" fxFlex="50%" class="attribute">
+    {{ 'Bank No.' | translate }}
+  </div>
+
+  <div *ngIf="paymentDetailData.bankNumber" fxFlex="50%">
+    {{ paymentDetailData.bankNumber }}
+  </div>
+</ng-container>

--- a/src/app/shared/transaction-payment-detail/transaction-payment-detail.component.scss
+++ b/src/app/shared/transaction-payment-detail/transaction-payment-detail.component.scss
@@ -1,0 +1,14 @@
+@import "assets/styles/helper";
+
+.content {
+  width: 100%;
+  background-color: $concrete;
+
+  div {
+    text-align: left;
+  }
+
+  .attribute {
+    font-weight: 500;
+  }
+}

--- a/src/app/shared/transaction-payment-detail/transaction-payment-detail.component.spec.ts
+++ b/src/app/shared/transaction-payment-detail/transaction-payment-detail.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TransactionPaymentDetailComponent } from './transaction-payment-detail.component';
+
+describe('TransactionPaymentDetailComponent', () => {
+  let component: TransactionPaymentDetailComponent;
+  let fixture: ComponentFixture<TransactionPaymentDetailComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TransactionPaymentDetailComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TransactionPaymentDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/transaction-payment-detail/transaction-payment-detail.component.ts
+++ b/src/app/shared/transaction-payment-detail/transaction-payment-detail.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { PaymentDetail } from './payment-detail-model';
+
+
+@Component({
+  selector: 'mifosx-transaction-payment-detail',
+  templateUrl: './transaction-payment-detail.component.html',
+  styleUrls: ['./transaction-payment-detail.component.scss']
+})
+export class TransactionPaymentDetailComponent implements OnInit {
+
+  @Input() paymentDetailData: PaymentDetail;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+
+}


### PR DESCRIPTION
## Description

The `datatables` are available now for Savings Account Transactions 

- Savings Account Transaction General tab for the transaction details

<img width="1153" alt="Screenshot 2023-09-01 at 20 18 47" src="https://github.com/openMF/web-app/assets/44206706/e4162d27-73c8-4fdf-ab79-8715aab62774">


- Additional Tabs for each Savings Account Transaction datatable defined

<img width="1152" alt="Screenshot 2023-09-01 at 20 18 35" src="https://github.com/openMF/web-app/assets/44206706/cf587bf4-ded5-47e1-8337-044b74531248">


## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
