### PR TITLE
Fixed Redundant "Add Clients" button 

### DIFF
--- a/src/app/groups/groups-view/groups-view.component.html
+++ b/src/app/groups/groups-view/groups-view.component.html
@@ -78,12 +78,6 @@
           </mat-icon>
           <span>{{ 'labels.buttons.Edit' | translate }}</span>
         </button>
-        <button mat-menu-item *mifosxHasPermission="'CREATE_CLIENT'" (click)="doAction('Manage Members')">
-          <mat-icon matListIcon>
-            <fa-icon icon="plus" size="sm"></fa-icon>
-          </mat-icon>
-          <span>{{ 'labels.buttons.Add Clients' | translate }}</span>
-        </button>
         <button mat-menu-item *mifosxHasPermission="'ASSOCIATECLIENTS_GROUP'" (click)="doAction('Transfer Clients')">
           <mat-icon matListIcon>
             <fa-icon icon="users" size="sm"></fa-icon>


### PR DESCRIPTION
## Description

Go to a group and click the button "Add Clients" and "Manage Members" of groups. Both of them lead to the "Manage Members" page.

This UI causes confusion since the "Manage Members" page already includes an option to add clients. 
To improve clarity, the best solution is to remove the "Add Clients" button from the group page.

This ensures that all client related management like adding/deleting happens under "Manage Members"

## Related issues and discussion

Fixes WEB-49
https://mifosforge.jira.com/browse/WEB-49

## Screenshots, if any
Before:
![image](https://github.com/user-attachments/assets/3b6e8b2a-37c5-49d2-a40d-16d03b9e995d)

Manage members page:
![image](https://github.com/user-attachments/assets/3579a82a-9547-4336-8ac8-21e72838b53b)

After:
![image](https://github.com/user-attachments/assets/09c066d1-e235-43b7-9e21-e57d5c15e494)



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
