### PR TITLE
fix: Client Members component

### DIFF
--- a/src/app/groups/groups-view/general-tab/general-tab.component.html
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.html
@@ -42,7 +42,7 @@
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.JLG Loan Application' | translate }}</th>
         <td mat-cell *matCellDef="let element">
           <div class="m-l-30" *ngIf="element.status.code !== 'clientStatusType.closed'">
-            <button class="account-action-button" mat-raised-button color="primary">
+            <button class="account-action-button" mat-raised-button color="primary" disabled>
               <i class="fa fa-plus" matTooltip="{{ 'tooltips.New Loan Application' | translate }}"></i>
             </button>
           </div>
@@ -53,7 +53,7 @@
       <tr
         mat-row
         *matRowDef="let row; columns: clientMemberColumns"
-        [routerLink]="['/clients', row.id, 'loans-accounts', 'create']"
+        [routerLink]="['/clients', row.id, 'general']"
         class="select-row"
       ></tr>
     </table>
@@ -424,7 +424,7 @@
       <tr
         mat-row
         *matRowDef="let row; columns: openSavingsColumns"
-        [routerLink]="['../', 'savings-accounts', row.id, 'general']"
+        [routerLink]="['../', 'savings-accounts', row.id, 'transactions']"
       ></tr>
     </table>
 


### PR DESCRIPTION
# Fixes issues WEB-91

### Fixed incorrect client links in the "Client Members" list. Clicking on a client's name now navigates correctly to the client details page (as if accessed via Institution → Clients).

### Disabled the JLG Application column and "+" button since JLG Applications are not supported in the first release of the Mifos X client.

### Steps to Verify:
Go to a Group and check the list of Client Members.

Click on a client’s name—it should navigate to the correct Client Details page.

The JLG Application column and "+" button should be disabled.
![image](https://github.com/user-attachments/assets/5c4ce7b7-e246-45c1-bc93-c10f24c0a2dc)
