### PR TITLE
Fixes double colon issue in baseApiUrl #2095

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -12,7 +12,7 @@ export const environment = {
   baseApiUrls: window['env']['fineractApiUrls'] ||
   'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://demo.fineract.dev,https://localhost:8443',
   // For connecting to server running elsewhere set the base API URL
-  baseApiUrl: window['env']['fineractApiUrl'] || window.location.protocol + '://' + window.location.hostname,
+  baseApiUrl: window['env']['fineractApiUrl'] || window.location.protocol + '//' + window.location.hostname,
   allowServerSwitch: env.allow_switching_backend_instance,
   apiProvider: window['env']['apiProvider'] || '/fineract-provider/api',
   apiVersion: window['env']['apiVersion'] || '/v1',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -16,9 +16,9 @@ export const environment = {
   // For connecting to others servers running elsewhere update the base API URL
   baseApiUrls: window['env']['fineractApiUrls'] ||
     'https://dev.mifos.io,https://demo.mifos.io,https://qa.mifos.io,https://staging.mifos.io,https://mobile.mifos.io,https://demo.fineract.dev,https://localhost:8443,'
-    + window.location.protocol + '://' + window.location.hostname + ':' + window.location.port,
+    + window.location.protocol + '//' + window.location.hostname + ':' + window.location.port,
   // For connecting to server running elsewhere set the base API URL
-  baseApiUrl: window['env']['baseApiUrl'] || window.location.protocol + '://' + window.location.hostname + ':' + window.location.port,
+  baseApiUrl: window['env']['baseApiUrl'] || window.location.protocol + '//' + window.location.hostname + ':' + window.location.port,
   allowServerSwitch: env.allow_switching_backend_instance,
   apiProvider: window['env']['apiProvider'] || '/fineract-provider/api',
   apiVersion: window['env']['apiVersion'] || '/v1',


### PR DESCRIPTION
## Description
As per the documentation here[1], window.location.protocol includes the colon ("http:", "https:") but in generating baseUrl, '://' is used resulting in double colon. This causes login failure due to wrong URL generated in some browsers.

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

[1] https://www.w3schools.com/jsref/prop_loc_protocol.asp