### PR TITLE
fix: Manage hooks functionality; Create hook, Edit Hook

### DIFF
--- a/src/app/system/manage-hooks/create-hook/create-hook.component.html
+++ b/src/app/system/manage-hooks/create-hook/create-hook.component.html
@@ -33,7 +33,7 @@
         </div>
 
         <div fxLayout="row wrap" fxLayout.lt-md="column" fxLayoutGap="4%">
-          <mat-form-field fxFlex="48%" *ngIf="hookForm.controls.name.value === 'Web'">
+          <mat-form-field fxFlex="40%" *ngIf="hookForm.controls.name.value === 'Web'">
             <mat-label>{{ 'labels.inputs.Content Type' | translate }}</mat-label>
             <mat-select required formControlName="contentType">
               <mat-option [value]="'json'">
@@ -49,7 +49,7 @@
             </mat-error>
           </mat-form-field>
 
-          <mat-form-field fxFlex="48%" *ngIf="hookForm.controls.name.value === 'SMS Bridge'">
+          <mat-form-field fxFlex="40%" *ngIf="hookForm.controls.name.value === 'SMS Bridge'">
             <mat-label>{{ 'labels.inputs.Phone Number' | translate }}</mat-label>
             <input matInput type="tel" #input maxlength="10" required formControlName="phoneNumber" />
             <mat-hint align="end">{{ input.value?.length || 0 }}/10</mat-hint>
@@ -59,7 +59,7 @@
             </mat-error>
           </mat-form-field>
 
-          <mat-form-field fxFlex="48%">
+          <mat-form-field fxFlex="40%">
             <mat-label>{{ 'labels.inputs.Payload URL' | translate }}</mat-label>
             <input matInput required formControlName="payloadUrl" />
             <mat-error *ngIf="hookForm.controls.payloadUrl.hasError('required')">
@@ -105,14 +105,23 @@
 
         <br />
 
-        <mat-divider [inset]="true"></mat-divider>
+        <!-- <mat-divider [inset]="true"></mat-divider> -->
 
         <br />
 
-        <div fxLayout="row wrap" fxLayoutGap="60%" fxLayout.lt-md="column">
-          <p fxFlex="20%" class="mat-title">{{ 'labels.inputs.Events' | translate }}</p>
+        <div fxLayout="row wrap" fxLayout.lt-md="column">
+          <p fxFlex="20%" class="mat-title">
+            {{ 'labels.inputs.Events' | translate }}<span style="color: red">*</span>
+          </p>
 
-          <button mat-raised-button fxFlex="20%" type="button" color="primary" (click)="addEvent()">
+          <button
+            mat-raised-button
+            class="AddEventButton"
+            fxFlex="20%"
+            type="button"
+            color="primary"
+            (click)="addEvent()"
+          >
             <fa-icon icon="plus" class="m-r-10"></fa-icon>
             {{ 'labels.buttons.Add' | translate }} {{ 'labels.inputs.Events' | translate }}
           </button>

--- a/src/app/system/manage-hooks/create-hook/create-hook.component.scss
+++ b/src/app/system/manage-hooks/create-hook/create-hook.component.scss
@@ -11,6 +11,14 @@
   }
 }
 
+mat-divider {
+  margin: 0 0 0.5em;
+}
+
 table {
   width: 100%;
+}
+
+.AddEventButton {
+  margin-bottom: 10px;
 }

--- a/src/app/system/manage-hooks/edit-hook/edit-hook.component.html
+++ b/src/app/system/manage-hooks/edit-hook/edit-hook.component.html
@@ -33,7 +33,7 @@
         </div>
 
         <div fxLayout="row wrap" fxLayout.lt-md="column" fxLayoutGap="4%">
-          <mat-form-field fxFlex="48%" *ngIf="hookForm.controls.name.value === 'Web'">
+          <mat-form-field fxFlex="40%" *ngIf="hookForm.controls.name.value === 'Web'">
             <mat-label>{{ 'labels.inputs.Content Type' | translate }}</mat-label>
             <mat-select required formControlName="contentType">
               <mat-option [value]="'json'">
@@ -49,7 +49,7 @@
             </mat-error>
           </mat-form-field>
 
-          <mat-form-field fxFlex="48%" *ngIf="hookForm.controls.name.value === 'SMS Bridge'">
+          <mat-form-field fxFlex="40%" *ngIf="hookForm.controls.name.value === 'SMS Bridge'">
             <mat-label>{{ 'labels.inputs.Phone Number' | translate }}</mat-label>
             <input matInput type="tel" #input maxlength="10" required formControlName="phoneNumber" />
             <mat-hint align="end">{{ input.value?.length || 0 }}/10</mat-hint>
@@ -59,7 +59,7 @@
             </mat-error>
           </mat-form-field>
 
-          <mat-form-field fxFlex="48%">
+          <mat-form-field fxFlex="40%">
             <mat-label>{{ 'labels.inputs.Payload URL' | translate }}</mat-label>
             <input matInput required formControlName="payloadUrl" />
             <mat-error *ngIf="hookForm.controls.payloadUrl.hasError('required')">
@@ -109,10 +109,19 @@
 
         <br />
 
-        <div fxLayout="row wrap" fxLayoutGap="60%" fxLayout.lt-md="column">
-          <p fxFlex="20%" class="mat-title">{{ 'labels.inputs.Events' | translate }}</p>
+        <div fxLayout="row wrap" fxLayout.lt-md="column">
+          <p fxFlex="20%" class="mat-title">
+            {{ 'labels.inputs.Events' | translate }} <span style="color: red">*</span>
+          </p>
 
-          <button mat-raised-button fxFlex="20%" type="button" color="primary" (click)="addEvent()">
+          <button
+            mat-raised-button
+            class="AddEventButton"
+            fxFlex="20%"
+            type="button"
+            color="primary"
+            (click)="addEvent()"
+          >
             <fa-icon icon="plus" class="m-r-10"></fa-icon>
             {{ 'labels.buttons.Add' | translate }} {{ 'labels.inputs.Events' | translate }}
           </button>
@@ -131,6 +140,10 @@
             <td mat-cell *matCellDef="let event">{{ event.actionName }}</td>
           </ng-container>
 
+          <div *ngIf="cannotDeleteLastEvent" class="error-message">
+            <p>At least one event is required. Cannot delete the last event.</p>
+          </div>
+
           <ng-container matColumnDef="actions">
             <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
             <td mat-cell *matCellDef="let i = index">
@@ -146,14 +159,16 @@
       </mat-card-content>
 
       <mat-card-actions fxLayout="row" fxLayout.xs="column" fxLayoutAlign="center" fxLayoutGap="5px">
-        <button type="button" mat-raised-button [routerLink]="['../']">{{ 'labels.inputs.Cancel' | translate }}</button>
+        <button type="button" mat-raised-button [routerLink]="['../']">
+          {{ 'labels.buttons.Cancel' | translate }}
+        </button>
         <button
           mat-raised-button
           color="primary"
           [disabled]="(!hookForm.valid || hookForm.pristine) && !eventsDataChanged"
           *mifosxHasPermission="'UPDATE_HOOK'"
         >
-          {{ 'labels.inputs.Submit' | translate }}
+          {{ 'labels.buttons.Submit' | translate }}
         </button>
       </mat-card-actions>
     </form>

--- a/src/app/system/manage-hooks/edit-hook/edit-hook.component.scss
+++ b/src/app/system/manage-hooks/edit-hook/edit-hook.component.scss
@@ -14,3 +14,26 @@
 table {
   width: 100%;
 }
+
+.AddEventButton {
+  margin-bottom: 10px;
+}
+
+.error-message {
+  color: red;
+  font-weight: bold;
+  margin-top: 10px;
+  padding: 5px;
+  background-color: #ffe6e6;
+  border: 1px solid red;
+  border-radius: 5px;
+}
+
+.error-snackbar {
+  background-color: #f44336;
+  color: white;
+}
+
+.error-snackbar .mat-simple-snackbar-action {
+  color: white;
+}


### PR DESCRIPTION
## Fixes Issues: WEB-69  

### Changes Made  

### UI Fixes  
As per the ticket, the following UI improvements have been implemented:  
- Ensured both bottom buttons have proper English translations (previously incorrect for editing existing hooks).  
- Adjusted spacing so buttons do not sit directly on other elements (e.g., “Add Events” button no longer overlaps with the box below).  
- Fixed horizontal ruler alignment—it now extends properly above the “Events” title instead of stopping early on the left side.  
- Standardized widths for **"Content Type"** and **"Hook Template"** fields so that the first two rows have the same column widths.  

### Logic Fixes  
- **Edit Hook:** Prevented users from deleting all events. If attempted, a toast notification now displays an error message.  
- **Create Hook:** Added a requirement to create at least one event before submission to prevent empty submissions.  

###  After fix Screenshot
![image](https://github.com/user-attachments/assets/cb6b8bc8-cfbf-4ac8-9ce3-d90c83cf31d5)

Ready for review. Let me know if any further improvements are needed.
