### PR TITLE
fix: now we can create standing instruction by using both destinantion

### DIFF
--- a/src/app/account-transfers/create-standing-instructions/create-standing-instructions.component.html
+++ b/src/app/account-transfers/create-standing-instructions/create-standing-instructions.component.html
@@ -95,7 +95,7 @@
 
           <mat-form-field fxFlex="48%">
             <mat-label>{{"labels.inputs.To Office" | translate}}</mat-label>
-            <mat-select required formControlName="toOfficeId" (selectionChange)="changeEvent()">
+            <mat-select [disabled]="ToOfficeId" required formControlName="toOfficeId" (selectionChange)="changeEvent()">
               <mat-option *ngFor="let toOfficeType of toOfficeTypeData" [value]="toOfficeType.id">
                 {{ toOfficeType.name }}
               </mat-option>
@@ -107,7 +107,7 @@
 
           <mat-form-field fxFlex="48%">
             <mat-label>{{"labels.inputs.Beneficiary" | translate}}</mat-label>
-            <mat-select required formControlName="toClientId" (selectionChange)="changeEvent()">
+            <mat-select [disabled]="ToClientId" required formControlName="toClientId" (selectionChange)="changeEvent()">
               <mat-option *ngFor="let toClientType of toClientTypeData" [value]="toClientType.id">
                 {{ toClientType.displayName }}
               </mat-option>
@@ -234,7 +234,7 @@
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
         <button type="button" mat-raised-button [routerLink]="['../']">{{"labels.buttons.Cancel" | translate}}</button>
         <button mat-raised-button color="primary" [disabled]="!createStandingInstructionsForm.valid" *mifosxHasPermission="'CREATE_STANDINGINSTRUCTION'"
-          (click)="submit()">{{"labels.buttons.Submit | translate}}</button>
+          (click)="submit()">{{"labels.buttons.Submit" | translate}}</button>
       </mat-card-actions>
 
     </form>

--- a/src/app/account-transfers/create-standing-instructions/create-standing-instructions.component.ts
+++ b/src/app/account-transfers/create-standing-instructions/create-standing-instructions.component.ts
@@ -58,6 +58,10 @@ export class CreateStandingInstructionsComponent implements OnInit {
   accountTypeId: any;
   /** Office Id */
   officeId: any;
+  /** ToOffice Id Boolean for disabling the officeId formControl */
+  ToOfficeId: any;
+  /** ToClient Id Boolean for disabling the officeId formControl */
+  ToClientId: any;
   /** Account Type */
   accountType: any;
   /** Client Id */
@@ -119,7 +123,7 @@ export class CreateStandingInstructionsComponent implements OnInit {
   createCreateStandingInstructionsForm() {
     this.createStandingInstructionsForm = this.formBuilder.group({
       'name': ['', Validators.required],
-      'applicant': [{value: '', disabled: true}],
+      'applicant': [{ value: '', disabled: true }],
       'transferType': ['', Validators.required],
       'priority': ['', Validators.required],
       'status': ['', Validators.required],
@@ -169,8 +173,8 @@ export class CreateStandingInstructionsComponent implements OnInit {
           'toOfficeId': this.officeId,
           'toClientId': this.clientId
         });
-        this.createStandingInstructionsForm.controls['toOfficeId'].disable();
-        this.createStandingInstructionsForm.controls['toClientId'].disable();
+        this.ToOfficeId = true;
+        this.ToClientId = true;
         this.changeEvent();
       } else {
         this.allowclientedit = true;


### PR DESCRIPTION
## Description
now we can create standing instruction by using both destinations, previously 
this.createStandingInstructionsForm.controls['toOfficeId'].disable();
diable() was excluding the form values too, therefore it was not woking

## Related issues and discussion
#1932 

## Screenshots, if any
<img width="1257" alt="Screenshot 2023-12-14 at 10 49 34 PM" src="https://github.com/openMF/web-app/assets/76156941/e989c11f-97dc-4669-9c85-e10ab8db9f3d">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
