### PR TITLE
fix: select actions button was mapping to enitity[0].actions

### DIFF
--- a/src/app/system/manage-hooks/add-event-dialog/add-event-dialog.component.ts
+++ b/src/app/system/manage-hooks/add-event-dialog/add-event-dialog.component.ts
@@ -26,8 +26,8 @@ export class AddEventDialogComponent implements OnInit {
    * @param {any} data Provides grouping, entities and actions data to fill dropdowns.
    */
   constructor(public dialogRef: MatDialogRef<AddEventDialogComponent>,
-              public formBuilder: UntypedFormBuilder,
-              @Inject(MAT_DIALOG_DATA) public data: any) {
+    public formBuilder: UntypedFormBuilder,
+    @Inject(MAT_DIALOG_DATA) public data: any) {
   }
 
   /**
@@ -59,7 +59,7 @@ export class AddEventDialogComponent implements OnInit {
   setEntityListener() {
     this.eventForm.get('entity').valueChanges
       .subscribe(changedEntity => {
-        this.actionData = this.entityData[0].actions;
+        this.actionData = this.entityData.find((entity: any) => entity.name === changedEntity).actions;
       });
   }
 


### PR DESCRIPTION
## Description
Now, select actions button is working fine and it is dependent on the selection of entity.

## Related issues and discussion
#1896 

## Screenshots, if any
<img width="1438" alt="Screenshot 2024-01-05 at 9 19 04 AM" src="https://github.com/openMF/web-app/assets/76156941/8541b0ec-0029-4688-9c2d-b138742e724a">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
