### PR TITLE
fix: Transaction details - hard-coded currency sign

### DIFF
--- a/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.html
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.html
@@ -67,7 +67,7 @@
         </div>
 
         <div fxFlex="50%">
-          {{ transactionData.amount | currency }} {{ transactionData.currency.code }}
+          {{ transactionData.amount | currency:transactionData.currency.code }}
         </div>
 
         <div fxFlex="50%" class="mat-body-strong">
@@ -85,7 +85,8 @@
       </div>
 
       <div fxLayout="row" fxLayoutAlign="center" fxLayoutGap="2%" fxLayout.lt-md="column">
-        <button type="button" mat-raised-button color="primary" [routerLink]="['../../']">{{ 'Back' | translate}}</button>
+        <button type="button" mat-raised-button color="primary" [routerLink]="['../../']">{{ 'Back' |
+          translate}}</button>
       </div>
     </mat-card-content>
 


### PR DESCRIPTION
## Description
Now currency code sign is dynamic

## Related issues and discussion
#1947 

## Screenshots, if any
<img width="1438" alt="i1336" src="https://github.com/openMF/web-app/assets/76156941/a611d1e0-f67f-4654-bedc-9f0d630e34af">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
