### PR TITLE
fix: enable business date config name renamed

### DIFF
--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -15,7 +15,7 @@ import { environment } from '../../environments/environment';
 export class SettingsService {
 
   public static businessDateFormat = 'yyyy-MM-dd';
-  public static businessDateConfigName = 'enable_business_date';
+  public static businessDateConfigName = 'enable-business-date';
   public static businessDateType = 'BUSINESS_DATE';
   public static cobDateType = 'COB_DATE';
   minAllowedDate = new Date(1950, 0, 1);


### PR DESCRIPTION
## Description

With a recent backend change, the Enable Business Date config name was changed from `enable_business_date` to `enable-business-date` 

## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
