### PR TITLE
Loan Product repayment due event values set by default from global co…

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
@@ -569,11 +569,16 @@
   <h3 class="mat-h3" fxFlexFill>Event Settings</h3>
 
   <div fxFlexFill>
+    <span fxFlex="40%">Use the Global Configurations values to the Repayment Event (notifications):</span>
+    <span fxFlex="60%">{{ loanProduct.useDueForRepaymentsConfigurations | yesNo }}</span>
+  </div>
+
+  <div fxFlexFill *ngIf="!loanProduct.useDueForRepaymentsConfigurations">
     <span fxFlex="40%">Due days for repayment event:</span>
     <span fxFlex="60%">{{ loanProduct.dueDaysForRepaymentEvent | number }}</span>
   </div>
 
-  <div fxFlexFill>
+  <div fxFlexFill *ngIf="!loanProduct.useDueForRepaymentsConfigurations">
     <span fxFlex="40%">OverDue days for repayment event:</span>
     <span fxFlex="60%">{{ loanProduct.overDueDaysForRepaymentEvent | number }}</span>
   </div>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -458,24 +458,21 @@
 
     <h3 fxFlex="23%" class="mat-h3">Event Settings <i class="fas fa-question"
       matTooltip="Setting for event notifications to be sent before or after repayments. Blue color means default value from global configurations."></i></h3>
-    <div fxFlexFill fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
+
+    <mat-checkbox fxFlex="48%" labelPosition="before" formControlName="useDueForRepaymentsConfigurations" matTooltip="Use or not the Global Configurations values to the Repayment Event (notifications)" class="margin-b">
+        Use the Global Configurations values to the Repayment Event (notifications)
+    </mat-checkbox>
+
+    <div fxFlexFill fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column" *ngIf="!loanProductSettingsForm.value.useDueForRepaymentsConfigurations">
 
       <mat-form-field fxFlex="48%">
         <mat-label>Due days for repayment event</mat-label>
-        <mat-select formControlName="dueDaysForRepaymentEvent" matTooltip="The Amortization value is input to calculating the repayment amounts for repayment of the loan." required>
-          <mat-option *ngFor="let item of getDaysForRepayments(DAYS_BEFORE_REPAYMENT_IS_DUE)" [value]="item.days">
-            <span [ngClass]="item.style">{{item.label}}</span>
-          </mat-option>
-        </mat-select>
+        <input type="number" matInput matTooltip="The maximum outstanding loan account balance allowed at a point in time." formControlName="dueDaysForRepaymentEvent">
       </mat-form-field>
 
       <mat-form-field fxFlex="48%">
         <mat-label>OverDue days for repayment event</mat-label>
-        <mat-select formControlName="overDueDaysForRepaymentEvent" matTooltip="The Amortization value is input to calculating the repayment amounts for repayment of the loan." required>
-          <mat-option *ngFor="let item of getDaysForRepayments(DAYS_AFTER_REPAYMENT_IS_OVERDUE)" [value]="item.days">
-            <span [ngClass]="item.style">{{item.label}}</span>
-          </mat-option>
-        </mat-select>
+        <input type="number" matInput matTooltip="The maximum outstanding loan account balance allowed at a point in time." formControlName="overDueDaysForRepaymentEvent">
       </mat-form-field>
     </div>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -132,10 +132,9 @@ export class LoanProductSettingsStepComponent implements OnInit {
       'multiDisburseLoan': this.loanProductsTemplate.multiDisburseLoan,
       'maxTrancheCount': this.loanProductsTemplate.maxTrancheCount,
       'outstandingLoanBalance': this.loanProductsTemplate.outstandingLoanBalance,
-      'dueDaysForRepaymentEvent': this.loanProductsTemplate.dueDaysForRepaymentEvent,
-      'overDueDaysForRepaymentEvent': this.loanProductsTemplate.overDueDaysForRepaymentEvent,
       'enableDownPayment': this.loanProductsTemplate.enableDownPayment,
-      'enableInstallmentLevelDelinquency': this.loanProductsTemplate.enableInstallmentLevelDelinquency
+      'enableInstallmentLevelDelinquency': this.loanProductsTemplate.enableInstallmentLevelDelinquency,
+      'useDueForRepaymentsConfigurations': this.loanProductsTemplate.useDueForRepaymentsConfigurations
     });
 
     if (this.loanProductsTemplate.delinquencyBucket) {
@@ -239,10 +238,9 @@ export class LoanProductSettingsStepComponent implements OnInit {
         'graceOnArrearsAgeing': [true]
       }),
       'delinquencyBucketId': ['', Validators.required],
-      'dueDaysForRepaymentEvent': [''],
-      'overDueDaysForRepaymentEvent': [''],
       'enableDownPayment': [false],
-      'enableInstallmentLevelDelinquency': [false]
+      'enableInstallmentLevelDelinquency': [false],
+      'useDueForRepaymentsConfigurations': [false]
     });
   }
 
@@ -432,14 +430,17 @@ export class LoanProductSettingsStepComponent implements OnInit {
         }
       });
 
-    this.loanProductSettingsForm.get('dueDaysForRepaymentEvent').valueChanges
-    .subscribe((dueDaysForRepaymentEvent: number) => {
-      this.setStyleDaysForRepayment(this.DAYS_BEFORE_REPAYMENT_IS_DUE, dueDaysForRepaymentEvent);
-    });
-
-    this.loanProductSettingsForm.get('overDueDaysForRepaymentEvent').valueChanges
-    .subscribe((overDueDaysForRepaymentEvent: number) => {
-      this.setStyleDaysForRepayment(this.DAYS_AFTER_REPAYMENT_IS_OVERDUE, overDueDaysForRepaymentEvent);
+    this.loanProductSettingsForm.get('useDueForRepaymentsConfigurations').valueChanges
+    .subscribe((useDueForRepaymentsConfigurations: boolean) => {
+      if (useDueForRepaymentsConfigurations) {
+        this.loanProductSettingsForm.removeControl('dueDaysForRepaymentEvent');
+        this.loanProductSettingsForm.removeControl('overDueDaysForRepaymentEvent');
+      } else {
+        this.loanProductSettingsForm.addControl('dueDaysForRepaymentEvent',
+          new UntypedFormControl(this.loanProductsTemplate.dueDaysForRepaymentEvent, [Validators.required, rangeValidator(1, 100) ]));
+        this.loanProductSettingsForm.addControl('overDueDaysForRepaymentEvent',
+          new UntypedFormControl(this.loanProductsTemplate.overDueDaysForRepaymentEvent, [Validators.required, rangeValidator(1, 100) ]));
+      }
     });
   }
 
@@ -481,6 +482,10 @@ export class LoanProductSettingsStepComponent implements OnInit {
     const productSettings = this.loanProductSettingsForm.value;
     if (!this.loanProductSettingsForm.value.multiDisburseLoan) {
       delete productSettings['disableScheduleExtensionForDownPayment'];
+    }
+    if (this.loanProductSettingsForm.value.useDueForRepaymentsConfigurations) {
+      delete productSettings['dueDaysForRepaymentEvent'];
+      delete productSettings['overDueDaysForRepaymentEvent'];
     }
     return productSettings;
   }

--- a/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.html
+++ b/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.html
@@ -562,11 +562,16 @@
   <h3 class="mat-h3" fxFlexFill>Event Settings</h3>
 
   <div fxFlexFill>
+    <span fxFlex="40%">Use the Global Configurations values to the Repayment Event (notifications):</span>
+    <span fxFlex="60%">{{ loanProduct.useDueForRepaymentsConfigurations | yesNo }}</span>
+  </div>
+
+  <div fxFlexFill *ngIf="!loanProduct.useDueForRepaymentsConfigurations">
     <span fxFlex="40%">Due days for repayment event:</span>
     <span fxFlex="60%">{{ loanProduct.dueDaysForRepaymentEvent | number }}</span>
   </div>
 
-  <div fxFlexFill>
+  <div fxFlexFill *ngIf="!loanProduct.useDueForRepaymentsConfigurations">
     <span fxFlex="40%">OverDue days for repayment event:</span>
     <span fxFlex="60%">{{ loanProduct.overDueDaysForRepaymentEvent | number }}</span>
   </div>

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -2,14 +2,14 @@
   window["env"] = window["env"] || {};
 
   // BackEnd Environment variables
-  window["env"]["fineractApiUrls"] = 'https://ps-test.dev.alluvial.cloud';
-  window["env"]["fineractApiUrl"]  = 'https://ps-test.dev.alluvial.cloud';
+  window["env"]["fineractApiUrls"] = '';
+  window["env"]["fineractApiUrl"]  = '';
 
   window["env"]["apiProvider"] = '';
   window["env"]["apiVersion"]  = '';
 
-  window["env"]["fineractPlatformTenantId"]  = 'pstest';
-  window["env"]["fineractPlatformTenantIds"]  = 'pstest';
+  window["env"]["fineractPlatformTenantId"]  = '';
+  window["env"]["fineractPlatformTenantIds"]  = '';
 
   // Language Environment variables
   window["env"]["defaultLanguage"] = '';


### PR DESCRIPTION
…nfigurations

## Description

As part of Loan Product enhancements in the create and edit actions some values are being used from the Global Configuration. In particular the Event (notifications) settings values, so those values must to be remarked to indicated the default value is set from the GLobal Configuration  

## Screenshots, if any
<img width="1306" alt="Screenshot 2023-10-29 at 5 52 18 p m" src="https://github.com/openMF/web-app/assets/44206706/9a784ad0-5629-40ed-8ca9-8d78b3123318">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
