### PR TITLE
fix: Prevent GLIM and GSIM without members

### DIFF
--- a/src/app/groups/groups-view/groups-view.component.html
+++ b/src/app/groups/groups-view/groups-view.component.html
@@ -114,20 +114,24 @@
           <button mat-menu-item *mifosxHasPermission="'CREATE_LOAN'" [routerLink]="['loans-accounts', 'create']">
             {{ 'labels.buttons.Group Loan Application' | translate }}
           </button>
-          <button
-            mat-menu-item
-            *mifosxHasPermission="'CREATE_LOAN'"
-            [routerLink]="['loans-accounts', 'glim-account', 'create']"
-          >
-            {{ 'labels.buttons.GLIM Application' | translate }}
-          </button>
-          <button
-            mat-menu-item
-            *mifosxHasPermission="'CREATE_GSIMACCOUNT'"
-            [routerLink]="['savings-accounts', 'gsim-account', 'create']"
-          >
-            {{ 'labels.buttons.GSIM Application' | translate }}
-          </button>
+          <span *ngIf="groupViewData.clientMembers">
+            <button
+              mat-menu-item
+              *mifosxHasPermission="'CREATE_LOAN'"
+              [routerLink]="['loans-accounts', 'glim-account', 'create']"
+            >
+              {{ 'labels.buttons.GLIM Application' | translate }}
+            </button>
+          </span>
+          <span *ngIf="groupViewData.clientMembers">
+            <button
+              mat-menu-item
+              *mifosxHasPermission="'CREATE_GSIMACCOUNT'"
+              [routerLink]="['savings-accounts', 'gsim-account', 'create']"
+            >
+              {{ 'labels.buttons.GSIM Application' | translate }}
+            </button>
+          </span>
         </mat-menu>
 
         <button mat-menu-item [matMenuTriggerFor]="More">{{ 'labels.buttons.More' | translate }}</button>

--- a/src/app/savings/gsim-account/create-gsim-account/create-gsim-account.component.ts
+++ b/src/app/savings/gsim-account/create-gsim-account/create-gsim-account.component.ts
@@ -94,7 +94,11 @@ export class CreateGsimAccountComponent {
    * Checks validity of overall savings account form.
    */
   get savingsAccountFormValid() {
-    return this.savingsAccountDetailsForm.valid && this.savingsAccountTermsForm.valid;
+    return (
+      this.savingsAccountDetailsForm.valid &&
+      this.savingsAccountTermsForm.valid &&
+      this.activeClientMembers.filter((m: any) => m.selected).length > 0
+    );
   }
 
   /**

--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.html
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.html
@@ -159,7 +159,7 @@
     <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
     {{ 'labels.buttons.Previous' | translate }}
   </button>
-  <button mat-raised-button matStepperNext>
+  <button mat-raised-button matStepperNext [disabled]="selectedClientMembers.selectedMembers.length === 0">
     {{ 'labels.buttons.Next' | translate }}
     <fa-icon icon="arrow-right" class="m-l-10"></fa-icon>
   </button>


### PR DESCRIPTION
Makes sure GLIM and GSIM application menu item doesn't appear without members. (This has already been in place for JLG.) Make sure GSIM can't be saved without selected members.

Fixes: WEB-62