### PR TITLE
Implemented language selector feature for small screen devices

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -54,6 +54,10 @@
     <mifosx-language-selector class="ml-1 language" fxHide.lt-md></mifosx-language-selector>
   </div>
 
+  <button mat-icon-button [matMenuTriggerFor]="languageMenu">
+    <mat-icon class="lg-icon">language</mat-icon>
+  </button>
+
   <div #notifications>
     <mifosx-notifications-tray fxHide.lt-md></mifosx-notifications-tray>
   </div>
@@ -68,6 +72,11 @@
     </button>
   </div>
 </mat-toolbar>
+
+<!-- Language selector menu for small screen view -->
+<mat-menu #languageMenu="matMenu">
+    <mifosx-language-selector class="ml-1 language"></mifosx-language-selector>
+</mat-menu>
 
 <mat-menu #institutionMenu="matMenu" [overlapTrigger]="false">
   <button mat-menu-item routerLink="/clients">{{'labels.menus.Clients' | translate}}</button>

--- a/src/app/core/shell/toolbar/toolbar.component.scss
+++ b/src/app/core/shell/toolbar/toolbar.component.scss
@@ -38,3 +38,15 @@
     margin-right: 1rem;
   }
 }
+
+// Show icon on small screens
+.lg-icon {
+  display: none;
+}
+
+@media (max-width: 959px) {
+  .lg-icon {
+    display: block; 
+    margin-left: 5px;
+  }
+}

--- a/src/app/shared/language-selector/language-selector.component.html
+++ b/src/app/shared/language-selector/language-selector.component.html
@@ -1,4 +1,4 @@
-<mat-form-field id="language-selector">
+<mat-form-field id="language-selector" class="m-l-10">
   <mat-label>{{'labels.inputs.Language' | translate}}</mat-label>
   <mat-select [formControl]="languageSelector" (selectionChange)="setLanguage()" class="languageselector">
     <mat-option *ngFor="let language of languages" [value]="language">


### PR DESCRIPTION
Implemented language selector feature for small screens by adding functionality for selecting a language using the language icon.

## Related issues and discussion

#2049

## Screen Recording

- Before (Language selector is not there for small screen)

[Screencast from 2024-03-22 02-36-05.webm](https://github.com/openMF/web-app/assets/106796672/8103be22-83ee-41a1-8059-fe23c6c69787)

- After (Language selector is  there for small screen)

[Screencast from 2024-03-22 02-15-35.webm](https://github.com/openMF/web-app/assets/106796672/1ed34079-ba0c-4540-97f1-6ca9d4caae62)

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
