### PR TITLE
Remark Loan Product attribute values set by default from global confi…

### DIFF
--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -63,7 +63,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
               private router: Router,
               private dialog: MatDialog,
               private configurationWizardService: ConfigurationWizardService,
-              private popoverService: PopoverService,) { }
+              private popoverService: PopoverService) { }
 
   /**
    * Sets the username of the authenticated user.

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -14,7 +14,7 @@ import { AmountCollectedPieComponent } from './dashboard/amount-collected-pie/am
 import { AmountDisbursedPieComponent } from './dashboard/amount-disbursed-pie/amount-disbursed-pie.component';
 import { ClientTrendsBarComponent } from './dashboard/client-trends-bar/client-trends-bar.component';
 import { TranslateModule } from '@ngx-translate/core';
-import { WarningDialogComponent } from './warning-dialog/warning-dialog.component'
+import { WarningDialogComponent } from './warning-dialog/warning-dialog.component';
 
 /**
  * Home Component

--- a/src/app/home/warning-dialog/warning-dialog.component.ts
+++ b/src/app/home/warning-dialog/warning-dialog.component.ts
@@ -3,7 +3,7 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { environment } from '../../../environments/environment';
 
 @Component({
-  selector: 'mifos-warning-dialog',
+  selector: 'mifosx-warning-dialog',
   templateUrl: './warning-dialog.component.html',
   styleUrls: ['./warning-dialog.component.scss']
 })

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
@@ -125,6 +125,11 @@ export class CreateLoanProductComponent implements OnInit {
 
   submit() {
     const loanProduct = this.loanProducts.buildPayload(this.loanProduct, this.itemsByDefault);
+    if (loanProduct['useDueForRepaymentsConfigurations'] === true) {
+      loanProduct['dueDaysForRepaymentEvent'] = null;
+      loanProduct['overDueDaysForRepaymentEvent'] = null;
+    }
+    delete loanProduct['useDueForRepaymentsConfigurations'];
 
     this.productsService.createLoanProduct(loanProduct)
       .subscribe((response: any) => {

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
@@ -142,6 +142,11 @@ export class EditLoanProductComponent implements OnInit {
 
   submit() {
     const loanProduct = this.loanProducts.buildPayload(this.loanProduct, this.itemsByDefault);
+    if (loanProduct['useDueForRepaymentsConfigurations'] === true) {
+      loanProduct['dueDaysForRepaymentEvent'] = null;
+      loanProduct['overDueDaysForRepaymentEvent'] = null;
+    }
+    delete loanProduct['useDueForRepaymentsConfigurations'];
 
     this.productsService.updateLoanProduct(this.loanProductAndTemplate.id, loanProduct)
       .subscribe((response: any) => {

--- a/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.html
+++ b/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.html
@@ -563,15 +563,15 @@
 
   <div fxFlexFill>
     <span fxFlex="40%">Use the Global Configurations values to the Repayment Event (notifications):</span>
-    <span fxFlex="60%">{{ loanProduct.useDueForRepaymentsConfigurations | yesNo }}</span>
+    <span fxFlex="60%">{{ useDueForRepaymentsConfigurations | yesNo }}</span>
   </div>
 
-  <div fxFlexFill *ngIf="!loanProduct.useDueForRepaymentsConfigurations">
+  <div fxFlexFill *ngIf="loanProduct.dueDaysForRepaymentEvent">
     <span fxFlex="40%">Due days for repayment event:</span>
     <span fxFlex="60%">{{ loanProduct.dueDaysForRepaymentEvent | number }}</span>
   </div>
 
-  <div fxFlexFill *ngIf="!loanProduct.useDueForRepaymentsConfigurations">
+  <div fxFlexFill *ngIf="loanProduct.overDueDaysForRepaymentEvent">
     <span fxFlex="40%">OverDue days for repayment event:</span>
     <span fxFlex="60%">{{ loanProduct.overDueDaysForRepaymentEvent | number }}</span>
   </div>

--- a/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.ts
+++ b/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.ts
@@ -18,9 +18,12 @@ export class GeneralTabComponent implements OnInit {
 
   advancePaymentAllocationData: AdvancePaymentAllocationData;
 
+  useDueForRepaymentsConfigurations = false;
+
   constructor(private route: ActivatedRoute) {
     this.route.data.subscribe((data: { loanProduct: any }) => {
       this.loanProduct = data.loanProduct;
+      this.useDueForRepaymentsConfigurations = (!this.loanProduct.dueDaysForRepaymentEvent && !this.loanProduct.overDueDaysForRepaymentEvent);
       this.advancePaymentAllocationData = {
         transactionTypes: this.loanProduct.advancedPaymentAllocationTransactionTypes,
         allocationTypes: this.loanProduct.advancedPaymentAllocationTypes,


### PR DESCRIPTION
…gurations

## Description
As part of Loan Product enhancements in the create and edit actions some values are being used from the Global Configuration. In particular the Event (notifications) settings values, so those values must to be remarked to indicated the default value is set from the Global Configuration

## Screenshots, if any

<img width="986" alt="Screenshot 2023-11-05 at 3 48 39 p m" src="https://github.com/openMF/web-app/assets/44206706/9e1664fb-0000-4d36-bcf2-1485bd1045f3">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
