### PR TITLE
Correct path to i18n dictionaries

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { HttpBackend, HttpClient, HttpClientModule } from '@angular/common/http';
 
 /** Environment Configuration */
 
@@ -58,15 +58,12 @@ export function HttpLoaderFactory(http: HttpClient) {
     TranslateModule.forRoot({
       loader: {
         provide: TranslateLoader,
-        useFactory: (http: HttpClient, locationStrategy: LocationStrategy) => {
-          return new TranslateHttpLoader(
-            http,
-            `${window.location.protocol}//${window.location.host}${locationStrategy.getBaseHref()}/assets/translations/`,
-            '.json'
-          );
+        useFactory: (httpBackend: HttpBackend, locationStrategy: LocationStrategy) => {
+          const http = new HttpClient(httpBackend);
+          return new TranslateHttpLoader(http, `/assets/translations/`, '.json');
         },
         deps: [
-          HttpClient,
+          HttpBackend,
           LocationStrategy
         ]
       }


### PR DESCRIPTION
## Description

The path to i18n could not be accessed by HttpClient because it is intervened by the general interceptor, in this change we use HttpClient without the interceptor, which allows the files to be loaded directly from the real path as a standard asset.

https://medium.com/nerd-for-tech/how-to-bypass-angular-http-interceptor-2491afca16a3

https://ngx-translate.org/getting-started/translation-files/

## Related issues and discussion

No issues reported

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
