### PR TITLE
The Next button should remain disabled until all the necessary details are filled

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.html
@@ -122,7 +122,15 @@
       <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
       {{ 'labels.buttons.Previous' | translate }}
     </button>
-    <button mat-raised-button matStepperNext [disabled]="!loansAccountDetailsForm.get('productId')?.value">
+    <button
+      mat-raised-button
+      matStepperNext
+      [disabled]="
+        !loansAccountDetailsForm.get('productId')?.value ||
+        !loansAccountDetailsForm.get('expectedDisbursementDate')?.value ||
+        !loansAccountDetailsForm.get('submittedOnDate')?.value
+      "
+    >
       {{ 'labels.buttons.Next' | translate }}
       <fa-icon icon="arrow-right" class="m-l-10"></fa-icon>
     </button>


### PR DESCRIPTION
## Description

Ensure that the "Next" button remains disabled until all necessary details are entered while creating a savings account. This prevents users from proceeding with incomplete information and improves the form validation experience.

## Related issues and discussion

#web-96

## Screenshots, if any
before :
![image](https://github.com/user-attachments/assets/29c3cbb8-61fb-498f-95a2-5e5136de81e0)
After : 
![image](https://github.com/user-attachments/assets/b6713175-2283-45d7-bd22-b9f5b32743b0)
![image](https://github.com/user-attachments/assets/0beb21f0-52f6-4d65-844e-3ea373a4eb4a)

## Checklist
- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
