### PR TITLE
Fix: Product charges use of Min and Max Cap values

### DIFF
--- a/src/app/products/charges/create-charge/create-charge.component.html
+++ b/src/app/products/charges/create-charge/create-charge.component.html
@@ -167,14 +167,12 @@
    * In saving case: Only for 1. charge time type is "withdrawlfee" or "savings no activity fee" with charge calculation type as "% amount"
    * In shares case: Only for charge time type: SHARE_PURCHASE and SHARE_REDEEM and with charge calculation type as % amount only
   -->
-            <mat-form-field fxFlex="48%"
-              *ngIf="(chargeForm.controls.chargeAppliesTo.value === 1 && (chargeForm.controls.chargeCalculationType.value === 2 || chargeForm.controls.chargeCalculationType.value === 3 || chargeForm.controls.chargeCalculationType.value === 4 || chargeForm.controls.chargeCalculationType.value==5)) || (chargeForm.controls.chargeAppliesTo.value === 2 && (chargeForm.controls.chargeTimeType.value === 16 || chargeForm.controls.chargeTimeType.value === 5)&&(chargeForm.controls.chargeCalculationType.value === 2)) || (chargeForm.controls.chargeAppliesTo.value === 4 && (chargeForm.controls.chargeTimeType.value==14 || chargeForm.controls.chargeTimeType.value==15) && chargeForm.controls.chargeCalculationType.value === 2)">
+            <mat-form-field fxFlex="48%" *ngIf="showMinMaxCap()">
               <mat-label>{{"labels.inputs.Minimum Charge Cap" | translate}}</mat-label>
               <input matInput formControlName="minCap">
             </mat-form-field>
 
-            <mat-form-field fxFlex="48%"
-              *ngIf="(chargeForm.controls.chargeAppliesTo.value === 1 && (chargeForm.controls.chargeCalculationType.value === 2 || chargeForm.controls.chargeCalculationType.value === 3 || chargeForm.controls.chargeCalculationType.value === 4 || chargeForm.controls.chargeCalculationType.value==5)) || (chargeForm.controls.chargeAppliesTo.value === 2 && (chargeForm.controls.chargeTimeType.value === 16 || chargeForm.controls.chargeTimeType.value === 5)&&(chargeForm.controls.chargeCalculationType.value === 2)) || (chargeForm.controls.chargeAppliesTo.value === 4 && (chargeForm.controls.chargeTimeType.value==14 || chargeForm.controls.chargeTimeType.value==15) && chargeForm.controls.chargeCalculationType.value === 2)">
+            <mat-form-field fxFlex="48%" *ngIf="showMinMaxCap()">
               <mat-label>{{"labels.inputs.Maximum Charge Cap" | translate}}</mat-label>
               <input matInput formControlName="maxCap">
             </mat-form-field>

--- a/src/app/products/charges/create-charge/create-charge.component.ts
+++ b/src/app/products/charges/create-charge/create-charge.component.ts
@@ -138,6 +138,21 @@ export class CreateChargeComponent implements OnInit {
     });
   }
 
+  showMinMaxCap(): boolean {
+    const chargeAppliesTo = this.chargeForm.controls.chargeAppliesTo.value;
+    const chargeCalculationType = this.chargeForm.controls.chargeCalculationType.value;
+    const chargeTimeType = this.chargeForm.controls.chargeTimeType.value;
+
+    if (chargeAppliesTo === 1) {
+      return (chargeCalculationType === 2 || chargeCalculationType === 3 || chargeCalculationType === 4 || chargeCalculationType === 5);
+    } else if (chargeAppliesTo === 2) {
+      return (chargeTimeType === 16 || chargeTimeType === 5) && (chargeCalculationType === 2);
+    } else if (chargeAppliesTo === 4) {
+      return ((chargeTimeType === 14 || chargeTimeType === 15) && chargeCalculationType === 2);
+    }
+    return false;
+  }
+
   /**
    * Sets the conditional controls of the user form
    */


### PR DESCRIPTION
## Description

Some Product charges with some Charge Time and Charge Calculation Types should use the Min and Max Cap attributes. We are considering the next rules:

For Loans:
It uses a `chargeCalculationType` as second parameter: 

For Savings:
It uses two parameters more `chargeTimeType` and `chargeCalculationType` 

For Shares: 
It uses two parameters more `chargeTimeType` and `chargeCalculationType` 

## Screenshots
- Loans
<img width="1331" alt="Screenshot 2024-04-18 at 5 01 00 p m" src="https://github.com/openMF/web-app/assets/154766431/b7480e3e-2700-4d69-81db-e02fabe9c1b0">

- Savings
<img width="1328" alt="Screenshot 2024-04-18 at 5 00 07 p m" src="https://github.com/openMF/web-app/assets/154766431/d0eda918-4f1e-466b-ad94-c23fae3cb31c">

- Shares
<img width="1303" alt="Screenshot 2024-04-18 at 5 02 13 p m" src="https://github.com/openMF/web-app/assets/154766431/dd984998-a85c-4eaa-8675-f5d18aeaed41">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
