### PR TITLE
fix: updated tooltip position on the sidenavbar of home page

### DIFF
--- a/src/app/core/shell/sidenav/sidenav.component.html
+++ b/src/app/core/shell/sidenav/sidenav.component.html
@@ -39,7 +39,7 @@
       </div>
       <div class="icon-menu">
         <div class="icon-menu-item" *ngFor="let activity of mappedActivities">
-          <button mat-raised-button [matTooltip]="activity.toolTip" [routerLink]="[activity.path]">
+          <button mat-raised-button [matTooltipPosition]="tooltipPosition" [matTooltip]="activity.toolTip" [routerLink]="[activity.path]">
             <fa-icon [icon]="activity.icon" size="lg"></fa-icon>
           </button>
         </div>
@@ -51,61 +51,61 @@
       </div>
 
       <mat-nav-list>
-        <mat-list-item [routerLink]="['/dashboard']" matTooltip="{{ 'tooltips.Dashboard' | translate}}">
+        <mat-list-item [routerLink]="['/dashboard']" [matTooltipPosition]="tooltipPosition" matTooltip="{{ 'tooltips.Dashboard' | translate}}">
           <mat-icon matListIcon >
             <fa-icon icon="tachometer-alt" size="sm"></fa-icon>
           </mat-icon>
           <a matLine #dashboard>{{'labels.menus.Dashboard' | translate}}</a>
         </mat-list-item>
-        <mat-list-item [routerLink]="['/navigation']" matTooltip="{{ 'tooltips.Navigation' | translate}}">
+        <mat-list-item [routerLink]="['/navigation']" [matTooltipPosition]="tooltipPosition" matTooltip="{{ 'tooltips.Navigation' | translate}}">
           <mat-icon matListIcon>
             <fa-icon icon="location-arrow" size="sm"></fa-icon>
           </mat-icon>
           <a matLine #navigation>{{'labels.menus.Navigation' | translate}}</a>
         </mat-list-item>
-        <mat-list-item [routerLink]="['/checker-inbox-and-tasks/checker-inbox']" matTooltip="{{ 'tooltips.Checker Inbox and Tasks' | translate}}">
+        <mat-list-item [routerLink]="['/checker-inbox-and-tasks/checker-inbox']" [matTooltipPosition]="tooltipPosition" matTooltip="{{ 'tooltips.Checker Inbox and Tasks' | translate}}">
           <mat-icon matListIcon>
             <i class="fa fa-check" ></i>
           </mat-icon>
           <a matLine>{{'labels.menus.Checker Inbox and Tasks' | translate}}</a>
         </mat-list-item>
-        <mat-list-item [routerLink]="['/collections/individual-collection-sheet']" matTooltip="{{ 'tooltips.Individual Collection Sheet' | translate}}">
+        <mat-list-item [routerLink]="['/collections/individual-collection-sheet']" [matTooltipPosition]="tooltipPosition" matTooltip="{{ 'tooltips.Individual Collection Sheet' | translate}}">
           <mat-icon matListIcon>
             <i class="fa fa-tasks "></i>
           </mat-icon>
           <a matLine>{{'labels.menus.Individual Collection Sheet' | translate}}</a>
         </mat-list-item>
-        <mat-list-item [routerLink]="['/notifications']" matTooltip="{{ 'tooltips.Notifications' | translate}}">
+        <mat-list-item [routerLink]="['/notifications']" [matTooltipPosition]="tooltipPosition" matTooltip="{{ 'tooltips.Notifications' | translate}}">
           <mat-icon matListIcon>
             <fa-icon icon="bell" size="sm"></fa-icon>
           </mat-icon>
           <a matLine>{{'labels.menus.Notifications' | translate}}</a>
         </mat-list-item>
-        <mat-list-item [routerLink]="['/accounting/journal-entries/frequent-postings']" matTooltip="{{ 'tooltips.Frequent Postings' | translate}}">
+        <mat-list-item [routerLink]="['/accounting/journal-entries/frequent-postings']" [matTooltipPosition]="tooltipPosition" matTooltip="{{ 'tooltips.Frequent Postings' | translate}}">
           <mat-icon matListIcon>
             <fa-icon icon="sync" size="sm"></fa-icon>
           </mat-icon>
           <a matLine #frequentPostings>{{'labels.menus.Frequent Postings' | translate}}</a>
         </mat-list-item>
-        <mat-list-item [routerLink]="['/accounting/journal-entries/create']" matTooltip="{{ 'tooltips.Create Journal Entry' | translate}}">
+        <mat-list-item [routerLink]="['/accounting/journal-entries/create']" [matTooltipPosition]="tooltipPosition" matTooltip="{{ 'tooltips.Create Journal Entry' | translate}}">
           <mat-icon matListIcon>
             <fa-icon icon="plus" size="sm"></fa-icon>
           </mat-icon>
           <a matLine #createJournalEntry>{{'labels.menus.Create Journal Entry' | translate}}</a>
         </mat-list-item>
-        <mat-list-item [routerLink]="['/accounting/chart-of-accounts']" matTooltip="{{ 'tooltips.Chart Of Accounts' | translate}}">
+        <mat-list-item [routerLink]="['/accounting/chart-of-accounts']" [matTooltipPosition]="tooltipPosition" matTooltip="{{ 'tooltips.Chart Of Accounts' | translate}}">
           <mat-icon matListIcon>
             <fa-icon icon="sitemap" size="sm"></fa-icon>
           </mat-icon>
           <a matLine #chartOfAccounts>{{'labels.menus.Chart of Accounts' | translate}}</a>
         </mat-list-item>
-        <mat-list-item (click)="showKeyboardShortcuts()" matTooltip="{{ 'tooltips.Keyboard Shortcuts' | translate}}">
+        <mat-list-item (click)="showKeyboardShortcuts()" [matTooltipPosition]="tooltipPosition" matTooltip="{{ 'tooltips.Keyboard Shortcuts' | translate}}">
           <mat-icon matListIcon>
             <fa-icon icon="keyboard" size="sm"></fa-icon>
           </mat-icon>
           <a matLine>{{'labels.menus.Keyboard Shortcuts' | translate}}</a>
         </mat-list-item>
-        <mat-list-item matTooltip="{{ 'tooltips.Help' | translate}}">
+        <mat-list-item [matTooltipPosition]="tooltipPosition" matTooltip="{{ 'tooltips.Help' | translate}}">
           <mat-icon matListIcon (click)="help()">
             <fa-icon icon="question-circle" size="sm"></fa-icon>
           </mat-icon>

--- a/src/app/core/shell/sidenav/sidenav.component.ts
+++ b/src/app/core/shell/sidenav/sidenav.component.ts
@@ -28,7 +28,8 @@ export class SidenavComponent implements OnInit, AfterViewInit {
 
   /** True if sidenav is in collapsed state. */
   @Input() sidenavCollapsed: boolean;
-
+  /** Tooltip position */
+  tooltipPosition: string = 'after';
   /** Username of authenticated user. */
   username: string;
   /** Array of all user activities */


### PR DESCRIPTION
## Description
Mttooltip position has been changed for having proper navigation through the sidenavbar located on home page
## Related issues and discussion
#1955
## Screenshots, if any
![image](https://github.com/openMF/web-app/assets/103763618/9ab9bad8-f160-45d1-8a15-7095b4b060f9)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
