### PR TITLE
Support same url with subdomain as backend server url

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -12,7 +12,7 @@ export const environment = {
   baseApiUrls: window['env']['fineractApiUrls'] ||
   'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://demo.fineract.dev,https://localhost:8443',
   // For connecting to server running elsewhere set the base API URL
-  baseApiUrl: window['env']['fineractApiUrl'] || 'https://demo.fineract.dev',
+  baseApiUrl: window['env']['fineractApiUrl'] || window.location.protocol + '://' + window.location.hostname,
   allowServerSwitch: env.allow_switching_backend_instance,
   apiProvider: window['env']['apiProvider'] || '/fineract-provider/api',
   apiVersion: window['env']['apiVersion'] || '/v1',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -15,9 +15,9 @@ export const environment = {
   fineractPlatformTenantIds: window['env']['fineractPlatformTenantIds'] || 'default',
   // For connecting to others servers running elsewhere update the base API URL
   baseApiUrls: window['env']['fineractApiUrls'] ||
-    'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://demo.fineract.dev,https://localhost:8443,http://localhost:8443',
+    'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://demo.fineract.dev,https://localhost:8443,' + window.location.protocol + '://' + window.location.hostname + ':' + window.location.port,
   // For connecting to server running elsewhere set the base API URL
-  baseApiUrl: window['env']['baseApiUrl'] || 'https://demo.fineract.dev',
+  baseApiUrl: window['env']['baseApiUrl'] || window.location.protocol + '://' + window.location.hostname + ':' + window.location.port,
   allowServerSwitch: env.allow_switching_backend_instance,
   apiProvider: window['env']['apiProvider'] || '/fineract-provider/api',
   apiVersion: window['env']['apiVersion'] || '/v1',


### PR DESCRIPTION
## Description

In order to manage same domain name with subdomains, we support same url with subdomain as backend server url added automatically by default  

## Screenshots

<img width="1931" alt="Screenshot 2024-05-21 at 10 27 30 p m" src="https://github.com/openMF/web-app/assets/154766431/185b6823-c712-4a1b-b47a-c8119c2b0d29">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
