### PR TITLE
Introduce a new type of ACTUAL during calculation of days in year

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/edit-repayment-schedule/edit-repayment-schedule.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/edit-repayment-schedule/edit-repayment-schedule.component.html
@@ -1,8 +1,9 @@
 <div class="container mat-elevation-z8">
   <mat-card>
     <mat-card-content>
-      <div fxLayout="column">
+      <div fxLayout="column" class="m-b-10">
         <mifosx-repayment-schedule-tab
+          *ngIf="repaymentScheduleDetails"
           fxFlex="100%"
           [repaymentScheduleDetails]="repaymentScheduleDetails"
           [forEditing]="true"
@@ -14,7 +15,7 @@
         <button type="button" mat-raised-button [routerLink]="['../../general']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
-        <button type="button" (click)="reset()">{{ 'labels.buttons.Reset' | translate }}</button>
+        <button type="button" mat-raised-button (click)="reset()">{{ 'labels.buttons.Reset' | translate }}</button>
         <button type="button" color="primary" mat-raised-button (click)="applyPattern()">
           {{ 'labels.buttons.Pattern' | translate }}
         </button>

--- a/src/app/loans/loans-view/loan-account-actions/edit-repayment-schedule/edit-repayment-schedule.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/edit-repayment-schedule/edit-repayment-schedule.component.ts
@@ -24,7 +24,7 @@ export class EditRepaymentScheduleComponent implements OnInit {
   /** Indicates If the Schedule has been validated */
   wasValidated = false;
   /** Stores the Repayment Schedule data */
-  repaymentScheduleDetails: any[] = [];
+  repaymentScheduleDetails: any[] | null = null;
   /** Stores the Installments changed */
   repaymentScheduleChanges: any = {};
 

--- a/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.html
+++ b/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  <div fxLayout="row" class="m-t-20" fxLayoutAlign="end center">
+  <div fxLayout="row" class="m-t-20" fxLayoutAlign="end center" *ngIf="!forEditing">
     <button mat-raised-button color="primary" (click)="exportToPDF()">
       <fa-icon icon="download" class="m-r-10"></fa-icon>Export to PDF
     </button>
@@ -8,52 +8,52 @@
   <table mat-table [dataSource]="repaymentScheduleDetails.periods" *ngIf="!forEditing" id="repaymentSchedule">
     <ng-container matColumnDef="number">
       <th mat-header-cell class="center" *matHeaderCellDef>#</th>
-      <td mat-cell class="right" *matCellDef="let ele">{{ ele.period }}</td>
+      <td mat-cell class="right" *matCellDef="let item">{{ item.period }}</td>
       <td mat-footer-cell *matFooterCellDef>&nbsp;</td>
     </ng-container>
 
     <ng-container matColumnDef="days">
       <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Days' | translate }}</th>
-      <td mat-cell class="center" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">{{ ele.daysInPeriod }}</td>
+      <td mat-cell class="center" *matCellDef="let item" [ngClass]="installmentStyle(item)">{{ item.daysInPeriod }}</td>
       <td mat-footer-cell class="center" *matFooterCellDef><b> Total</b></td>
     </ng-container>
 
     <ng-container matColumnDef="date">
       <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Date' | translate }}</th>
-      <td mat-cell class="m-r-5" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.dueDate | dateFormat }}
+      <td mat-cell class="m-r-5" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.dueDate | dateFormat }}
       </td>
       <td mat-footer-cell *matFooterCellDef></td>
     </ng-container>
 
     <ng-container matColumnDef="paiddate">
       <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Paid Date' | translate }}</th>
-      <td mat-cell class="center" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.obligationsMetOnDate | dateFormat }}
+      <td mat-cell class="center" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.obligationsMetOnDate | dateFormat }}
       </td>
       <td mat-footer-cell *matFooterCellDef></td>
     </ng-container>
 
     <ng-container matColumnDef="check">
       <th mat-header-cell *matHeaderCellDef>&nbsp;</th>
-      <td mat-cell class="center" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        <span *ngIf="ele.obligationsMetOnDate"> <i class="fa fa-check"></i> </span>
+      <td mat-cell class="center" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        <span *ngIf="item.obligationsMetOnDate"> <i class="fa fa-check"></i> </span>
       </td>
       <td mat-footer-cell *matFooterCellDef></td>
     </ng-container>
 
     <ng-container matColumnDef="balanceOfLoan">
       <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance Of Loan' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.principalLoanBalanceOutstanding | formatNumber }}
+      <td mat-cell class="r-amount" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.principalLoanBalanceOutstanding | formatNumber }}
       </td>
       <td mat-footer-cell class="r-amount" *matFooterCellDef>&nbsp;</td>
     </ng-container>
 
     <ng-container matColumnDef="principalDue">
       <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Principal Due' | translate }}</th>
-      <td mat-cell class="check r-amount" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.principalDue | formatNumber }}
+      <td mat-cell class="check r-amount" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.principalDue | formatNumber }}
       </td>
       <td mat-footer-cell class="check r-amount" *matFooterCellDef>
         <b>
@@ -64,8 +64,8 @@
 
     <ng-container matColumnDef="interest">
       <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Interest' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.interestOriginalDue | formatNumber }}
+      <td mat-cell class="r-amount" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.interestOriginalDue | formatNumber }}
       </td>
       <td mat-footer-cell class="r-amount" *matFooterCellDef>
         <b>
@@ -76,8 +76,8 @@
 
     <ng-container matColumnDef="fees">
       <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Fees' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.feeChargesDue | formatNumber }}
+      <td mat-cell class="r-amount" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.feeChargesDue | formatNumber }}
       </td>
       <td mat-footer-cell class="r-amount" *matFooterCellDef>
         <b>
@@ -88,8 +88,8 @@
 
     <ng-container matColumnDef="penalties">
       <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Penalties' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.penaltyChargesDue | formatNumber }}
+      <td mat-cell class="r-amount" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.penaltyChargesDue | formatNumber }}
       </td>
       <td mat-footer-cell class="r-amount" *matFooterCellDef>
         <b>
@@ -100,8 +100,8 @@
 
     <ng-container matColumnDef="due">
       <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Due' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.totalDueForPeriod | formatNumber }}
+      <td mat-cell class="r-amount" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.totalDueForPeriod | formatNumber }}
       </td>
       <td mat-footer-cell class="r-amount" *matFooterCellDef>
         <b>
@@ -112,8 +112,8 @@
 
     <ng-container matColumnDef="paid">
       <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Paid' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.totalPaidForPeriod | formatNumber }}
+      <td mat-cell class="r-amount" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.totalPaidForPeriod | formatNumber }}
       </td>
       <td mat-footer-cell class="r-amount" *matFooterCellDef>
         <b> {{ repaymentScheduleDetails.totalRepayment | currency: currencyCode : 'symbol-narrow' : '1.2-2' }} </b>
@@ -122,8 +122,8 @@
 
     <ng-container matColumnDef="inadvance">
       <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.In advance' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.totalPaidInAdvanceForPeriod | formatNumber }}
+      <td mat-cell class="r-amount" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.totalPaidInAdvanceForPeriod | formatNumber }}
       </td>
       <td mat-footer-cell class="r-amount" *matFooterCellDef>
         <b> {{ repaymentScheduleDetails.totalPaidInAdvance | currency: currencyCode : 'symbol-narrow' : '1.2-2' }} </b>
@@ -132,8 +132,8 @@
 
     <ng-container matColumnDef="late">
       <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Late' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-        {{ ele.totalPaidLateForPeriod | formatNumber }}
+      <td mat-cell class="r-amount" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+        {{ item.totalPaidLateForPeriod | formatNumber }}
       </td>
       <td mat-footer-cell class="r-amount" *matFooterCellDef>
         <b> {{ repaymentScheduleDetails.totalPaidLate | currency: currencyCode : 'symbol-narrow' : '1.2-2' }} </b>
@@ -143,8 +143,8 @@
     <ng-container *ngIf="isWaived">
       <ng-container matColumnDef="waived">
         <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Waived' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let ele" [ngClass]="installmentStyle(ele)">
-          {{ ele.totalWaivedForPeriod | formatNumber }}
+        <td mat-cell class="r-amount" *matCellDef="let item" [ngClass]="installmentStyle(item)">
+          {{ item.totalWaivedForPeriod | formatNumber }}
         </td>
         <td mat-footer-cell class="r-amount" *matFooterCellDef>
           <b> {{ repaymentScheduleDetails.totalWaived | currency: currencyCode : 'symbol-narrow' : '1.2-2' }} </b>
@@ -155,14 +155,14 @@
     <ng-container *ngIf="!isWaived">
       <ng-container matColumnDef="waived">
         <th mat-header-cell *matHeaderCellDef></th>
-        <td mat-cell *matCellDef="let ele"></td>
+        <td mat-cell *matCellDef="let item"></td>
         <td mat-footer-cell *matFooterCellDef><b> </b></td>
       </ng-container>
     </ng-container>
 
     <ng-container matColumnDef="outstanding">
       <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Outstanding' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let ele">{{ ele.totalOutstandingForPeriod | formatNumber }}</td>
+      <td mat-cell class="r-amount" *matCellDef="let item">{{ item.totalOutstandingForPeriod | formatNumber }}</td>
       <td mat-footer-cell class="r-amount" *matFooterCellDef>
         <b> {{ repaymentScheduleDetails.totalOutstanding | currency: currencyCode : 'symbol-narrow' : '1.2-2' }} </b>
       </td>
@@ -200,98 +200,95 @@
   </table>
 
   <!-- Repayment Schedule to be Edited -->
-  <div *ngIf="forEditing" fxLayout="column" fxFlex="100%">
-    <table mat-table [dataSource]="repaymentScheduleDetails.periods">
-      <ng-container matColumnDef="number">
-        <th mat-header-cell class="center" *matHeaderCellDef>#</th>
-        <td mat-cell *matCellDef="let ele">{{ ele.period }}</td>
-        <td mat-footer-cell *matFooterCellDef>&nbsp;</td>
-      </ng-container>
+  <table
+    mat-table
+    [dataSource]="repaymentScheduleDetails.periods"
+    *ngIf="forEditing && repaymentScheduleDetails.periods.length > 0"
+  >
+    <ng-container matColumnDef="number">
+      <th mat-header-cell class="center" *matHeaderCellDef>#</th>
+      <td mat-cell *matCellDef="let item">{{ item.period }}</td>
+    </ng-container>
 
-      <ng-container matColumnDef="date">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Date' | translate }}</th>
-        <td mat-cell class="m-r-10" *matCellDef="let ele">{{ ele.dueDate | dateFormat }}</td>
-        <td mat-footer-cell *matFooterCellDef></td>
-      </ng-container>
+    <ng-container matColumnDef="date">
+      <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Date' | translate }}</th>
+      <td mat-cell class="m-r-10" *matCellDef="let item">
+        <ng-container>
+          {{ item.dueDate | dateFormat }}
+        </ng-container>
+      </td>
+    </ng-container>
 
-      <ng-container matColumnDef="balanceOfLoan">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance Of Loan' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let ele">
-          {{ ele.principalLoanBalanceOutstanding | formatNumber }}
-        </td>
-        <td mat-footer-cell class="r-amount" *matFooterCellDef>&nbsp;</td>
-      </ng-container>
+    <ng-container matColumnDef="balanceOfLoan">
+      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance Of Loan' | translate }}</th>
+      <td mat-cell class="r-amount" *matCellDef="let item">
+        {{ item.principalLoanBalanceOutstanding | formatNumber }}
+      </td>
+    </ng-container>
 
-      <ng-container matColumnDef="principalDue">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Principal Due' | translate }}</th>
-        <td mat-cell class="check r-amount" *matCellDef="let ele">{{ ele.principalDue | formatNumber }}</td>
-        <td mat-footer-cell class="check r-amount" *matFooterCellDef>
-          <b>
-            {{
-              repaymentScheduleDetails.totalPrincipalExpected | currency: currencyCode : 'symbol-narrow' : '1.2-2'
-            }}</b
-          >
-        </td>
-      </ng-container>
+    <ng-container matColumnDef="principalDue">
+      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Principal Due' | translate }}</th>
+      <td mat-cell class="r-amount" *matCellDef="let item">
+        <ng-container>
+          {{ item.principalDue | formatNumber }}
+        </ng-container>
+      </td>
+    </ng-container>
 
-      <ng-container matColumnDef="interest">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Interest' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let ele">{{ ele.interestOriginalDue | formatNumber }}</td>
-        <td mat-footer-cell class="r-amount" *matFooterCellDef>
-          <b>
-            {{ repaymentScheduleDetails.totalInterestCharged | currency: currencyCode : 'symbol-narrow' : '1.2-2' }}
-          </b>
-        </td>
-      </ng-container>
+    <ng-container matColumnDef="interest">
+      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Interest' | translate }}</th>
+      <td mat-cell class="r-amount" *matCellDef="let item">{{ item.interestOriginalDue | formatNumber }}</td>
+    </ng-container>
 
-      <ng-container matColumnDef="fees">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Fees' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let ele">{{ ele.feeChargesDue | formatNumber }}</td>
-        <td mat-footer-cell class="r-amount" *matFooterCellDef>
-          <b>
-            {{ repaymentScheduleDetails.totalFeeChargesCharged | currency: currencyCode : 'symbol-narrow' : '1.2-2' }}
-          </b>
-        </td>
-      </ng-container>
+    <ng-container matColumnDef="fees">
+      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Fees' | translate }}</th>
+      <td mat-cell class="r-amount" *matCellDef="let item">{{ item.feeChargesDue | formatNumber }}</td>
+    </ng-container>
 
-      <ng-container matColumnDef="due">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Installment Amount' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let ele">
-          <span *ngIf="!ele.changed">
-            {{ ele.totalDueForPeriod | formatNumber }}
-          </span>
-          <span *ngIf="ele.changed" class="amount-changed">
-            <b>{{ ele.totalDueForPeriod | formatNumber }}</b>
-          </span>
-        </td>
-        <td mat-footer-cell class="r-amount" *matFooterCellDef>
-          <b>
-            {{ repaymentScheduleDetails.totalRepaymentExpected | currency: currencyCode : 'symbol-narrow' : '1.2-2' }}
-          </b>
-        </td>
-      </ng-container>
+    <ng-container matColumnDef="due">
+      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Installment Amount' | translate }}</th>
+      <td mat-cell class="r-amount" *matCellDef="let item">
+        <span *ngIf="!item.changed">
+          {{ item.totalDueForPeriod | formatNumber }}
+        </span>
+        <span *ngIf="item.changed" class="amount-changed">
+          <b>{{ item.totalDueForPeriod | formatNumber }}</b>
+        </span>
+      </td>
+    </ng-container>
 
-      <ng-container matColumnDef="actions">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let ele">
-          <button
-            *ngIf="ele.period"
-            type="button"
-            color="primary"
-            mat-icon-button
-            matTooltip="{{ 'tooltips.Edit' | translate }}"
-            matTooltipPosition="above"
-            (click)="editPeriod(ele)"
-          >
-            <fa-icon icon="edit" size="lg"></fa-icon>
-          </button>
-        </td>
-        <td mat-footer-cell *matFooterCellDef></td>
-      </ng-container>
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+      <td mat-cell class="center" *matCellDef="let item">
+        <span *ngIf="item.period && item.period + 1 < repaymentScheduleDetails.periods.length">
+          <ng-container>
+            <button
+              type="button"
+              color="primary"
+              mat-icon-button
+              matTooltip="{{ 'tooltips.Edit' | translate }}"
+              matTooltipPosition="above"
+              (click)="editInstallment(item)"
+            >
+              <fa-icon icon="edit" size="lg"></fa-icon>
+            </button>
+            <button
+              type="button"
+              color="warn"
+              mat-icon-button
+              matTooltip="{{ 'tooltips.Delete' | translate }}"
+              matTooltipPosition="above"
+              (click)="startEdit(item.period)"
+            >
+              <fa-icon icon="trash" size="lg"></fa-icon>
+            </button>
+          </ng-container>
+        </span>
+      </td>
+      <td mat-footer-cell *matFooterCellDef></td>
+    </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumnsEdit"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumnsEdit"></tr>
-      <tr mat-footer-row *matFooterRowDef="displayedColumnsEdit"></tr>
-    </table>
-  </div>
+    <tr mat-header-row *matHeaderRowDef="displayedColumnsEdit"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumnsEdit"></tr>
+  </table>
 </div>

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -496,6 +496,11 @@
     <span fxFlex="53%">{{ loanProduct.daysInYearType?.value | translateKey: 'catalogs' }}</span>
   </div>
 
+  <div fxFlexFill *ngIf="isAdvancedPaymentAllocation && loanProduct.daysInYearCustomStrategy">
+    <span fxFlex="47%">{{ 'labels.inputs.Days in year custom strategy' | translate }}:</span>
+    <span fxFlex="53%">{{ loanProduct.daysInYearCustomStrategy.value | translateKey: 'catalogs' }}</span>
+  </div>
+
   <div fxFlexFill>
     <span fxFlex="47%">{{ 'labels.inputs.Days in month' | translate }}:</span>
     <span fxFlex="53%">{{ loanProduct.daysInMonthType?.value | translateKey: 'catalogs' }}</span>

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
@@ -275,6 +275,13 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
         this.loanProductsTemplate.daysInYearTypeOptions
       );
       this.loanProduct.daysInYearType = optionValue;
+      if (this.isAdvancedPaymentAllocation && this.loanProduct.daysInYearType.id == 1) {
+        optionValue = this.optionDataLookUp(
+          this.loanProduct.daysInYearCustomStrategy,
+          this.loanProductsTemplate.daysInYearCustomStrategyOptions
+        );
+      }
+      this.loanProduct.daysInYearCustomStrategy = optionValue;
       optionValue = this.optionDataLookUp(
         this.loanProduct.interestRateFrequencyType,
         this.loanProductsTemplate.interestRateFrequencyTypeOptions

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.scss
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.scss
@@ -1,4 +1,6 @@
 .container {
+  max-width: 86rem;
+  width: 96%;
   padding-bottom: 30px;
 }
 

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.scss
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.scss
@@ -1,3 +1,5 @@
 .container {
+  max-width: 86rem;
+  width: 96%;
   padding-bottom: 30px;
 }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -330,6 +330,21 @@
       </mat-error>
     </mat-form-field>
 
+    <mat-form-field fxFlex="48%" *ngIf="useDaysInYearCustomStrategy">
+      <mat-label>{{ 'labels.inputs.Days in year custom strategy' | translate }}</mat-label>
+      <mat-select
+        matTooltip="{{ 'tooltips.To calculate interest' | translate }}"
+        formControlName="daysInYearCustomStrategy"
+      >
+        <mat-option
+          *ngFor="let daysInYearCustomStrategy of daysInYearCustomStrategyOptions"
+          [value]="daysInYearCustomStrategy.id"
+        >
+          {{ daysInYearCustomStrategy.value | translateKey: 'catalogs' }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
     <mat-form-field fxFlex="48%">
       <mat-label>{{ 'labels.inputs.Days in month' | translate }}</mat-label>
       <mat-select

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -45,6 +45,8 @@ export class LoanProductSettingsStepComponent implements OnInit {
   useDueForRepaymentsConfigurations = false;
   rescheduleStrategyTypeDisabled = false;
   chargeOffBehaviourData: StringEnumOptionData[] = [];
+  daysInYearCustomStrategyOptions: OptionData[] = [];
+  useDaysInYearCustomStrategy = false;
 
   /** Values to Days for Repayments */
   defaultConfigValues: GlobalConfiguration[] = [];
@@ -88,8 +90,7 @@ export class LoanProductSettingsStepComponent implements OnInit {
     this.loanScheduleTypeData = this.loanProductsTemplate.loanScheduleTypeOptions;
     this.loanScheduleProcessingTypeData = this.loanProductsTemplate.loanScheduleProcessingTypeOptions;
     this.chargeOffBehaviourData = this.loanProductsTemplate.chargeOffBehaviourOptions;
-
-    // this.useDueForRepaymentsConfigurations = (!this.loanProduct.dueDaysForRepaymentEvent && !this.loanProduct.overDueDaysForRepaymentEvent);
+    this.daysInYearCustomStrategyOptions = this.loanProductsTemplate.daysInYearCustomStrategyOptions;
 
     const transactionProcessingStrategyCode: string =
       this.loanProductsTemplate.transactionProcessingStrategyCode || this.transactionProcessingStrategyData[0].code;
@@ -318,6 +319,23 @@ export class LoanProductSettingsStepComponent implements OnInit {
 
   setConditionalControls() {
     const allowAttributeOverrides = this.loanProductSettingsForm.get('allowAttributeOverrides');
+
+    this.loanProductSettingsForm.get('daysInYearType').valueChanges.subscribe((daysInYearType: any) => {
+      if (this.isAdvancedTransactionProcessingStrategy) {
+        this.useDaysInYearCustomStrategy = daysInYearType == 1;
+        if (this.useDaysInYearCustomStrategy) {
+          const daysInYearCustomStrategy: string = this.loanProductsTemplate.daysInYearCustomStrategy?.id
+            ? this.loanProductsTemplate.daysInYearCustomStrategy.id
+            : '';
+          this.loanProductSettingsForm.addControl(
+            'daysInYearCustomStrategy',
+            new UntypedFormControl(daysInYearCustomStrategy, Validators.required)
+          );
+        } else {
+          this.loanProductSettingsForm.removeControl('daysInYearCustomStrategy');
+        }
+      }
+    });
 
     this.loanProductSettingsForm
       .get('interestCalculationPeriodType')
@@ -696,6 +714,7 @@ export class LoanProductSettingsStepComponent implements OnInit {
     if (productSettings['delinquencyBucketId'] === '') {
       productSettings['delinquencyBucketId'] = null;
     }
+    console.log(productSettings);
     return productSettings;
   }
 

--- a/src/app/products/loan-products/models/loan-product.model.ts
+++ b/src/app/products/loan-products/models/loan-product.model.ts
@@ -52,6 +52,7 @@ export interface LoanProduct {
   paymentAllocation?: PaymentAllocation[];
   creditAllocation?: CreditAllocation[];
   daysInMonthType: OptionData;
+  daysInYearCustomStrategy?: OptionData;
   daysInYearType: OptionData;
   isInterestRecalculationEnabled: boolean;
   interestRecalculationData?: InterestRecalculationData;

--- a/src/app/products/loan-products/view-loan-product/view-loan-product.component.scss
+++ b/src/app/products/loan-products/view-loan-product/view-loan-product.component.scss
@@ -1,6 +1,6 @@
 .product-card {
   margin: 0 auto;
-  max-width: 80rem;
+  max-width: 90rem;
   width: 90%;
   padding: 0;
 

--- a/src/app/shared/icons.module.ts
+++ b/src/app/shared/icons.module.ts
@@ -111,7 +111,8 @@ import {
   faCalendarCheck,
   faPause,
   faReceipt,
-  faTableCells
+  faTableCells,
+  faSave
 } from '@fortawesome/free-solid-svg-icons';
 
 /**
@@ -235,7 +236,8 @@ export class IconsModule {
       faBars,
       faUndo,
       faReceipt,
-      faTableCells
+      faTableCells,
+      faSave
     );
   }
 }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -741,7 +741,9 @@
       "Check loan repayment due": "Zkontrolujte splatnost půjčky",
       "Transfer to Savings": "Převod do Úspory",
       "Zero interest after charge-off": "Nulový úrok po nabití",
-      "Accelerate maturity to charge-off date": "Urychlete splatnost do data odúčtování"
+      "Accelerate maturity to charge-off date": "Urychlete splatnost do data odúčtování",
+      "Full Leap Year": "Úplný přestupný rok",
+      "Feb 29 Period Only": "Pouze období 29. února"
     },
     "commons": {
       "50 characters long": "50 znaků dlouhé",
@@ -1458,6 +1460,7 @@
       "Days From": "Dny od",
       "Days Till": "Dny do",
       "Days in Year": "Dny v roce",
+      "Days in year custom strategy": "Vlastní strategie dnů v roce",
       "Days in month": "Dny v měsíci",
       "Days in year": "Dny v roce",
       "Days to Dormancy": "Dny do dormance",
@@ -2498,6 +2501,7 @@
       "Deposit": "Vklad",
       "Disburse": "Vyplatit",
       "Disburse to Savings": "Výplata na Úspory",
+      "Edit Repayment Schedule": "Upravit splátkový kalendář",
       "Foreclosure": "Exekuce",
       "Frequent Postings": "Časté příspěvky",
       "Frequently Accessed": "Často používané",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -741,7 +741,9 @@
       "Check loan repayment due": "Prüfen Sie, ob die Kreditrückzahlung fällig ist",
       "Transfer to Savings": "Übertragen auf Ersparnisse",
       "Zero interest after charge-off": "Null Zinsen nach Abschreibung",
-      "Accelerate maturity to charge-off date": "Fälligkeit bis zum Abschreibungsdatum beschleunigen"
+      "Accelerate maturity to charge-off date": "Fälligkeit bis zum Abschreibungsdatum beschleunigen",
+      "Full Leap Year": "Volles Schaltjahr",
+      "Feb 29 Period Only": "Nur für den Zeitraum vom 29. Februar"
     },
     "commons": {
       "50 characters long": "50 Zeichen lang",
@@ -1458,6 +1460,7 @@
       "Days From": "Tage ab",
       "Days Till": "Tage bis",
       "Days in Year": "Tage im Jahr",
+      "Days in year custom strategy": "Tage im Jahr, individuelle Strategie",
       "Days in month": "Tage im Monat",
       "Days in year": "Tage im Jahr",
       "Days to Dormancy": "Tage bis zur Ruhephase",
@@ -2498,6 +2501,7 @@
       "Deposit": "Kaution",
       "Disburse": "Auszahlen",
       "Disburse to Savings": "An die Ersparnisse auszahlen",
+      "Edit Repayment Schedule": "Bearbeiten Sie den Rückzahlungsplan",
       "Foreclosure": "Zwangsvollstreckung",
       "Frequent Postings": "Häufige Beiträge",
       "Frequently Accessed": "Häufig aufgerufen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -744,7 +744,9 @@
       "Check loan repayment due": "Check loan repayment due",
       "Transfer to Savings": "Transfer to Savings",
       "Zero interest after charge-off": "Zero interest after charge-off",
-      "Accelerate maturity to charge-off date": "Accelerate maturity to charge-off date"
+      "Accelerate maturity to charge-off date": "Accelerate maturity to charge-off date",
+      "Full Leap Year": "Full Leap Year",
+      "Feb 29 Period Only": "Feb 29 Period Only"
     },
     "commons": {
       "50 characters long": "50 characters long",
@@ -1461,6 +1463,7 @@
       "Days From": "Days From",
       "Days Till": "Days Till",
       "Days in Year": "Days in Year",
+      "Days in year custom strategy": "Days in year custom strategy",
       "Days in month": "Days in month",
       "Days in year": "Days in year",
       "Days to Dormancy": "Days to Dormancy",
@@ -2504,6 +2507,7 @@
       "Deposit": "Deposit",
       "Disburse": "Disburse",
       "Disburse to Savings": "Disburse to Savings",
+      "Edit Repayment Schedule": "Edit Repayment Schedule",
       "Foreclosure": "Foreclosure",
       "Frequent Postings": "Frequent Postings",
       "Frequently Accessed": "Frequently Accessed",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -740,7 +740,9 @@
       "Check loan repayment due": "Verificar pagos a vencer de préstamos",
       "Transfer to Savings": "Transferir a Ahorros",
       "Zero interest after charge-off": "Cero intereses después de la cancelación",
-      "Accelerate maturity to charge-off date": "Acelerar el vencimiento hasta la fecha de amortización"
+      "Accelerate maturity to charge-off date": "Acelerar el vencimiento hasta la fecha de amortización",
+      "Full Leap Year": "Año bisiesto completo",
+      "Feb 29 Period Only": "Solo periodo del 29 de febrero"
     },
     "commons": {
       "50 characters long": "50 caracteres de largo",
@@ -1457,6 +1459,7 @@
       "Days From": "Días desde",
       "Days Till": "Días hasta",
       "Days in Year": "Días en el año",
+      "Days in year custom strategy": "Estrategia personalizada de días en el año",
       "Days in month": "Dias en el mes",
       "Days in year": "Dias en el año",
       "Days to Dormancy": "Días hasta la Inactividad",
@@ -2498,6 +2501,7 @@
       "Deposit": "Depósito",
       "Disburse": "Desembolsar",
       "Disburse to Savings": "Desembolsar a Ahorros",
+      "Edit Repayment Schedule": "Editar calendario de pagos",
       "Foreclosure": "Juicio hipotecario",
       "Frequent Postings": "Publicaciones frecuentes",
       "Frequently Accessed": "Acceso frecuente",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -740,7 +740,9 @@
       "Check loan repayment due": "Verificar pagos a vencer de préstamos",
       "Transfer to Savings": "Transferir a Ahorros",
       "Zero interest after charge-off": "Cero intereses después de la cancelación",
-      "Accelerate maturity to charge-off date": "Acelerar el vencimiento hasta la fecha de amortización"
+      "Accelerate maturity to charge-off date": "Acelerar el vencimiento hasta la fecha de amortización",
+      "Full Leap Year": "Año bisiesto completo",
+      "Feb 29 Period Only": "Solo periodo del 29 de febrero"
     },
     "commons": {
       "50 characters long": "50 caracteres de largo",
@@ -1457,6 +1459,7 @@
       "Days From": "Días desde",
       "Days Till": "Días hasta",
       "Days in Year": "Días en el año",
+      "Days in year custom strategy": "Estrategia personalizada de días en el año",
       "Days in month": "Dias en el mes",
       "Days in year": "Dias en el año",
       "Days to Dormancy": "Días hasta la Inactividad",
@@ -2498,6 +2501,7 @@
       "Deposit": "Depósito",
       "Disburse": "Desembolsar",
       "Disburse to Savings": "Desembolsar a Ahorros",
+      "Edit Repayment Schedule": "Editar calendario de pagos",
       "Foreclosure": "Juicio hipotecario",
       "Frequent Postings": "Publicaciones frecuentes",
       "Frequently Accessed": "Acceso frecuente",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -741,7 +741,9 @@
       "Check loan repayment due": "Vérifier le remboursement du prêt dû",
       "Transfer to Savings": "Transfert vers l'épargne",
       "Zero interest after charge-off": "Zéro intérêt après radiation",
-      "Accelerate maturity to charge-off date": "Accélérer la maturité jusqu'à la date de radiation"
+      "Accelerate maturity to charge-off date": "Accélérer la maturité jusqu'à la date de radiation",
+      "Full Leap Year": "Année bissextile complète",
+      "Feb 29 Period Only": "Période du 29 février seulement"
     },
     "commons": {
       "50 characters long": "50 caractères",
@@ -1458,6 +1460,7 @@
       "Days From": "Jours à partir de",
       "Days Till": "Jours jusqu'à",
       "Days in Year": "Jours dans l'année",
+      "Days in year custom strategy": "Stratégie personnalisée jours par an",
       "Days in month": "Jours dans le mois",
       "Days in year": "Jours dans l'année",
       "Days to Dormancy": "Jours avant la dormance",
@@ -2498,6 +2501,7 @@
       "Deposit": "Dépôt",
       "Disburse": "Débourser",
       "Disburse to Savings": "Versement de l'épargne",
+      "Edit Repayment Schedule": "Modifier le calendrier de remboursement",
       "Foreclosure": "Forclusion",
       "Frequent Postings": "Publications fréquentes",
       "Frequently Accessed": "Fréquemment consulté",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -741,7 +741,9 @@
       "Check loan repayment due": "Controllare il rimborso del prestito in scadenza",
       "Transfer to Savings": "Trasferimento al risparmio",
       "Zero interest after charge-off": "Zero interessi dopo la cancellazione",
-      "Accelerate maturity to charge-off date": "Accelerare la scadenza alla data di cancellazione"
+      "Accelerate maturity to charge-off date": "Accelerare la scadenza alla data di cancellazione",
+      "Full Leap Year": "Anno bisestile completo",
+      "Feb 29 Period Only": "Solo periodo del 29 febbraio"
     },
     "commons": {
       "50 characters long": "50 caratteri di lunghezza",
@@ -1458,6 +1460,7 @@
       "Days From": "Giorni da",
       "Days Till": "Giorni fino",
       "Days in Year": "Giorni nell'anno",
+      "Days in year custom strategy": "Strategia personalizzata per i giorni dell'anno",
       "Days in month": "Giorni nel mese",
       "Days in year": "Giorni nell'anno",
       "Days to Dormancy": "Giorni di dormienza",
@@ -2498,6 +2501,7 @@
       "Deposit": "Depositare",
       "Disburse": "Sborsare",
       "Disburse to Savings": "Versare al risparmio",
+      "Edit Repayment Schedule": "Modifica il piano di rimborso",
       "Foreclosure": "Pignoramento",
       "Frequent Postings": "Pubblicazioni frequenti",
       "Frequently Accessed": "Accesso frequente",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -741,7 +741,9 @@
       "Check loan repayment due": "대출 상환 기한 확인",
       "Transfer to Savings": "저축으로 이체",
       "Zero interest after charge-off": "대손충당 후 이자 없음",
-      "Accelerate maturity to charge-off date": "만기일을 대금상환일로 앞당기세요"
+      "Accelerate maturity to charge-off date": "만기일을 대금상환일로 앞당기세요",
+      "Full Leap Year": "전체 윤년",
+      "Feb 29 Period Only": "2월 29일 기간만"
     },
     "commons": {
       "50 characters long": "50자(영문 기준)",
@@ -1459,6 +1461,7 @@
       "Days From": "일수:",
       "Days Till": "남은 일수",
       "Days in Year": "연간 일수",
+      "Days in year custom strategy": "연간 맞춤형 전략",
       "Days in month": "월별 일수",
       "Days in year": "연간 일수",
       "Days to Dormancy": "휴면까지의 일수",
@@ -2499,6 +2502,7 @@
       "Deposit": "보증금",
       "Disburse": "지불",
       "Disburse to Savings": "저축으로 지출",
+      "Edit Repayment Schedule": "상환 일정 편집",
       "Foreclosure": "유질",
       "Frequent Postings": "자주 게시되는 게시물",
       "Frequently Accessed": "자주 액세스됨",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -741,7 +741,9 @@
       "Check loan repayment due": "Patikrinkite paskolos grąžinimo terminą",
       "Transfer to Savings": "Perkėlimas į santaupas",
       "Zero interest after charge-off": "Nulinės palūkanos po apmokestinimo",
-      "Accelerate maturity to charge-off date": "Paspartinkite terminą iki nurašymo datos"
+      "Accelerate maturity to charge-off date": "Paspartinkite terminą iki nurašymo datos",
+      "Full Leap Year": "Visi keliamieji metai",
+      "Feb 29 Period Only": "Tik vasario 29 d"
     },
     "commons": {
       "50 characters long": "50 simbolių ilgio",
@@ -1458,6 +1460,7 @@
       "Days From": "Dienos nuo",
       "Days Till": "Dienos Iki",
       "Days in Year": "Dienos per metus",
+      "Days in year custom strategy": "Dienų per metus pritaikyta strategija",
       "Days in month": "Dienos per mėnesį",
       "Days in year": "Dienos metuose",
       "Days to Dormancy": "Dienos iki ramybės",
@@ -2498,6 +2501,7 @@
       "Deposit": "Užstatas",
       "Disburse": "Išmokėti",
       "Disburse to Savings": "Išmokėkite santaupoms",
+      "Edit Repayment Schedule": "Redaguoti grąžinimo grafiką",
       "Foreclosure": "Uždarymas",
       "Frequent Postings": "Dažni skelbimai",
       "Frequently Accessed": "Dažnai prieinama",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -741,7 +741,9 @@
       "Check loan repayment due": "Pārbaudiet aizdevuma atmaksas termiņu",
       "Transfer to Savings": "Pārskaitījums uz uzkrājumiem",
       "Zero interest after charge-off": "Nulle procenti pēc atskaitīšanas",
-      "Accelerate maturity to charge-off date": "Paātriniet dzēšanas termiņu līdz izņemšanas datumam"
+      "Accelerate maturity to charge-off date": "Paātriniet dzēšanas termiņu līdz izņemšanas datumam",
+      "Full Leap Year": "Pilns lēciens gads",
+      "Feb 29 Period Only": "Tikai 29. februāris"
     },
     "commons": {
       "50 characters long": "50 rakstzīmes garš",
@@ -1458,6 +1460,7 @@
       "Days From": "Dienas No",
       "Days Till": "Dienas Līdz",
       "Days in Year": "Dienas gadā",
+      "Days in year custom strategy": "Dienu gadā pielāgotā stratēģija",
       "Days in month": "Dienas mēnesī",
       "Days in year": "Dienas gadā",
       "Days to Dormancy": "Dienas līdz miegainībai",
@@ -2498,6 +2501,7 @@
       "Deposit": "Depozīts",
       "Disburse": "Izmaksāt",
       "Disburse to Savings": "Izmaksa uzkrājumiem",
+      "Edit Repayment Schedule": "Rediģēt atmaksas grafiku",
       "Foreclosure": "Preces ierobežošana",
       "Frequent Postings": "Bieža publicēšana",
       "Frequently Accessed": "Bieži piekļūts",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -741,7 +741,9 @@
       "Check loan repayment due": "ऋण तिर्न बाँकी जाँच गर्नुहोस्",
       "Transfer to Savings": "बचतमा स्थानान्तरण गर्नुहोस्",
       "Zero interest after charge-off": "चार्ज अफ पछि शून्य ब्याज",
-      "Accelerate maturity to charge-off date": "चार्ज अफ मितिमा परिपक्वतालाई गति दिनुहोस्"
+      "Accelerate maturity to charge-off date": "चार्ज अफ मितिमा परिपक्वतालाई गति दिनुहोस्",
+      "Full Leap Year": "पूर्ण छलांग वर्ष",
+      "Feb 29 Period Only": "फेब्रुअरी 29 अवधि मात्र"
     },
     "commons": {
       "50 characters long": "५० वर्ण लामो",
@@ -1458,6 +1460,7 @@
       "Days From": "दिनहरू देखि",
       "Days Till": "दिन सम्म",
       "Days in Year": "वर्षमा दिनहरू",
+      "Days in year custom strategy": "वर्ष अनुकूलन रणनीति मा दिन",
       "Days in month": "महिनामा दिनहरू",
       "Days in year": "वर्षमा दिनहरू",
       "Days to Dormancy": "सुप्तावस्थाका दिनहरू",
@@ -2498,6 +2501,7 @@
       "Deposit": "जम्मा",
       "Disburse": "वितरण गर्नुहोस्",
       "Disburse to Savings": "बचतमा वितरण गर्नुहोस्",
+      "Edit Repayment Schedule": "पुन: भुक्तानी तालिका सम्पादन गर्नुहोस्",
       "Foreclosure": "फोरक्लोजर",
       "Frequent Postings": "बारम्बार पोस्टिंगहरू",
       "Frequently Accessed": "बारम्बार पहुँच",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -741,7 +741,9 @@
       "Check loan repayment due": "Verifique o vencimento do empréstimo",
       "Transfer to Savings": "Transferência para Poupança",
       "Zero interest after charge-off": "Juros zero após baixa",
-      "Accelerate maturity to charge-off date": "Acelerar o vencimento até à data de baixa"
+      "Accelerate maturity to charge-off date": "Acelerar o vencimento até à data de baixa",
+      "Full Leap Year": "Ano bissexto completo",
+      "Feb 29 Period Only": "Somente período de 29 de fevereiro"
     },
     "commons": {
       "50 characters long": "50 caracteres",
@@ -1458,6 +1460,7 @@
       "Days From": "Dias a partir de",
       "Days Till": "Dias até",
       "Days in Year": "Dias no ano",
+      "Days in year custom strategy": "Estratégia personalizada para dias do ano",
       "Days in month": "Dias no mês",
       "Days in year": "Dias no ano",
       "Days to Dormancy": "Dias para Dormência",
@@ -2498,6 +2501,7 @@
       "Deposit": "Depósito",
       "Disburse": "Desembolsar",
       "Disburse to Savings": "Desembolsar para poupança",
+      "Edit Repayment Schedule": "Editar cronograma de reembolso",
       "Foreclosure": "Execução hipotecária",
       "Frequent Postings": "Postagens frequentes",
       "Frequently Accessed": "Acessado com frequência",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -741,7 +741,9 @@
       "Check loan repayment due": "Angalia ulipaji wa mkopo unaodaiwa",
       "Transfer to Savings": "Hamisha kwa Akiba",
       "Zero interest after charge-off": "Riba sifuri baada ya kutozwa",
-      "Accelerate maturity to charge-off date": "Kuharakisha ukomavu hadi tarehe ya kukomesha malipo"
+      "Accelerate maturity to charge-off date": "Kuharakisha ukomavu hadi tarehe ya kukomesha malipo",
+      "Full Leap Year": "Mwaka Kamili wa Kurukaruka",
+      "Feb 29 Period Only": "Feb 29 Kipindi Pekee"
     },
     "commons": {
       "50 characters long": "Urefu wa herufi 50",
@@ -1458,6 +1460,7 @@
       "Days From": "Siku Kutoka",
       "Days Till": "Siku Hadi",
       "Days in Year": "Siku katika Mwaka",
+      "Days in year custom strategy": "Mkakati maalum wa siku kwa mwaka",
       "Days in month": "Siku katika mwezi",
       "Days in year": "Siku katika mwaka",
       "Days to Dormancy": "Siku za kulala",
@@ -2498,6 +2501,7 @@
       "Deposit": "Amana",
       "Disburse": "Lipa",
       "Disburse to Savings": "Lipa kwa Akiba",
+      "Edit Repayment Schedule": "Badilisha Ratiba ya Ulipaji",
       "Foreclosure": "Foreclosure",
       "Frequent Postings": "Machapisho ya Mara kwa Mara",
       "Frequently Accessed": "Zinazofikiwa mara kwa mara",

--- a/src/environments/.env.ts
+++ b/src/environments/.env.ts
@@ -2,8 +2,8 @@
 /* tslint:disable */
 export default {
   'mifos_x': {
-    'version': '250226',
-    'hash': 'ea15eecf'
+    'version': '250320',
+    'hash': 'ea493973'
   },
   'allow_switching_backend_instance': true
 };


### PR DESCRIPTION
## Description

We need to introduce a new dropdown option if the customer selected Actual for days in year, which is available for progressive loans only on the loan product, where we can instruct Fineract to only consider leap year (366 days in year) for the period that contains the day of 29th of Feb or for the full year!

If the flag is TRUE, we need to implement the above logic during the time we calculate the days in year!

## Screenshots

<img width="1502" alt="Screenshot 2025-03-20 at 10 58 57 a m" src="https://github.com/user-attachments/assets/b7c9eb11-8b92-4b32-94f0-f4195271eb38" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
