### PR TITLE
fix: Improve S3 Export Validation by Checking all amazon S3 configurations

### DIFF
--- a/src/app/reports/run-report/run-report.component.ts
+++ b/src/app/reports/run-report/run-report.component.ts
@@ -85,12 +85,23 @@ export class RunReportComponent implements OnInit {
     this.route.data.subscribe((data: { reportParameters: ReportParameter[]; configurations: any }) => {
       this.paramData = data.reportParameters;
       if (this.isTableReport()) {
-        data.configurations.globalConfiguration.forEach((config: GlobalConfiguration) => {
-          if (config.name === 'report-export-s3-folder-name') {
-            this.exportToS3Allowed = config.enabled;
-            this.exportToS3Repository = config.stringValue;
-          }
-        });
+        const amazonS3Config = data.configurations.globalConfiguration.find(
+          (config: GlobalConfiguration) => config.name === 'amazon-s3'
+        );
+        const reportExportS3Config = data.configurations.globalConfiguration.find(
+          (config: GlobalConfiguration) => config.name === 'report-export-s3-folder-name'
+        );
+
+        if (
+          amazonS3Config &&
+          amazonS3Config.enabled &&
+          reportExportS3Config &&
+          reportExportS3Config.enabled &&
+          reportExportS3Config.stringValue
+        ) {
+          this.exportToS3Allowed = true;
+          this.exportToS3Repository = reportExportS3Config.stringValue;
+        }
       }
     });
   }


### PR DESCRIPTION
## Description

It improves the logic for enabling report exports to S3. Previously, `exportToS3Allowed` was determined solely by the `report-export-s3-folder-name` configuration. However, this did not ensure that Amazon S3 itself was enabled, leading to potential misconfigurations.

Now, `exportToS3Allowed` is set to true only if:
- The `amazon-s3` configuration is present and enabled.
- The `report-export-s3-folder-name` configuration is enabled and has a valid stringValue.

## Related issues and discussion

Partially solves [WEB-46](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?selectedIssue=WEB-46)

## Screenshots, if any

- If exportToS3Allowed is not allowed based on the conditions
![image](https://github.com/user-attachments/assets/5572245b-0b5d-45a6-8b56-3861006b3ce4)

- If exportToS3Allowed is allowed
![image](https://github.com/user-attachments/assets/a2a7592b-7c00-4598-8132-f597ddfe3f81)
![image](https://github.com/user-attachments/assets/788eeb86-016c-4173-9775-f822bacbf99d)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
