### PR TITLE
FINERACT-2104: Enable Accrual Activity Posting on Loan Products - UI Changes

### DIFF
--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -728,6 +728,11 @@
     <span  fxFlex="53%">{{ 'labels.accounting.' + getAccountingRuleName(accountingRuleData[accountingRule() - 1]) | translate }}</span>
   </div>
 
+  <div fxFlexFill *ngIf="isAccountingAccrualBased">
+    <span fxFlex="47%">{{ 'labels.inputs.Enable Accrual Activity Posting on Installment Due Date' | translate }}:</span>
+    <span  fxFlex="53%">{{ loanProduct.enableAccrualActivityPosting | yesNo }}</span>
+  </div>
+
   <div fxFlexFill *ngIf="isAccountingEnabled()" fxLayout="row wrap"
     fxLayout.lt-md="column">
 

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
@@ -313,6 +313,10 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
       this.loanProduct.accountingRule.id : this.loanProduct.accountingRule;
   }
 
+  get isAccountingAccrualBased(): boolean {
+    return this.accountingRule() === 3 || this.accountingRule() === 4;
+  }
+
   isAccountingEnabled(): boolean {
     return (this.accountingRule() >= 2);
   }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
@@ -11,6 +11,7 @@
     <mat-divider fxFlex="98%"></mat-divider>
 
     <div *ngIf="loanProductAccountingForm.value.accountingRule >= 2 && loanProductAccountingForm.value.accountingRule <= 4" fxFlexFill fxLayout="row wrap" fxLayoutGap="2%" fxLayout.lt-md="column">
+      <mat-checkbox *ngIf="isAccountingAccrualBased" fxFlex="73%" formControlName="enableAccrualActivityPosting">{{'labels.inputs.Enable Accrual Activity Posting on Installment Due Date' | translate}}</mat-checkbox>
 
       <h4 fxFlex="98%" class="mat-h4">{{'labels.heading.Assets' | translate}} / {{'labels.heading.Liabilities' | translate}}</h4>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -66,6 +66,9 @@ export class LoanProductAccountingStepComponent implements OnInit {
           'receivableFeeAccountId': accountingMappings.receivableFeeAccount.id,
           'receivablePenaltyAccountId': accountingMappings.receivablePenaltyAccount.id,
         });
+        this.loanProductAccountingForm.patchValue({
+          'enableAccrualActivityPosting': this.loanProductsTemplate.enableAccrualActivityPosting
+        });
         /* falls through */
       case 2:
         this.loanProductAccountingForm.patchValue({
@@ -170,10 +173,12 @@ export class LoanProductAccountingStepComponent implements OnInit {
           this.loanProductAccountingForm.addControl('receivableInterestAccountId', new UntypedFormControl('', Validators.required));
           this.loanProductAccountingForm.addControl('receivableFeeAccountId', new UntypedFormControl('', Validators.required));
           this.loanProductAccountingForm.addControl('receivablePenaltyAccountId', new UntypedFormControl('', Validators.required));
+          this.loanProductAccountingForm.addControl('enableAccrualActivityPosting', new UntypedFormControl(false));
         } else {
           this.loanProductAccountingForm.removeControl('receivableInterestAccountId');
           this.loanProductAccountingForm.removeControl('receivableFeeAccountId');
           this.loanProductAccountingForm.removeControl('receivablePenaltyAccountId');
+          this.loanProductAccountingForm.removeControl('enableAccrualActivityPosting');
         }
       });
   }
@@ -302,6 +307,11 @@ export class LoanProductAccountingStepComponent implements OnInit {
       })
     ];
     return formfields;
+  }
+
+  get isAccountingAccrualBased() {
+    const accountingRule = this.loanProductAccountingForm.value.accountingRule;
+    return accountingRule  === 3 || accountingRule === 4;
   }
 
   get loanProductAccounting() {

--- a/src/app/products/loan-products/models/loan-product.model.ts
+++ b/src/app/products/loan-products/models/loan-product.model.ts
@@ -124,6 +124,7 @@ export interface LoanProduct {
   paymentChannelToFundSourceMappings?:                       PaymentChannelToFundSourceMapping[];
   feeToIncomeAccountMappings?:                               ChargeToIncomeAccountMapping[];
   penaltyToIncomeAccountMappings?:                           ChargeToIncomeAccountMapping[];
+  enableAccrualActivityPosting?:                             boolean;
 }
 
 

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1494,6 +1494,7 @@
       "Email Address": "Emailová adresa",
       "Email ID": "ID e-mailu",
       "Email should be a": "Email by měl být a",
+      "Enable Accrual Activity Posting on Installment Due Date": "Povolit účtování akruální činnosti v den splatnosti splátky",
       "Enable installment level Delinquency": "Povolit prodlení na úrovni splátek",
       "Enable Auto Repayment for Down Payment": "Povolit automatické splácení zálohy",
       "Enable Dormancy Tracking": "Povolit sledování dormance",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1494,6 +1494,7 @@
       "Email Address": "E-Mail-Adresse",
       "Email ID": "E-Mail-ID",
       "Email should be a": "E-Mail sollte a sein",
+      "Enable Accrual Activity Posting on Installment Due Date": "Aktivieren Sie die Buchung von Rückstellungsaktivitäten am Fälligkeitsdatum der Ratenzahlung",
       "Enable installment level Delinquency": "Aktivieren Sie den Verzug auf Ratenebene",
       "Enable Auto Repayment for Down Payment": "Aktivieren Sie die automatische Rückzahlung für die Anzahlung",
       "Enable Dormancy Tracking": "Aktivieren Sie die Ruheverfolgung",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1495,6 +1495,7 @@
             "Email Address": "Email Address",
             "Email ID": "Email ID",
             "Email should be a": "Email should be a",
+            "Enable Accrual Activity Posting on Installment Due Date": "Enable Accrual Activity Posting on Installment Due Date",
             "Enable installment level Delinquency": "Enable installment level Delinquency",
             "Enable Auto Repayment for Down Payment": "Enable Auto Repayment for Down Payment",
             "Enable Dormancy Tracking": "Enable Dormancy Tracking",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1493,6 +1493,7 @@
             "Email Address": "Correo electrónico",
             "Email ID": "Id de correo",
             "Email should be a": "El correo electrónico debe ser un",
+            "Enable Accrual Activity Posting on Installment Due Date": "Habilitar la publicación de actividad acumulada en la fecha de vencimiento del pago a plazos",
             "Enable installment level Delinquency": "Habilitar morosidad a nivel de cuotas",
             "Enable Auto Repayment for Down Payment": "Habilitar el pago automático para el pago inicial",
             "Enable Dormancy Tracking": "Habilitar seguimiento de inactividad",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1494,6 +1494,7 @@
       "Email Address": "Adresse e-mail",
       "Email ID": "Identifiant de courrier électronique",
       "Email should be a": "L'e-mail doit être un",
+      "Enable Accrual Activity Posting on Installment Due Date": "Activer la comptabilisation des activités de régularisation à la date d'échéance du versement",
       "Enable installment level Delinquency": "Activer la délinquance au niveau des versements",
       "Enable Auto Repayment for Down Payment": "Activer le remboursement automatique pour l'acompte",
       "Enable Dormancy Tracking": "Activer le suivi de la dormance",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1494,6 +1494,7 @@
       "Email Address": "Indirizzo e-mail",
       "Email ID": "E-mail identificativo utente",
       "Email should be a": "L'e-mail dovrebbe essere un file",
+      "Enable Accrual Activity Posting on Installment Due Date": "Abilita la registrazione dell'attività di accumulo alla data di scadenza della rata",
       "Enable installment level Delinquency": "Abilita la delinquenza a livello di rata",
       "Enable Auto Repayment for Down Payment": "Abilita il rimborso automatico per l'acconto",
       "Enable Dormancy Tracking": "Abilita il monitoraggio della dormienza",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1495,6 +1495,7 @@
       "Email Address": "이메일 주소",
       "Email ID": "이메일 주소",
       "Email should be a": "이메일은",
+      "Enable Accrual Activity Posting on Installment Due Date": "할부 만기일에 발생 활동 전기를 활성화합니다",
       "Enable installment level Delinquency": "할부 수준 연체 활성화",
       "Enable Auto Repayment for Down Payment": "계약금 자동 상환 활성화",
       "Enable Dormancy Tracking": "휴면 추적 활성화",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1494,6 +1494,7 @@
       "Email Address": "Elektroninio pašto adresas",
       "Email ID": "Elektroninio pašto ID",
       "Email should be a": "El. paštas turi būti a",
+      "Enable Accrual Activity Posting on Installment Due Date": "Įgalinti kaupimo veiklos registravimą įmokos mokėjimo dieną",
       "Enable installment level Delinquency": "Įgalinti įmokos lygio pažeidimą",
       "Enable Auto Repayment for Down Payment": "Įgalinti automatinį pradinio įnašo grąžinimą",
       "Enable Dormancy Tracking": "Įgalinti ramybės būsenos stebėjimą",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1494,6 +1494,7 @@
       "Email Address": "Epasta adrese",
       "Email ID": "E-pasta ID",
       "Email should be a": "E-pastam jābūt a",
+      "Enable Accrual Activity Posting on Installment Due Date": "Iespējot uzkrāšanas darbību grāmatošanu iemaksas termiņā",
       "Enable installment level Delinquency": "Iespējot iemaksas līmeņa likumpārkāpumus",
       "Enable Auto Repayment for Down Payment": "Iespējot pirmās iemaksas automātisko atmaksu",
       "Enable Dormancy Tracking": "Iespējot miega režīma izsekošanu",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1494,6 +1494,7 @@
       "Email Address": "इ - मेल ठेगाना",
       "Email ID": "इमेल आईडी",
       "Email should be a": "इमेल एक हुनुपर्छ",
+      "Enable Accrual Activity Posting on Installment Due Date": "किस्ताको मितिमा पोष्ट गर्ने कार्य सक्रिय गर्नुहोस्",
       "Enable installment level Delinquency": "किस्त स्तर अपराध सक्षम गर्नुहोस्",
       "Enable Auto Repayment for Down Payment": "डाउन पेमेन्टको लागि स्वत: भुक्तानी सक्षम गर्नुहोस्",
       "Enable Dormancy Tracking": "निष्क्रियता ट्र्याकिङ सक्षम गर्नुहोस्",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1494,6 +1494,7 @@
       "Email Address": "Endereço de email",
       "Email ID": "Identificação do email",
       "Email should be a": "O e-mail deve ser um",
+      "Enable Accrual Activity Posting on Installment Due Date": "Ativar lançamento de atividades de acumulação na data de vencimento da prestação",
       "Enable installment level Delinquency": "Habilitar inadimplência em nível de parcelamento",
       "Enable Auto Repayment for Down Payment": "Ativar reembolso automático para adiantamento",
       "Enable Dormancy Tracking": "Habilitar rastreamento de dormência",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1494,6 +1494,7 @@
       "Email Address": "Barua pepe",
       "Email ID": "Kitambulisho cha barua pepe",
       "Email should be a": "Barua pepe inapaswa kuwa a",
+      "Enable Accrual Activity Posting on Installment Due Date": "Washa Utumaji wa Shughuli ya Jumla kwa Tarehe ya Kukamilisha Malipo ya Malipo",
       "Enable installment level Delinquency": "Washa Uhalifu wa kiwango cha malipo",
       "Enable Auto Repayment for Down Payment": "Washa Ulipaji Kiotomatiki kwa Malipo ya Chini",
       "Enable Dormancy Tracking": "Washa Ufuatiliaji wa Malalamiko",

--- a/src/environments/.env.ts
+++ b/src/environments/.env.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 export default {
   'mifos_x': {
-    'version': '240417',
-    'hash': '29d3d08e'
+    'version': '240706',
+    'hash': '71b9b7d7'
   },
   'allow_switching_backend_instance': true
 };


### PR DESCRIPTION
Create checkbox input to enable or disable accrual activity posting on loan products.
Checkbox and summary row is visible only is accrual type accounting is selected.

## Description
Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion
#FINERACT-2104

## Screenshots, if any
### Loan Product Summaries
![Screenshot from 2024-07-06 08-38-01](https://github.com/openMF/web-app/assets/81624028/90aa683f-5e83-429a-900f-fb102de12751)
### Loan Product Accounting Step
![Screenshot from 2024-07-06 08-35-48](https://github.com/openMF/web-app/assets/81624028/74a58d5b-b184-492a-8d8b-8cf808b5f5ad)


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
