### PR TITLE
fix: Remove wrong required text in Group transfer clients dialog

### DIFF
--- a/src/app/groups/groups-view/group-actions/group-transfer-clients/group-transfer-clients.component.html
+++ b/src/app/groups/groups-view/group-actions/group-transfer-clients/group-transfer-clients.component.html
@@ -10,10 +10,6 @@
                 {{ member.displayName }}
               </mat-option>
             </mat-select>
-            <mat-error *ngIf="transferClientsForm.controls.clients.hasError('required')">
-              {{ 'labels.inputs.Office' | translate }} {{ 'labels.commons.is' | translate }}
-              <strong>{{ 'labels.commons.required' | translate }}</strong>
-            </mat-error>
           </mat-form-field>
 
           <mat-checkbox
@@ -40,7 +36,7 @@
           </mat-option>
         </mat-autocomplete>
 
-        <div class="mat-table" *ngIf="transferClientsForm.get('destinationGroupId').value">
+        <div class="mat-table" *ngIf="transferClientsForm.get('destinationGroupId').value?.id">
           <div class="mat-header-row">
             <div class="mat-header-cell">{{ 'labels.inputs.Destination Group Details' | translate }}</div>
           </div>


### PR DESCRIPTION
Removes a wrong required text in the group transfer clients dialog and prevents empty fields appear below before a destination group is found.

Fixes: WEB-82