### PR TITLE
fix: login form

### DIFF
--- a/src/app/login/login-form/login-form.component.html
+++ b/src/app/login/login-form/login-form.component.html
@@ -17,9 +17,10 @@
     <mat-label>{{ 'labels.inputs.Password' | translate }}</mat-label>
     <input matInput type="{{ passwordInputType }}" formControlName="password" />
     <button
+      type="button"
       mat-button
-      *ngIf="loginForm.controls.password.value && !loading"
       matSuffix
+      *ngIf="loginForm.controls.password.value && !loading"
       mat-icon-button
       (mousedown)="togglePasswordVisibility()"
       (mouseup)="togglePasswordVisibility()"
@@ -28,7 +29,7 @@
       <fa-icon *ngIf="passwordInputType === 'text'" icon="eye-slash"></fa-icon>
     </button>
     <mat-error *ngIf="loginForm.controls.password.hasError('required')">
-      {{ 'labels.inputs.Password' | translate }} <strong>{{ 'labels.commons.is required' | translate }}</strong>
+      {{ 'labels.inputs.Password' | translate }} <strong>{{ 'labels.commons.pass is required' | translate }}</strong>
     </mat-error>
   </mat-form-field>
 

--- a/src/app/login/login-form/login-form.component.ts
+++ b/src/app/login/login-form/login-form.component.ts
@@ -68,7 +68,7 @@ export class LoginFormComponent implements OnInit {
    * Changes the input type between 'password' and 'text'.
    */
 
-  togglePasswordVisbility() {
+  togglePasswordVisibility() {
     this.passwordInputType = this.passwordInputType === 'password' ? 'text' : 'password';
   }
 

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -772,6 +772,7 @@
       "is": "is",
       "Is": "is",
       "is required": "is required",
+      "pass is required": "is required(min length 8)",
       "least one uppercase": "least one uppercase",
       "lowercase and special character": "lowercase and special character",
       "must be": "must be",


### PR DESCRIPTION
## Description

View password option works correctly. 
Login form  submits only on clicking Login
Minimum 8 charcters limit (which was already set for passwords) is now mentioned to users.

## Fixes issue: WEB-34
Before fix:

https://github.com/user-attachments/assets/8fb9373c-f357-4b50-95c1-82710d6c1a17



After fix:
https://github.com/user-attachments/assets/a82765e9-9a50-491f-ba74-03468fb25f75



