### PR TITLE
fix: Make View Guarantors work even if no summary is sent by Fineract

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/view-guarantors/view-guarantors.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/view-guarantors/view-guarantors.component.html
@@ -62,8 +62,8 @@
             <tr>
               <td>{{ 'labels.inputs.Arrears By' | translate }}</td>
               <td>
-                {{ dataObject.summary.totalOverdue | formatNumber }}
-                <span *ngIf="dataObject.summary.totalOverdue < 0">{{ 'labels.inputs.Not Provided' | translate }}</span>
+                {{ dataObject.summary?.totalOverdue | formatNumber }}
+                <span *ngIf="dataObject.summary?.totalOverdue < 0">{{ 'labels.inputs.Not Provided' | translate }}</span>
               </td>
             </tr>
           </tbody>
@@ -106,7 +106,7 @@
           <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Relationship' | translate }}</th>
           <td mat-cell *matCellDef="let guarantor">
             <span *ngIf="!guarantor.guarantorFundingDetails">
-              {{ guarantor.clientRelationshipType.name }}
+              {{ guarantor.clientRelationshipType?.name }}
             </span>
           </td>
         </ng-container>


### PR DESCRIPTION
This makes the View Guarantors work even if no Loan summary property is sent in the Fineract response. (This is naturally the case when the status of the Loan is not active.)
This also guarantees the page is rendered without errors in case no clientRelationshipType is configured for the guarantor, which is possible.

FIXES: WEB-22