### PR TITLE
Fix Loan Product Delinquency bucket

### DIFF
--- a/src/app/centers/centers-view/centers-view.component.ts
+++ b/src/app/centers/centers-view/centers-view.component.ts
@@ -98,7 +98,6 @@ export class CentersViewComponent implements OnInit {
    * Unassign's the centers's staff.
    */
   private centersUnassignStaff() {
-    const dialogcontext: string = ""
     const unAssignStaffDialogRef = this.dialog.open(ConfirmationDialogComponent, {
       data: { heading: this.translateService.instant('labels.heading.Unassign Staff'), dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want Unassign Staff') }
     });

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-view/charges-tab/charges-tab.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-view/charges-tab/charges-tab.component.ts
@@ -66,7 +66,7 @@ export class ChargesTabComponent implements OnInit {
     private router: Router,
     public dialog: MatDialog,
     private translateService: TranslateService,
-    private settingsService: SettingsService,) {
+    private settingsService: SettingsService) {
     this.route.parent.data.subscribe((data: { recurringDepositsAccountData: any }) => {
       this.recurringDepositsAccountData = data.recurringDepositsAccountData;
       this.chargesData = this.recurringDepositsAccountData.charges;
@@ -128,7 +128,9 @@ export class ChargesTabComponent implements OnInit {
    * @param {any} chargeId Charge Id
    */
   waiveCharge(chargeId: any) {
-    const waiveChargeDialogRef = this.dialog.open(RecurringDepositConfirmationDialogComponent, { data: { heading: this.translateService.instant('labels.heading.Waive Charge'), dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want to waive charge with id: ')+ `${chargeId} ?` } });
+    const waiveChargeDialogRef = this.dialog.open(RecurringDepositConfirmationDialogComponent,
+      { data: { heading: this.translateService.instant('labels.heading.Waive Charge'),
+      dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want to waive charge with id: ') + `${chargeId} ?` } });
     waiveChargeDialogRef.afterClosed().subscribe((response: any) => {
       if (response.confirm) {
         this.savingsService.executeSavingsAccountChargesCommand(this.recurringDepositsAccountData.id, 'waive', {}, chargeId)

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-view/recurring-deposits-account-view.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-view/recurring-deposits-account-view.component.ts
@@ -50,7 +50,7 @@ export class RecurringDepositsAccountViewComponent implements OnInit {
               private recurringDepositsService: RecurringDepositsService,
               private savingsService: SavingsService,
               public dialog: MatDialog,
-              private translateService:TranslateService) {
+              private translateService: TranslateService) {
     this.route.data.subscribe((data: { recurringDepositsAccountData: any, savingsDatatables: any }) => {
       this.recurringDepositsAccountData = data.recurringDepositsAccountData;
       this.charges = this.recurringDepositsAccountData.charges;
@@ -225,7 +225,9 @@ export class RecurringDepositsAccountViewComponent implements OnInit {
    */
   private postInterest() {
     const postInterestAccountDialogRef = this.dialog.open(RecurringDepositConfirmationDialogComponent, {
-      data: { heading: this.translateService.instant('labels.heading.Post Interest'), dialogContext:this.translateService.instant('lables.dialogContext.Are you sure you want to post interest ?')  }
+      data: { heading: this.translateService.instant('labels.heading.Post Interest'),
+        dialogContext: this.translateService.instant('lables.dialogContext.Are you sure you want to post interest ?')
+      }
     });
     postInterestAccountDialogRef.afterClosed().subscribe((response: any) => {
       if (response.confirm) {

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-view/transactions-tab/view-transaction/view-transaction.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-view/transactions-tab/view-transaction/view-transaction.component.ts
@@ -25,7 +25,6 @@ export class ViewTransactionComponent {
 
   /** Transaction data. */
   transactionData: any;
-  
 
   /**
    * Retrieves the Transaction data from `resolve`.
@@ -41,7 +40,7 @@ export class ViewTransactionComponent {
     private dateUtils: Dates,
     private router: Router,
     public dialog: MatDialog,
-    private translateService:TranslateService,
+    private translateService: TranslateService,
     private settingsService: SettingsService, ) {
     this.route.data.subscribe((data: { recurringDepositsAccountTransaction: any }) => {
       this.transactionData = data.recurringDepositsAccountTransaction;

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
@@ -54,7 +54,7 @@
   </div>
 
   <div fxFlexFill>
-    <span fxFlex="40%">{{"labels.inputs.Loan term" | translate}}:</span>
+    <span fxFlex="40%">{{"labels.inputs.Loan Term" | translate}}:</span>
     <span fxFlex="60%">{{ loansAccount.loanTermFrequency }}
       {{loansAccount.loanTermFrequencyType | find: loansAccountProductTemplate.termFrequencyTypeOptions:'id':'name'}}</span>
   </div>

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
@@ -179,7 +179,9 @@ export class TransactionsTabComponent implements OnInit {
     }
 
     const undoTransactionAccountDialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      data: { heading: this.translateService.instant('labels.heading.Undo Transaction'), dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want undo the transaction type') + `${transaction.type.value}` + this.translateService.instant('labels.dialogContext.with id') + `${transaction.id}` }
+      data: { heading: this.translateService.instant('labels.heading.Undo Transaction'),
+      dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want undo the transaction type') + `${transaction.type.value}` + this.translateService.instant('labels.dialogContext.with id') + `${transaction.id}`
+      }
     });
     undoTransactionAccountDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
       if (response.confirm) {

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -384,7 +384,13 @@
 
   <div fxFlexFill *ngIf="loanProduct.delinquencyBucket">
     <span fxFlex="47%">Delinquency Bucket:</span>
-    <span  fxFlex="53%">{{ loanProduct.delinquencyBucket.name }}</span>
+    <span fxFlex="53%" *ngIf="loanProduct.delinquencyBucket.name">{{ loanProduct.delinquencyBucket.name }}</span>
+    <span fxFlex="53%" *ngIf="!loanProduct.delinquencyBucket.name">{{ 'labels.inputs.Unassigned' | translate }}</span>
+  </div>
+
+  <div fxFlexFill *ngIf="!loanProduct.delinquencyBucket">
+    <span fxFlex="47%">Delinquency Bucket:</span>
+    <span fxFlex="53%">{{ 'labels.inputs.Unassigned' | translate }}</span>
   </div>
 
   <div fxFlexFill>

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
-import { LoanProduct } from '../../models/loan-product.model';
+import { DelinquencyBucket, LoanProduct } from '../../models/loan-product.model';
 import { AccountingMapping, Charge, ChargeToIncomeAccountMapping, GLAccount, PaymentChannelToFundSourceMapping, PaymentType, PaymentTypeOption } from '../../../../shared/models/general.model';
 import { AdvancePaymentAllocationData, PaymentAllocation } from '../../loan-product-stepper/loan-product-payment-strategy-step/payment-allocation-model';
 import { LoanProducts } from '../../loan-products';
@@ -62,6 +62,7 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
 
     } else {
       this.accountingMappings = {};
+
       if ((this.loanProduct.accountingRule && this.loanProduct.accountingRule > 1) || this.loanProductsTemplate.accountingRule.value !== 'NONE') {
         const assetAccountData = this.loanProductsTemplate.accountingMappingOptions.assetAccountOptions || [];
         const incomeAccountData = this.loanProductsTemplate.accountingMappingOptions.incomeAccountOptions || [];
@@ -161,6 +162,10 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
 
       optionValue = this.optionDataLookUp(this.loanProduct.repaymentStartDateType, this.loanProductsTemplate.repaymentStartDateTypeOptions);
       this.loanProduct.repaymentStartDateType = optionValue;
+
+      if (this.loanProduct.delinquencyBucketId) {
+        this.loanProduct.delinquencyBucket = this.delinquencyBucketLookUp(this.loanProduct.delinquencyBucketId, this.loanProductsTemplate.delinquencyBucketOptions);
+      }
 
       const codeValue: CodeName = this.codeNameLookUpByCode(this.loanProduct.transactionProcessingStrategyCode,
         this.loanProductsTemplate.transactionProcessingStrategyOptions);
@@ -273,6 +278,18 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
       });
     }
     return paymentType;
+  }
+
+  delinquencyBucketLookUp(delinquencyBucketId: any, delinquencyBuckets: DelinquencyBucket[]): DelinquencyBucket {
+    let delinquencyBucketData: DelinquencyBucket | null = null;
+    if (delinquencyBucketId) {
+      delinquencyBuckets.some((delinquencyBucket: DelinquencyBucket) => {
+        if (delinquencyBucket.id === delinquencyBucketId) {
+          delinquencyBucketData = { id: delinquencyBucket.id, name: delinquencyBucket.name };
+        }
+      });
+    }
+    return delinquencyBucketData;
   }
 
   accountingRule(): number {

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -168,6 +168,10 @@
           {{ delinquencyBucket.name }}
         </mat-option>
       </mat-select>
+      <button mat-button *ngIf="loanProductSettingsForm.controls.delinquencyBucketId" matSuffix mat-icon-button
+        aria-label="Clear" (click)="clearProperty($event, 'delinquencyBucketId')">
+        <mat-icon>close</mat-icon>
+      </button>
     </mat-form-field>
 
     <mat-checkbox fxFlex="48%" labelPosition="before" formControlName="enableInstallmentLevelDelinquency" class="margin-v">

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -496,6 +496,16 @@ export class LoanProductSettingsStepComponent implements OnInit {
     return value;
   }
 
+  clearProperty($event: Event, propertyName: string): void {
+    if (propertyName === 'delinquencyBucketId') {
+      this.loanProductSettingsForm.patchValue({
+        'delinquencyBucketId': ''
+      });
+    }
+    this.loanProductSettingsForm.markAsDirty();
+    $event.stopPropagation();
+  }
+
   get loanProductSettings() {
     const productSettings = this.loanProductSettingsForm.value;
     if (!this.loanProductSettingsForm.value.multiDisburseLoan) {
@@ -504,6 +514,9 @@ export class LoanProductSettingsStepComponent implements OnInit {
     if (this.loanProductSettingsForm.value.useDueForRepaymentsConfigurations) {
       productSettings['dueDaysForRepaymentEvent'] = null;
       productSettings['overDueDaysForRepaymentEvent'] = null;
+    }
+    if (productSettings['delinquencyBucketId'] === '') {
+      delete productSettings['delinquencyBucketId'];
     }
     return productSettings;
   }

--- a/src/app/products/loan-products/models/loan-product.model.ts
+++ b/src/app/products/loan-products/models/loan-product.model.ts
@@ -82,6 +82,7 @@ export interface LoanProduct {
   isEqualAmortization:                                       boolean;
   delinquencyBucketOptions:                                  DelinquencyBucket[];
   delinquencyBucket:                                         DelinquencyBucket;
+  delinquencyBucketId?:                                      number;
   graceOnPrincipalPayment?:                                  number;
   graceOnInterestPayment?:                                   number;
   graceOnInterestCharged?:                                   number;
@@ -137,9 +138,9 @@ export interface AllowAttributeOverrides {
 }
 
 export interface DelinquencyBucket {
-  id:     number;
-  name:   string;
-  ranges: Range[];
+  id:      number;
+  name:    string;
+  ranges?: Range[];
 }
 
 export interface Range {


### PR DESCRIPTION
## Description

Fix Loan Product Delinquency bucket when It was not selected was sending an empty string value. Plus we have the option to clear the current value selected with a clic in the close icon

<img width="1317" alt="Screenshot 2023-12-20 at 12 22 02 p m" src="https://github.com/openMF/web-app/assets/44206706/36fefe6a-3e0d-490d-aad5-ecc73bd07eca">

This involves minor changes to remove tslint warning messages

<img width="1538" alt="Screenshot 2023-12-20 at 12 26 59 p m" src="https://github.com/openMF/web-app/assets/44206706/3b10d015-b141-4cd7-86ec-7464ff0d9e96">


## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
