### PR TITLE
fix: Display the Loan account Interest rate period type

### DIFF
--- a/src/app/loans/loans-view/account-details/account-details.component.html
+++ b/src/app/loans/loans-view/account-details/account-details.component.html
@@ -12,7 +12,10 @@
             <span fxFlex="50%">{{"labels.inputs.Repayments" | translate}}</span>
             <span fxFlex="50%">{{loanDetails.numberOfRepayments}} every {{loanDetails.repaymentEvery}}&nbsp;{{loanDetails.repaymentFrequencyType.value | translateKey:'catalogs' }}
             <span *ngIf="loanDetails.repaymentFrequencyType?.id == 2 && loanDetails.repaymentFrequencyNthDayType?.id != 0 && loanDetails.repaymentFrequencyDayOfWeekType?.id != 0" class="m-l-10">
-              <span class="m-l-10">{{"labels.commons.on" | translate}}</span>{{loanDetails.repaymentFrequencyNthDayType?.value}}&nbsp;{{loanDetails.repaymentFrequencyDayOfWeekType?.value | translateKey:'catalogs' }}
+              <span *ngIf="loanDetails.repaymentFrequencyDayOfWeekType">
+                <span class="m-l-10">{{"labels.commons.on" | translate}}</span>{{loanDetails.repaymentFrequencyNthDayType?.value}}
+                <span class="m-l-10">{{loanDetails.repaymentFrequencyDayOfWeekType?.value | translateKey:'catalogs' }}</span>
+              </span>
             </span>
             </span>
         </div>


### PR DESCRIPTION
## Description

In the Loan account is possible to override the Interest Rate Period type then the Loan account details were not displaying the right value for this 

## Screenshots, if any

<img width="953" alt="Screenshot 2024-11-04 at 4 25 35 a m" src="https://github.com/user-attachments/assets/3ba04bd8-7478-4c8a-9f5b-3d87a2575d65">

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
