### PR TITLE
fix: created by (user) adding Client Note bug

### DIFF
--- a/src/app/clients/clients-view/notes-tab/notes-tab.component.ts
+++ b/src/app/clients/clients-view/notes-tab/notes-tab.component.ts
@@ -1,5 +1,5 @@
 /** Angular Imports */
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Components */
@@ -16,7 +16,7 @@ import { AuthenticationService } from 'app/core/authentication/authentication.se
   templateUrl: './notes-tab.component.html',
   styleUrls: ['./notes-tab.component.scss']
 })
-export class NotesTabComponent {
+export class NotesTabComponent implements OnInit {
   /** Client ID */
   entityId: string;
   /** Username */
@@ -34,9 +34,13 @@ export class NotesTabComponent {
     private clientsService: ClientsService,
     private authenticationService: AuthenticationService
   ) {
+    this.entityId = this.route.parent.snapshot.params['clientId'];
+    this.addNote = this.addNote.bind(this);
+  }
+
+  ngOnInit(): void {
     const credentials = this.authenticationService.getCredentials();
     this.username = credentials.username;
-    this.entityId = this.route.parent.snapshot.params['clientId'];
     this.route.data.subscribe((data: { clientNotes: any }) => {
       this.entityNotes = data.clientNotes;
     });


### PR DESCRIPTION
### Description
When adding a note to a client, the "Created By" (user) was not reflected immediately. However, after a page refresh, it appeared correctly.

#### Root Cause
The issue was due to a mismatch in the this context when calling addNote(). The this reference inside addNote() was different from the one used during component initialization, leading to this.username being undefined.

#### Fix
Ensured that this.addNote() was binded to the correct this.
Kept the constructor clean and moved logic to ngOnInit()

### Related issues and discussion
Fixed issue [WEB-66](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?selectedIssue=WEB-66)

### Screenshots, if any
![image](https://github.com/user-attachments/assets/6066b6f6-073e-494d-aa38-6b544949471a)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-66]: https://mifosforge.jira.com/browse/WEB-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ