### PR TITLE
replaced language selection field with common language selector compo…

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -51,7 +51,7 @@
   </div>
 
   <div #languageSelector>
-    <mifosx-language-selector class="ml-1 language" fxHide.lt-md></mifosx-language-selector>
+    <mifosx-language-selector class="ml-1 language" [styles]="{'max-width': '6rem'}" fxHide.lt-md></mifosx-language-selector>
   </div>
 
   <div #notifications>

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -34,7 +34,7 @@
 
     <!-- Language Selector to the extreme right -->
     <div fxLayout="row-reverse" fxFlex="1 0 auto">
-      <mifosx-language-selector class="p-r-10 p-t-10"></mifosx-language-selector>
+      <mifosx-language-selector class="p-r-10 p-t-10" [styles]="{'max-width': '6rem'}"></mifosx-language-selector>
       <mifosx-theme-toggle class="p-r-10 p-t-10"></mifosx-theme-toggle>
       <div fxFlex></div>
       <mifosx-server-selector class="p-l-10 p-t-10" *ngIf="environment.allowServerSwitch"></mifosx-server-selector>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -15,14 +15,7 @@
 
       <div fxLayout="column">
 
-        <mat-form-field>
-          <mat-label>{{'labels.inputs.Default Language' | translate}}</mat-label>
-          <mat-select [formControl]="language" [compareWith]="compareOptions">
-            <mat-option *ngFor="let language of languages" [value]="language">
-              {{ language.name }}
-            </mat-option>
-          </mat-select>
-        </mat-form-field>
+        <mifosx-language-selector></mifosx-language-selector>
 
         <mat-form-field>
           <mat-label>{{'labels.inputs.Default Date Format' | translate}}</mat-label>

--- a/src/app/shared/language-selector/language-selector.component.html
+++ b/src/app/shared/language-selector/language-selector.component.html
@@ -1,4 +1,4 @@
-<mat-form-field id="language-selector">
+<mat-form-field id="language-selector" [ngStyle]="styles">
   <mat-label>{{'labels.inputs.Language' | translate}}</mat-label>
   <mat-select [formControl]="languageSelector" (selectionChange)="setLanguage()" class="languageselector">
     <mat-option *ngFor="let language of languages" [value]="language">

--- a/src/app/shared/language-selector/language-selector.component.scss
+++ b/src/app/shared/language-selector/language-selector.component.scss
@@ -1,4 +1,1 @@
-#language-selector,
-.languageselector {
-  max-width: 6rem;
-}
+

--- a/src/app/shared/language-selector/language-selector.component.ts
+++ b/src/app/shared/language-selector/language-selector.component.ts
@@ -1,5 +1,5 @@
 /** Angular Imports */
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 
 /** Custom Services */
@@ -18,6 +18,14 @@ import { SettingsService } from 'app/settings/settings.service';
   styleUrls: ['./language-selector.component.scss']
 })
 export class LanguageSelectorComponent implements OnInit {
+
+  /**
+   * Optional css styles for the language selector component.
+   */
+  @Input() styles = {
+    width: '100%',
+    'max-width': '100%',
+  }
 
   /** Language selector form control. */
   languageSelector = new UntypedFormControl();


### PR DESCRIPTION
In the main configuration section of settings, used the common  'language-selector' component, to fix the issue of languages are not being loaded. Also removed the hard-coded width value for the component and added a styles object input for the language selector component for adding optional CSS if needed. Additionally, updated the existing usages of the component in toolbar component and login component as well.