### PR TITLE
Fix to display the Advance Payment Allocation data in Loan Product ge…

### DIFF
--- a/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.html
+++ b/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.html
@@ -336,7 +336,8 @@
     <span fxFlex="60%">
       <mat-accordion>
         <mifosx-view-advance-paymeny-allocation *ngFor="let paymentAllocation of loanProduct.paymentAllocation"
-          [paymentAllocation]="paymentAllocation">
+          [paymentAllocation]="paymentAllocation"
+          [advancePaymentAllocationData]="advancePaymentAllocationData">
         </mifosx-view-advance-paymeny-allocation>
       </mat-accordion>
     </span>

--- a/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.ts
+++ b/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { AdvancePaymentAllocationData } from '../../loan-product-stepper/loan-product-payment-strategy-step/payment-allocation-model';
 
 @Component({
   selector: 'mifosx-general-tab',
@@ -14,6 +15,8 @@ export class GeneralTabComponent implements OnInit {
   chargesDisplayedColumns: string[] = ['name', 'chargeCalculationType', 'amount', 'chargeTimeType'];
   paymentFundSourceDisplayedColumns: string[] = ['paymentTypeId', 'fundSourceAccountId'];
   feesPenaltyIncomeDisplayedColumns: string[] = ['chargeId', 'incomeAccountId'];
+
+  advancePaymentAllocationData: AdvancePaymentAllocationData | null = null;
 
   constructor(private route: ActivatedRoute) {
     this.route.data.subscribe((data: { loanProduct: any }) => {

--- a/src/app/products/loan-products/view-loan-product/shared/view-advance-paymeny-allocation/view-advance-paymeny-allocation.component.ts
+++ b/src/app/products/loan-products/view-loan-product/shared/view-advance-paymeny-allocation/view-advance-paymeny-allocation.component.ts
@@ -17,16 +17,25 @@ export class ViewAdvancePaymenyAllocationComponent implements OnInit {
   }
 
   transactionTypeValue(code: string): string {
+    if (this.advancePaymentAllocationData == null) {
+      return code;
+    }
     const transactionType =  this.advancePaymentAllocationData.transactionTypes.find(t => t.code === code);
     return transactionType.value;
   }
 
   allocationRuleValue(code: string): string {
+    if (this.advancePaymentAllocationData == null) {
+      return code;
+    }
     const allocationType =  this.advancePaymentAllocationData.allocationTypes.find(t => t.code === code);
     return allocationType.value;
   }
 
   futureInstallmentRuleValue(code: string): string {
+    if (this.advancePaymentAllocationData == null) {
+      return code;
+    }
     const futureInstallmentAllocationRule =  this.advancePaymentAllocationData.futureInstallmentAllocationRules.find(t => t.code === code);
     return futureInstallmentAllocationRule.value;
   }


### PR DESCRIPTION
…neral tab

## Description
Fix to display the Advance Payment Allocation data in Loan Product general tab

## Screenshots, if any
<img width="1770" alt="Screenshot 2023-10-09 at 10 14 49 p m" src="https://github.com/openMF/web-app/assets/44206706/a4e9d908-9723-40cf-83de-6878fb626624">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
