### PR TITLE
fix: Ensure missing keys display original text instead of prefixed labels

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -40,8 +40,20 @@ import { PortalModule } from '@angular/cdk/portal';
 /** Main Routing Module */
 import { AppRoutingModule } from './app-routing.module';
 import { DatePipe, LocationStrategy } from '@angular/common';
-import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import {
+  TranslateLoader,
+  TranslateModule,
+  MissingTranslationHandler,
+  MissingTranslationHandlerParams
+} from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+
+export class CustomMissingTranslationHandler implements MissingTranslationHandler {
+  handle(params: MissingTranslationHandlerParams): string {
+    // Remove the 'labels.catalogs.' prefix and return the fallback value
+    return params.key.replace('labels.catalogs.', '');
+  }
+}
 
 /**
  * App Module
@@ -66,7 +78,8 @@ export function HttpLoaderFactory(http: HttpClient) {
           HttpBackend,
           LocationStrategy
         ]
-      }
+      },
+      missingTranslationHandler: { provide: MissingTranslationHandler, useClass: CustomMissingTranslationHandler }
     }),
     BrowserModule,
     BrowserAnimationsModule,

--- a/src/app/clients/clients-view/address-tab/address-tab.component.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.ts
@@ -156,7 +156,7 @@ export class AddressTabComponent {
 
     for (let index = 0; index < this.clientAddressTemplate.addressTypeIdOptions.length; index++) {
       this.clientAddressTemplate.addressTypeIdOptions[index].name = this.translateService.instant(
-        `${this.clientAddressTemplate.addressTypeIdOptions[index].name}`
+        `labels.catalogs.${this.clientAddressTemplate.addressTypeIdOptions[index].name}`
       );
     }
 


### PR DESCRIPTION

## Description

This PR fixes an issue where dropdown options were displaying raw translation keys prefixed with `labels.catalogs.` instead of the actual values when a translation was missing from the JSON catalog.

### **Key Changes:**
- **Added a custom `MissingTranslationHandler` in `app.module.ts`** to ensure missing translation keys default to their original text instead of displaying the prefixed label.
- **Updated `TranslateModule` configuration** to apply this behavior globally across the application.
- **Removed an unnecessary change in `address-tab.component.ts`** that was introduced in a previous PR but was no longer required as this fix resolves the issue properly.



## Related issues and discussion
- **JIRA Issue:** [WEB-56](https://mifosforge.jira.com/browse/WEB-56) 
- **Related discussion:** [WEB-42](https://mifosforge.jira.com/browse/WEB-42)

## Screenshots, if any
![Working dropdown](https://github.com/user-attachments/assets/4360dfe1-410e-4309-a3e4-b8ae53834599)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-56]: https://mifosforge.jira.com/browse/WEB-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-42]: https://mifosforge.jira.com/browse/WEB-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ