### PR TITLE
Add Advanced Payment Alloc Data in Loan Product view

### DIFF
--- a/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.ts
+++ b/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.ts
@@ -16,11 +16,16 @@ export class GeneralTabComponent implements OnInit {
   paymentFundSourceDisplayedColumns: string[] = ['paymentTypeId', 'fundSourceAccountId'];
   feesPenaltyIncomeDisplayedColumns: string[] = ['chargeId', 'incomeAccountId'];
 
-  advancePaymentAllocationData: AdvancePaymentAllocationData | null = null;
+  advancePaymentAllocationData: AdvancePaymentAllocationData;
 
   constructor(private route: ActivatedRoute) {
     this.route.data.subscribe((data: { loanProduct: any }) => {
       this.loanProduct = data.loanProduct;
+      this.advancePaymentAllocationData = {
+        transactionTypes: this.loanProduct.advancedPaymentAllocationTransactionTypes,
+        allocationTypes: this.loanProduct.advancedPaymentAllocationTypes,
+        futureInstallmentAllocationRules: this.loanProduct.advancedPaymentAllocationFutureInstallmentAllocationRules
+      };
     });
   }
 


### PR DESCRIPTION
## Description

Add Advanced Payment Alloc Data in Loan Product view to have labels in a human readable way

## Screenshots, if any
<img width="1729" alt="Screenshot 2023-10-10 at 5 48 24 p m" src="https://github.com/openMF/web-app/assets/44206706/2d16f984-42da-4e86-81e5-2ba943415b66">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
