### PR TITLE
Error in disabled previous buttons

### DIFF
--- a/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.html
+++ b/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.html
@@ -160,7 +160,7 @@
   </div>
 
   <div fxLayout="row" class="margin-t" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="2%">
-    <button mat-raised-button matStepperPrevious disabled>
+    <button mat-raised-button matStepperPrevious>
       <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
       {{ 'labels.buttons.Previous' | translate }}
     </button>

--- a/src/app/shares/shares-account-stepper/shares-account-terms-step/shares-account-terms-step.component.html
+++ b/src/app/shares/shares-account-stepper/shares-account-terms-step/shares-account-terms-step.component.html
@@ -97,7 +97,7 @@
   </div>
 
   <div fxLayout="row" class="margin-t" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="2%">
-    <button mat-raised-button matStepperPrevious disabled>
+    <button mat-raised-button matStepperPrevious>
       <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
       {{ 'labels.buttons.Previous' | translate }}
     </button>


### PR DESCRIPTION
## Description
Go to clients and while creating a new savings/share account in the terms section, the previous button is disabled. Which can cause inconvenience while filling the form.

Before: 
![WhatsApp Image 2025-03-23 at 20 23 58_350b089d](https://github.com/user-attachments/assets/b48f2ec5-9b27-4040-b2e1-7d1024225fe1)
![WhatsApp Image 2025-03-23 at 20 24 33_cd13cbf4](https://github.com/user-attachments/assets/6630a3fd-aa73-4736-b955-f55a7c87faec)


After:
![WhatsApp Image 2025-03-23 at 20 28 15_f91300bb](https://github.com/user-attachments/assets/5497d3a6-eca8-49f7-a0ec-be354cd674b1)
![WhatsApp Image 2025-03-23 at 20 29 01_8d6097d5](https://github.com/user-attachments/assets/3ca40e97-56fa-444d-8226-b4ae3b5e17e9)

## Related issues and discussion

Fixes WEB-87: https://mifosforge.jira.com/browse/WEB-87

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
