### PR TITLE
FINERACT-1981: Introduce Interest should not be calculated on past due principal amount on API

### DIFF
--- a/src/app/loans/loans-view/loan-term-variations-tab/loan-term-variations-tab.component.ts
+++ b/src/app/loans/loans-view/loan-term-variations-tab/loan-term-variations-tab.component.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute } from '@angular/router';
   templateUrl: './loan-term-variations-tab.component.html',
   styleUrls: ['./loan-term-variations-tab.component.scss']
 })
-export class LoanTermVariationsTabComponent implements OnInit {
+export class LoanTermVariationsTabComponent {
 
   /** Loan Details Data */
   loanTermVariationsData: any[] = [];
@@ -21,8 +21,4 @@ export class LoanTermVariationsTabComponent implements OnInit {
     });
     this.loanId = this.route.parent.parent.snapshot.params['loanId'];
   }
-
-  ngOnInit(): void {
-  }
-
 }

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -542,15 +542,19 @@
     <div fxFlexFill *ngIf="loanProduct.interestRecalculationData.recalculationRestFrequencyType.id !== 1"
       fxLayout="row wrap" fxLayout.lt-md="column">
       <span fxFlex="47%">{{ 'labels.inputs.Frequency Interval for recalculation' | translate}}:</span>
-      <span  fxFlex="53%">{{ loanProduct.interestRecalculationData.recalculationRestFrequencyInterval }}</span>
+      <span fxFlex="53%">{{ loanProduct.interestRecalculationData.recalculationRestFrequencyInterval }}</span>
       <div fxFlexFill *ngIf="loanProduct.recalculationRestFrequencyDate">
         <span fxFlex="47%">{{ 'labels.inputs.Rest Frequency Date' | translate}}:</span>
-        <span  fxFlex="53%">{{ loanProduct.interestRecalculationData.recalculationRestFrequencyDate }}</span>
+        <span fxFlex="53%">{{ loanProduct.interestRecalculationData.recalculationRestFrequencyDate }}</span>
       </div>
     </div>
     <div fxFlexFill>
       <span fxFlex="47%">{{ 'labels.inputs.Is Arrears recognization based on original schedule' | translate}}:</span>
-      <span  fxFlex="53%">{{ loanProduct.isArrearsBasedOnOriginalSchedule | yesNo }}</span>
+      <span fxFlex="53%">{{ loanProduct.interestRecalculationData.isArrearsBasedOnOriginalSchedule | yesNo }}</span>
+    </div>
+    <div fxFlexFill *ngIf="loanProduct.loanScheduleType.code === 'PROGRESSIVE'">
+      <span fxFlex="47%">{{ 'labels.inputs.Do not calculate interest on past due principal balances' | translate}}:</span>
+      <span fxFlex="53%">{{ loanProduct.interestRecalculationData.disallowInterestCalculationOnPastDue | yesNo }}</span>
     </div>
   </div>
 

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
@@ -160,7 +160,8 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
           allowCompoundingOnEod: this.loanProduct.allowCompoundingOnEod,
           isArrearsBasedOnOriginalSchedule: this.loanProduct.isArrearsBasedOnOriginalSchedule,
           isCompoundingToBePostedAsTransaction: this.loanProduct.isCompoundingToBePostedAsTransaction,
-          recalculationRestFrequencyInterval: this.loanProduct.recalculationRestFrequencyInterval
+          recalculationRestFrequencyInterval: this.loanProduct.recalculationRestFrequencyInterval,
+          disallowInterestCalculationOnPastDue: this.loanProduct.disallowInterestCalculationOnPastDue,
         };
       }
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -433,6 +433,10 @@
         {{'labels.inputs.Is Arrears recognization based on original schedule' | translate}}?
       </mat-checkbox>
 
+      <mat-checkbox *ngIf="loanProductSettingsForm.value.loanScheduleType === 'PROGRESSIVE'" fxFlex="98%" labelPosition="before" formControlName="disallowInterestCalculationOnPastDue" class="margin-v">
+        {{'labels.inputs.Do not calculate interest on past due principal balances' | translate}}
+      </mat-checkbox>
+
     </div>
 
     <mat-divider fxFlex="98%"></mat-divider>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -370,6 +370,7 @@ export class LoanProductSettingsStepComponent implements OnInit {
           this.loanProductSettingsForm.removeControl('recalculationRestFrequencyType');
           this.loanProductSettingsForm.removeControl('isArrearsBasedOnOriginalSchedule');
         }
+        this.enableFieldsWhenScheduleTypeIsProgressiveAndInterestRateRecalculationEnabled();
       });
 
     this.loanProductSettingsForm.get('holdGuaranteeFunds').valueChanges
@@ -491,7 +492,23 @@ export class LoanProductSettingsStepComponent implements OnInit {
         this.setRescheduleStrategies();
       }
       this.processingStrategyService.initialize(this.isAdvancedTransactionProcessingStrategy);
+      this.enableFieldsWhenScheduleTypeIsProgressiveAndInterestRateRecalculationEnabled();
     });
+  }
+
+  private enableFieldsWhenScheduleTypeIsProgressiveAndInterestRateRecalculationEnabled() {
+    const isProgressiveLoan = this.loanProductSettingsForm.get('loanScheduleType').value === LoanProducts.LOAN_SCHEDULE_TYPE_PROGRESSIVE;
+    const isInterestRecalculationEnabled = this.loanProductSettingsForm.get('isInterestRecalculationEnabled').value == true;
+    const shouldControlExists = isProgressiveLoan && isInterestRecalculationEnabled;
+    const isControlExists = this.loanProductSettingsForm.contains('disallowInterestCalculationOnPastDue');
+
+    if (shouldControlExists && !isControlExists) {
+      this.loanProductSettingsForm.addControl('disallowInterestCalculationOnPastDue', new UntypedFormControl(''));
+      this.loanProductSettingsForm.patchValue({'disallowInterestCalculationOnPastDue': this.loanProductsTemplate.interestRecalculationData?.disallowInterestCalculationOnPastDue ?? false});
+    } else if (isControlExists && !shouldControlExists) {
+      this.loanProductSettingsForm.patchValue({'disallowInterestCalculationOnPastDue': undefined });
+      this.loanProductSettingsForm.removeControl('disallowInterestCalculationOnPastDue');
+    }
   }
 
   private setRescheduleStrategies() {

--- a/src/app/products/loan-products/models/loan-product.model.ts
+++ b/src/app/products/loan-products/models/loan-product.model.ts
@@ -52,6 +52,7 @@ export interface LoanProduct {
   recalculationCompoundingFrequencyType?:                    number;
   recalculationRestFrequencyType?:                           number;
   allowCompoundingOnEod?:                                    boolean;
+  disallowInterestCalculationOnPastDue?:                     boolean;
   isArrearsBasedOnOriginalSchedule?:                         boolean;
   isCompoundingToBePostedAsTransaction?:                     boolean;
   recalculationRestFrequencyInterval?:                       number;
@@ -168,4 +169,5 @@ export interface InterestRecalculationData {
   isCompoundingToBePostedAsTransaction:   boolean;
   preClosureInterestCalculationStrategy:  OptionData;
   allowCompoundingOnEod:                  boolean;
+  disallowInterestCalculationOnPastDue:   boolean;
 }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1505,6 +1505,7 @@
       "Dividend Period End Date": "Datum ukončení dividendového období",
       "Dividend Period Start Date": "Datum zahájení dividendového období",
       "Dividends": "Dividendy",
+      "Do not calculate interest on past due principal balances": "Neúčtovat úroky z dlužných hlavních zůstatků",
       "Documents": "Dokumenty",
       "Document Key": "Klíč dokumentu",
       "Document Type": "Typ dokumentu",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1505,6 +1505,7 @@
       "Dividend Period End Date": "Enddatum des Dividendenzeitraums",
       "Dividend Period Start Date": "Startdatum des Dividendenzeitraums",
       "Dividends": "Dividenden",
+      "Do not calculate interest on past due principal balances": "Berechnen Sie keine Zinsen auf überfällige Hauptbeträge",
       "Documents": "Unterlagen",
       "Document Key": "Dokumentschlüssel",
       "Document Type": "Art des Dokuments",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1506,6 +1506,7 @@
             "Dividend Period End Date": "Dividend Period End Date",
             "Dividend Period Start Date": "Dividend Period Start Date",
             "Dividends": "Dividends",
+            "Do not calculate interest on past due principal balances": "Do not calculate interest on past due principal balances",
             "Documents": "Documents",
             "Document Key": "Document Key",
             "Document Type": "Document Type",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1503,6 +1503,7 @@
             "Dividend Period End Date": "Fecha de finalización del período de dividendos",
             "Dividend Period Start Date": "Fecha de inicio del período de dividendos",
             "Dividends": "Dividendos",
+            "Do not calculate interest on past due principal balances": "No calcular intereses sobre saldos principales vencidos",
             "Documents": "Documentos",
             "Document Key": "Clave de documento",
             "Document Type": "Tipo de Documento",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1505,6 +1505,7 @@
       "Dividend Period End Date": "Date de fin de la période de dividende",
       "Dividend Period Start Date": "Date de début de la période de dividende",
       "Dividends": "Dividendes",
+      "Do not calculate interest on past due principal balances": "Ne pas calculer d'intérêts sur les soldes principaux échus",
       "Documents": "Documents",
       "Document Key": "Clé du document",
       "Document Type": "Type de document",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1505,6 +1505,7 @@
       "Dividend Period End Date": "Data di fine del periodo di dividendo",
       "Dividend Period Start Date": "Data di inizio del periodo di dividendo",
       "Dividends": "Dividendi",
+      "Do not calculate interest on past due principal balances": "Non calcolare interessi sui saldi principali scaduti",
       "Documents": "Documenti",
       "Document Key": "Chiave del documento",
       "Document Type": "tipo di documento",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1506,6 +1506,7 @@
       "Dividend Period End Date": "배당기간 종료일",
       "Dividend Period Start Date": "배당기간 개시일",
       "Dividends": "배당금",
+      "Do not calculate interest on past due principal balances": "연체된 원금 잔액에 대한 이자를 계산하지 마십시오",
       "Documents": "서류",
       "Document Key": "문서 키",
       "Document Type": "문서 유형",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1505,6 +1505,7 @@
       "Dividend Period End Date": "Dividendų laikotarpio pabaigos data",
       "Dividend Period Start Date": "Dividendų laikotarpio pradžios data",
       "Dividends": "Dividendai",
+      "Do not calculate interest on past due principal balances": "Neskaičiuoti palūkanų už pradelstus pagrindinius likučius",
       "Documents": "Dokumentai",
       "Document Key": "Dokumento raktas",
       "Document Type": "dokumento tipas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1505,6 +1505,7 @@
       "Dividend Period End Date": "Dividenžu perioda beigu datums",
       "Dividend Period Start Date": "Dividenžu perioda sākuma datums",
       "Dividends": "Dividendes",
+      "Do not calculate interest on past due principal balances": "Neskaitīt procentus par kavētajiem pamatkapitāla atlikumiem",
       "Documents": "Dokumenti",
       "Document Key": "Dokumenta atslēga",
       "Document Type": "Dokumenta veids",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1505,6 +1505,7 @@
       "Dividend Period End Date": "लाभांश अवधि समाप्ति मिति",
       "Dividend Period Start Date": "लाभांश अवधि सुरु मिति",
       "Dividends": "लाभांश",
+      "Do not calculate interest on past due principal balances": "बकाया मूल चित्तको ब्याज गणना नगर्नुहोस्।",
       "Documents": "कागजातहरू",
       "Document Key": "कागजात कुञ्जी",
       "Document Type": "कागजात प्रकार",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1505,6 +1505,7 @@
       "Dividend Period End Date": "Data de término do período de dividendos",
       "Dividend Period Start Date": "Data de início do período de dividendos",
       "Dividends": "Dividendos",
+      "Do not calculate interest on past due principal balances": "Não calcular juros sobre os saldos principais em atraso",
       "Documents": "Documentos",
       "Document Key": "Chave do documento",
       "Document Type": "tipo de documento",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1505,6 +1505,7 @@
       "Dividend Period End Date": "Tarehe ya Mwisho ya Kipindi cha Gawio",
       "Dividend Period Start Date": "Tarehe ya Kuanza kwa Kipindi cha Gawio",
       "Dividends": "Gawio",
+      "Do not calculate interest on past due principal balances": "Usihesabu riba juu ya salio la msingi lililokawia",
       "Documents": "Nyaraka",
       "Document Key": "Ufunguo wa Hati",
       "Document Type": "Aina ya Hati",


### PR DESCRIPTION
This P.R. introduces a new flag under the interest recalculation section on the loan product.

It also contains some minor fixes.