### PR TITLE
feat: Adjust keyboard shortcut dialog divider position

### DIFF
--- a/src/app/shared/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.component.html
+++ b/src/app/shared/keyboard-shortcuts-dialog/keyboard-shortcuts-dialog.component.html
@@ -3,6 +3,7 @@
 <div mat-dialog-content>
   <div fxLayout="column" fxLayoutGap="2%">
     <ng-container *ngFor="let item of buttonConfig.buttonCombinations">
+      <mat-divider [inset]="true"></mat-divider>
       <div fxFlexFill fxFlex="50%">
         <span fxFlex="50%">
           <span *ngIf="item.ctrlKey"> <span class="modifierKey">{{ 'labels.inputs.Ctrl' | translate }}</span> + </span>
@@ -12,7 +13,6 @@
         </span>
         <span fxFlex="50%">{{ item.title }}</span>
       </div>
-      <mat-divider [inset]="true"></mat-divider>
     </ng-container>
   </div>
 </div>


### PR DESCRIPTION
Fixes an issue with the keyboard shortcut dialog by shifting the divider upwards.This change improves the appearance and usability of the dialog

- The divider position is now adjusted for better alignment.
- Resolves visual discrepancies and enhances overall user experience.

## Description
Shifted the **mat-divider** to the starting of **ng-container** from last.

## Related issues and discussion
#1956

## Screenshots,(Before/After)

- Before change

![Screenshot from 2024-02-09 22-27-53](https://github.com/openMF/web-app/assets/106796672/c897fd70-8370-40c2-983d-689de8ddf9ab)

- After change

![Screenshot from 2024-02-09 21-59-56](https://github.com/openMF/web-app/assets/106796672/3a370e50-6d6f-405c-8252-9a9851e9e4a0)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
