### PR TITLE
Manage Tax configurations views to use i18n

### DIFF
--- a/src/app/pipes/date-format.pipe.ts
+++ b/src/app/pipes/date-format.pipe.ts
@@ -16,6 +16,7 @@ export class DateFormatPipe implements PipeTransform {
       return '';
     }
     let dateVal;
+    moment.locale(this.settingsService.language.code);
     if (value instanceof Array) {
       dateVal = moment(value.join('-'), 'YYYY-MM-DD');
     } else {

--- a/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.html
+++ b/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.html
@@ -9,84 +9,75 @@
         <div fxLayout="column">
 
           <mat-form-field>
-            <mat-label>Name</mat-label>
+            <mat-label>{{'labels.inputs.Name' | translate}}</mat-label>
             <input matInput required formControlName="name">
             <mat-error *ngIf="taxComponentForm.controls.name.hasError('required')">
-              Name is <strong>required</strong>
+              {{'labels.inputs.Name' | translate}} {{'labels.commons.is' | translate}}
+              <strong>{{'labels.commons.required' | translate}}</strong>
             </mat-error>
           </mat-form-field>
 
           <mat-form-field>
-            <mat-label>Percentage</mat-label>
+            <mat-label>{{'labels.inputs.Percentage' | translate}}</mat-label>
             <input type="number" matInput required formControlName="percentage">
             <mat-error *ngIf="taxComponentForm.controls.percentage.hasError('required')">
-              Percentage is <strong>required</strong>
+              {{'labels.inputs.Percentage ' | translate}} {{'labels.commons.is' | translate}}
+              <strong>{{'labels.commons.required' | translate}}</strong>
             </mat-error>
             <mat-error *ngIf="taxComponentForm.controls.percentage.hasError('pattern') ||
             taxComponentForm.controls.percentage.hasError('max')">
-              Percentage <strong>should</strong> be larger than 0 and at most 100
+              {{'labels.inputs.Percentage' | translate}} <strong>should</strong> be larger than 0 and at most 100
             </mat-error>
           </mat-form-field>
 
           <mat-form-field>
-            <mat-label>Debit Account Type</mat-label>
+            <mat-label>{{'labels.inputs.Debit Account Type' | translate}}</mat-label>
             <mat-select formControlName="debitAccountType">
               <mat-option *ngFor="let debitAccountType of debitAccountTypeData" [value]="debitAccountType.id">
-                {{ debitAccountType.value }}
+                {{ 'labels.inputs.accounting.' + debitAccountType.value | translate }}
               </mat-option>
             </mat-select>
           </mat-form-field>
 
-          <mat-form-field *ngIf="taxComponentForm.controls.debitAccountType.value">
-            <mat-label>Debit Account</mat-label>
-            <mat-select required formControlName="debitAcountId">
-              <mat-option *ngFor="let debitAccount of debitAccountData" [value]="debitAccount.id">
-                {{ debitAccount.name }}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="taxComponentForm.controls.debitAcountId.hasError('required')">
-              Debit account is <strong>required</strong>
-            </mat-error>
-          </mat-form-field>
+          <mifosx-gl-account-selector *ngIf="debitAccountData.length > 0"
+            [inputFormControl]="taxComponentForm.controls.debitAcountId"
+            [glAccountList]="debitAccountData" [required]="false" [inputLabel]="'Credit Account'">
+          </mifosx-gl-account-selector>
 
           <mat-form-field>
-            <mat-label>Credit Account Type</mat-label>
+            <mat-label>{{'labels.inputs.Credit Account Type' | translate}}</mat-label>
             <mat-select formControlName="creditAccountType">
               <mat-option *ngFor="let creditAccountType of creditAccountTypeData" [value]="creditAccountType.id">
-                {{ creditAccountType.value }}
+                {{ 'labels.inputs.accounting.' + creditAccountType.value | translate }}
               </mat-option>
             </mat-select>
           </mat-form-field>
 
-          <mat-form-field *ngIf="taxComponentForm.controls.creditAccountType.value">
-            <mat-label>Credit Account</mat-label>
-            <mat-select required formControlName="creditAcountId">
-              <mat-option *ngFor="let creditAccount of creditAccountData" [value]="creditAccount.id">
-                {{ creditAccount.name }}
-              </mat-option>
-            </mat-select>
-            <mat-error *ngIf="taxComponentForm.controls.creditAcountId.hasError('required')">
-              Credit account is <strong>required</strong>
+          <mifosx-gl-account-selector *ngIf="creditAccountData.length > 0"
+            [inputFormControl]="taxComponentForm.controls.creditAcountId"
+            [glAccountList]="creditAccountData" [required]="false" [inputLabel]="'Credit Account'">
+          </mifosx-gl-account-selector>
+
+          <mat-form-field (click)="startDatePicker.open()">
+            <mat-label>{{'labels.inputs.Start Date' | translate}}</mat-label>
+            <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="startDatePicker" required
+              formControlName="startDate">
+            <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
+            <mat-datepicker #startDatePicker></mat-datepicker>
+            <mat-error *ngIf="taxComponentForm.controls.startDate.hasError('required')">
+              {{'labels.inputs.Start Date' | translate}} {{'labels.commons.is' | translate}}
+              <strong>{{'labels.commons.required' | translate}}</strong>
             </mat-error>
           </mat-form-field>
-
-        <mat-form-field (click)="startDatePicker.open()">
-          <mat-label>Start date</mat-label>
-          <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="startDatePicker" required formControlName="startDate">
-          <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
-          <mat-datepicker #startDatePicker></mat-datepicker>
-          <mat-error *ngIf="taxComponentForm.controls.startDate.hasError('required')">
-            Start date is <strong>required</strong>
-          </mat-error>
-        </mat-form-field>
 
         </div>
 
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../']">Cancel</button>
-        <button mat-raised-button color="primary" [disabled]="!taxComponentForm.valid" *mifosxHasPermission="'CREATE_TAXCOMPONENT'">Submit</button>
+        <button type="button" mat-raised-button [routerLink]="['../']">{{'labels.buttons.Cancel' | translate}}</button>
+        <button mat-raised-button color="primary" [disabled]="!taxComponentForm.valid"
+          *mifosxHasPermission="'CREATE_TAXCOMPONENT'">{{'labels.buttons.Submit' | translate}}</button>
       </mat-card-actions>
 
     </form>

--- a/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.ts
+++ b/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.ts
@@ -29,11 +29,11 @@ export class CreateTaxComponentComponent implements OnInit {
   /** Credit Account Type data. */
   creditAccountTypeData: any;
   /** Credit Account data. */
-  creditAccountData: any;
+  creditAccountData: any[] = [];
   /** Debit Account Type data. */
   debitAccountTypeData: any;
   /** Debit Account data. */
-  debitAccountData: any;
+  debitAccountData: any[] = [];
 
   /**
    * Retrieves the tax Component template data from `resolve`.

--- a/src/app/products/manage-tax-components/edit-tax-component/edit-tax-component.component.html
+++ b/src/app/products/manage-tax-components/edit-tax-component/edit-tax-component.component.html
@@ -9,38 +9,38 @@
         <div fxLayout="column">
 
           <mat-form-field>
-            <mat-label>Name</mat-label>
+            <mat-label>{{'labels.inputs.Name' | translate}}</mat-label>
             <input matInput required formControlName="name">
             <mat-error *ngIf="taxComponentForm.controls.name.hasError('required')">
-              Name is <strong>required</strong>
+              {{'labels.inputs.Name' | translate}} {{'labels.commons.is' | translate}} <strong>{{'labels.commons.required' | translate}}</strong>
             </mat-error>
           </mat-form-field>
 
           <mat-form-field>
-            <mat-label>Percentage</mat-label>
+            <mat-label>{{'labels.inputs.Percentage' | translate}}</mat-label>
             <input matInput required formControlName="percentage">
             <mat-error *ngIf="taxComponentForm.controls.name.hasError('required')">
-              Percentage is <strong>required</strong>
+              {{'labels.inputs.Percentage' | translate}} {{'labels.commons.is' | translate}} <strong>{{'labels.commons.required' | translate}}</strong>
             </mat-error>
           </mat-form-field>
 
           <mat-form-field *ngIf="taxComponentData.creditAccountType.value">
-            <mat-label>Credit Account Type</mat-label>
+            <mat-label>{{'labels.inputs.Credit Account Type' | translate}}</mat-label>
             <input matInput formControlName="creditAccountType">
           </mat-form-field>
 
           <mat-form-field *ngIf="taxComponentData.creditAccount.name">
-            <mat-label>Credit Account</mat-label>
+            <mat-label>{{'labels.inputs.Credit Account' | translate}}</mat-label>
             <input matInput formControlName="creditAccount">
           </mat-form-field>
 
           <mat-form-field (click)="startDatePicker.open()">
-            <mat-label>Start Date</mat-label>
+            <mat-label>{{'labels.inputs.Start Date' | translate}}</mat-label>
             <input matInput [min]="minDate" [max]="maxDate" [matDatepicker]="startDatePicker" required formControlName="startDate">
             <mat-datepicker-toggle matSuffix [for]="startDatePicker"></mat-datepicker-toggle>
             <mat-datepicker #startDatePicker></mat-datepicker>
             <mat-error *ngIf="taxComponentForm.controls.startDate.hasError('required')">
-              Start Date is <strong>required</strong>
+              {{'labels.inputs.Start Date' | translate}} {{'labels.commons.is' | translate}} <strong>{{'labels.commons.required' | translate}}</strong>
             </mat-error>
           </mat-form-field>
 
@@ -49,8 +49,8 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../']">Cancel</button>
-        <button mat-raised-button color="primary" [disabled]="!taxComponentForm.valid" *mifosxHasPermission="'UPDATE_TAXCOMPONENT'">Submit</button>
+        <button type="button" mat-raised-button [routerLink]="['../']">{{'labels.buttons.Cancel' | translate}}</button>
+        <button mat-raised-button color="primary" [disabled]="!taxComponentForm.valid" *mifosxHasPermission="'UPDATE_TAXCOMPONENT'">{{'labels.buttons.Submit' | translate}}</button>
       </mat-card-actions>
 
     </form>

--- a/src/app/products/manage-tax-components/edit-tax-component/edit-tax-component.component.ts
+++ b/src/app/products/manage-tax-components/edit-tax-component/edit-tax-component.component.ts
@@ -7,6 +7,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { ProductsService } from '../../products.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { Dates } from 'app/core/utils/dates';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * Edit tax component.
@@ -41,7 +42,8 @@ export class EditTaxComponentComponent implements OnInit {
               private route: ActivatedRoute,
               private router: Router,
               private dateUtils: Dates,
-              private settingsService: SettingsService) {
+              private settingsService: SettingsService,
+              private translateService: TranslateService) {
     this.route.data.subscribe((data: { taxComponent: any }) => {
       this.taxComponentData = data.taxComponent;
     });
@@ -64,7 +66,7 @@ export class EditTaxComponentComponent implements OnInit {
       'name': [this.taxComponentData.name, [Validators.required]],
       'percentage': [this.taxComponentData.percentage, [Validators.required, Validators.pattern('^(0*[1-9][0-9]*(\\.[0-9]+)?|0+\\.[0-9]*[1-9][0-9]*)$'), Validators.max(100)]],
       'startDate': [this.taxComponentData.startDate && new Date(this.taxComponentData.startDate)],
-      'creditAccountType': [{ value: this.taxComponentData.creditAccountType.value, disabled: true }],
+      'creditAccountType': [{ value: this.translateService.instant('labels.inputs.accounting.' + this.taxComponentData.creditAccountType.value), disabled: true }],
       'creditAccount': [{ value: this.taxComponentData.creditAccount.name, disabled: true }]
     });
   }

--- a/src/app/products/manage-tax-components/manage-tax-components.component.html
+++ b/src/app/products/manage-tax-components/manage-tax-components.component.html
@@ -1,7 +1,7 @@
 <div class="container m-b-20" fxLayout="row" fxLayoutAlign="end" fxLayoutGap="20px">
     <button mat-raised-button color="primary" [routerLink]="['create']" *mifosxHasPermission="'CREATE_TAXCOMPONENT'">
       <fa-icon icon="plus" class="m-r-10"></fa-icon>
-      Create Tax Component
+      {{'labels.buttons.Create Tax Component' | translate}}
     </button>
   </div>
 
@@ -19,13 +19,23 @@
       <table mat-table [dataSource]="dataSource" matSort>
 
         <ng-container matColumnDef="name">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header> Name </th>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header> {{'labels.inputs.Name' | translate}} </th>
           <td mat-cell *matCellDef="let taxComponent"> {{ taxComponent.name }} </td>
         </ng-container>
 
         <ng-container matColumnDef="percentage">
-          <th mat-header-cell *matHeaderCellDef mat-sort-header> Percentage </th>
-          <td mat-cell *matCellDef="let taxComponent"> {{ taxComponent.percentage }} </td>
+          <th mat-header-cell *matHeaderCellDef mat-sort-header> {{'labels.inputs.Percentage' | translate}} %</th>
+          <td mat-cell *matCellDef="let taxComponent"> {{ taxComponent.percentage | formatNumber }} </td>
+        </ng-container>
+
+        <ng-container matColumnDef="startDate">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header> {{'labels.inputs.Start Date' | translate}} </th>
+          <td mat-cell *matCellDef="let taxComponent"> {{ taxComponent.startDate | dateFormat }} </td>
+        </ng-container>
+
+        <ng-container matColumnDef="glAccount">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header> {{'labels.inputs.Account' | translate}} </th>
+          <td mat-cell *matCellDef="let taxComponent"> ({{ taxComponent.creditAccount.glCode }}) {{ taxComponent.creditAccount.name }} </td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/src/app/products/manage-tax-components/manage-tax-components.component.ts
+++ b/src/app/products/manage-tax-components/manage-tax-components.component.ts
@@ -21,7 +21,7 @@ export class ManageTaxComponentsComponent implements OnInit {
   /** Tax Components data. */
   taxComponentData: any;
   /** Columns to be displayed in tax component table. */
-  displayedColumns: string[] = ['name', 'percentage'];
+  displayedColumns: string[] = ['name', 'percentage', 'startDate', 'glAccount'];
   /** Data source for tax component table. */
   dataSource: MatTableDataSource<any>;
 

--- a/src/app/products/manage-tax-components/view-tax-component/view-tax-component.component.html
+++ b/src/app/products/manage-tax-components/view-tax-component/view-tax-component.component.html
@@ -1,7 +1,7 @@
 <div class="container m-b-20" fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="end" fxLayoutGap="2%">
   <button mat-raised-button color="primary" [routerLink]="['edit']" *mifosxHasPermission="'UPDATE_TAXCOMPONENT'">
     <fa-icon icon="edit" class="m-r-10"></fa-icon>
-    Edit
+    {{'labels.buttons.Edit' | translate}}
   </button>
 </div>
 
@@ -14,7 +14,7 @@
       <div fxLayout="row wrap" class="content">
 
         <div fxFlex="50%" class="mat-body-strong">
-          Name
+          {{ 'labels.inputs.Name' | translate}}
         </div>
 
         <div fxFlex="50%">
@@ -22,7 +22,7 @@
         </div>
 
         <div fxFlex="50%" class="mat-body-strong">
-          Percentage
+          {{ 'labels.inputs.Percentage' | translate}}
         </div>
 
         <div fxFlex="50%">
@@ -30,7 +30,7 @@
         </div>
 
         <div fxFlex="50%" class="mat-body-strong" *ngIf="taxComponentData.debitAccountType">
-          Debit Account Type
+          {{'labels.inputs.Debit Account Type' | translate }}
         </div>
 
         <div fxFlex="50%" *ngIf="taxComponentData.debitAccountType">
@@ -38,31 +38,31 @@
         </div>
 
         <div fxFlex="50%" class="mat-body-strong" *ngIf="taxComponentData.debitAccount">
-          Debit Account
+          {{ 'labels.inputs.Debit Account' | translate }}
         </div>
 
         <div fxFlex="50%" *ngIf="taxComponentData.debitAccount">
-          {{ taxComponentData.debitAccount.name}}
+          ({{ 'labels.inputs.accounting.' + taxComponentData.debitAccount.glCode }}) {{ taxComponentData.debitAccount.name | translate }}
         </div>
 
         <div fxFlex="50%" class="mat-body-strong" *ngIf="taxComponentData.creditAccountType">
-          Credit Account Type
+          {{ 'labels.inputs.Credit Account Type' | translate }}
         </div>
 
         <div fxFlex="50%" *ngIf="taxComponentData.creditAccountType">
-          {{ taxComponentData.creditAccountType.value }}
+          {{ 'labels.inputs.accounting.' + taxComponentData.creditAccountType.value | translate }}
         </div>
 
         <div fxFlex="50%" class="mat-body-strong" *ngIf="taxComponentData.creditAccount">
-          Credit Account
+          {{ 'labels.inputs.Credit Account' | translate }}
         </div>
 
         <div fxFlex="50%" *ngIf="taxComponentData.creditAccount">
-          {{ taxComponentData.creditAccount.name }}
+          ({{ taxComponentData.creditAccount.glCode }}) {{ taxComponentData.creditAccount.name }}
         </div>
 
         <div fxFlex="50%" class="mat-body-strong">
-          Start date
+          {{ 'labels.inputs.Start Date' | translate }}
         </div>
 
         <div fxFlex="50%">
@@ -74,7 +74,7 @@
     </mat-card-content>
 
     <div fxLayout="row" fxLayoutAlign="center" fxLayoutGap="2%" fxLayout.lt-md="column">
-      <button type="button" color="primary" mat-raised-button [routerLink]="['../']">Back</button>
+      <button type="button" color="primary" mat-raised-button [routerLink]="['../']">{{'labels.buttons.Back' | translate}}</button>
     </div>
   </mat-card>
 

--- a/src/app/products/manage-tax-configurations/manage-tax-configurations.component.html
+++ b/src/app/products/manage-tax-configurations/manage-tax-configurations.component.html
@@ -12,8 +12,8 @@
             <mat-icon matListIcon>
               <fa-icon icon="building" size="sm"></fa-icon>
             </mat-icon>
-            <h4 matLine>Manage Tax Components</h4>
-            <p matLine>Define Tax components</p>
+            <h4 matLine>{{'labels.heading.Manage Tax Components' | translate}}</h4>
+            <p matLine>{{'labels.heading.Define Tax Components' | translate}}</p>
           </mat-list-item>
 
         </mat-nav-list>
@@ -28,8 +28,8 @@
             <mat-icon matListIcon>
               <fa-icon icon="building" size="sm"></fa-icon>
             </mat-icon>
-            <h4 matLine>Manage Tax Groups</h4>
-            <p matLine>Define Tax Groups</p>
+            <h4 matLine>{{'labels.heading.Manage Tax Groups' | translate}}</h4>
+            <p matLine>{{'labels.heading.Define Tax Groups' | translate}}</p>
           </mat-list-item>
 
         </mat-nav-list>

--- a/src/app/products/manage-tax-groups/create-tax-group/create-tax-group.component.html
+++ b/src/app/products/manage-tax-groups/create-tax-group/create-tax-group.component.html
@@ -9,46 +9,43 @@
         <div fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
 
           <mat-form-field fxFlex="100%">
-            <mat-label>Name</mat-label>
+            <mat-label>{{'labels.inputs.Name' | translate}}</mat-label>
             <input matInput required formControlName="name">
             <mat-error *ngIf="taxGroupForm.controls.name.hasError('required')">
-              Name is <strong>required</strong>
+              {{'labels.inputs.Name' | translate}} {{'labels.commons.is' | translate}} <strong>{{'labels.commons.required' | translate}}</strong>
             </mat-error>
           </mat-form-field>
 
-          <h3 fxFlex="40%" class="mat-h3">Tax Components</h3>
+          <h3 fxFlex="40%" class="mat-h3">{{'labels.inputs.Tax Components' | translate}}</h3>
 
           <div fxFlex="40%" fxLayout="row" fxLayoutAlign="start center">
             <button type="button" mat-raised-button color="primary" (click)="addTaxGroup()">
               <fa-icon icon="plus" class="m-r-10"></fa-icon>
-              Add
+              {{'labels.buttons.Add' | translate}}
             </button>
           </div>
 
           <table mat-table [dataSource]="taxComponentsDataSource" [hidden]="taxComponentsDataSource.length === 0">
 
             <ng-container matColumnDef="name">
-              <th mat-header-cell *matHeaderCellDef> Name </th>
+              <th mat-header-cell *matHeaderCellDef> {{'labels.inputs.Name' | translate}} </th>
               <td mat-cell *matCellDef="let taxComponent">
                 {{ taxComponent.taxComponentId | find: taxComponentOptions:'id':'name'}} </td>
             </ng-container>
 
             <ng-container matColumnDef="startDate">
-              <th mat-header-cell *matHeaderCellDef> Start Date </th>
+              <th mat-header-cell *matHeaderCellDef> {{'labels.inputs.Start Date' | translate}} </th>
               <td mat-cell *matCellDef="let taxComponent"> {{ taxComponent.startDate | dateFormat }}
               </td>
             </ng-container>
 
             <ng-container matColumnDef="actions">
-              <th mat-header-cell *matHeaderCellDef> Actions </th>
+              <th mat-header-cell *matHeaderCellDef> {{'labels.inputs.Actions' | translate}} </th>
               <td mat-cell *matCellDef="let taxComponent; let taxComponentIndex = index">
-                <button type="button" mat-icon-button color="primary" (click)="editTaxGroup(taxComponent, taxComponentIndex)"
-                  matTooltip="Edit" matTooltipPosition="left">
+                <button type="button" mat-icon-button color="primary" (click)="editTaxGroup(taxComponent, taxComponentIndex)">
                   <fa-icon icon="edit"></fa-icon>
                 </button>
-                <button type="button" mat-icon-button color="warn"
-                  (click)="delete(taxComponentIndex)" matTooltip="Delete"
-                  matTooltipPosition="left">
+                <button type="button" mat-icon-button color="warn" (click)="delete(taxComponentIndex)" matTooltipPosition="left">
                   <fa-icon icon="trash"></fa-icon>
                 </button>
               </td>
@@ -64,8 +61,8 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../']">Cancel</button>
-        <button mat-raised-button color="primary" [disabled]="!taxGroupForm.valid" *mifosxHasPermission="'CREATE_TAXGROUP'">Submit</button>
+        <button type="button" mat-raised-button [routerLink]="['../']">{{'labels.buttons.Cancel' | translate}}</button>
+        <button mat-raised-button color="primary" [disabled]="!taxGroupForm.valid" *mifosxHasPermission="'CREATE_TAXGROUP'">{{'labels.buttons.Submit' | translate}}</button>
       </mat-card-actions>
 
     </form>

--- a/src/app/products/manage-tax-groups/create-tax-group/create-tax-group.component.ts
+++ b/src/app/products/manage-tax-groups/create-tax-group/create-tax-group.component.ts
@@ -15,6 +15,7 @@ import { DatepickerBase } from 'app/shared/form-dialog/formfield/model/datepicke
 import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
 import { Dates } from 'app/core/utils/dates';
+import { TranslateService } from '@ngx-translate/core';
 
 /**
  * Create Tax Group component.
@@ -57,8 +58,9 @@ export class CreateTaxGroupComponent implements OnInit {
               private route: ActivatedRoute,
               private router: Router,
               private dateUtils: Dates,
-              public dialog: MatDialog,
-              private settingsService: SettingsService) {
+              private dialog: MatDialog,
+              private settingsService: SettingsService,
+              private translateService: TranslateService) {
     this.route.data.subscribe((data: { taxGroupTemplate: any }) => {
       this.taxGroupTemplateData = data.taxGroupTemplate;
       this.taxComponentOptions = this.taxGroupTemplateData.taxComponents;
@@ -86,20 +88,20 @@ export class CreateTaxGroupComponent implements OnInit {
     const formfields: FormfieldBase[] = [
       new SelectBase({
         controlName: 'taxComponentId',
-        label: 'Tax Component',
+        label: this.translateService.instant('labels.inputs.Tax Component'),
         options: { label: 'name', value: 'id', data: this.taxComponentOptions },
         order: 1
       }),
       new DatepickerBase({
         controlName: 'startDate',
-        label: 'Start Date',
+        label: this.translateService.instant('labels.inputs.Start Date'),
         minDate: this.minDate,
         maxDate: this.maxDate,
         order: 2
       })
     ];
     const data = {
-      title: 'Add Tax Component',
+      title: this.translateService.instant('labels.buttons.Add') + ' ' + this.translateService.instant('labels.inputs.Tax Component'),
       layout: { addButtonText: 'Add' },
       formfields: formfields
     };

--- a/src/app/products/manage-tax-groups/edit-tax-group/edit-tax-group.component.html
+++ b/src/app/products/manage-tax-groups/edit-tax-group/edit-tax-group.component.html
@@ -9,47 +9,46 @@
         <div fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
 
           <mat-form-field fxFlex="100%">
-            <mat-label>Name</mat-label>
+            <mat-label>{{'labels.inputs.Name' | translate}}</mat-label>
             <input matInput required formControlName="name">
             <mat-error *ngIf="taxGroupForm.controls.name.hasError('required')">
-              Name is <strong>required</strong>
+              {{'labels.inputs.Name' | translate}} {{'labels.commons.is' | translate}} <strong>{{'labels.commons.required' | translate}}</strong>
             </mat-error>
           </mat-form-field>
 
-          <h3 fxFlex="40%" class="mat-h3">Tax Components</h3>
+          <h3 fxFlex="40%" class="mat-h3">{{'labels.inputs.Tax Components' | translate}}</h3>
 
           <div fxFlex="40%" fxLayout="row" fxLayoutAlign="start center">
             <button type="button" mat-raised-button color="primary" (click)="addTaxGroup()">
               <fa-icon icon="plus" class="m-r-10"></fa-icon>
-              Add
+              {{'labels.buttons.Add' | translate}}
             </button>
           </div>
 
           <table mat-table [dataSource]="taxComponentsDataSource" [hidden]="taxComponentsDataSource.length === 0">
 
             <ng-container matColumnDef="name">
-              <th mat-header-cell *matHeaderCellDef> Name </th>
+              <th mat-header-cell *matHeaderCellDef> {{'labels.inputs.Name' | translate}} </th>
               <td mat-cell *matCellDef="let taxComponent">
                 {{ taxComponent.taxComponentId | find: taxComponentOptions:'id':'name'}} </td>
             </ng-container>
 
             <ng-container matColumnDef="startDate">
-              <th mat-header-cell *matHeaderCellDef> Start Date </th>
+              <th mat-header-cell *matHeaderCellDef> {{'labels.inputs.Start Date' | translate}} </th>
               <td mat-cell *matCellDef="let taxComponent"> {{ taxComponent.startDate | dateFormat }}
               </td>
             </ng-container>
 
             <ng-container matColumnDef="endDate">
-              <th mat-header-cell *matHeaderCellDef> End Date </th>
+              <th mat-header-cell *matHeaderCellDef> {{'labels.inputs.End Date' | translate}} </th>
               <td mat-cell *matCellDef="let taxComponent"> {{ taxComponent.endDate ? (taxComponent.endDate | dateFormat) : '' }}
               </td>
             </ng-container>
 
             <ng-container matColumnDef="actions">
-              <th mat-header-cell *matHeaderCellDef> Actions </th>
+              <th mat-header-cell *matHeaderCellDef> {{'labels.inputs.Actions' | translate}} </th>
               <td mat-cell *matCellDef="let taxComponent; let taxComponentIndex = index">
-                <button type="button" mat-icon-button color="primary" (click)="editTaxGroup(taxComponent, taxComponentIndex)"
-                  matTooltip="Edit" matTooltipPosition="left">
+                <button type="button" mat-icon-button color="primary" (click)="editTaxGroup(taxComponent, taxComponentIndex)">
                   <fa-icon icon="edit"></fa-icon>
                 </button>
                 <button type="button" mat-icon-button color="warn" *ngIf="taxComponent.isNew"
@@ -70,8 +69,8 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../']">Cancel</button>
-        <button mat-raised-button color="primary" [disabled]="!taxGroupForm.valid" *mifosxHasPermission="'UPDATE_TAXGROUP'">Submit</button>
+        <button type="button" mat-raised-button [routerLink]="['../']">{{'labels.buttons.Cancel' | translate}}</button>
+        <button mat-raised-button color="primary" [disabled]="!taxGroupForm.valid" *mifosxHasPermission="'UPDATE_TAXGROUP'">{{'labels.buttons.Submit' | translate}}</button>
       </mat-card-actions>
 
     </form>

--- a/src/app/products/manage-tax-groups/manage-tax-groups.component.html
+++ b/src/app/products/manage-tax-groups/manage-tax-groups.component.html
@@ -1,7 +1,7 @@
 <div class="container m-b-20" fxLayout="row" fxLayoutAlign="end" fxLayoutGap="20px">
   <button mat-raised-button color="primary" [routerLink]="['create']" *mifosxHasPermission="'CREATE_TAXGROUP'">
     <fa-icon icon="plus" class="m-r-10"></fa-icon>
-    Create Tax Groups
+    {{'labels.buttons.Create Tax Groups' | translate }}
   </button>
 </div>
 
@@ -19,7 +19,7 @@
     <table mat-table [dataSource]="dataSource" matSort>
 
       <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header> Name </th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header> {{'labels.inputs.Name' | translate }} </th>
         <td mat-cell *matCellDef="let taxGroups"> {{ taxGroups.name }} </td>
       </ng-container>
 

--- a/src/app/products/manage-tax-groups/view-tax-group/view-tax-group.component.html
+++ b/src/app/products/manage-tax-groups/view-tax-group/view-tax-group.component.html
@@ -1,7 +1,7 @@
 <div class="container m-b-20" fxLayout="row" fxLayout.lt-md="column" fxLayoutAlign="end" fxLayoutGap="2%">
   <button mat-raised-button color="primary" [routerLink]="['edit']" *mifosxHasPermission="'UPDATE_TAXGROUP'">
     <fa-icon icon="edit" class="m-r-10"></fa-icon>
-    Edit
+    {{ 'labels.buttons.Edit' | translate}}
   </button>
 </div>
 
@@ -14,7 +14,7 @@
       <div fxLayout="row wrap" class="content">
 
         <div fxFlex="33%" class="mat-body-strong">
-          Name
+          {{'labels.inputs.Name' | translate}}
         </div>
 
         <div fxFlex="67%">
@@ -22,15 +22,15 @@
         </div>
 
         <div fxFlex="34%" class="mat-body-strong">
-          Tax-Component Name
+          {{'labels.inputs.Tax Component' | translate}}
         </div>
 
         <div fxFlex="33%" class="mat-body-strong">
-          Start Date
+          {{'labels.inputs.Start Date' | translate}}
         </div>
 
         <div fxFlex="33%" class="mat-body-strong">
-          End Date
+          {{'labels.inputs.End Date' | translate}}
         </div>
 
       </div>

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -637,6 +637,8 @@
       "Dashboard": "Přístrojová deska",
       "Default Shares per Client": "Výchozí podíly na klienta",
       "Define New Mapping": "Definujte nové mapování",
+      "Define Tax Components": "Definujte daňové složky",
+      "Define Tax Groups": "Definujte daňové skupiny",
       "Delete": "Vymazat",
       "Delete Client Signature": "Smazat podpis klienta",
       "Delete Checker": "Odstranit kontrolu",
@@ -891,6 +893,13 @@
       "successfully select option": "úspěšně. Chcete-li pokračovat dále, vyberte si z níže uvedených možností."
     },
     "inputs": {
+      "accounting": {
+        "ASSET": "AKTIVUM",
+        "LIABILITY": "ODPOVĚDNOST",
+        "EQUITY": "SPRAVEDLNOST",
+        "INCOME": "PŘÍJEM",
+        "EXPENSE": "NÁKLADY"
+      },
       "ACCOUNTING": "ÚČETNICTVÍ",
       "ADDRESS": "ADRESA",
       "Above Changes are Effective from": "Výše uvedené změny jsou účinné od",
@@ -1190,6 +1199,7 @@
       "Debit": "Debetní",
       "Debit Account": "Debetní účet",
       "Debit Account Name": "Název debetního účtu",
+      "Debit Account Type": "Typ debetního účtu",
       "Debit Amount": "Debetní částka",
       "Debit Tags": "Debetní štítky",
       "Decimal Places": "Desetinná místa",
@@ -1972,6 +1982,8 @@
       "Table Fields": "Pole tabulky",
       "Tag": "Štítek",
       "Tax Group": "Daňová skupina",
+      "Tax Component": "Daňová složka",
+      "Tax Components": "Složky daně",
       "Tax-Component Name": "Název daňové složky",
       "Teller": "Pokladník",
       "Teller Name": "Jméno Teller",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -638,6 +638,8 @@
       "Dashboard": "Armaturenbrett",
       "Default Shares per Client": "Standardanteile pro Kunde",
       "Define New Mapping": "Definieren Sie eine neue Zuordnung",
+      "Define Tax Components": "Steuerkomponenten definieren",
+      "Define Tax Groups": "Steuergruppen definieren",
       "Delete": "Löschen",
       "Delete Client Signature": "Client-Signatur löschen",
       "Delete Checker": "Überprüfung löschen",
@@ -892,6 +894,13 @@
       "successfully select option": "erfolgreich. Bitte wählen Sie eine der folgenden Optionen aus, um fortzufahren."
     },
     "inputs": {
+      "accounting": {
+        "ASSET": "VERMÖGENSWERT",
+        "LIABILITY": "HAFTUNG",
+        "EQUITY": "EIGENKAPITAL",
+        "INCOME": "EINKOMMEN",
+        "EXPENSE": "KOSTEN"
+      },
       "ACCOUNTING": "BUCHHALTUNG",
       "ADDRESS": "ADRESSE",
       "Above Changes are Effective from": "Die oben genannten Änderungen gelten ab",
@@ -1190,6 +1199,7 @@
       "Debit": "Lastschrift",
       "Debit Account": "Sollkonto",
       "Debit Account Name": "Name des Lastschriftkontos",
+      "Debit Account Type": "Typ debetního účtu",
       "Debit Amount": "Sollbetrag",
       "Debit Tags": "Debit-Tags",
       "Decimal Places": "Nachkommastellen",
@@ -1972,6 +1982,8 @@
       "Table Fields": "Tabellenfelder",
       "Tag": "Etikett",
       "Tax Group": "Steuergruppe",
+      "Tax Component": "Steuerkomponente",
+      "Tax Components": "Steuerkomponenten",
       "Tax-Component Name": "Name der Steuerkomponente",
       "Teller": "Erzähler",
       "Teller Name": "Name des Kassierers",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -638,6 +638,8 @@
             "Dashboard": "Dashboard",
             "Default Shares per Client": "Default Shares per Client",
             "Define New Mapping": "Define New Mapping",
+            "Define Tax Components": "Define Tax Components",
+            "Define Tax Groups": "Define Tax Groups",	
             "Delete": "Delete",
             "Delete Client Signature": "Delete Client Signature",
             "Delete Checker": "Delete Checker",
@@ -891,6 +893,13 @@
             "successfully select option": "successfully. Please select from the options below to proceed furthur."
         },
         "inputs": {
+            "accounting": {
+                "ASSET": "ASSET",
+                "LIABILITY": "LIABILITY",
+                "EQUITY": "EQUITY",
+                "INCOME": "INCOME",
+                "EXPENSE": "EXPENSE"
+            },
             "ACCOUNTING": "ACCOUNTING",
             "ADDRESS": "ADDRESS",
             "Above Changes are Effective from": "Above Changes are Effective from",
@@ -1189,6 +1198,7 @@
             "Debit": "Debit",
             "Debit Account": "Debit Account",
             "Debit Account Name": "Debit Account Name",
+            "Debit Account Type": "Debit Account Type",
             "Debit Amount": "Debit Amount",
             "Debit Tags": "Debit Tags",
             "Decimal Places": "Decimal Places",
@@ -1971,6 +1981,8 @@
             "Table Fields": "Table Fields",
             "Tag": "Tag",
             "Tax Group": "Tax Group",
+            "Tax Component": "Tax Component",
+            "Tax Components": "Tax Components",
             "Tax-Component Name": "Tax-Component Name",
             "Teller": "Teller",
             "Teller Name": "Teller Name",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -638,6 +638,8 @@
             "Dashboard": "Tableros",
             "Default Shares per Client": "Acciones predeterminadas por cliente",
             "Define New Mapping": "Definir nueva asignación",
+            "Define Tax Components": "Definir impuestos",
+            "Define Tax Groups": "Definir grupos de impuestos",
             "Delete": "Borrar",
             "Delete Client Signature": "Eliminar firma del cliente",
             "Delete Checker": "Boldeador de eliminación",
@@ -892,6 +894,13 @@
             "successfully select option": "exitosamente. Seleccione una de las opciones siguientes para continuar."
         },
         "inputs": {
+            "accounting": {
+                "ASSET": "ACTIVO",
+                "LIABILITY": "PASIVO",
+                "EQUITY": "CAPITAL",
+                "INCOME": "INGRESO",
+                "EXPENSE": "EGRESO"      
+            },
             "ACCOUNTING": "CONTABILIDAD",
             "ADDRESS": "DOMICILIO",
             "Above Changes are Effective from": "Los cambios anteriores son efectivos desde",
@@ -1190,6 +1199,7 @@
             "Debit": "Débito",
             "Debit Account": "Cuenta de debito",
             "Debit Account Name": "Nombre de la cuenta de débito",
+            "Debit Account Type": "Tipo de cuenta de débito",
             "Debit Amount": "Monto del Débito",
             "Debit Tags": "Etiquetas de débito",
             "Decimal Places": "Lugares decimales",
@@ -1972,6 +1982,8 @@
             "Table Fields": "Campos de tabla",
             "Tag": "Etiqueta",
             "Tax Group": "Grupo de Impuesto",
+            "Tax Component": "Componente Impuesto",
+            "Tax Components": "Componentes Impuestos",
             "Tax-Component Name": "Nombre del componente de impuesto",
             "Teller": "Ventanilla",
             "Teller Name": "Nombre del cajero",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -638,6 +638,8 @@
       "Dashboard": "Tableau de bord",
       "Default Shares per Client": "Actions par défaut par client",
       "Define New Mapping": "Définir un nouveau mappage",
+      "Define Tax Components": "Définir les composants fiscaux",
+      "Define Tax Groups": "Définir des groupes de taxes",
       "Delete": "Supprimer",
       "Delete Client Signature": "Supprimer la signature du client",
       "Delete Checker": "Supprimer un vérificateur",
@@ -892,6 +894,13 @@
       "successfully select option": "avec succès. Veuillez sélectionner parmi les options ci-dessous pour continuer."
     },
     "inputs": {
+      "accounting": {
+        "ASSET": "ACTIF",
+        "LIABILITY": "RESPONSABILITÉ",
+        "EQUITY": "ÉQUITÉ",
+        "INCOME": "REVENU",
+        "EXPENSE": "FRAIS"
+      },
       "ACCOUNTING": "COMPTABILITÉ",
       "ADDRESS": "ADRESSE",
       "Above Changes are Effective from": "Les modifications ci-dessus entrent en vigueur à partir de",
@@ -1190,6 +1199,7 @@
       "Debit": "Débit",
       "Debit Account": "Compte de débit",
       "Debit Account Name": "Nom du compte de débit",
+      "Debit Account Type": "Type de compte de débit",
       "Debit Amount": "Montant du débit",
       "Debit Tags": "Étiquettes de débit",
       "Decimal Places": "Décimales",
@@ -1972,6 +1982,8 @@
       "Table Fields": "Champs du tableau",
       "Tag": "Étiqueter",
       "Tax Group": "Groupe fiscal",
+      "Tax Component": "Composante fiscale",
+      "Tax Components": "Composantes fiscales",
       "Tax-Component Name": "Nom du composant fiscal",
       "Teller": "Caissier",
       "Teller Name": "Nom du caissier",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -638,6 +638,8 @@
       "Dashboard": "Pannello di controllo",
       "Default Shares per Client": "Condivisioni predefinite per cliente",
       "Define New Mapping": "Definire nuova mappatura",
+      "Define Tax Components": "Definire le componenti fiscali",
+      "Define Tax Groups": "Definire i gruppi fiscali",
       "Delete": "Eliminare",
       "Delete Client Signature": "Elimina firma cliente",
       "Delete Checker": "Elimina Checker",
@@ -892,6 +894,13 @@
       "successfully select option": "con successo. Seleziona una delle opzioni seguenti per procedere ulteriormente."
     },
     "inputs": {
+      "accounting": {
+        "ASSET": "RISORSA",
+        "LIABILITY": "RESPONSABILITÀ",
+        "EQUITY": "EQUITÀ",
+        "INCOME": "REDDITO",
+        "EXPENSE": "SPESE"
+      },
       "ACCOUNTING": "CONTABILITÀ",
       "ADDRESS": "INDIRIZZO",
       "Above Changes are Effective from": "Le modifiche di cui sopra entrano in vigore a partire dal",
@@ -1190,6 +1199,7 @@
       "Debit": "Addebito",
       "Debit Account": "Conto di debito",
       "Debit Account Name": "Nome del conto di addebito",
+      "Debit Account Type": "Tipo di conto di addebito",
       "Debit Amount": "Importo del debito",
       "Debit Tags": "Tag di debito",
       "Decimal Places": "Decimali",
@@ -1972,6 +1982,8 @@
       "Table Fields": "Campi della tabella",
       "Tag": "Etichetta",
       "Tax Group": "Gruppo fiscale",
+      "Tax Component": "Componente fiscale",	
+      "Tax Components": "Componenti fiscali",
       "Tax-Component Name": "Nome della componente fiscale",
       "Teller": "Cassiere",
       "Teller Name": "Nome del cassiere",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -638,6 +638,8 @@
       "Dashboard": "계기반",
       "Default Shares per Client": "클라이언트당 기본 공유",
       "Define New Mapping": "새 매핑 정의",
+      "Define Tax Components": "세금 요소 정의",
+      "Define Tax Groups": "세금 그룹 정의",
       "Delete": "삭제",
       "Delete Client Signature": "클라이언트 서명 삭제",
       "Delete Checker": "체커 삭제",
@@ -893,6 +895,13 @@
       "successfully select option": "성공적으로. 계속 진행하려면 아래 옵션 중에서 선택하세요."
     },
     "inputs": {
+      "accounting": {
+        "ASSET": "유산",
+        "LIABILITY": "책임",
+        "EQUITY": "형평성",
+        "INCOME": "소득",
+        "EXPENSE": "비용"
+      },
       "ACCOUNTING": "회계",
       "ADDRESS": "주소",
       "Above Changes are Effective from": "위 변경사항은 다음부터 적용됩니다.",
@@ -1191,6 +1200,7 @@
       "Debit": "직불",
       "Debit Account": "직불 계좌",
       "Debit Account Name": "직불 계좌 이름",
+      "Debit Account Type": "차변 계좌 유형",
       "Debit Amount": "차변 금액",
       "Debit Tags": "직불 태그",
       "Decimal Places": "소수점 자리",
@@ -1974,6 +1984,8 @@
       "Tag": "꼬리표",
       "Tax Group": "세금 그룹",
       "Tax-Component Name": "세금 구성요소 이름",
+      "Tax Component": "세금 구성요소",	
+      "Tax Components": "세금 구성요소",
       "Teller": "말하는 사람",
       "Teller Name": "출납원 이름",
       "Template Message": "템플릿 메시지",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -638,6 +638,8 @@
       "Dashboard": "Prietaisų skydelis",
       "Default Shares per Client": "Numatytosios akcijos vienam klientui",
       "Define New Mapping": "Apibrėžkite naują atvaizdavimą",
+      "Define Tax Components": "Apibrėžkite mokesčių komponentus",
+      "Define Tax Groups": "Apibrėžkite mokesčių grupes",
       "Delete": "Ištrinti",
       "Delete Client Signature": "Ištrinkite kliento parašą",
       "Delete Checker": "Ištrinkite tikrintuvą",
@@ -892,6 +894,13 @@
       "successfully select option": "sėkmingai. Jei norite tęsti, pasirinkite iš toliau pateiktų parinkčių."
     },
     "inputs": {
+      "accounting": {
+        "ASSET": "TURTAS",
+        "LIABILITY": "ATSAKOMYBĖ",
+        "EQUITY": "NUOSAVYBĖ",
+        "INCOME": "PAJAMOS",
+        "EXPENSE": "IŠLAIDOS"
+      },
       "ACCOUNTING": "APSKAITA",
       "ADDRESS": "ADRESAS",
       "Above Changes are Effective from": "Aukščiau pateikti pakeitimai galioja nuo",
@@ -1190,6 +1199,7 @@
       "Debit": "Debetas",
       "Debit Account": "Debeto sąskaita",
       "Debit Account Name": "Debeto sąskaitos pavadinimas",
+      "Debit Account Type": "Debeto sąskaitos tipas",
       "Debit Amount": "Debeto suma",
       "Debit Tags": "Debeto žymos",
       "Decimal Places": "Dešimtainės vietos",
@@ -1972,6 +1982,8 @@
       "Table Fields": "Lentelės laukai",
       "Tag": "Žyma",
       "Tax Group": "Mokesčių grupė",
+      "Tax Component": "Mokesčių komponentas",
+      "Tax Components": "Mokesčių komponentai",
       "Tax-Component Name": "Mokesčių komponento pavadinimas",
       "Teller": "Teikėjas",
       "Teller Name": "Teikėjo vardas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -638,6 +638,8 @@
       "Dashboard": "Mērinstrumentu panelis",
       "Default Shares per Client": "Noklusējuma akcijas vienam klientam",
       "Define New Mapping": "Definējiet jaunu kartēšanu",
+      "Define Tax Components": "Definējiet nodokļu sastāvdaļas",
+      "Define Tax Groups": "Definējiet nodokļu grupas",
       "Delete": "Dzēst",
       "Delete Client Signature": "Dzēst klienta parakstu",
       "Delinquency Buckets": "Noziedzības spaiņi",
@@ -892,6 +894,13 @@
       "successfully select option": "veiksmīgi. Lūdzu, atlasiet kādu no tālāk norādītajām opcijām, lai turpinātu."
     },
     "inputs": {
+      "accounting": {
+        "ASSET": "AKTĪVS",
+        "LIABILITY": "ATBILDĪBA",
+        "EQUITY": "KAPITĀLS",
+        "INCOME": "IENĀKUMI",
+        "EXPENSE": "IZDEVUMI"
+      },
       "ACCOUNTING": "GRĀMATVEDĪBA",
       "ADDRESS": "ADRESE",
       "Above Changes are Effective from": "Iepriekš minētās izmaiņas ir spēkā no",
@@ -1190,6 +1199,7 @@
       "Debit": "Debets",
       "Debit Account": "Debeta konts",
       "Debit Account Name": "Debeta konta nosaukums",
+      "Debit Account Type": "Debeta konta veids",
       "Debit Amount": "Debeta summa",
       "Debit Tags": "Debeta tagi",
       "Decimal Places": "Decimālzīmes",
@@ -1972,6 +1982,8 @@
       "Table Fields": "Tabulas lauki",
       "Tag": "Tag",
       "Tax Group": "Nodokļu grupa",
+      "Tax Component": "Nodokļu sastāvdaļa",
+      "Tax Components": "Nodokļu sastāvdaļas",
       "Tax-Component Name": "Nodokļa komponenta nosaukums",
       "Teller": "Teicējs",
       "Teller Name": "Teicēja vārds",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -638,6 +638,8 @@
       "Dashboard": "ड्यासबोर्ड",
       "Default Shares per Client": "प्रति ग्राहक पूर्वनिर्धारित शेयरहरू",
       "Define New Mapping": "नयाँ म्यापिङ परिभाषित गर्नुहोस्",
+      "Define Tax Components": "कर अवयवहरू परिभाषित गर्नुहोस्",
+      "Define Tax Groups": "कर समूहहरू परिभाषित गर्नुहोस्",
       "Delete": "मेटाउन",
       "Delete Client Signature": "ग्राहक हस्ताक्षर मेटाउनुहोस्",
       "Delete Checker": "चोर्क परीक्षक",
@@ -892,6 +894,13 @@
       "successfully select option": "सफलतापूर्वक। अगाडि बढ्नको लागि कृपया तलका विकल्पहरूबाट चयन गर्नुहोस्।"
     },
     "inputs": {
+      "accounting": {
+        "ASSET": "सम्पत्ति",
+        "LIABILITY": "दायित्व",
+        "EQUITY": "इक्विटी",
+        "INCOME": "आय",
+        "EXPENSE": "खर्च"
+      },
       "ACCOUNTING": "लेखा",
       "ADDRESS": "ठेगाना",
       "Above Changes are Effective from": "माथिका परिवर्तनहरू बाट प्रभावकारी छन्",
@@ -1190,6 +1199,7 @@
       "Debit": "डेबिट",
       "Debit Account": "डेबिट खाता",
       "Debit Account Name": "डेबिट खाता नाम",
+      "Debit Account Type": "डेबिट खाता प्रकार",
       "Debit Amount": "डेबिट रकम",
       "Debit Tags": "डेबिट ट्यागहरू",
       "Decimal Places": "दशमलव स्थानहरू",
@@ -1972,6 +1982,8 @@
       "Table Fields": "तालिका क्षेत्रहरू",
       "Tag": "ट्याग",
       "Tax Group": "कर समूह",
+      "Tax Component": "कर घटक",
+      "Tax Components": "कर अवयवहरू",
       "Tax-Component Name": "कर-घटक नाम",
       "Teller": "टेलर",
       "Teller Name": "टेलरको नाम",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -638,6 +638,8 @@
       "Dashboard": "Painel",
       "Default Shares per Client": "Compartilhamentos padrão por cliente",
       "Define New Mapping": "Definir novo mapeamento",
+      "Define Tax Components": "Definir componentes fiscais",
+      "Define Tax Groups": "Definir grupos fiscais",
       "Delete": "Excluir",
       "Delete Client Signature": "Excluir assinatura do cliente",
       "Delete Checker": "Exclua verificador",
@@ -892,6 +894,13 @@
       "successfully select option": "com sucesso. Selecione uma das opções abaixo para prosseguir."
     },
     "inputs": {
+      "accounting": {
+        "ASSET": "ATIVO",
+        "LIABILITY": "RESPONSABILIDADE",
+        "EQUITY": "EQUIDADE",
+        "INCOME": "RENDA",
+        "EXPENSE": "DESPESA"
+      },
       "ACCOUNTING": "CONTABILIDADE",
       "ADDRESS": "ENDEREÇO",
       "Above Changes are Effective from": "As alterações acima entram em vigor a partir de",
@@ -1190,6 +1199,7 @@
       "Debit": "Débito",
       "Debit Account": "Conta de débito",
       "Debit Account Name": "Nome da conta de débito",
+      "Debit Account Type": "Tipo de conta de débito",
       "Debit Amount": "Valor do débito",
       "Debit Tags": "Tags de débito",
       "Decimal Places": "Casas decimais",
@@ -1972,6 +1982,8 @@
       "Table Fields": "Campos da tabela",
       "Tag": "Marcação",
       "Tax Group": "Grupo Fiscal",
+      "Tax Component": "Componente Fiscal",
+      "Tax Components": "Componentes fiscais",
       "Tax-Component Name": "Nome do componente fiscal",
       "Teller": "Caixa",
       "Teller Name": "Nome do caixa",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -638,6 +638,8 @@
       "Dashboard": "Dashibodi",
       "Default Shares per Client": "Hisa Chaguomsingi kwa kila Mteja",
       "Define New Mapping": "Bainisha Ramani Mpya",
+      "Define Tax Components": "Bainisha Vipengee vya Ushuru",
+      "Define Tax Groups": "Bainisha Vikundi vya Ushuru",
       "Delete": "Futa",
       "Delete Client Signature": "Futa Sahihi ya Mteja",
       "Delete Checker": "Futa ukaguzi",
@@ -892,6 +894,13 @@
       "successfully select option": "kwa mafanikio. Tafadhali chagua kutoka kwa chaguo zilizo hapa chini ili kuendelea zaidi."
     },
     "inputs": {
+      "accounting": {
+        "ASSET": "ASSET",
+        "LIABILITY": "DHIMA",
+        "EQUITY": "USAWA",
+        "INCOME": "MAPATO",
+        "EXPENSE": "GHARAMA"
+      },
       "ACCOUNTING": "UHASIBU",
       "ADDRESS": "ANWANI",
       "Above Changes are Effective from": "Mabadiliko Hapo Juu yanatumika kutoka",
@@ -1190,6 +1199,7 @@
       "Debit": "Debit",
       "Debit Account": "Akaunti ya Debit",
       "Debit Account Name": "Jina la Akaunti ya Debit",
+      "Debit Account Type": "Aina ya Akaunti ya Debit",
       "Debit Amount": "Kiasi cha Debit",
       "Debit Tags": "Lebo za Debit",
       "Decimal Places": "Maeneo ya decimal",
@@ -1972,6 +1982,8 @@
       "Table Fields": "Viwanja vya Jedwali",
       "Tag": "Lebo",
       "Tax Group": "Kikundi cha Ushuru",
+      "Tax Component": "Sehemu ya Ushuru",
+      "Tax Components": "Vipengele vya Ushuru",
       "Tax-Component Name": "Jina la Sehemu ya Ushuru",
       "Teller": "Mtangazaji",
       "Teller Name": "Jina la Mtangazaji",


### PR DESCRIPTION
## Description

Manage Tax configurations views to use i18n

<img width="1326" alt="Screenshot 2024-04-16 at 5 27 08 p m" src="https://github.com/openMF/web-app/assets/154766431/0511a0eb-65bc-4b7e-bd1e-8573dbc4d3a4">


## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
