### PR TITLE
Avoid override Tenant Identifier with default value on refresh

### DIFF
--- a/src/app/web-app.component.ts
+++ b/src/app/web-app.component.ts
@@ -197,7 +197,9 @@ export class WebAppComponent implements OnInit {
     // Set the server list from the env var FINERACT_API_URLS
     this.settingsService.setServers(environment.baseApiUrls.split(','));
     // Set the Tenant Identifier(s) list from the env var
-    this.settingsService.setTenantIdentifier(environment.fineractPlatformTenantId || 'default');
+    if (!localStorage.getItem('mifosXTenantIdentifier')) {
+      this.settingsService.setTenantIdentifier(environment.fineractPlatformTenantId || 'default');
+    }
     this.settingsService.setTenantIdentifiers(environment.fineractPlatformTenantIds.split(','));
   }
 


### PR DESCRIPTION
## Description

When we use more than one Tenant Identifier with the env variable `FINERACT_PLATFORM_TENANTS_IDENTIFIER` we were overriding the Tenant Identifier selected in current session with the default Tenant Identifier value from the env variable `FINERACT_PLATFORM_TENANT_IDENTIFIER` 


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
