### PR TITLE
fix: fix html template syntax error

### DIFF
--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
@@ -28,9 +28,9 @@
     </mat-form-field>
 
     <mat-form-field *ngIf="createClientForm.contains('fullname')" fxFlex="48%">
-      <mat-label>{{
-        'labels.inputs.' + getDateLabel(createClientForm.value.legalFormId, ['Name', 'Entity Name']) | translate
-      }}</mat-label>
+      <mat-label>
+        {{ 'labels.inputs.' + getDateLabel(createClientForm.value.legalFormId, ['Name', 'Entity Name']) | translate }}
+      </mat-label>
       <input matInput required formControlName="fullname" />
       <mat-error *ngIf="createClientForm.controls.fullname.hasError('required')">
         {{ 'labels.inputs.Client name' | translate }} {{ 'labels.commons.is' | translate }}
@@ -80,10 +80,12 @@
     <mat-divider></mat-divider>
 
     <mat-form-field fxFlex="48%" (click)="dateOfBirthDatePicker.open()">
-      <mat-label>{{
-        'labels.inputs.' + getDateLabel(createClientForm.value.legalFormId, ['Date of Birth', 'Incorporation Date'])
-          | translate
-      }}</mat-label>
+      <mat-label>
+        {{
+          'labels.inputs.' + getDateLabel(createClientForm.value.legalFormId, ['Date of Birth', 'Incorporation Date'])
+            | translate
+        }}
+      </mat-label>
       <input matInput [max]="maxDate" [matDatepicker]="dateOfBirthDatePicker" formControlName="dateOfBirth" />
       <mat-datepicker-toggle matSuffix [for]="dateOfBirthDatePicker"></mat-datepicker-toggle>
       <mat-datepicker #dateOfBirthDatePicker></mat-datepicker>

--- a/src/app/users/edit-user/edit-user.component.html
+++ b/src/app/users/edit-user/edit-user.component.html
@@ -17,7 +17,7 @@
             <input matInput required formControlName="email" />
             <mat-error *ngIf="editUserForm.controls.email.hasError('email')">
               {{ 'labels.inputs.Email' | translate }} {{ 'labels.commons.is' | translate }}
-              <strong>{{"labels.commons.invalid' | translate}}</strong>
+              <strong>{{ 'labels.commons.invalid' | translate }}</strong>
             </mat-error>
             <mat-error *ngIf="editUserForm.controls.email.hasError('required')">
               {{ 'labels.inputs.Email' | translate }} {{ 'labels.commons.is' | translate }}


### PR DESCRIPTION
## Description

- Fixed a typo in the translation key for the Email field in edit-user.component.html.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
