### PR TITLE
url validation fixed

### DIFF
--- a/src/app/core/utils/datatables.ts
+++ b/src/app/core/utils/datatables.ts
@@ -160,7 +160,8 @@ export class Datatables {
 
   public isValidUrl(urlString: string): boolean {
       try {
-        return Boolean(new URL(urlString));
+        const url = new URL(urlString);
+        return url.protocol.startsWith("http") || url.protocol.startsWith("https");
       } catch (e) {
         return false;
       }


### PR DESCRIPTION
## Description
Had to change url validation because when the input string had ":" in it, it was enough to return true, resulting in an invalid url.

## Related issues and discussion
#1901
