### PR TITLE
fix: Remove unusable Task Management menu item from Self Service

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -132,9 +132,9 @@
   <button mat-menu-item [routerLink]="['/self-service/app-configuration']">
     {{ 'labels.menus.App Configuration' | translate }}
   </button>
-  <button mat-menu-item [routerLink]="['/self-service/task-management']">
+  <!-- <button mat-menu-item [routerLink]="['/self-service/task-management']">
     {{ 'labels.menus.Task Management' | translate }}
-  </button>
+  </button> -->
 </mat-menu>
 
 <!-- Application User Help Menu -->


### PR DESCRIPTION
Task Management in the Self Service area does not work and is not prioritized currently. It therefore should be removed from what is available in the UI. (Based on a discussion with Ed Cable 2025-02-28.)

Fixes: WEB-24