### PR TITLE
Run and Download direct table reports as XLS file

### DIFF
--- a/src/app/reports/run-report/run-report.component.html
+++ b/src/app/reports/run-report/run-report.component.html
@@ -2,7 +2,7 @@
 
   <mat-card *ngIf="!isCollapsed">
 
-    <form [formGroup]="reportForm" (ngSubmit)="run()">
+    <form [formGroup]="reportForm">
 
       <mat-card-content fxLayout="column">
 
@@ -78,9 +78,13 @@
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
         <button type="button" mat-raised-button [routerLink]="['/reports']">{{"labels.buttons.Cancel" | translate}}</button>
-        <button mat-raised-button color="primary" [disabled]="!reportForm.valid" id="runreport">
+        <button mat-raised-button color="primary" [disabled]="!reportForm.valid || isProcessing" id="runreport" (click)="run()">
           <fa-icon icon="file-export" class="m-r-10"></fa-icon>
           {{"labels.buttons.Run Report" | translate}}
+        </button>
+        <button *ngIf="isTableReport()" mat-raised-button color="primary" [disabled]="!reportForm.valid || isProcessing" (click)="runReportAndExport($event)">
+          <fa-icon icon="download" class="m-r-10"></fa-icon>
+          {{"labels.buttons.Run and Download Report" | translate}}
         </button>
       </mat-card-actions>
 

--- a/src/app/users/view-user/view-user.component.ts
+++ b/src/app/users/view-user/view-user.component.ts
@@ -53,7 +53,7 @@ export class ViewUserComponent implements OnInit {
       if (response.delete) {
         this.usersService.deleteUser(this.userData.id)
           .subscribe(() => {
-            this.router.navigate(['/users']);
+            this.router.navigate(['/appusers']);
           });
       }
     });
@@ -74,7 +74,7 @@ export class ViewUserComponent implements OnInit {
         const firstname = this.userData.firstname;
         const data = {password: password, repeatPassword: repeatPassword, firstname: firstname};
         this.usersService.changePassword(this.userData.id, data).subscribe(() => {
-          this.router.navigate(['/users']);
+          this.router.navigate(['/appusers']);
         });
       }
     });

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -446,6 +446,7 @@
       "Reset Password": "Obnovit heslo",
       "Retrieve": "Načíst",
       "Revert Transaction": "Vrátit transakci",
+      "Run and Download Report": "Spusťte a stahujte zprávu",
       "Run Catch-Up": "Spusťte Catch-Up",
       "Run Periodic Accruals": "Spusťte periodické časové rozlišení",
       "Run Report": "Spustit zprávu",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -446,6 +446,7 @@
       "Reset Password": "Passwort zurücksetzen",
       "Retrieve": "Abrufen",
       "Revert Transaction": "Transaktion rückgängig machen",
+      "Run and Download Report": "Bericht ausführen und herunterladen",
       "Run Catch-Up": "Führen Sie Catch-Up durch",
       "Run Periodic Accruals": "Führen Sie periodische Rückstellungen durch",
       "Run Report": "Bericht ausführen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -446,6 +446,7 @@
             "Reset Password": "Reset Password",
             "Retrieve": "Retrieve",
             "Revert Transaction": "Revert Transaction",
+            "Run and Download Report": "Run and Download Report",
             "Run Catch-Up": "Run Catch-Up",
             "Run Periodic Accruals": "Run Periodic Accruals",
             "Run Report": "Run Report",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -446,6 +446,7 @@
             "Reset Password": "Restablecer la contraseña",
             "Retrieve": "Recuperar",
             "Revert Transaction": "Revertir transacción",
+            "Run and Download Report": "Ejecutar y descargar informe",
             "Run Catch-Up": "Correr para ponerse al día",
             "Run Periodic Accruals": "Ejecutar acumulaciones periódicas",
             "Run Report": "Sacar un reporte",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -446,6 +446,7 @@
       "Reset Password": "réinitialiser le mot de passe",
       "Retrieve": "Récupérer",
       "Revert Transaction": "Annuler la transaction",
+      "Run and Download Report": "Rapport d'exécution et de téléchargement",
       "Run Catch-Up": "Exécuter un rattrapage",
       "Run Periodic Accruals": "Exécuter des régularisations périodiques",
       "Run Report": "Rapport d'exécution",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -446,6 +446,7 @@
       "Reset Password": "Resetta la password",
       "Retrieve": "Recuperare",
       "Revert Transaction": "Annulla transazione",
+      "Run and Download Report": "Esegui e scarica il rapporto",
       "Run Catch-Up": "Esegui il recupero",
       "Run Periodic Accruals": "Esegui ratei periodici",
       "Run Report": "Esegui rapporto",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -446,6 +446,7 @@
       "Reset Password": "암호를 재설정",
       "Retrieve": "검색하다",
       "Revert Transaction": "거래 되돌리기",
+      "Run and Download Report": "보고서를 실행하고 다운로드하십시오",
       "Run Catch-Up": "따라잡기 실행",
       "Run Periodic Accruals": "정기적인 발생 실행",
       "Run Report": "보고서 실행",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -446,6 +446,7 @@
       "Reset Password": "Atstatyti slaptažodį",
       "Retrieve": "Atgauti",
       "Revert Transaction": "Grąžinti operaciją",
+      "Run and Download Report": "Paleisti ir atsisiųsti ataskaitą",
       "Run Catch-Up": "Vykdykite „Catch-Up“.",
       "Run Periodic Accruals": "Vykdykite periodinius kaupimus",
       "Run Report": "Vykdyti ataskaitą",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -446,6 +446,7 @@
       "Reset Password": "Atiestatīt paroli",
       "Retrieve": "Atgūt",
       "Revert Transaction": "Atsaukt darījumu",
+      "Run and Download Report": "Palaist un lejupielādēt pārskatu",
       "Run Catch-Up": "Palaist Catch-Up",
       "Run Periodic Accruals": "Veiciet periodiskus uzkrājumus",
       "Run Report": "Palaist ziņojumu",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -446,6 +446,7 @@
       "Reset Password": "पासवर्ड रिसेट",
       "Retrieve": "पुन: प्राप्त गर्नुहोस्",
       "Revert Transaction": "लेनदेन उल्टाउनुहोस्",
+      "Run and Download Report": "रन र डाउनलोड रिपोर्ट डाउनलोड गर्नुहोस्",
       "Run Catch-Up": "क्याच-अप चलाउनुहोस्",
       "Run Periodic Accruals": "आवधिक आम्दानी चलाउनुहोस्",
       "Run Report": "रिपोर्ट चलाउनुहोस्",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -446,6 +446,7 @@
       "Reset Password": "Redefinir senha",
       "Retrieve": "Recuperar",
       "Revert Transaction": "Reverter transação",
+      "Run and Download Report": "Relatório de execução e download",
       "Run Catch-Up": "Execute o catch-up",
       "Run Periodic Accruals": "Executar acumulações periódicas",
       "Run Report": "Executar relatório",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -446,6 +446,7 @@
       "Reset Password": "Weka upya Nenosiri",
       "Retrieve": "Rejesha",
       "Revert Transaction": "Rejesha Muamala",
+      "Run and Download Report": "Kukimbia na kupakua ripoti",
       "Run Catch-Up": "Run Catch-Up",
       "Run Periodic Accruals": "Endesha Mapato ya Mara kwa Mara",
       "Run Report": "Endesha Ripoti",


### PR DESCRIPTION
## Description

Now, when we will run a medium/large size table report, we have the option to run it and download direct the report content as xlsx file without the need to display the huge data in the html

<img width="1034" alt="Screenshot 2024-01-17 at 9 39 40 p m" src="https://github.com/openMF/web-app/assets/154766431/79e283fe-0532-4b95-90ff-c0799daa7abd">

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
