### PR TITLE
fix: view charge does not show minCap and maxCap

### DIFF
--- a/src/app/products/charges/create-charge/create-charge.component.html
+++ b/src/app/products/charges/create-charge/create-charge.component.html
@@ -11,7 +11,8 @@
           <mat-form-field fxFlex="48%">
             <mat-label>Charge Applies To</mat-label>
             <mat-select required formControlName="chargeAppliesTo">
-              <mat-option *ngFor="let chargeAppliesTo of chargesTemplateData.chargeAppliesToOptions" [value]="chargeAppliesTo.id">
+              <mat-option *ngFor="let chargeAppliesTo of chargesTemplateData.chargeAppliesToOptions"
+                [value]="chargeAppliesTo.id">
                 {{ chargeAppliesTo.value }}
               </mat-option>
             </mat-select>
@@ -22,7 +23,8 @@
 
           <mat-divider [inset]="true"></mat-divider>
 
-          <div *ngIf="chargeForm.controls.chargeAppliesTo.value" fxFlexFill fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
+          <div *ngIf="chargeForm.controls.chargeAppliesTo.value" fxFlexFill fxLayout="row wrap" fxLayoutGap="2%"
+            fxLayout.lt-md="column">
 
             <mat-form-field fxFlex="48%">
               <mat-label>Charge Name</mat-label>
@@ -59,7 +61,8 @@
             <mat-form-field fxFlex="48%">
               <mat-label>Charge Calculation Type</mat-label>
               <mat-select required formControlName="chargeCalculationType">
-                <mat-option *ngFor="let chargeCalculationType of filteredChargeCalculationType()" [value]="chargeCalculationType.id">
+                <mat-option *ngFor="let chargeCalculationType of filteredChargeCalculationType()"
+                  [value]="chargeCalculationType.id">
                   {{ chargeCalculationType.value }}
                 </mat-option>
               </mat-select>
@@ -71,7 +74,8 @@
             <mat-form-field *ngIf="chargeForm.controls.chargeAppliesTo.value === 1" fxFlex="48%">
               <mat-label>Charge Payment Mode</mat-label>
               <mat-select required formControlName="chargePaymentMode">
-                <mat-option *ngFor="let chargePaymentMode of chargesTemplateData.chargePaymetModeOptions" [value]="chargePaymentMode.id">
+                <mat-option *ngFor="let chargePaymentMode of chargesTemplateData.chargePaymetModeOptions"
+                  [value]="chargePaymentMode.id">
                   {{ chargePaymentMode.value }}
                 </mat-option>
               </mat-select>
@@ -86,7 +90,9 @@
               </mat-checkbox>
             </div>
 
-            <mat-form-field *ngIf="chargeForm.controls.chargeTimeType.value === 9 && chargeForm.controls.addFeeFrequency.value" fxFlex="48%">
+            <mat-form-field
+              *ngIf="chargeForm.controls.chargeTimeType.value === 9 && chargeForm.controls.addFeeFrequency.value"
+              fxFlex="48%">
               <mat-label>Frequency Interval</mat-label>
               <input matInput required formControlName="feeInterval">
               <mat-error *ngIf="chargeForm.controls.feeInterval.hasError('required')">
@@ -97,10 +103,13 @@
               </mat-error>
             </mat-form-field>
 
-            <mat-form-field *ngIf="chargeForm.controls.chargeTimeType.value === 9 && chargeForm.controls.addFeeFrequency.value" fxFlex="48%">
+            <mat-form-field
+              *ngIf="chargeForm.controls.chargeTimeType.value === 9 && chargeForm.controls.addFeeFrequency.value"
+              fxFlex="48%">
               <mat-label>Charge Frequency</mat-label>
               <mat-select required formControlName="feeFrequency">
-                <mat-option *ngFor="let feeFrequency of chargesTemplateData.feeFrequencyOptions" [value]="feeFrequency.id">
+                <mat-option *ngFor="let feeFrequency of chargesTemplateData.feeFrequencyOptions"
+                  [value]="feeFrequency.id">
                   {{ feeFrequency.value }}
                 </mat-option>
               </mat-select>
@@ -109,9 +118,12 @@
               </mat-error>
             </mat-form-field>
 
-            <mat-form-field (click)="dueDatePicker.open()" *ngIf="chargeForm.controls.chargeTimeType.value === 6 || chargeForm.controls.chargeTimeType.value === 7" fxFlex="48%">
+            <mat-form-field (click)="dueDatePicker.open()"
+              *ngIf="chargeForm.controls.chargeTimeType.value === 6 || chargeForm.controls.chargeTimeType.value === 7"
+              fxFlex="48%">
               <mat-label>Due Date</mat-label>
-              <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="dueDatePicker" required formControlName="feeOnMonthDay">
+              <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="dueDatePicker" required
+                formControlName="feeOnMonthDay">
               <mat-datepicker-toggle matSuffix [for]="dueDatePicker"></mat-datepicker-toggle>
               <mat-datepicker #dueDatePicker></mat-datepicker>
               <mat-error *ngIf="chargeForm.controls.feeOnMonthDay.hasError('required')">
@@ -119,13 +131,15 @@
               </mat-error>
             </mat-form-field>
 
-            <mat-form-field fxFlex="48%" *ngIf="chargeForm.controls.chargeTimeType.value === 7 || chargeForm.controls.chargeTimeType.value === 11">
+            <mat-form-field fxFlex="48%"
+              *ngIf="chargeForm.controls.chargeTimeType.value === 7 || chargeForm.controls.chargeTimeType.value === 11">
               <mat-label>Repeat Every ({{ repeatEveryLabel }})</mat-label>
               <input matInput required formControlName="feeInterval">
               <mat-error *ngIf="chargeForm.controls.feeInterval.hasError('required')">
                 Repeat Every ({{ repeatEveryLabel }}) is <strong>required</strong>
               </mat-error>
-              <mat-error *ngIf="(chargeForm.controls.feeInterval.hasError('min') || chargeForm.controls.feeInterval.hasError('max')) && !chargeForm.controls.feeInterval.hasError('pattern')">
+              <mat-error
+                *ngIf="(chargeForm.controls.feeInterval.hasError('min') || chargeForm.controls.feeInterval.hasError('max')) && !chargeForm.controls.feeInterval.hasError('pattern')">
                 Repeat Every ({{ repeatEveryLabel }}) <strong>must be between 1 and 12</strong>
               </mat-error>
               <mat-error *ngIf="chargeForm.controls.feeInterval.hasError('pattern')">
@@ -140,19 +154,27 @@
                 Amount is <strong>required</strong>
               </mat-error>
               <mat-error *ngIf="chargeForm.controls.amount.hasError('pattern') && currencyDecimalPlaces !== undefined">
-                Amount must be <strong>a positive number with {{ currencyDecimalPlaces ? 'up to ' + currencyDecimalPlaces : 'no' }} decimal places</strong>
+                Amount must be <strong>a positive number with {{ currencyDecimalPlaces ? 'up to ' +
+                  currencyDecimalPlaces : 'no' }} decimal places</strong>
               </mat-error>
               <mat-error *ngIf="chargeForm.controls.amount.hasError('pattern') && currencyDecimalPlaces === undefined">
                 Amount must be <strong>a positive number</strong>
               </mat-error>
             </mat-form-field>
-
-            <mat-form-field fxFlex="48%">
+            <!--
+   * minCap and maxCap only allowed for loan ,shares and savings entitites
+   * In Loan case: Only for the "charge calculation type" set as "%amount", "% loan amount+interest", "%interest",and"%disbursement amount". 
+   * In saving case: Only for 1. charge time type is "withdrawlfee" or "savings no activity fee" with charge calculation type as "% amount"
+   * In shares case: Only for charge time type: SHARE_PURCHASE and SHARE_REDEEM and with charge calculation type as % amount only
+  -->
+            <mat-form-field fxFlex="48%"
+              *ngIf="(chargeForm.controls.chargeAppliesTo.value === 1 && (chargeForm.controls.chargeCalculationType.value === 2 || chargeForm.controls.chargeCalculationType.value === 3 || chargeForm.controls.chargeCalculationType.value === 4 || chargeForm.controls.chargeCalculationType.value==5)) || (chargeForm.controls.chargeAppliesTo.value === 2 && (chargeForm.controls.chargeTimeType.value === 16 || chargeForm.controls.chargeTimeType.value === 5)&&(chargeForm.controls.chargeCalculationType.value === 2)) || (chargeForm.controls.chargeAppliesTo.value === 4 && (chargeForm.controls.chargeTimeType.value==14 || chargeForm.controls.chargeTimeType.value==15) && chargeForm.controls.chargeCalculationType.value === 2)">
               <mat-label>Minimum Charge Cap</mat-label>
               <input matInput formControlName="minCap">
             </mat-form-field>
 
-            <mat-form-field fxFlex="48%">
+            <mat-form-field fxFlex="48%"
+              *ngIf="(chargeForm.controls.chargeAppliesTo.value === 1 && (chargeForm.controls.chargeCalculationType.value === 2 || chargeForm.controls.chargeCalculationType.value === 3 || chargeForm.controls.chargeCalculationType.value === 4 || chargeForm.controls.chargeCalculationType.value==5)) || (chargeForm.controls.chargeAppliesTo.value === 2 && (chargeForm.controls.chargeTimeType.value === 16 || chargeForm.controls.chargeTimeType.value === 5)&&(chargeForm.controls.chargeCalculationType.value === 2)) || (chargeForm.controls.chargeAppliesTo.value === 4 && (chargeForm.controls.chargeTimeType.value==14 || chargeForm.controls.chargeTimeType.value==15) && chargeForm.controls.chargeCalculationType.value === 2)">
               <mat-label>Maximum Charge Cap</mat-label>
               <input matInput formControlName="maxCap">
             </mat-form-field>
@@ -174,7 +196,8 @@
             <mat-form-field *ngIf="chargeForm.controls.chargeAppliesTo.value === 3" fxFlex="48%">
               <mat-label>Income from Charge </mat-label>
               <mat-select formControlName="incomeAccountId">
-                <mat-option *ngFor="let incomeOrLiabilityAccount of incomeAndLiabilityAccountData" [value]="incomeOrLiabilityAccount.id">
+                <mat-option *ngFor="let incomeOrLiabilityAccount of incomeAndLiabilityAccountData"
+                  [value]="incomeOrLiabilityAccount.id">
                   {{ incomeOrLiabilityAccount.name }}
                 </mat-option>
               </mat-select>
@@ -197,7 +220,8 @@
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
         <button type="button" mat-raised-button [routerLink]="['../']">Cancel</button>
-        <button mat-raised-button color="primary" [disabled]="!chargeForm.valid" *mifosxHasPermission="'CREATE_CHARGE'">Submit</button>
+        <button mat-raised-button color="primary" [disabled]="!chargeForm.valid"
+          *mifosxHasPermission="'CREATE_CHARGE'">Submit</button>
       </mat-card-actions>
 
     </form>

--- a/src/app/products/charges/create-charge/create-charge.component.ts
+++ b/src/app/products/charges/create-charge/create-charge.component.ts
@@ -47,11 +47,11 @@ export class CreateChargeComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor(private formBuilder: UntypedFormBuilder,
-              private productsService: ProductsService,
-              private route: ActivatedRoute,
-              private router: Router,
-              private dateUtils: Dates,
-              private settingsService: SettingsService) {
+    private productsService: ProductsService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private dateUtils: Dates,
+    private settingsService: SettingsService) {
     this.route.data.subscribe((data: { chargesTemplate: any }) => {
       this.chargesTemplateData = data.chargesTemplate;
       if (data.chargesTemplate.incomeOrLiabilityAccountOptions.liabilityAccountOptions) {

--- a/src/app/products/charges/edit-charge/edit-charge.component.html
+++ b/src/app/products/charges/edit-charge/edit-charge.component.html
@@ -11,7 +11,8 @@
           <mat-form-field fxFlex="48%">
             <mat-label>Charges applies to</mat-label>
             <mat-select required formControlName="chargeAppliesTo">
-              <mat-option *ngFor="let chargeAppliesTo of chargeData.chargeAppliesToOptions" [value]="chargeAppliesTo.id">
+              <mat-option *ngFor="let chargeAppliesTo of chargeData.chargeAppliesToOptions"
+                [value]="chargeAppliesTo.id">
                 {{ chargeAppliesTo.value }}
               </mat-option>
             </mat-select>
@@ -70,7 +71,8 @@
           <mat-form-field fxFlex="48%" *ngIf="chargePaymentMode">
             <mat-label>Charge Payment By</mat-label>
             <mat-select required formControlName="chargePaymentMode">
-              <mat-option *ngFor="let chargePaymentMode of chargeData.chargePaymetModeOptions" [value]="chargePaymentMode.id">
+              <mat-option *ngFor="let chargePaymentMode of chargeData.chargePaymetModeOptions"
+                [value]="chargePaymentMode.id">
                 {{ chargePaymentMode.value }}
               </mat-option>
             </mat-select>
@@ -86,11 +88,28 @@
               Amount <strong>is required</strong>
             </mat-error>
           </mat-form-field>
+          <!--
+   * minCap and maxCap only allowed for loan ,shares and savings entitites
+   * In Loan case: Only for the "charge calculation type" set as "%amount", "% loan amount+interest", "%interest",and "%disbursement amount".
+   * In saving case: Only for 1. charge time type is "withdrawlfee" or "savings no activity fee" with charge calculation type as "% amount"
+   * In shares case: Only for charge time type: SHARE_PURCHASE and SHARE_REDEEM and with charge calculation type as % amount only
+  -->
+          <mat-form-field fxFlex="48%"
+            *ngIf="(chargeForm.controls.chargeAppliesTo.value === 1 && (chargeForm.controls.chargeCalculationType.value === 2 || chargeForm.controls.chargeCalculationType.value === 3 || chargeForm.controls.chargeCalculationType.value === 4 || chargeForm.controls.chargeCalculationType.value==5)) || (chargeForm.controls.chargeAppliesTo.value === 2 && (chargeForm.controls.chargeTimeType.value === 16 || chargeForm.controls.chargeTimeType.value === 5)&&(chargeForm.controls.chargeCalculationType.value === 2)) || (chargeForm.controls.chargeAppliesTo.value === 4 && (chargeForm.controls.chargeTimeType.value==14 || chargeForm.controls.chargeTimeType.value==15) && chargeForm.controls.chargeCalculationType.value === 2)">
+            <mat-label>Minimum Charge Cap </mat-label>
+            <input matInput autofocus formControlName="minCap">
+          </mat-form-field>
+          <mat-form-field fxFlex="48%"
+            *ngIf="(chargeForm.controls.chargeAppliesTo.value === 1 && (chargeForm.controls.chargeCalculationType.value === 2 || chargeForm.controls.chargeCalculationType.value === 3 || chargeForm.controls.chargeCalculationType.value === 4 || chargeForm.controls.chargeCalculationType.value==5)) || (chargeForm.controls.chargeAppliesTo.value === 2 && (chargeForm.controls.chargeTimeType.value === 16 || chargeForm.controls.chargeTimeType.value === 5)&&(chargeForm.controls.chargeCalculationType.value === 2)) || (chargeForm.controls.chargeAppliesTo.value === 4 && (chargeForm.controls.chargeTimeType.value==14 || chargeForm.controls.chargeTimeType.value==15) && chargeForm.controls.chargeCalculationType.value === 2)">
+            <mat-label>Maximum Charge Cap </mat-label>
+            <input matInput autofocus formControlName="maxCap">
+          </mat-form-field>
 
           <mat-form-field fxFlex="48%" *ngIf="showGLAccount">
             <mat-label>Income from charge</mat-label>
             <mat-select required formControlName="incomeAccountId">
-              <mat-option *ngFor="let income of chargeData.incomeOrLiabilityAccountOptions.incomeAccountOptions" [value]="income.id">
+              <mat-option *ngFor="let income of chargeData.incomeOrLiabilityAccountOptions.incomeAccountOptions"
+                [value]="income.id">
                 {{ income.name }}
               </mat-option>
             </mat-select>
@@ -115,7 +134,8 @@
           </mat-form-field>
 
           <div fxFlex="48%" class="password-never-expires-wrapper checkbox" *ngIf="addFeeFrequency">
-            <mat-checkbox labelPosition="before" [checked]="addFeeFrequency && showFeeOptions" (change)="getFeeFrequency($event.checked)">
+            <mat-checkbox labelPosition="before" [checked]="addFeeFrequency && showFeeOptions"
+              (change)="getFeeFrequency($event.checked)">
               Add Fee Frequency
             </mat-checkbox>
           </div>
@@ -161,7 +181,8 @@
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
         <button type="button" mat-raised-button [routerLink]="['../']">Cancel</button>
-        <button mat-raised-button color="primary" [disabled]="!chargeForm.valid" *mifosxHasPermission="'UPDATE_CHARGE'">Submit</button>
+        <button mat-raised-button color="primary" [disabled]="!chargeForm.valid"
+          *mifosxHasPermission="'UPDATE_CHARGE'">Submit</button>
       </mat-card-actions>
 
     </form>

--- a/src/app/products/charges/edit-charge/edit-charge.component.ts
+++ b/src/app/products/charges/edit-charge/edit-charge.component.ts
@@ -54,10 +54,10 @@ export class EditChargeComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor(private productsService: ProductsService,
-              private formBuilder: UntypedFormBuilder,
-              private route: ActivatedRoute,
-              private router: Router,
-              private settingsService: SettingsService) {
+    private formBuilder: UntypedFormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private settingsService: SettingsService) {
     this.route.data.subscribe((data: { chargesTemplate: any }) => {
       this.chargeData = data.chargesTemplate;
     });
@@ -80,6 +80,8 @@ export class EditChargeComponent implements OnInit {
       'amount': [this.chargeData.amount, Validators.required],
       'active': [this.chargeData.active],
       'penalty': [this.chargeData.penalty],
+      'minCap': [this.chargeData.minCap],
+      'maxCap': [this.chargeData.maxCap],
       'chargeTimeType': [this.chargeData.chargeTimeType.id, Validators.required],
       'chargeCalculationType': [this.chargeData.chargeCalculationType.id, Validators.required],
     });
@@ -151,6 +153,12 @@ export class EditChargeComponent implements OnInit {
     charges.locale = this.settingsService.language.code;
     if (charges.taxGroupId.value === '') {
       delete charges.taxGroupId;
+    }
+    if (!charges.minCap) {
+      delete charges.minCap;
+    }
+    if (!charges.maxCap) {
+      delete charges.maxCap;
     }
     this.productsService.updateCharge(this.chargeData.id.toString(), charges)
       .subscribe((response: any) => {

--- a/src/app/products/charges/view-charge/view-charge.component.html
+++ b/src/app/products/charges/view-charge/view-charge.component.html
@@ -49,6 +49,22 @@
           {{ chargeData.amount }}
         </div>
 
+        <div fxFlex="50%" class="mat-body-strong" *ngIf="minCap">
+          Minimum Charge Cap
+        </div>
+
+        <div fxFlex="50%" *ngIf="minCap">
+          {{ chargeData.minCap }}
+        </div>
+
+        <div fxFlex="50%" class="mat-body-strong" *ngIf="maxCap">
+          Maximum Charge Cap
+        </div>
+
+        <div fxFlex="50%" *ngIf="maxCap">
+          {{ chargeData.maxCap }}
+        </div>
+        
         <div fxFlex="50%" class="mat-body-strong">
           Charge Time Type
         </div>
@@ -93,7 +109,8 @@
           Fee Frequency
         </div>
 
-        <div fxFlex="50%" *ngIf="chargeData.chargeTimeType.id == 9 && chargeData.feeFrequency && chargeData.feeFrequency">
+        <div fxFlex="50%"
+          *ngIf="chargeData.chargeTimeType.id == 9 && chargeData.feeFrequency && chargeData.feeFrequency">
           {{ chargeData.feeFrequency.value }}
         </div>
 

--- a/src/app/products/charges/view-charge/view-charge.component.ts
+++ b/src/app/products/charges/view-charge/view-charge.component.ts
@@ -21,7 +21,9 @@ export class ViewChargeComponent implements OnInit {
 
   /** Charge data. */
   chargeData: any;
-
+  /** Boolean for MinCap and MaxCap */
+  minCap: boolean;
+  maxCap: boolean;
   /**
    * Retrieves the charge data from `resolve`.
    * @param {ProductsService} productsService Products Service.
@@ -30,11 +32,18 @@ export class ViewChargeComponent implements OnInit {
    * @param {MatDialog} dialog Dialog reference.
    */
   constructor(private productsService: ProductsService,
-              private route: ActivatedRoute,
-              private router: Router,
-              private dialog: MatDialog) {
+    private route: ActivatedRoute,
+    private router: Router,
+    private dialog: MatDialog) {
     this.route.data.subscribe((data: { charge: any }) => {
+      console.log(data.charge);
       this.chargeData = data.charge;
+      if (this.chargeData.minCap) {
+        this.minCap = true;
+      }
+      if (this.chargeData.maxCap) {
+        this.maxCap = true;
+      }
     });
   }
 


### PR DESCRIPTION
## Description
Now we can view the Minimum and Maximum Charges Cap and also can edit and create when following parameters are selected:
Loan entity

Only for the "charge calculation type" set as "%amount", "% loan amount+interest", "%interest".
Savings Entity

Only for 1. charge time type is "withdrawlfee" or "savings no activity fee" with charge calculation type as "% amount"
Shares Entity

SHARE_PURCHASE and SHARE_REDEEM in charge time type and  % amount in charge calculation time can be defined and min max values can be saved

## Related issues and discussion
#1923 

## Screenshots, if any

https://github.com/openMF/web-app/assets/76156941/fdd6172b-b6a9-4eb2-8806-2aacda2ead55



## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
