### PR TITLE
fix: Description tooltip in Global Configurations

### DIFF
--- a/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.html
+++ b/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.html
@@ -14,7 +14,7 @@
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef mat-sort-header> {{'labels.inputs.name' | translate}} </th>
         <td mat-cell *matCellDef="let configuration"> {{ configuration.name }}&nbsp;&nbsp;
-        <fa-icon icon="question-circle" matTooltip="{{ getTooltip(configuration.description) | translate }}" matTooltipPosition="right"></fa-icon>
+        <fa-icon *ngIf="configuration.description" icon="question-circle" matTooltip="{{ configuration.description | translate }}" matTooltipPosition="right"></fa-icon>
         </td>
       </ng-container>
 

--- a/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.ts
+++ b/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.ts
@@ -149,11 +149,4 @@ export class GlobalConfigurationsTabComponent implements OnInit, AfterViewInit {
     this.router.navigate(['/system']);
   }
 
-  getTooltip(description: string): string {
-    if (description === undefined) {
-      return description;
-    }
-    return 'labels.text.No Description';
-  }
-
 }


### PR DESCRIPTION
## Description
Due to a bug in getTooltip, the tooltips were never shown. This change shows the tooltip when there is a description for the configuration option. If there's no description, the icon is not displayed (rather than showing 'No description', which adds litte value in my opinion).

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
