### PR TITLE
Introduce interestChargedFromDisbursementDate to control when interes…

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
@@ -326,6 +326,13 @@
       <p>{{ 'labels.inputs.Calculate interest for exact days in partial period' | translate }}</p>
     </mat-checkbox>
 
+    <mat-checkbox
+      fxFlex="48%"
+      formControlName="interestRecognitionOnDisbursementDate"
+    >
+      <p>{{ 'labels.inputs.Is interest recognition on disbursement date?' | translate }}</p>
+    </mat-checkbox>
+
     <mat-form-field fxFlex="48%">
       <mat-label>{{ 'labels.inputs.Arrears tolerance' | translate }} </mat-label>
       <input

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -158,7 +158,8 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
         interestRateDifferential: this.loansAccountTermsData.interestRateDifferential,
         multiDisburseLoan: this.loansAccountTermsData.multiDisburseLoan,
         interestRateFrequencyType: this.loansAccountTermsData.interestRateFrequencyType.id,
-        balloonRepaymentAmount: this.loansAccountTermsData.balloonRepaymentAmount
+        balloonRepaymentAmount: this.loansAccountTermsData.balloonRepaymentAmount,
+        interestRecognitionOnDisbursementDate: this.loansAccountTermsData.interestRecognitionOnDisbursementDate || false
       });
 
       this.setAdvancedPaymentStrategyControls();
@@ -263,7 +264,8 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
         interestRateDifferential: this.loansAccountTermsData.interestRateDifferential,
         multiDisburseLoan: this.loansAccountTermsData.multiDisburseLoan,
         interestRateFrequencyType: this.loansAccountTermsData.interestRateFrequencyType.id,
-        balloonRepaymentAmount: this.loansAccountTermsData.balloonRepaymentAmount
+        balloonRepaymentAmount: this.loansAccountTermsData.balloonRepaymentAmount,
+        interestRecognitionOnDisbursementDate: this.loansAccountTermsData.interestRecognitionOnDisbursementDate || false
       });
     }
     this.createloansAccountTermsForm();
@@ -413,7 +415,8 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
       ],
       multiDisburseLoan: [false],
       interestRateFrequencyType: [''],
-      balloonRepaymentAmount: ['']
+      balloonRepaymentAmount: [''],
+      interestRecognitionOnDisbursementDate: [false]
     });
   }
 

--- a/src/app/loans/loans-view/account-details/account-details.component.html
+++ b/src/app/loans/loans-view/account-details/account-details.component.html
@@ -123,6 +123,13 @@
     </div>
 
     <div fxFlexFill>
+      <span fxFlex="50%"
+        >{{ 'labels.inputs.Is interest recognition on disbursement date?' | translate }}:</span
+      >
+      <span fxFlex="50%">{{ loanDetails.interestRecognitionOnDisbursementDate | yesNo }}</span>
+    </div>
+
+    <div fxFlexFill>
       <span fxFlex="50%"> {{ 'labels.inputs.Submitted on' | translate }}</span>
       <span fxFlex="50%"> {{ loanDetails.timeline.submittedOnDate | dateFormat }} </span>
     </div>

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -355,13 +355,20 @@
     <span fxFlex="53%">{{ loanProduct.interestCalculationPeriodType?.value | translateKey: 'catalogs' }}</span>
   </div>
 
-  <div fxFlexFill *ngIf="loanProduct.allowPartialPeriodInterestCalculation">
+  <div fxFlexFill>
     <span fxFlex="47%"
       >{{ 'labels.inputs.Allow Partial Interest Calculation with same as repayment' | translate }}:</span
     >
     <span fxFlex="53%">{{ loanProduct.allowPartialPeriodInterestCalculation | yesNo }}</span>
   </div>
 
+  <div fxFlexFill>
+    <span fxFlex="47%"
+      >{{ 'labels.inputs.Is interest recognition on disbursement date?' | translate }}:</span
+    >
+    <span fxFlex="53%">{{ loanProduct.interestRecognitionOnDisbursementDate | yesNo }}</span>
+  </div>
+  
   <h3 class="mat-h3" fxFlexFill>{{ 'labels.inputs.Loan Schedule' | translate }}</h3>
 
   <mat-divider [inset]="true"></mat-divider>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -119,6 +119,10 @@
 
     <mat-divider fxFlex="98%"></mat-divider>
 
+    <mat-checkbox fxFlex="96%" labelPosition="before" formControlName="interestRecognitionOnDisbursementDate">
+      {{ 'labels.inputs.Is interest recognition on disbursement date?' | translate }}
+    </mat-checkbox>
+
     <h3 fxFlex="23%" class="mat-h3">{{ 'labels.inputs.Interest Rates' | translate }}</h3>
 
     <mat-checkbox
@@ -129,7 +133,7 @@
     >
       {{ 'labels.inputs.Is Zero Interest Rate?' | translate }}
     </mat-checkbox>
-
+    
     <mat-checkbox
       fxFlex="32%"
       labelPosition="before"

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -86,7 +86,8 @@ export class LoanProductTermsStepComponent implements OnInit, OnChanges {
       repaymentFrequencyType: this.loanProductsTemplate.repaymentFrequencyType.id,
       minimumDaysBetweenDisbursalAndFirstRepayment:
         this.loanProductsTemplate.minimumDaysBetweenDisbursalAndFirstRepayment,
-      repaymentStartDateType: this.loanProductsTemplate.repaymentStartDateType.id || 1
+      repaymentStartDateType: this.loanProductsTemplate.repaymentStartDateType.id || 1,
+      interestRecognitionOnDisbursementDate: this.loanProductsTemplate.interestRecognitionOnDisbursementDate || false
     });
 
     if (this.loanProductsTemplate.allowApprovedDisbursedAmountsOverApplied) {
@@ -173,7 +174,8 @@ export class LoanProductTermsStepComponent implements OnInit, OnChanges {
       ],
       minimumDaysBetweenDisbursalAndFirstRepayment: [''],
       repaymentStartDateType: [1],
-      fixedLength: [null]
+      fixedLength: [null],
+      interestRecognitionOnDisbursementDate: [false]
     });
   }
 

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1761,6 +1761,7 @@
       "Is Floating Rate": "Je pohyblivá sazba",
       "Is Floating calculation allowed?": "Je povolen plovoucí výpočet?",
       "Is Interest Posting required on closure date": "Je požadováno zveřejnění zájmu v den uzávěrky",
+      "Is interest recognition on disbursement date?": "Je úrok uznán k datu výplaty?",
       "Is Linked to floating interest rates?": "Je spojeno s pohyblivými úrokovými sazbami?",
       "Is Loan Officer": "Je úvěrový úředník",
       "Is Mandatory Deposit": "Je povinná záloha",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1761,6 +1761,7 @@
       "Is Floating Rate": "Ist ein variabler Zinssatz",
       "Is Floating calculation allowed?": "Ist eine gleitende Berechnung zulässig?",
       "Is Interest Posting required on closure date": "Ist eine Zinsbuchung am Abschlussdatum erforderlich?",
+      "Is interest recognition on disbursement date?": "Erfolgt die Anerkennung der Zinsen am Auszahlungstag?",
       "Is Linked to floating interest rates?": "Ist es mit variablen Zinssätzen verbunden?",
       "Is Loan Officer": "Ist Kreditsachbearbeiter",
       "Is Mandatory Deposit": "Ist eine obligatorische Anzahlung",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1762,6 +1762,7 @@
       "Is Floating Rate": "Is Floating Rate",
       "Is Floating calculation allowed?": "Is Floating calculation allowed?",
       "Is Interest Posting required on closure date": "Is Interest Posting required on closure date",
+      "Is interest recognition on disbursement date?": "Is interest recognition on disbursement date?",
       "Is Linked to floating interest rates?": "Is Linked to floating interest rates?",
       "Is Loan Officer": "Is Loan Officer",
       "Is Mandatory Deposit": "Is Mandatory Deposit",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1760,6 +1760,7 @@
       "Is Floating Rate": "¿Es tasa variable",
       "Is Floating calculation allowed?": "¿Se permite el cálculo flotante?",
       "Is Interest Posting required on closure date": "¿Se requiere la publicación de intereses en la fecha de cierre?",
+      "Is interest recognition on disbursement date?": "¿El reconocimiento de intereses se realiza en la fecha de desembolso?",
       "Is Linked to floating interest rates?": "¿Está vinculado a tasas de interés flotantes?",
       "Is Loan Officer": "Es oficial de Créditos",
       "Is Mandatory Deposit": "Es depósito obligatorio",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1761,6 +1761,7 @@
       "Is Floating Rate": "Le taux est flottant",
       "Is Floating calculation allowed?": "Le calcul flottant est-il autorisé ?",
       "Is Interest Posting required on closure date": "La publication des intérêts est-elle requise à la date de clôture",
+      "Is interest recognition on disbursement date?": "Les intérêts sont-ils reconnus à la date de décaissement ?",
       "Is Linked to floating interest rates?": "Est-ce lié à des taux d’intérêt flottants ?",
       "Is Loan Officer": "est agent de crédit",
       "Is Mandatory Deposit": "Le dépôt est-il obligatoire",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1760,6 +1760,7 @@
       "Is Floating Rate": "È il tasso variabile",
       "Is Floating calculation allowed?": "È consentito il calcolo flottante?",
       "Is Interest Posting required on closure date": "È richiesta la registrazione degli interessi alla data di chiusura",
+      "Is interest recognition on disbursement date?": "Il riconoscimento degli interessi avviene alla data di erogazione?",
       "Is Linked to floating interest rates?": "È legato a tassi di interesse variabili?",
       "Is Loan Officer": "È l'ufficiale di prestito",
       "Is Mandatory Deposit": "È un deposito obbligatorio",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1762,6 +1762,7 @@
       "Is Floating Rate": "변동금리인가",
       "Is Floating calculation allowed?": "부동 계산이 허용됩니까?",
       "Is Interest Posting required on closure date": "마감일에 관심 게시가 필요합니까?",
+      "Is interest recognition on disbursement date?": "지급일에 이자가 인식되나요?",
       "Is Linked to floating interest rates?": "변동금리와 연동되나요?",
       "Is Loan Officer": "대출담당자인가",
       "Is Mandatory Deposit": "필수 예금인가요?",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1761,6 +1761,7 @@
       "Is Floating Rate": "Ar kintama norma",
       "Is Floating calculation allowed?": "Ar leidžiamas plaukiojantis skaičiavimas?",
       "Is Interest Posting required on closure date": "Ar uždarymo dieną būtina paskelbti palūkanas",
+      "Is interest recognition on disbursement date?": "Ar palūkanų pripažinimas išmokėjimo dieną?",
       "Is Linked to floating interest rates?": "Ar susieta su kintamomis palūkanų normomis?",
       "Is Loan Officer": "Yra paskolos pareigūnas",
       "Is Mandatory Deposit": "Yra privalomas depozitas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1761,6 +1761,7 @@
       "Is Floating Rate": "Ir mainīgā likme",
       "Is Floating calculation allowed?": "Vai ir atļauts peldošs aprēķins?",
       "Is Interest Posting required on closure date": "Vai slēgšanas datumā ir nepieciešams publicēt procentus",
+      "Is interest recognition on disbursement date?": "Vai procentu atzīšana izmaksas datumā?",
       "Is Linked to floating interest rates?": "Vai ir saistīts ar mainīgajām procentu likmēm?",
       "Is Loan Officer": "Ir aizdevuma amatpersona",
       "Is Mandatory Deposit": "Ir obligāts depozīts",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1761,6 +1761,7 @@
       "Is Floating Rate": "फ्लोटिंग रेट हो",
       "Is Floating calculation allowed?": "फ्लोटिंग गणना गर्न अनुमति छ?",
       "Is Interest Posting required on closure date": "समापन मितिमा रुचि पोस्टिंग आवश्यक छ",
+      "Is interest recognition on disbursement date?": "के वितरण मितिमा ब्याज मान्यता छ?",
       "Is Linked to floating interest rates?": "फ्लोटिंग ब्याज दर संग जोडिएको छ?",
       "Is Loan Officer": "ऋण अधिकारी हुनुहुन्छ",
       "Is Mandatory Deposit": "अनिवार्य निक्षेप छ",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1761,6 +1761,7 @@
       "Is Floating Rate": "É taxa flutuante",
       "Is Floating calculation allowed?": "O cálculo flutuante é permitido?",
       "Is Interest Posting required on closure date": "O lançamento de juros é obrigatório na data de fechamento",
+      "Is interest recognition on disbursement date?": "O reconhecimento dos juros ocorre na data do desembolso?",
       "Is Linked to floating interest rates?": "Está vinculado a taxas de juros flutuantes?",
       "Is Loan Officer": "É oficial de empréstimo",
       "Is Mandatory Deposit": "É Depósito Obrigatório",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1761,6 +1761,7 @@
       "Is Floating Rate": "Ni Kiwango cha Kuelea",
       "Is Floating calculation allowed?": "Je, hesabu ya kuelea inaruhusiwa?",
       "Is Interest Posting required on closure date": "Je! Uchapishaji wa Maslahi unahitajika katika tarehe ya kufungwa",
+      "Is interest recognition on disbursement date?": "Je, ni utambuzi wa riba katika tarehe ya malipo?",
       "Is Linked to floating interest rates?": "Je, Inahusishwa na viwango vya riba vinavyoelea?",
       "Is Loan Officer": "Ni Afisa Mikopo",
       "Is Mandatory Deposit": "Ni Amana ya Lazima",


### PR DESCRIPTION
…t charging should start

## Description

In case the interestRecognitionOnDisbursementDate field is configured on during the loan creation:

if TRUE, we should start interest charging from Day 0 (disbursement date) EOD.
if it is not provided or FALSE, we should start interest charging from Day 1 (disbursement date+1) EOD. (legacy, default behaviour)

## Screenshots
<img width="1318" alt="Screenshot 2025-02-03 at 2 19 57 p m" src="https://github.com/user-attachments/assets/03ea43ba-40c1-4271-8fdb-0e5f607f1cb0" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
