### PR TITLE
Block undo Loan Interest Refund transaction

### DIFF
--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
@@ -133,9 +133,10 @@ export class TransactionsTabComponent implements OnInit {
    * DOWN_PAYMENT:28
    * REAGE:29
    * REAMORTIZE:30
+   * INTEREST REFUND:33
    */
   showTransactions(transactionsData: LoanTransaction) {
-    if ([1, 2, 4, 9, 20, 21, 22, 23, 26, 28, 29, 30, 31].includes(transactionsData.type.id)) {
+    if ([1, 2, 4, 9, 20, 21, 22, 23, 26, 28, 29, 30, 31, 33].includes(transactionsData.type.id)) {
       this.router.navigate([transactionsData.id], { relativeTo: this.route });
     }
   }
@@ -144,7 +145,9 @@ export class TransactionsTabComponent implements OnInit {
     if (transaction.manuallyReversed) {
       return false;
     }
-    return !(transaction.type.disbursement || transaction.type.chargeoff || this.isReAgoeOrReAmortize(transaction.type) );
+    return !(transaction.type.disbursement || transaction.type.chargeoff || this.isReAgoeOrReAmortize(transaction.type)
+      || transaction.type.interestRefund
+     );
   }
 
   loanTransactionColor(transaction: LoanTransaction): string {

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
@@ -75,7 +75,7 @@ export class ViewTransactionComponent implements OnInit {
       this.transactionData = data.loansAccountTransaction;
       this.transactionType = this.transactionData.type;
       this.allowEdition = !this.transactionData.manuallyReversed && !this.allowTransactionEdition(this.transactionData.type.id);
-      this.allowUndo = !this.transactionData.manuallyReversed;
+      this.allowUndo = this.allowUndoTransaction(this.transactionData.manuallyReversed, this.transactionType);
       this.allowChargeback = this.allowChargebackTransaction(this.transactionType) && !this.transactionData.manuallyReversed;
       let transactionsChargebackRelated = false;
       if (this.transactionData.transactionRelations) {
@@ -126,6 +126,16 @@ export class ViewTransactionComponent implements OnInit {
     return (transactionType.repayment || transactionType.interestPaymentWaiver
       || transactionType.goodwillCredit || transactionType.payoutRefund
       || transactionType.merchantIssuedRefund || transactionType.downPayment);
+  }
+
+  allowUndoTransaction(manuallyReversed: boolean, transactionType: LoanTransactionType): boolean {
+    if (manuallyReversed) {
+      return false;
+    }
+    if (transactionType.interestRefund) {
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/src/app/products/loan-products/models/loan-account.model.ts
+++ b/src/app/products/loan-products/models/loan-account.model.ts
@@ -1,3 +1,4 @@
+import { LoanTransactionType } from 'app/loans/models/loan-transaction-type.model';
 import { Currency } from 'app/shared/models/general.model';
 
 export interface LoanTransaction {
@@ -23,39 +24,4 @@ export interface LoanTransaction {
     loanChargePaidByList:      any[];
     numberOfRepayments:        number;
     transactionRelations:      any[];
-}
-
-
-export interface LoanTransactionType {
-    id:                      number;
-    code:                    string;
-    value:                   string;
-    disbursement:            boolean;
-    repaymentAtDisbursement: boolean;
-    repayment:               boolean;
-    merchantIssuedRefund:    boolean;
-    payoutRefund:            boolean;
-    goodwillCredit:          boolean;
-    interestPaymentWaiver:   boolean;
-    chargeRefund:            boolean;
-    contra:                  boolean;
-    waiveInterest:           boolean;
-    waiveCharges:            boolean;
-    accrual:                 boolean;
-    writeOff:                boolean;
-    recoveryRepayment:       boolean;
-    initiateTransfer:        boolean;
-    approveTransfer:         boolean;
-    withdrawTransfer:        boolean;
-    rejectTransfer:          boolean;
-    chargePayment:           boolean;
-    refund:                  boolean;
-    refundForActiveLoans:    boolean;
-    creditBalanceRefund:     boolean;
-    chargeAdjustment:        boolean;
-    chargeback:              boolean;
-    chargeoff:               boolean;
-    downPayment:             boolean;
-    reAge:                   boolean;
-    reAmortize:              boolean;
 }


### PR DESCRIPTION
## Description

Customer should not be able tor reverse Interest Refund transaction directly.

It is created as part of Merchant issued / payout refund and should be reversed when these transactions were reversed.

## Screenshots, if any

<img width="1009" alt="Screenshot 2024-11-18 at 12 31 18 p m" src="https://github.com/user-attachments/assets/f429af96-5cdd-463b-88d5-7f9e9e1562e9">


## Checklist
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
