### PR TITLE
fixed ui issue and content overlapping on login screen

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -33,10 +33,9 @@
   <div fxLayout="column" fxFlex.gt-md="1 0 30%" class="login-container">
 
     <!-- Language Selector to the extreme right -->
-    <div fxLayout="row-reverse" fxFlex="1 0 auto">
-      <mifosx-language-selector class="p-r-10 p-t-10"></mifosx-language-selector>
+    <div fxLayout="row-reverse" fxFlex="1 0 auto" fxLayoutAlign="center center">
+      <mifosx-language-selector class=" p-t-10"></mifosx-language-selector>
       <mifosx-theme-toggle class="p-r-10 p-t-10"></mifosx-theme-toggle>
-      <div fxFlex></div>
       <mifosx-server-selector class="p-l-10 p-t-10" *ngIf="environment.allowServerSwitch"></mifosx-server-selector>
     </div>
 

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -15,11 +15,54 @@ import { UntypedFormControl } from '@angular/forms';
 })
 export class SettingsComponent implements OnInit {
 
-  /** Placeholder for languages. update once translations are set up */
   languages: any[] = [
+    {
+      name: 'Čeština (Czech)',
+      code: 'cs'
+    },
+    {
+      name: 'Deutsch (German)',
+      code: 'de'
+    },
     {
       name: 'English',
       code: 'en'
+    },
+    {
+      name: 'Español (Spanish)',
+      code: 'es'
+    },
+    {
+      name: 'Français (French)',
+      code: 'fr'
+    },
+    {
+      name: 'Italiano (Italian)',
+      code: 'it'
+    },
+    {
+      name: '한국어 (Korean)',
+      code: 'ko'
+    },
+    {
+      name: 'Lietuvių (Lithuanian)',
+      code: 'lt'
+    },
+    {
+      name: 'Latviešu (Latvian)',
+      code: 'lv'
+    },
+    {
+      name: 'नेपाली (Nepali)',
+      code: 'ne'
+    },
+    {
+      name: 'Português (Portuguese)',
+      code: 'pt'
+    },
+    {
+      name: 'Kiswahili (Swahili)',
+      code: 'sw'
     }
   ];
   /** Date formats. */


### PR DESCRIPTION
## Description
Fixed the layout of the login screen and removed overlapping content
Added languages in the default language dropdown on settings screen

## Related issues and discussion
#2038 and #2039

## Screenshots, if any
- overlapping ui
<img width="1092" alt="image" src="https://github.com/openMF/web-app/assets/47862474/1d4ae91b-f18d-4e0a-a0fa-9efe858a5cf2">

- Language
<img width="751" alt="image" src="https://github.com/openMF/web-app/assets/47862474/f79de463-6984-4f25-bd5f-8622b10b2891">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
