### PR TITLE
fix: Correct back button routing on Add Clients page

### DIFF
--- a/src/app/groups/groups-view/group-actions/manage-group-members/manage-group-members.component.html
+++ b/src/app/groups/groups-view/group-actions/manage-group-members/manage-group-members.component.html
@@ -54,6 +54,8 @@
   </mat-card>
 
   <div fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-    <button type="button" mat-raised-button [routerLink]="['../']">{{ 'labels.buttons.Back' | translate }}</button>
+    <button type="button" mat-raised-button [routerLink]="['/groups', groupData.id, 'general']">
+      {{ 'labels.buttons.Back' | translate }}
+    </button>
   </div>
 </div>


### PR DESCRIPTION


## Description

- Updated the back button to use a proper routerLink: `/groups/:id/general`
- Fixed the issue where clicking "Back" led to a 404 error

## Related issues and discussion
Closes [WEB-48](https://mifosforge.jira.com/jira/software/c/projects/WEB/issues/WEB-48)


## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-48]: https://mifosforge.jira.com/browse/WEB-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ