### PR TITLE
Fix: Loan product missed i18n labels

### DIFF
--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -609,7 +609,7 @@
 	    "In advanced interest": "Zájem předem",
       "Next installment": "Další splátka",
 	    "Last installment": "Poslední splátka",
-	    "Reamotization": "Reamotizace",
+	    "Reamortization": "Reamortizace",
 	    "equals": "rovná se",
 	    "greater than": "větší než",
 	    "Equal installments": "Stejné splátky",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -609,7 +609,7 @@
 	    "In advanced interest": "Im Voraus Zinsen",
       "Next installment": "Nächste Folge",
 	    "Last installment": "Letzte Rate",
-	    "Reamotization": "Reamotisierung",
+	    "Reamortization": "Reamortisation",
 	    "equals": "gleicht",
 	    "greater than": "größer als",
 	    "Equal installments": "Gleiche Raten",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -609,7 +609,7 @@
             "In advanced interest": "In advanced interest",
             "Next installment": "Next installment",
 	        "Last installment": "Last installment",
-            "Reamotization": "Reamotization",
+            "Reamortization": "Reamortization",
             "equals": "equals",
             "greater than": "greater than",
             "Equal installments": "Equal installments",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -609,7 +609,7 @@
             "In advanced interest": "interés anticipado",
             "Next installment": "Próxima cuota",
             "Last installment": "Última cuota",
-            "Reamotization": "Reamotización",
+            "Reamortization": "Reamortización",
             "equals": "Igual a",
             "greater than": "Mayor a",
             "Equal installments": "Cuotas iguales",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -609,7 +609,7 @@
 	    "In advanced interest": "Intérêts d'avance",
       "Next installment": "Prochain versement",
 	    "Last installment": "Dernier versement",
-	    "Reamotization": "Réamotisation",
+	    "Reamortization": "Réamortissement",
 	    "equals": "équivaut à",
 	    "greater than": "plus grand que",
 	    "Equal installments": "Versements égaux",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -609,7 +609,7 @@
 	    "In advanced interest": "Interessi anticipati",
       "Next installment": "Prossima puntata",
 	    "Last installment": "Ultima puntata",
-	    "Reamotization": "Riamotizzazione",
+	    "Reamortization": "Riammortamento",
 	    "equals": "equivale",
 	    "greater than": "più grande di",
 	    "Equal installments": "Rate uguali",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -609,7 +609,7 @@
 	    "In advanced interest": "사전이자",
       "Next installment": "다음 편",
 	    "Last installment": "마지막 할부",
-	    "Reamotization": "재분할화",
+	    "Reamortization": "재상환",
 	    "equals": "같음",
 	    "greater than": "~보다 큰",
 	    "Equal installments": "균등할부",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -609,7 +609,7 @@
 	    "In advanced interest": "Iš anksto palūkanas",
       "Next installment": "Kita įmoka",
 	    "Last installment": "Paskutinė įmoka",
-	    "Reamotization": "Reomatizacija",
+	    "Reamortization": "Reamortizacija",
 	    "equals": "lygus",
 	    "greater than": "geresnis negu",
 	    "Equal installments": "Lygiomis dalimis",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -609,7 +609,7 @@
 	    "In advanced interest": "Iepriekš procentos",
       "Next installment": "Nākamā iemaksa",
 	    "Last installment": "Pēdējā iemaksa",
-	    "Reamotization": "Reomatizācija",
+	    "Reamortization": "Reamortizācija",
 	    "equals": "vienāds",
 	    "greater than": "lielāks nekā",
 	    "Equal installments": "Vienādas iemaksas",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -609,7 +609,7 @@
 	    "In advanced interest": "अग्रिम ब्याजमा",
       "Next installment": "अर्को किस्ता",
 	    "Last installment": "अन्तिम किस्ता",
-	    "Reamotization": "रिमोटाइजेशन",
+	    "Reamortization": "रिमोर्टाइजेशन",
 	    "equals": "बराबर",
 	    "greater than": "भन्दा ठुलो",
 	    "Equal installments": "बराबर किस्ता",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -609,7 +609,7 @@
 	    "In advanced interest": "Juros antecipados",
       "Next installment": "Próxima parcela",
 	    "Last installment": "Última parcela",
-	    "Reamotization": "Reamotização",
+	    "Reamortization": "Reamortização",
 	    "equals": "é igual a",
 	    "greater than": "Maior que",
 	    "Equal installments": "Parcelas iguais",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -609,7 +609,7 @@
 	    "In advanced interest": "Maslahi ya mapema",
       "Next installment": "Awamu inayofuata",
 	    "Last installment": "Awamu ya mwisho",
-	    "Reamotization": "Remotization",
+	    "Reamortization": "Remortization",
 	    "equals": "sawa",
 	    "greater than": "kubwa kuliko",
 	    "Equal installments": "Awamu sawa",


### PR DESCRIPTION
## Description

Fix: Loan product missed i18n labels in the Advanced Payment Allocation

## Screenshots

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
