### PR TITLE
Fix: Created By appears immediately after adding Group Note

### DIFF
--- a/src/app/groups/groups-view/notes-tab/notes-tab.component.ts
+++ b/src/app/groups/groups-view/notes-tab/notes-tab.component.ts
@@ -1,5 +1,5 @@
 /** Angular Imports */
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -16,7 +16,7 @@ import { GroupsService } from '../../groups.service';
   templateUrl: './notes-tab.component.html',
   styleUrls: ['./notes-tab.component.scss']
 })
-export class NotesTabComponent {
+export class NotesTabComponent implements OnInit {
   /** Group ID */
   entityId: string;
   /** Username */
@@ -35,9 +35,13 @@ export class NotesTabComponent {
     private authenticationService: AuthenticationService,
     private groupsService: GroupsService
   ) {
+    this.entityId = this.route.parent.snapshot.params['groupId'];
+    this.addNote = this.addNote.bind(this);
+  }
+
+  ngOnInit() {
     const savedCredentials = this.authenticationService.getCredentials();
     this.username = savedCredentials.username;
-    this.entityId = this.route.parent.snapshot.params['groupId'];
     this.route.data.subscribe((data: { groupNotes: any }) => {
       this.entityNotes = data.groupNotes;
     });


### PR DESCRIPTION
## Description

When adding a note to a group, the "Created By" (user) was not reflected immediately. However, after a page refresh, it appeared correctly.

#### Root Cause
The issue was due to a mismatch in the this context when calling `addNote()`. The `this` reference inside `addNote()` was different from the one used during component initialization, leading to `this.username` being undefined.

#### Fix
Ensured that `this.addNote()` was binded to the correct `this`.
Kept the constructor clean and moved logic to `ngOnInit()`

## Related issues and discussion

Fixed issue [web-37](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?selectedIssue=WEB-37)

## Screenshots, if any

![Screenshot from 2025-03-06 21-53-55](https://github.com/user-attachments/assets/f83caeee-e324-4ab5-b29a-7c35183500c9)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
