### PR TITLE
feat: Display or Hide Tenant selector in Login view

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ MIFOS_WAIT_TIME_FOR_CATCHUP=30
 ```
 
 
+Setting for display or hide the Tenant selector in the Login view (mainly for Production environments and for security reasons), Default true
+```
+MIFOS_DISPLAY_TENANT_SELECTOR=false
+```
+
+
+Setting for display or hide the Backend info (url) in the footer part (mainly for security reasons), Default true
+```
+MIFOS_DISPLAY_BACKEND_INFO=false
+```
+
+
 For more information look the env.sample file in the root directory of the project
 
 ## Want to help? [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/openMF/web-app/issues)

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -46,7 +46,7 @@
     </div>
 
     <!-- Tenant Identifier Name -->
-    <div fxLayout="row" fxLayoutAlign="center center" fxFlex="1 0 auto" *ngIf="!environment.production">
+    <div fxLayout="row" fxLayoutAlign="center center" fxFlex="1 0 auto" *ngIf="displayTenantSelector()">
       <mifosx-tenant-selector></mifosx-tenant-selector>
     </div>
 

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -77,4 +77,8 @@ export class LoginComponent implements OnInit, OnDestroy {
     window.location.reload();
   }
 
+  displayTenantSelector(): boolean {
+    return environment.displayTenantSelector === 'false' ? false : true;
+  }
+
 }

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -23,6 +23,9 @@
   // Display or not the BackEnd Info
   window['env']['displayBackEndInfo'] = '';
 
+  // Display or not the Tenant Selector
+  window['env']['displayTenantSelector'] = '';
+
   // Time in seconds for Notifications, default 60 seconds
   window['env']['waitTimeForNotifications'] = '';
 

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -23,6 +23,9 @@
   // Display or not the BackEnd Info
   window['env']['displayBackEndInfo'] = '$MIFOS_DISPLAY_BACKEND_INFO';
 
+  // Display or not the Tenant Selector
+  window['env']['displayTenantSelector'] = '$MIFOS_DISPLAY_TENANT_SELECTOR';
+
   // Time in seconds for Notifications, default 60 seconds
   window['env']['waitTimeForNotifications'] = '$MIFOS_WAIT_TIME_FOR_NOTIFICATIONS';
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -33,6 +33,7 @@ export const environment = {
   defaultCharDelimiter: window['env']['defaultCharDelimiter'] || ',',
 
   displayBackEndInfo: window['env']['displayBackEndInfo'] || 'true',
+  displayTenantSelector: window['env']['displayTenantSelector'] || 'true',
   // Time in seconds, default 60 seconds
   waitTimeForNotifications: window['env']['waitTimeForNotifications'] || 60,
   // Time in seconds, default 30 seconds

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -39,6 +39,7 @@ export const environment = {
   defaultCharDelimiter: window['env']['defaultCharDelimiter'] || ',',
 
   displayBackEndInfo: window['env']['displayBackEndInfo'] || 'true',
+  displayTenantSelector: window['env']['displayTenantSelector'] || 'true',
   // Time in seconds, default 60 seconds
   waitTimeForNotifications: window['env']['waitTimeForNotifications'] || 60,
   // Time in seconds, default 30 seconds


### PR DESCRIPTION
## Description

Thinking in productive environments and other cases that involves security reasons, we are able to shod or hide the Tenant Id selector. 

We can manage this with the new environment variable `MIFOS_DISPLAY_TENANT_SELECTOR` with a boolean value

For more configs please refer to the `README.md` file

## Screenshots

- Show the Tenant selector (Default)
<img width="2048" alt="Screenshot 2024-05-24 at 2 29 23 p m" src="https://github.com/openMF/web-app/assets/154766431/2500ffe6-6b1d-4ec0-9231-dab7a853ba21">

- Hide the Tenant selector
<img width="2047" alt="Screenshot 2024-05-24 at 2 39 49 p m" src="https://github.com/openMF/web-app/assets/154766431/b3d600c5-06e3-4598-83a5-7187b5bc0966">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
