### PR TITLE
Fix Loan Product edit due delinquencyBucketId was 0

### DIFF
--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
@@ -159,6 +159,10 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
       this.loanProduct.daysInYearType = optionValue;
       optionValue = this.optionDataLookUp(this.loanProduct.interestRateFrequencyType, this.loanProductsTemplate.interestRateFrequencyTypeOptions);
       this.loanProduct.interestRateFrequencyType = optionValue;
+      if (!this.loanProduct.repaymentFrequencyType.id) {
+        optionValue = this.optionDataLookUp(this.loanProduct.repaymentFrequencyType, this.loanProductsTemplate.repaymentFrequencyTypeOptions);
+        this.loanProduct.repaymentFrequencyType = optionValue;
+      }
 
       optionValue = this.optionDataLookUp(this.loanProduct.repaymentStartDateType, this.loanProductsTemplate.repaymentStartDateTypeOptions);
       this.loanProduct.repaymentStartDateType = optionValue;

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -138,7 +138,7 @@ export class LoanProductSettingsStepComponent implements OnInit {
 
     if (this.loanProductsTemplate.delinquencyBucket) {
       this.loanProductSettingsForm.patchValue({
-        'delinquencyBucketId': this.loanProductsTemplate.delinquencyBucket.id
+        'delinquencyBucketId': this.loanProductsTemplate.delinquencyBucket.id > 0 ? this.loanProductsTemplate.delinquencyBucket.id : ''
       });
     }
 

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -2563,6 +2563,7 @@
       "Provisioning Criteria": "Kritéria poskytování",
       "Provisioning Entries": "Poskytování záznamů",
       "Provisioning criteria definitions": "Vyplňte všechny definice kritérií poskytování.",
+      "Recover From Guarantor": "Zotavit se z ručitele",
       "Recurring Deposit Account Charges": "Opakované poplatky za vkladový účet",
       "Recurring Deposit Account Interest Rate Chart": "Graf úrokových sazeb pro opakující se vkladový účet",
       "Recurring Deposit Account Standing Instructions": "Pokyny k trvalému vkladovému účtu",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -2562,6 +2562,7 @@
       "Provisioning Criteria": "Bereitstellungskriterien",
       "Provisioning Entries": "Bereitstellungseinträge",
       "Provisioning criteria definitions": "Bitte füllen Sie alle Definitionen der Bereitstellungskriterien aus.",
+      "Recover From Guarantor": "Sich von Garantie erholen",
       "Recurring Deposit Account Charges": "Wiederkehrende Kontogebühren",
       "Recurring Deposit Account Interest Rate Chart": "Zinssatztabelle für wiederkehrende Einlagenkonten",
       "Recurring Deposit Account Standing Instructions": "Anweisungen zum Kontostand für wiederkehrende Einlagen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2564,6 +2564,7 @@
             "Provisioning Criteria": "Provisioning Criteria",
             "Provisioning Entries": "Provisioning Entries",
             "Provisioning criteria definitions": "Please fill all provisioning criteria definitions.",
+            "Recover From Guarantor": "Recover From Guarantor",
             "Recurring Deposit Account Charges": "Recurring Deposit Account Charges",
             "Recurring Deposit Account Interest Rate Chart": "Recurring Deposit Account Interest Rate Chart",
             "Recurring Deposit Account Standing Instructions": "Recurring Deposit Account Standing Instructions",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -2563,6 +2563,7 @@
             "Provisioning Criteria": "Criterios de aprovisionamiento",
             "Provisioning Entries": "Entradas de aprovisionamiento",
             "Provisioning criteria definitions": "Complete todas las definiciones de criterios de aprovisionamiento.",
+            "Recover From Guarantor": "Recuperar del garante",
             "Recurring Deposit Account Charges": "Cargos recurrentes de la cuenta de depósito",
             "Recurring Deposit Account Interest Rate Chart": "Tabla de tasas de interés de cuentas de depósito recurrentes",
             "Recurring Deposit Account Standing Instructions": "Instrucciones para la situación de la cuenta de depósito recurrente",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -2563,6 +2563,7 @@
       "Provisioning Criteria": "Critères d'approvisionnement",
       "Provisioning Entries": "Entrées de provisionnement",
       "Provisioning criteria definitions": "Veuillez remplir toutes les définitions des critères de provisionnement.",
+      "Recover From Guarantor": "Récupérer du garant",
       "Recurring Deposit Account Charges": "Frais de compte de dépôt récurrents",
       "Recurring Deposit Account Interest Rate Chart": "Tableau des taux d’intérêt des comptes de dépôt récurrents",
       "Recurring Deposit Account Standing Instructions": "Instructions permanentes pour les comptes de dépôt récurrents",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -2563,6 +2563,7 @@
       "Provisioning Criteria": "Criteri di fornitura",
       "Provisioning Entries": "Voci di provisioning",
       "Provisioning criteria definitions": "Compila tutte le definizioni dei criteri di provisioning.",
+      "Recover From Guarantor": "Recuperare dal garante",
       "Recurring Deposit Account Charges": "Spese ricorrenti sul conto di deposito",
       "Recurring Deposit Account Interest Rate Chart": "Grafico del tasso di interesse del conto di deposito ricorrente",
       "Recurring Deposit Account Standing Instructions": "Istruzioni per la permanenza del conto di deposito ricorrente",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -2563,6 +2563,7 @@
       "Provisioning Criteria": "프로비저닝 기준",
       "Provisioning Entries": "프로비저닝 항목",
       "Provisioning criteria definitions": "모든 프로비저닝 기준 정의를 입력하세요.",
+      "Recover From Guarantor": "보증인에서 회복하십시오",
       "Recurring Deposit Account Charges": "반복 예금 계좌 수수료",
       "Recurring Deposit Account Interest Rate Chart": "정기예금 계좌 이자율 차트",
       "Recurring Deposit Account Standing Instructions": "정기예금 계좌 유지 지침",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -2563,6 +2563,7 @@
       "Provisioning Criteria": "Aprūpinimo kriterijai",
       "Provisioning Entries": "Aprūpinimo įrašai",
       "Provisioning criteria definitions": "Užpildykite visus teikimo kriterijų apibrėžimus.",
+      "Recover From Guarantor": "Atsigauti nuo garanto",
       "Recurring Deposit Account Charges": "Pasikartojantys indėlio sąskaitos mokesčiai",
       "Recurring Deposit Account Interest Rate Chart": "Periodinio indėlio sąskaitos palūkanų normų diagrama",
       "Recurring Deposit Account Standing Instructions": "Periodinio indėlio sąskaitos nuolatinės instrukcijos",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -2563,6 +2563,7 @@
       "Provisioning Criteria": "Nodrošinājuma kritēriji",
       "Provisioning Entries": "Nodrošinājuma ieraksti",
       "Provisioning criteria definitions": "Lūdzu, aizpildiet visas nodrošināšanas kritēriju definīcijas.",
+      "Recover From Guarantor": "Atgūties no galvotāja",
       "Recurring Deposit Account Charges": "Periodiskas depozīta konta izmaksas",
       "Recurring Deposit Account Interest Rate Chart": "Atkārtota depozīta konta procentu likmju diagramma",
       "Recurring Deposit Account Standing Instructions": "Atkārtota depozīta konta pastāvīgās lietošanas instrukcijas",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -2563,6 +2563,7 @@
       "Provisioning Criteria": "प्रावधान मापदण्ड",
       "Provisioning Entries": "प्रावधान प्रविष्टिहरू",
       "Provisioning criteria definitions": "कृपया सबै प्रावधान मापदण्ड परिभाषाहरू भर्नुहोस्।",
+      "Recover From Guarantor": "ग्यारेन्टरबाट पुन: प्राप्ति गर्नुहोस्",
       "Recurring Deposit Account Charges": "आवर्ती जम्मा खाता शुल्कहरू",
       "Recurring Deposit Account Interest Rate Chart": "आवर्ती जम्मा खाता ब्याज दर चार्ट",
       "Recurring Deposit Account Standing Instructions": "आवर्ती जम्मा खाता स्थायी निर्देशनहरू",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -2563,6 +2563,7 @@
       "Provisioning Criteria": "Critérios de provisionamento",
       "Provisioning Entries": "Entradas de provisionamento",
       "Provisioning criteria definitions": "Preencha todas as definições de critérios de provisionamento.",
+      "Recover From Guarantor": "Recuperar do garante",
       "Recurring Deposit Account Charges": "Cobranças recorrentes da conta de depósito",
       "Recurring Deposit Account Interest Rate Chart": "Gráfico de taxas de juros de contas de depósito recorrente",
       "Recurring Deposit Account Standing Instructions": "Instruções sobre a situação da conta de depósito recorrente",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -2563,6 +2563,7 @@
       "Provisioning Criteria": "Vigezo vya Utoaji",
       "Provisioning Entries": "Utoaji wa Maingizo",
       "Provisioning criteria definitions": "Tafadhali jaza ufafanuzi wa vigezo vyote vya utoaji.",
+      "Recover From Guarantor": "Kupona kutoka kwa mdhamini",
       "Recurring Deposit Account Charges": "Malipo ya Akaunti ya Amana ya Mara kwa Mara",
       "Recurring Deposit Account Interest Rate Chart": "Chati ya Kiwango cha Riba cha Akaunti ya Amana ya Mara kwa Mara",
       "Recurring Deposit Account Standing Instructions": "Maagizo ya Kudumu ya Akaunti ya Amana",


### PR DESCRIPTION
## Description

Fix in Loan Product edition because when there is not a Delinquency Bucket set to the Loan Product, the `delinquencyBucketId` was set to 0, then the backend can not update the Loan Product because this is not a valid entity id

## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
