### PR TITLE
Added helm charts for deploying the web-app in a kubernetes cluster

### DIFF
--- a/src/k8s/helm-charts/web-app/.helmignore
+++ b/src/k8s/helm-charts/web-app/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/src/k8s/helm-charts/web-app/Chart.yaml
+++ b/src/k8s/helm-charts/web-app/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: openmf-webapp
+description: A Helm chart for openmf-webapp
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.1.0"

--- a/src/k8s/helm-charts/web-app/environment/values-prod.yaml
+++ b/src/k8s/helm-charts/web-app/environment/values-prod.yaml
@@ -1,0 +1,36 @@
+# Default values for fineract-ui.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+revisionHistoryLimit: 3
+
+app: openmf-webapp
+
+updateStrategy:
+  maxSurge: 25%
+  maxUnavailable: 25%
+  terminationGracePeriodSeconds: 30
+
+image:
+  repository: mojomojomojo/web-app
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0"
+
+service:
+  name: openmf-webapp
+  type: LoadBalancer
+  port: 80
+  targetPort: 80
+
+livenessProbe:
+  httpGet:
+      path: /
+      port: 80
+  initialDelaySeconds: 5
+  timeoutSeconds: 1
+  periodSeconds: 10
+  failureThreshold: 3
+
+containerPort: 80

--- a/src/k8s/helm-charts/web-app/environment/values-stage.yaml
+++ b/src/k8s/helm-charts/web-app/environment/values-stage.yaml
@@ -1,0 +1,36 @@
+# Default values for fineract-ui.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+revisionHistoryLimit: 3
+
+app: openmf-webapp
+
+updateStrategy:
+  maxSurge: 25%
+  maxUnavailable: 25%
+  terminationGracePeriodSeconds: 30
+
+image:
+  repository: mojomojomojo/web-app
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0"
+
+service:
+  name: openmf-webapp
+  type: LoadBalancer
+  port: 80
+  targetPort: 80
+
+livenessProbe:
+  httpGet:
+      path: /
+      port: 80
+  initialDelaySeconds: 5
+  timeoutSeconds: 1
+  periodSeconds: 10
+  failureThreshold: 3
+
+containerPort: 80

--- a/src/k8s/helm-charts/web-app/templates/deployment.yaml
+++ b/src/k8s/helm-charts/web-app/templates/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}-deployment
+  labels:
+    app: {{ .Values.app }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    rollingUpdate:
+      maxSurge: {{ .Values.updateStrategy.maxSurge }}
+      maxUnavailable: {{ .Values.updateStrategy.maxUnavailable }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: {{ .Values.app }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.app }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.updateStrategy.terminationGracePeriodSeconds }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        livenessProbe:
+          httpGet:
+              path: {{ .Values.livenessProbe.httpGet.path }}
+              port: {{ .Values.livenessProbe.httpGet.port }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+        ports:
+        - containerPort: {{ .Values.containerPort }}
+          name: http
+          protocol: TCP
+        env:
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value }}
+            {{- end }}

--- a/src/k8s/helm-charts/web-app/templates/service.yaml
+++ b/src/k8s/helm-charts/web-app/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-service
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ .Values.app }}
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: {{ .Values.service.targetPort }}

--- a/src/k8s/helm-charts/web-app/values.yaml
+++ b/src/k8s/helm-charts/web-app/values.yaml
@@ -1,0 +1,36 @@
+# Default values for fineract-ui.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+revisionHistoryLimit: 3
+
+app: openmf-webapp
+
+updateStrategy:
+  maxSurge: 25%
+  maxUnavailable: 25%
+  terminationGracePeriodSeconds: 30
+
+image:
+  repository: mojomojomojo/web-app
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v0"
+
+service:
+  name: openmf-webapp
+  type: LoadBalancer
+  port: 80
+  targetPort: 80
+
+livenessProbe:
+  httpGet:
+      path: /
+      port: 80
+  initialDelaySeconds: 5
+  timeoutSeconds: 1
+  periodSeconds: 10
+  failureThreshold: 3
+
+containerPort: 80


### PR DESCRIPTION
## Description
Change includes Helm charts for deploying the web-app in a kubernetes cluster. The charts currently contain a default docker image which is tested on an EKS cluster using the command:<br>` helm upgrade --install openmfwebapprelease -f web-app/environment/values-prod.yaml --set image.tag=v0 web-app` The docker repository can be modified in the values.yaml files. _environments/_ folder contains _values.yaml_ files with different configurations which can be modified as per the need. Although the docker-compose file is present, adding k8s yaml files  helps in directly deploying web-app to any kubernetes cluster which was not present in the web-app project code so far.

This change does not include any breaking change in the existing project code. [skip ci]

## Related issues and discussion
#NA

## Screenshots, if any
NA
## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
