### PR TITLE
Backdated delinquency pause with end date in the past validation

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
@@ -221,13 +221,13 @@
       <input type="number" matInput formControlName="fixedEmiAmount">
     </mat-form-field>
 
-    <ng-container *ngIf="loansAccountTermsData?.canUseForTopup">
+    <ng-container *ngIf="loansAccountTermsData?.isTopup">
 
-      <mat-checkbox fxFlex="48%" formControlName="isTopup">
+      <mat-checkbox fxFlex="20%" formControlName="isTopup">
         <p>{{"labels.inputs.Is Topup Loan" | translate}}?</p>
       </mat-checkbox>
 
-      <mat-form-field fxFlex="48%" *ngIf="loansAccountTermsForm.controls.isTopup.value">
+      <mat-form-field fxFlex="24%" *ngIf="loansAccountTermsForm.controls.isTopup.value">
         <mat-label>{{"labels.inputs.Loan closed with Topup" | translate}}</mat-label>
         <mat-select formControlName="loanIdToClose">
           <mat-option *ngFor="let clientActiveLoan of clientActiveLoanData" [value]="clientActiveLoan.id">

--- a/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.ts
+++ b/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.ts
@@ -129,7 +129,22 @@ export class LoanDelinquencyTagsTabComponent implements OnInit {
 
   isCurrentAndPauseAction(item: LoanDelinquencyAction): boolean {
     if (this.currentLoanDelinquencyAction != null) {
-      return (this.currentLoanDelinquencyAction.id === item.id && item.action === 'PAUSE');
+      if (this.currentLoanDelinquencyAction.id === item.id) {
+        if (item.action === 'PAUSE') {
+          const businessDate: Date = this.settingsService.businessDate;
+          const startDate: Date = this.dateUtils.parseDate(item.startDate);
+          if (businessDate < startDate) {
+            return false;
+          }
+          if (item.endDate) {
+            const endDate: Date = this.dateUtils.parseDate(item.endDate);
+            if (businessDate > endDate) {
+              return false;
+            }
+          }
+          return true;
+        }
+      }
     }
     return false;
   }


### PR DESCRIPTION
## Description

When backdated delinquency pause is created with both start and end date in the past, the API will close the pause period, but on the UI the resume button will be still visible amd active (clicking on t will result an error as expected)

## Screenshots

- Past end date (no resume button showed)
<img width="1380" alt="Screenshot 2024-01-17 at 10 26 38 p m" src="https://github.com/openMF/web-app/assets/154766431/2080d121-cae5-48ef-8874-46dd8e5d2f3d">

- Future end date (resume button showed)
<img width="1421" alt="Screenshot 2024-01-17 at 10 27 26 p m" src="https://github.com/openMF/web-app/assets/154766431/7775a3a4-a598-4d3c-8d8b-db3d484e470e">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
