### PR TITLE
Fixed client and group page responsiveness

### DIFF
--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -53,7 +53,7 @@
             <b>{{ 'labels.inputs.Client Name' | translate }} :</b
             ><mifosx-entity-name entityName="{{ clientViewData.displayName }}"></mifosx-entity-name>
           </h3>
-          <div fxFlex="5%">
+          <div fxFlex="5%" fxLayoutAlign="end center">
             <button mat-icon-button [matMenuTriggerFor]="clientMenu" aria-label="Client actions" yPosition="below">
               <mat-icon matListIcon class="actions-menu">
                 <fa-icon icon="bars" size="sm"></fa-icon>

--- a/src/app/groups/groups-view/groups-view.component.html
+++ b/src/app/groups/groups-view/groups-view.component.html
@@ -18,7 +18,7 @@
             {{ 'labels.heading.Group Name' | translate }} : {{ groupViewData.name }}
           </h3>
 
-          <div fxFlex="5%">
+          <div fxFlex="5%" fxFlex.sm="10%" fxFlex.md="5%" fxFlex.xs="15%">
             <button mat-icon-button [matMenuTriggerFor]="groupMenu" aria-label="Group actions" yPosition="below">
               <mat-icon matListIcon class="actions-menu">
                 <fa-icon icon="bars" size="sm"></fa-icon>

--- a/src/app/groups/groups-view/groups-view.component.scss
+++ b/src/app/groups/groups-view/groups-view.component.scss
@@ -34,7 +34,7 @@
 
   .group-meeting {
     align-self: flex-end;
-    width: 300px;
+    width: 100%;
 
     div,
     ng-template > div {


### PR DESCRIPTION
## Description
Go to Institution, then go to Groups or Clients, it appears like this: 
![image](https://github.com/user-attachments/assets/97e4e346-65d1-4c89-840c-ded708e5f3e8)

However, when we resize the screen to any phone size, we can see the meeting details, they are overflowing, and also the hamburger icon cannot be seen and is unusable.


## Related issues and discussion

Fixes WEB-58: https://mifosforge.jira.com/browse/WEB-58

## Screenshots, if any
Before: 
![image](https://github.com/user-attachments/assets/39d4b892-e649-4c41-a7b5-b4928db03133)
![image](https://github.com/user-attachments/assets/f5874cc1-f2b8-4d72-9702-2d07903f14e8)

After:
![image](https://github.com/user-attachments/assets/6da46c1b-d91e-4eea-b96d-a9668a297f5f)
![image](https://github.com/user-attachments/assets/8df42ea1-b1d5-40a7-844d-492c7f50873c)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
