### PR TITLE
Use of environment variables to set wait time for reading notificatio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,18 @@ Setting for exporting report table to CSV file using this field delimiter
 MIFOS_DEFAULT_CHAR_DELIMITER=,
 ```
 
+
+Setting for Wait time in seconds for reading the user notifications, Default 60 seconds
+```
+MIFOS_WAIT_TIME_FOR_NOTIFICATIONS=60
+```
+
+Setting for Wait time in seconds for reading the COB Catch-Up status, Default 30 seconds
+```
+MIFOS_WAIT_TIME_FOR_CATCHUP=30
+```
+
+
 For more information look the env.sample file in the root directory of the project
 
 ## Want to help? [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/openMF/web-app/issues)

--- a/src/app/shared/notifications-tray/notifications-tray.component.ts
+++ b/src/app/shared/notifications-tray/notifications-tray.component.ts
@@ -6,6 +6,7 @@ import { forkJoin } from 'rxjs';
 
 /** Custom Services */
 import { NotificationsService } from 'app/notifications/notifications.service';
+import { environment } from 'environments/environment';
 
 /**
  * Notifications Tray Component
@@ -17,7 +18,8 @@ import { NotificationsService } from 'app/notifications/notifications.service';
   encapsulation: ViewEncapsulation.None
 })
 export class NotificationsTrayComponent implements OnInit, OnDestroy {
-
+  /** Wait time between API status calls 60 seg */
+  waitTime = environment.waitTimeForNotifications || 60;
   /** Read Notifications */
   readNotifications: any[] = [];
   /** Displayed Read Notifications */
@@ -57,7 +59,7 @@ export class NotificationsTrayComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    setTimeout(() => { this.fetchUnreadNotifications(); }, 60000);
+    this.fetchUnreadNotifications();
   }
 
   ngOnDestroy() {
@@ -81,7 +83,7 @@ export class NotificationsTrayComponent implements OnInit, OnDestroy {
       this.setNotifications();
     });
     // this.mockNotifications(); // Uncomment for Testing.
-    this.timer = setTimeout(() => { this.fetchUnreadNotifications(); }, 60000);
+    this.timer = setTimeout(() => { this.fetchUnreadNotifications(); }, this.waitTime * 1000);
   }
 
   /**

--- a/src/app/shared/tenant-selector/tenant-selector.component.ts
+++ b/src/app/shared/tenant-selector/tenant-selector.component.ts
@@ -16,11 +16,10 @@ export class TenantSelectorComponent implements OnInit {
    * Sets the Tenant Identifier of the application in the selector on initial setup.
    * @param {SettingsService} settingsService Settings Service.
    */
-  constructor(private settingsService: SettingsService) {
-    this.tenantSelector.setValue(this.settingsService.tenantIdentifier);
-  }
+  constructor(private settingsService: SettingsService) { }
 
   ngOnInit(): void {
+    this.tenantSelector.setValue(this.settingsService.tenantIdentifier);
   }
 
   /**

--- a/src/app/system/manage-jobs/cob-workflow/cob-workflow.component.ts
+++ b/src/app/system/manage-jobs/cob-workflow/cob-workflow.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { SystemService } from 'app/system/system.service';
+import { environment } from 'environments/environment';
 
 @Component({
   selector: 'mifosx-cob-workflow',
@@ -8,7 +9,7 @@ import { SystemService } from 'app/system/system.service';
 })
 export class CobWorkflowComponent implements OnInit, OnDestroy {
   /** Wait time between API status calls 30 seg */
-  waitTime = 30000;
+  waitTime = environment.waitTimeForCOBCatchUp || 30;
   /** Process running flag */
   @Input() isCatchUpRunning = true;
   /** Timer to refetch COB Catch-Up status every 5 seconds */
@@ -17,7 +18,6 @@ export class CobWorkflowComponent implements OnInit, OnDestroy {
   constructor(private systemService: SystemService) { }
 
   ngOnInit(): void {
-    setTimeout(() => { this.getCOBCatchUpStatus(); }, this.waitTime);
     this.getCOBCatchUpStatus();
   }
 
@@ -28,11 +28,8 @@ export class CobWorkflowComponent implements OnInit, OnDestroy {
   getCOBCatchUpStatus(): void {
     this.systemService.getCOBCatchUpStatus().subscribe((response: any) => {
       this.isCatchUpRunning = response.isCatchUpRunning;
-      if (!this.isCatchUpRunning) {
-        this.waitTime = 30000;
-      }
     });
-    this.timer = setTimeout(() => { this.getCOBCatchUpStatus(); }, this.waitTime);
+    this.timer = setTimeout(() => { this.getCOBCatchUpStatus(); }, this.waitTime * 1000);
   }
 
   runCatchUp(): void {

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -23,4 +23,9 @@
   // Display or not the BackEnd Info
   window['env']['displayBackEndInfo'] = '';
 
+  // Time in seconds for Notifications, default 60 seconds
+  window['env']['waitTimeForNotifications'] = '';
+
+  // Time in seconds for COB Catch-Up, default 30 seconds
+  window['env']['waitTimeForCOBCatchUp'] = '';
 })(this);

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -23,4 +23,9 @@
   // Display or not the BackEnd Info
   window['env']['displayBackEndInfo'] = '$MIFOS_DISPLAY_BACKEND_INFO';
 
+  // Time in seconds for Notifications, default 60 seconds
+  window['env']['waitTimeForNotifications'] = '$MIFOS_WAIT_TIME_FOR_NOTIFICATIONS';
+
+  // Time in seconds for COB Catch-Up, default 30 seconds
+  window['env']['waitTimeForCOBCatchUp'] = '$MIFOS_WAIT_TIME_FOR_CATCHUP';
 })(this);

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -32,7 +32,11 @@ export const environment = {
 
   defaultCharDelimiter: window['env']['defaultCharDelimiter'] || ',',
 
-  displayBackEndInfo: window['env']['displayBackEndInfo'] || 'true'
+  displayBackEndInfo: window['env']['displayBackEndInfo'] || 'true',
+  // Time in seconds, default 60 seconds
+  waitTimeForNotifications: window['env']['waitTimeForNotifications'] || 60,
+  // Time in seconds, default 30 seconds
+  waitTimeForCOBCatchUp: window['env']['waitTimeForCOBCatchUp'] || 30
 };
 
 // Server URL

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -37,7 +37,11 @@ export const environment = {
 
   defaultCharDelimiter: window['env']['defaultCharDelimiter'] || ',',
 
-  displayBackEndInfo: window['env']['displayBackEndInfo'] || 'true'
+  displayBackEndInfo: window['env']['displayBackEndInfo'] || 'true',
+  // Time in seconds, default 60 seconds
+  waitTimeForNotifications: window['env']['waitTimeForNotifications'] || 60,
+  // Time in seconds, default 30 seconds
+  waitTimeForCOBCatchUp: window['env']['waitTimeForCOBCatchUp'] || 30
 };
 
 // Server URL


### PR DESCRIPTION
…ns and catch-up apis

## Description

Use of environment variables to set wait time for reading `notifications` and `is-catch-up-running` apis

We have now the option to set environment variables for these two timers

- `MIFOS_WAIT_TIME_FOR_NOTIFICATIONS`
- `MIFOS_WAIT_TIME_FOR_CATCHUP`

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
