### PR TITLE
Display Loan interest refund transaction relations

### DIFF
--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
@@ -78,21 +78,19 @@ export class ViewTransactionComponent implements OnInit {
       this.allowUndo = !this.transactionData.manuallyReversed;
       this.allowChargeback = this.allowChargebackTransaction(this.transactionType) && !this.transactionData.manuallyReversed;
       let transactionsChargebackRelated = false;
-      if (this.allowChargeback) {
-        if (this.transactionData.transactionRelations) {
-          this.transactionRelations.data = this.transactionData.transactionRelations;
-          this.existTransactionRelations = (this.transactionData.transactionRelations.length > 0);
-          let amountRelations = 0;
-          this.transactionData.transactionRelations.forEach((relation: any) => {
-            if (relation.relationType === 'CHARGEBACK') {
-              amountRelations += relation.amount;
-              transactionsChargebackRelated = true;
-            }
-          });
-          this.amountRelationsAllowed = this.transactionData.amount - amountRelations;
-          this.isFullRelated = (this.amountRelationsAllowed === 0);
-          this.allowChargeback = this.allowChargebackTransaction(this.transactionType) && !this.isFullRelated;
-        }
+      if (this.transactionData.transactionRelations) {
+        this.transactionRelations.data = this.transactionData.transactionRelations;
+        this.existTransactionRelations = (this.transactionData.transactionRelations.length > 0);
+        let amountRelations = 0;
+        this.transactionData.transactionRelations.forEach((relation: any) => {
+          if (relation.relationType === 'CHARGEBACK') {
+            amountRelations += relation.amount;
+            transactionsChargebackRelated = true;
+          }
+        });
+        this.amountRelationsAllowed = this.transactionData.amount - amountRelations;
+        this.isFullRelated = (this.amountRelationsAllowed === 0);
+        this.allowChargeback = this.allowChargebackTransaction(this.transactionType) && !this.isFullRelated;
       }
       if (!this.allowChargeback) {
         this.allowEdition = false;

--- a/src/app/loans/models/loan-transaction-type.model.ts
+++ b/src/app/loans/models/loan-transaction-type.model.ts
@@ -10,6 +10,7 @@ export interface LoanTransactionType {
   payoutRefund:            boolean;
   goodwillCredit:          boolean;
   interestPaymentWaiver:   boolean;
+  interestRefund:          boolean;
   chargeRefund:            boolean;
   contra:                  boolean;
   waiveInterest:           boolean;


### PR DESCRIPTION
## Description

On the UI, user should be able to click on the “Interest Refund” transaction and show the relationships of it, similarly as Repayment transaction.

## Related issues and discussion
#{Issue Number}

## Screenshots, if any

## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
