### PR TITLE
test(workflow): Add test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  testRigor:
+    runs-on: ubuntu-latest
+    env:
+      MIFOS_TEST_SUITE_ID: ${{secrets.MIFOS_TEST_SUITE_ID}}
+      MIFOS_AUTH_TOKEN: ${{secrets.MIFOS_AUTH_TOKEN}}
+      LOCALHOST_URL: ${{secrets.LOCALHOST_URL}}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v1
+        with:
+          node-version: '22.9.0'
+
+      - name: Install testRigor Command Line
+        run: |
+          npm install -g --verbose testrigor-cli
+
+      - name: Run testRigor tests
+        run: |
+          echo "$MIFOS_TEST_SUITE_ID"
+          chmod +x ./e2e/testRigor/run_testrigor_tests.sh && ./e2e/testRigor/run_testrigor_tests.sh

--- a/e2e/testRigor/run_testrigor_tests.sh
+++ b/e2e/testRigor/run_testrigor_tests.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -x
+env
 
 BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
 COMMIT_NAME="$(git rev-parse --verify HEAD)"
@@ -15,3 +17,4 @@ RULES_PATH="e2e/testRigor/rules/**/*.txt"
 
 # Command to run the tests using the testRigor CLI
 testrigor test-suite run "$MIFOS_TEST_SUITE_ID" --token "$MIFOS_AUTH_TOKEN" --localhost --url "$LOCALHOST_URL" --test-cases-path "$TEST_CASES_PATH" --rules-path "$RULES_PATH" --branch "$BRANCH_NAME" --commit "$COMMIT_NAME"
+set +x

--- a/e2e/testRigor/testcases/invalid-login.txt
+++ b/e2e/testRigor/testcases/invalid-login.txt
@@ -1,6 +1,7 @@
 // Setting wrong credentials
 save value "wrong" as "username"
 save value "wrongpassword" as "password"
+validate-login-page 
 login
 // validate invalid login message
 check that page contains "Invalid User Details. Please try again!"


### PR DESCRIPTION
Add separate test.yml workflow for running e2e tests on Mifos sandbox.

## Description

Add a new test.yml file for running test jobs separate from the main build. Add a test job for end-to-end testRigor testing.

## Related issues and discussion

Complete integration of new tests started on PR #2200 , following instructions from @IOhacker .

Tests are run against Mifos Sandbox, currently passing. [Check here](https://app.testrigor.com/test-suites/X3THbQd9nxLMxkdPu/runs/pb8YPzxE8kiAgw2wA).

## Checklist

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
