### PR TITLE
Fix: Recurring Deposit product edition using IRC ids

### DIFF
--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-interest-rate-chart-step/recurring-deposit-product-interest-rate-chart-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-interest-rate-chart-step/recurring-deposit-product-interest-rate-chart-step.component.ts
@@ -111,6 +111,7 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
       this.chartsDetail[i].chartSlabs.forEach((chartSlabDetail: any, j: number) => {
 
         const chartSlabInfo = this.formBuilder.group({
+          id: [chartSlabDetail.id],
           amountRangeFrom: [chartSlabDetail.amountRangeFrom],
           amountRangeTo: [chartSlabDetail.amountRangeTo],
           annualInterestRate: [chartSlabDetail.annualInterestRate, Validators.required],
@@ -154,6 +155,9 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
         name: chartData.name,
         chartSlabs: this.getChartSlabsData(chartData)
       };
+      if (chartData.id) {
+        chart['id'] = chartData.id;
+      }
       this.chartsDetail.push(chart);
     });
     this.recurringDepositProductInterestRateChartForm.patchValue({
@@ -182,6 +186,9 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
         toPeriod: eachChartSlabData.toPeriod,
         incentives: this.getIncentivesData(chartSlabData)
       };
+      if (eachChartSlabData.id) {
+        chartSlab['id'] = eachChartSlabData.id;
+      }
       chartSlabs.push(chartSlab);
     });
     return chartSlabs;
@@ -224,6 +231,7 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
 
   createChartForm(): UntypedFormGroup {
     return this.formBuilder.group({
+      'id': [null],
       'name': [''],
       'description': [''],
       'fromDate': ['', Validators.required],
@@ -376,13 +384,16 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
     for (const chart of recurringDepositProductInterestRateChart.charts) {
       chart.dateFormat = dateFormat;
       chart.locale = locale;
-      chart.fromDate = this.dateUtils.formatDate(chart.fromDate, dateFormat) || '';
+      chart.fromDate = this.dateUtils.formatDate(chart.fromDate, dateFormat);
       chart.endDate = this.dateUtils.formatDate(chart.endDate, dateFormat) || '';
       if (chart.endDate === '') {
         delete chart.endDate;
       }
       if (chart.description === '') {
         delete chart.description;
+      }
+      if (chart.id === null) {
+        delete chart.id;
       }
     }
     return recurringDepositProductInterestRateChart;

--- a/src/app/products/recurring-deposit-products/view-recurring-deposit-product/recurring-deposit-general-tab/recurring-deposit-general-tab.component.html
+++ b/src/app/products/recurring-deposit-products/view-recurring-deposit-product/recurring-deposit-general-tab/recurring-deposit-general-tab.component.html
@@ -380,8 +380,10 @@
           <div fxFlexFill fxLayout="row wrap" fxLayout.lt-md="column">
             <span fxFlex="40%">Interest on savings:</span>
             <span fxFlex="60%">{{ recurringDepositProduct.accountingMappings.interestOnSavingsAccount.name }}</span>
-            <span fxFlex="40%">Write-off:</span>
-            <span fxFlex="60%">{{ recurringDepositProduct.accountingMappings.writeOffAccount.name }}</span>
+            <span *ngIf="recurringDepositProduct.accountingMappings.writeOffAccount">
+              <span fxFlex="40%">Write-off:</span>
+              <span fxFlex="60%">{{ recurringDepositProduct.accountingMappings.writeOffAccount.name }}</span>  
+            </span>
           </div>
 
           <h4 fxFlexFill class="mat-h4">Income</h4>


### PR DESCRIPTION
## Description

There was an issue when we try to edit a Recurring Deposit product, the Interest Rate charts were not including the `id` attribute, then Fineract was trying to create those charts and send an overlapping error

## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
