### PR TITLE
Fix saving account, product label

### DIFF
--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -420,7 +420,7 @@
     </ng-container>
 
     <ng-container matColumnDef="Saving Account">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Saving Product' | translate }}</th>
+      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Savings Product' | translate }}</th>
       <td mat-cell *matCellDef="let element">
         <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
       </td>


### PR DESCRIPTION
This PR fixes a translation issue in the closed accounts view for Saving Accounts. Previously, the label "labels.inputs.Saving Product" was displayed instead of the correctly translated text. This has been updated to "labels.inputs.Savings Product" to ensure proper translation rendering.

## Fixes issue: WEB-26