### PR TITLE
Production login uses same domain. Fixes #2093

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -12,8 +12,8 @@ export const environment = {
   baseApiUrls: window['env']['fineractApiUrls'] ||
   'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://demo.fineract.dev,https://localhost:8443',
   // For connecting to server running elsewhere set the base API URL
-  baseApiUrl: window['env']['fineractApiUrl'] || 'https://demo.fineract.dev',
-  allowServerSwitch: env.allow_switching_backend_instance,
+  baseApiUrl: window['env']['fineractApiUrl'] || 'https://' + window.location.hostname,
+  allowServerSwitch: false,
   apiProvider: window['env']['apiProvider'] || '/fineract-provider/api',
   apiVersion: window['env']['apiVersion'] || '/v1',
   serverUrl: '',


### PR DESCRIPTION
## Description
Since for production in a multi-tenant setup where each tenant wants to connect to the same tenant backend, we want to connect to the same domain backend and don't want the option to select the backend. So allowServerSwitch is set to false and default backend is set to 'https://' + window.location.hostname.

## Related issues and discussion
#2093 

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
