### PR TITLE
fix: Loan disbursement action is not being displayed

### DIFF
--- a/src/app/loans/loans-routing.module.ts
+++ b/src/app/loans/loans-routing.module.ts
@@ -302,7 +302,8 @@ const routes: Routes = [
         component: LoanAccountActionsComponent,
         data: { title: 'Loan Account Actions', breadcrumb: 'action', routeParamBreadcrumb: 'action' },
         resolve: {
-          actionButtonData: LoanActionButtonResolver
+          actionButtonData: LoanActionButtonResolver,
+          loanDetailsData: LoanDetailsResolver
         }
       },
       {

--- a/src/app/loans/loans-view/loan-account-actions/loan-account-actions.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/loan-account-actions.component.ts
@@ -89,8 +89,9 @@ export class LoanAccountActionsComponent {
    * @param route Activated Route.
    */
   constructor(private route: ActivatedRoute) {
-      this.route.data.subscribe(( data: { actionButtonData: any }) => {
+      this.route.data.subscribe(( data: { actionButtonData: any, loanDetailsData: any }) => {
         this.actionButtonData = data.actionButtonData;
+        this.actionButtonData.currency = data.loanDetailsData.currency;
       });
 
     this.route.params.subscribe(params => {


### PR DESCRIPTION
## Description

Loan disbursement action is not being displayed due missed currency value to use in the transaction amount input field

## Screenshots
<img width="1018" alt="Screenshot 2024-06-12 at 8 27 02 a m" src="https://github.com/openMF/web-app/assets/154766431/974bc02b-be24-4e60-99a9-0105f60503c1">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
