### PR TITLE
WEB-28 Fixed issue with loan account approval not working

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/loan-account-actions.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/loan-account-actions.component.ts
@@ -99,7 +99,10 @@ export class LoanAccountActionsComponent {
     private route: ActivatedRoute,
     private router: Router
   ) {
-    this.navigationData = this.router.getCurrentNavigation().extras.state.data;
+    const currentNavigation = this.router.getCurrentNavigation();
+    // Safely access data with optional chaining
+    this.navigationData = currentNavigation?.extras?.state?.data;
+
     this.route.data.subscribe((data: { actionButtonData: any }) => {
       this.actionButtonData = data.actionButtonData;
     });
@@ -110,9 +113,9 @@ export class LoanAccountActionsComponent {
         this.actionName = 'Assign Loan Officer';
       }
       for (const key of Object.keys(this.actions)) {
-        this.actions[key] = false;
+        this.actions[key as keyof typeof this.actions] = false;
       }
-      this.actions[this.actionName] = true;
+      this.actions[this.actionName as keyof typeof this.actions] = true;
     });
   }
 }


### PR DESCRIPTION
**Description**

Fixed a critical bug in the LoanAccountActionsComponent where navigation to the component would fail when clicking on the checkbox in the Loan Accounts section. The issue was caused by attempting to access properties on undefined navigation state data. Added optional chaining and null checks to handle cases when navigation state data is missing, preventing the application from crashing with "Cannot read properties of undefined (reading 'data')" errors.

Related issues and discussion
This fix addresses the issue where users would see a blank page when clicking on the ticked checkbox in the Action column for Loan Accounts. The error was causing the page to fail to load, preventing users from performing loan approval actions.

fix [WEB-28](https://mifosforge.jira.com/browse/WEB-28)

## Screenshots

**Before**


https://github.com/user-attachments/assets/f4758f1f-7a23-44e9-84c9-bc8a519049aa


**After**


https://github.com/user-attachments/assets/f0b8cee2-5668-4240-9713-5dc5ab6aac14



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-28]: https://mifosforge.jira.com/browse/WEB-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ