### PR TITLE
fix: make loan product save when "Enable installment" was clicked and…

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -679,7 +679,8 @@ export class LoanProductSettingsStepComponent implements OnInit {
   clearProperty($event: Event, propertyName: string): void {
     if (propertyName === 'delinquencyBucketId') {
       this.loanProductSettingsForm.patchValue({
-        delinquencyBucketId: ''
+        delinquencyBucketId: '',
+        enableInstallmentLevelDelinquency: false
       });
     }
     this.loanProductSettingsForm.markAsDirty();


### PR DESCRIPTION
… Delinquency removed

If the user deselects the Delinquency, but the "Enable installment" checkbox was ticked, saving failed.

Fixes: WEB-25