### PR TITLE
Display Savings account transaction reversed

### DIFF
--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-view/transactions-tab/transactions-tab.component.html
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-view/transactions-tab/transactions-tab.component.html
@@ -13,6 +13,11 @@
 
     <table mat-table [dataSource]="dataSource">
 
+      <ng-container matColumnDef="row">
+        <th mat-header-cell *matHeaderCellDef> # </th>
+        <td mat-cell *matCellDef="let idx = index;">{{(idx + 1)}}</td>
+      </ng-container>
+
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef> {{"labels.inputs.ID" | translate }} </th>
         <td mat-cell *matCellDef="let transaction"> {{ transaction.id }} </td>

--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-view/transactions-tab/transactions-tab.component.ts
@@ -22,7 +22,7 @@ export class TransactionsTabComponent implements OnInit {
   /** Form control to handle accural parameter */
   hideAccrualsParam: UntypedFormControl;
   /** Columns to be displayed in transactions table. */
-  displayedColumns: string[] = ['id', 'transactionDate', 'transactionType', 'debit', 'credit', 'balance', 'actions'];
+  displayedColumns: string[] = ['row', 'id', 'transactionDate', 'transactionType', 'debit', 'credit', 'balance', 'actions'];
   /** Data source for transactions table. */
   dataSource: MatTableDataSource<any>;
 

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-view/transactions-tab/transactions-tab.component.html
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-view/transactions-tab/transactions-tab.component.html
@@ -13,6 +13,11 @@
 
     <table mat-table [dataSource]="dataSource">
 
+      <ng-container matColumnDef="row">
+        <th mat-header-cell *matHeaderCellDef> # </th>
+        <td mat-cell *matCellDef="let idx = index;">{{(idx + 1)}}</td>
+      </ng-container>
+
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef> {{"labels.inputs.ID" | translate }} </th>
         <td mat-cell *matCellDef="let transaction" [ngClass]="{'strike': transaction.reversed}"> {{ transaction.id }} </td>

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-view/transactions-tab/transactions-tab.component.ts
@@ -23,7 +23,7 @@ export class TransactionsTabComponent implements OnInit {
   /** Form control to handle accural parameter */
   hideAccrualsParam: UntypedFormControl;
   /** Columns to be displayed in transactions table. */
-  displayedColumns: string[] = ['id', 'transactionDate', 'transactionType', 'debit', 'credit', 'balance'];
+  displayedColumns: string[] = ['row', 'id', 'transactionDate', 'transactionType', 'debit', 'credit', 'balance'];
   /** Data source for transactions table. */
   dataSource: MatTableDataSource<any>;
 

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.html
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.html
@@ -13,6 +13,11 @@
 
   <table mat-table [dataSource]="dataSource" matSort>
 
+    <ng-container matColumnDef="row">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> # </th>
+      <td mat-cell *matCellDef="let idx = index;">{{(idx + 1)}}</td>
+    </ng-container>
+
     <ng-container matColumnDef="id">
       <th mat-header-cell *matHeaderCellDef mat-sort-header> {{"labels.inputs.Id" | translate}} </th>
       <td mat-cell *matCellDef="let transaction" [ngClass]="loanTransactionColor(transaction)"> {{ transaction.id }}

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
@@ -27,7 +27,7 @@ export class TransactionsTabComponent implements OnInit {
   /** Stores the status of the loan account */
   status: string;
   /** Columns to be displayed in original schedule table. */
-  displayedColumns: string[] = ['id', 'office', 'externalId', 'date', 'transactionType', 'amount', 'principal', 'interest', 'fee', 'penalties', 'loanBalance', 'actions'];
+  displayedColumns: string[] = ['row', 'id', 'office', 'externalId', 'date', 'transactionType', 'amount', 'principal', 'interest', 'fee', 'penalties', 'loanBalance', 'actions'];
 
   dataSource: MatTableDataSource<any>;
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;

--- a/src/app/savings/models/savings-account-transaction.model.ts
+++ b/src/app/savings/models/savings-account-transaction.model.ts
@@ -1,0 +1,57 @@
+import { Currency } from 'app/shared/models/general.model';
+
+export interface SavingsAccountTransaction {
+    id:                    number;
+    transactionType:       SavingsAccountTransactionType;
+    entryType:             string;
+    accountId:             number;
+    accountNo:             string;
+    date:                  number[];
+    currency:              Currency;
+    amount:                number;
+    runningBalance:        number;
+    reversed:              boolean;
+    transfer:              Transfer;
+    submittedOnDate:       number[];
+    interestedPostedAsOn:  boolean;
+    submittedByUsername:   string;
+    isManualTransaction:   boolean;
+    isReversal:            boolean;
+    originalTransactionId: number;
+    lienTransaction:       boolean;
+    releaseTransactionId:  number;
+    chargesPaidByData:     any[];
+}
+
+
+export interface SavingsAccountTransactionType {
+    id:                number;
+    code:              string;
+    value:             string;
+    deposit:           boolean;
+    dividendPayout:    boolean;
+    withdrawal:        boolean;
+    interestPosting:   boolean;
+    feeDeduction:      boolean;
+    initiateTransfer:  boolean;
+    approveTransfer:   boolean;
+    withdrawTransfer:  boolean;
+    rejectTransfer:    boolean;
+    overdraftInterest: boolean;
+    writtenoff:        boolean;
+    overdraftFee:      boolean;
+    withholdTax:       boolean;
+    escheat:           boolean;
+    amountHold:        boolean;
+    amountRelease:     boolean;
+    accrual:           boolean;
+}
+
+export interface Transfer {
+    id:                  number;
+    reversed:            boolean;
+    currency:            Currency;
+    transferAmount:      number;
+    transferDate:        number[];
+    transferDescription: string;
+}

--- a/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.html
+++ b/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.html
@@ -7,6 +7,8 @@
         <h3>All Transactions</h3>
       </div>
       <div class="action-button m-b-20" fxLayout="row" fxLayoutGap="20px" *ngIf="checkStatus()">
+        <mat-checkbox [formControl]="hideReversedParam" (click)="hideReversed()" class="accruals">
+          {{"labels.inputs.Hide Reversed" | translate}}</mat-checkbox>
         <mat-checkbox [formControl]="hideAccrualsParam" (click)="hideAccruals()" class="accruals">
           {{"labels.inputs.Hide Accruals" | translate}}</mat-checkbox>
         <button mat-raised-button color="primary" [routerLink]="['/accounting', 'journal-entries']">View Journal Entries</button>
@@ -15,6 +17,11 @@
     </div>
 
     <table mat-table [dataSource]="dataSource" matSort>
+
+      <ng-container matColumnDef="row">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header> # </th>
+        <td mat-cell *matCellDef="let idx = index;">{{(idx + 1)}}</td>
+      </ng-container>
 
       <ng-container matColumnDef="id">
         <th mat-header-cell *matHeaderCellDef mat-sort-header> Id </th>

--- a/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.scss
+++ b/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.scss
@@ -23,3 +23,8 @@
     }
   }
 }
+
+.strike {
+  text-decoration: line-through;
+  color: red;
+}

--- a/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.ts
@@ -5,6 +5,7 @@ import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute, Router } from '@angular/router';
+import { SavingsAccountTransaction } from 'app/savings/models/savings-account-transaction.model';
 
 /**
  * Transactions Tab Component.
@@ -19,13 +20,14 @@ export class TransactionsTabComponent implements OnInit {
   /** Savings Account Status */
   status: any;
   /** Transactions Data */
-  transactionsData: any;
+  transactionsData: SavingsAccountTransaction[] = [];
   /** Temporary Transaction Data */
   tempTransaction: any;
   /** Form control to handle accural parameter */
   hideAccrualsParam: UntypedFormControl;
+  hideReversedParam: UntypedFormControl;
   /** Columns to be displayed in transactions table. */
-  displayedColumns: string[] = ['id', 'date', 'transactionType', 'debit', 'credit', 'balance', 'actions'];
+  displayedColumns: string[] = ['row', 'id', 'date', 'transactionType', 'debit', 'credit', 'balance', 'actions'];
   /** Data source for transactions table. */
   dataSource: MatTableDataSource<any>;
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
@@ -48,6 +50,7 @@ export class TransactionsTabComponent implements OnInit {
 
   ngOnInit() {
     this.hideAccrualsParam = new UntypedFormControl(false);
+    this.hideReversedParam = new UntypedFormControl(false);
     this.setTransactions();
   }
 
@@ -117,6 +120,21 @@ export class TransactionsTabComponent implements OnInit {
     } else {
       this.dataSource = new MatTableDataSource(this.transactionsData);
     }
+  }
+
+  hideReversed() {
+    let transactions: SavingsAccountTransaction[] = this.transactionsData;
+    if (!this.hideReversedParam.value) {
+      transactions = [];
+      this.transactionsData.forEach((t: SavingsAccountTransaction) => {
+        if (!t.reversed) {
+          transactions.push(t);
+        }
+      });
+    }
+    this.dataSource = new MatTableDataSource(transactions);
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
 }

--- a/src/assets/styles/_colours.scss
+++ b/src/assets/styles/_colours.scss
@@ -94,8 +94,3 @@ $error-log: #ffa726;
 .cdk-drag-placeholder {
   background: $peter-river;
 }
-
-.strike {
-  text-decoration: line-through;
-  color: red;
-}

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1348,6 +1348,7 @@
       "Groups": "Skupiny",
       "Guarantor Type": "Typ ručitele",
       "Hide Accruals": "Skrýt časové rozlišení",
+      "Hide Reversed": "Skrýt obrácené",
       "Holiday Name": "Název dovolené",
       "Hook Name": "Jméno háčku",
       "Hook Template": "Šablona háčku",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1348,6 +1348,7 @@
       "Groups": "Gruppen",
       "Guarantor Type": "Bürgentyp",
       "Hide Accruals": "Rückstellungen ausblenden",
+      "Hide Reversed": "Versteck umgekehrt",
       "Holiday Name": "Feiertagsname",
       "Hook Name": "Hook-Name",
       "Hook Template": "Hakenvorlage",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1347,6 +1347,7 @@
             "Groups": "Groups",
             "Guarantor Type": "Guarantor Type",
             "Hide Accruals": "Hide Accruals",
+            "Hide Reversed": "Hide Reversed",
             "Holiday Name": "Holiday Name",
             "Hook Name": "Hook Name",
             "Hook Template": "Hook Template",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1348,6 +1348,7 @@
             "Groups": "Grupos",
             "Guarantor Type": "Tipo de garante",
             "Hide Accruals": "Ocultar Devengos",
+            "Hide Reversed": "Ocultar Reversos",
             "Holiday Name": "Nombre de festivo",
             "Hook Name": "Nombre del gancho",
             "Hook Template": "Plantilla de gancho",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1348,6 +1348,7 @@
       "Groups": "Groupes",
       "Guarantor Type": "Type de garant",
       "Hide Accruals": "Masquer les provisions",
+      "Hide Reversed": "Cacher inversé",
       "Holiday Name": "Nom de la fête",
       "Hook Name": "Nom du crochet",
       "Hook Template": "Modèle de crochet",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1348,6 +1348,7 @@
       "Groups": "Gruppi",
       "Guarantor Type": "Tipo di garante",
       "Hide Accruals": "Nascondi ratei",
+      "Hide Reversed": "Nascondi invertiti",
       "Holiday Name": "Nome della festività",
       "Hook Name": "Nome del gancio",
       "Hook Template": "Modello di gancio",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1349,6 +1349,7 @@
       "Groups": "여러 떼",
       "Guarantor Type": "보증인 종류",
       "Hide Accruals": "발생액 숨기기",
+      "Hide Reversed": "반전 된 숨기십시오",
       "Holiday Name": "휴일 이름",
       "Hook Name": "후크 이름",
       "Hook Template": "후크 템플릿",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1348,6 +1348,7 @@
       "Groups": "Grupės",
       "Guarantor Type": "Garanto tipas",
       "Hide Accruals": "Slėpti sukaupimus",
+      "Hide Reversed": "Slėpti atvirkštinę",
       "Holiday Name": "Šventės pavadinimas",
       "Hook Name": "Kabliuko pavadinimas",
       "Hook Template": "Kabliuko šablonas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1348,6 +1348,7 @@
       "Groups": "Grupas",
       "Guarantor Type": "Galvotāja veids",
       "Hide Accruals": "Slēpt uzkrājumus",
+      "Hide Reversed": "Paslēpt apgrieztu",
       "Holiday Name": "Svētku nosaukums",
       "Hook Name": "Āķa nosaukums",
       "Hook Template": "Āķa veidne",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1348,6 +1348,7 @@
       "Groups": "समूहहरू",
       "Guarantor Type": "ग्यारेन्टर प्रकार",
       "Hide Accruals": "आम्दानी लुकाउनुहोस्",
+      "Hide Reversed": "लुकाइएको लुकाउनुहोस्",
       "Holiday Name": "छुट्टीको नाम",
       "Hook Name": "हुक नाम",
       "Hook Template": "हुक टेम्प्लेट",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1348,6 +1348,7 @@
       "Groups": "Grupos",
       "Guarantor Type": "Tipo de fiador",
       "Hide Accruals": "Ocultar acumulações",
+      "Hide Reversed": "Ocultar invertido",
       "Holiday Name": "Nome do feriado",
       "Hook Name": "Nome do Gancho",
       "Hook Template": "Modelo de gancho",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1348,6 +1348,7 @@
       "Groups": "Vikundi",
       "Guarantor Type": "Aina ya Mdhamini",
       "Hide Accruals": "Ficha Accruals",
+      "Hide Reversed": "Ficha kurudi nyuma",
       "Holiday Name": "Jina la Likizo",
       "Hook Name": "Jina la Hook",
       "Hook Template": "Kigezo cha ndoano",

--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -75,7 +75,7 @@
               font-size: 14px;
 
               tr:nth-child(even) {
-                background-color: transparent;
+                background-color: transparent !important;
               }
             }
           }
@@ -140,6 +140,14 @@
     color: white;
   }
 
+}
+
+body.dark-theme {
+  table {
+    tr:nth-child(even) {
+      background-color: #303135 !important;
+    }
+  }
 }
 
 .dark-theme {


### PR DESCRIPTION
## Description

Display Savings account transaction reversed

## Screenshots
<img width="1384" alt="Screenshot 2024-03-09 at 7 45 11 a m" src="https://github.com/openMF/web-app/assets/154766431/50cd3cd8-98e7-4a4f-8ae9-e3a57e6b06fa">

- Option to Hide Reversed transactions
<img width="1361" alt="Screenshot 2024-03-09 at 7 45 28 a m" src="https://github.com/openMF/web-app/assets/154766431/1fe6a5f0-7dcd-4f91-8d0f-93b3d7478827">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
