### PR TITLE
fix: Create Guarantor form issues

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/create-guarantor/create-guarantor.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/create-guarantor/create-guarantor.component.html
@@ -37,7 +37,7 @@
               </mat-select>
             </mat-form-field>
 
-            <ng-container *ngIf="accountOptions.length > 0">
+            <ng-container *ngIf="accountOptions?.length > 0">
               <mat-form-field>
                 <mat-label>{{ 'labels.inputs.Account' | translate }}</mat-label>
                 <mat-select formControlName="savingsId">
@@ -137,7 +137,7 @@
       </mat-card-content>
     </form>
 
-    <ng-container *ngIf="!(newGuarantorForm.controls.name === undefined)">
+    <ng-container *ngIf="newGuarantorForm?.controls?.name?.value">
       <div class="mat-table">
         <div class="mat-header-row">
           <div class="mat-header-cell">{{ 'labels.inputs.Client Details' | translate }}</div>

--- a/src/app/loans/loans-view/loan-account-actions/create-guarantor/create-guarantor.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/create-guarantor/create-guarantor.component.ts
@@ -28,7 +28,7 @@ export class CreateGuarantorComponent implements OnInit, AfterViewInit {
   /** Show Client Details Form */
   showClientDetailsForm = false;
   /** Minimum date allowed. */
-  minDate = new Date(2000, 0, 1);
+  minDate = new Date(1900, 0, 1);
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Client data. */


### PR DESCRIPTION
Client Detail must only be shown when Name got selected. Prevent any Javascript errors. Enable the user to enter a date of birth before 2000.

Fixes: WEB-30
