### PR TITLE
Removed back button on "Add Clients" page to prevent 404 errors

### DIFF
--- a/src/app/groups/groups-view/group-actions/manage-group-members/manage-group-members.component.html
+++ b/src/app/groups/groups-view/group-actions/manage-group-members/manage-group-members.component.html
@@ -52,8 +52,4 @@
       </div>
     </mat-nav-list>
   </mat-card>
-
-  <div fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-    <button type="button" mat-raised-button [routerLink]="['../']">{{ 'labels.buttons.Back' | translate }}</button>
-  </div>
 </div>


### PR DESCRIPTION
## Description

Removed Back button on "Add Clients", which is broken and leads to a 404 page

## Related issues and discussion

Fixes WEB-48
https://mifosforge.jira.com/browse/WEB-48

## Screenshots, if any
Before:
![WhatsApp Image 2025-03-09 at 23 29 27_26d9c324](https://github.com/user-attachments/assets/091b11b3-7d20-4d6f-beb7-3baf3b400da4)

After:
![image](https://github.com/user-attachments/assets/288a6f4c-1ee1-49fc-a35b-0f9593f0582e)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
