### PR TITLE
fix: Add Client charge with future due date

### DIFF
--- a/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.ts
+++ b/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.ts
@@ -55,7 +55,7 @@ export class AddClientChargeComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.maxDate = this.settingsService.businessDate;
+    this.maxDate = this.settingsService.maxFutureDate;
     this.createClientsChargeForm();
     this.buildDependencies();
   }


### PR DESCRIPTION
## Description

We were not able to add a Client charge with specific due date in the future, after the business date

## Screenshots
<img width="1231" alt="Screenshot 2024-05-24 at 3 01 22 p m" src="https://github.com/openMF/web-app/assets/154766431/4c987bed-b277-450b-998e-0eabee6c7503">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
