### PR TITLE
Add browser ChromeHeadless for automated testing

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -113,6 +113,7 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
+            "browsers": "ChromeHeadless",
             "main": "src/test.ts",
             "karmaConfig": "src/karma.conf.ts",
             "polyfills": "src/polyfills.ts",


### PR DESCRIPTION
## Description

In order to carry out the automated tests, it is necessary to add a browser that can be run from the console. This step is essential to be able to add the automatic integrity and update tests. It is essential to be able to guarantee the future of this source given that the version of angular 14 is obsolete, for this source to survive it is necessary that it can be updated to later versions and this will not be achieved without first being able to check the source before applying significant changes, due to the large gap that exists between angular 14 and angular 19 it is necessary to have absolute control of integrity. This small step is the first step.

## Related issues and discussion

# No Issued

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
