### PR TITLE
fix: Prevent account transfer charges when no savings account is linked

### DIFF
--- a/src/app/loans/create-loans-account/create-loans-account.component.html
+++ b/src/app/loans/create-loans-account/create-loans-account.component.html
@@ -53,6 +53,7 @@
         [loansAccountProductTemplate]="loansAccountProductTemplate"
         [loansAccountTemplate]="loansAccountTemplate"
         [loansAccountFormValid]="loansAccountFormValid"
+        [loansSavingsAccountLinked]="loansSavingsAccountLinked"
       >
       </mifosx-loans-account-charges-step>
     </mat-step>

--- a/src/app/loans/create-loans-account/create-loans-account.component.ts
+++ b/src/app/loans/create-loans-account/create-loans-account.component.ts
@@ -119,6 +119,10 @@ export class CreateLoansAccountComponent {
     return this.loansAccountDetailsForm.valid && this.loansAccountTermsForm.valid;
   }
 
+  get loansSavingsAccountLinked() {
+    return this.loansAccountDetailsStep.loansAccountDetailsForm.get('linkAccountId').value;
+  }
+
   /** Gets principal Amount */
   get loanPrincipal() {
     return this.loansAccountTermsStep.loansAccountTermsForm.value.principal;

--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
@@ -34,6 +34,8 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
   @Input() loansAccountFormValid: boolean;
   /** active Client Members in case of GSIM Account */
   @Input() activeClientMembers?: any;
+  // returns the chosen savings account linked to the loan account
+  @Input() loansSavingsAccountLinked: any;
 
   /** Charges Data */
   chargeData: any;
@@ -111,6 +113,12 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
     if (this.loansAccountProductTemplate) {
       this.loanPurposeOptions = this.loansAccountProductTemplate.loanPurposeOptions;
       this.chargeData = this.loansAccountProductTemplate.chargeOptions;
+      // filter chargeData to have charges that have chargePaymentMode not 'Account Transfer' if loansSavingsAccountLinked is false
+      if (!this.loansSavingsAccountLinked) {
+        this.chargeData = this.chargeData.filter(
+          (charge: any) => charge.chargePaymentMode?.value != 'Account transfer'
+        );
+      }
       if (this.loansAccountProductTemplate.overdueCharges) {
         this.overDueChargesDataSource = this.loansAccountProductTemplate.overdueCharges;
       }


### PR DESCRIPTION
- Added getter to check if a savings account is linked (loansSavingsAccountLinked).
- Filtered out charges with 'Account transfer' payment mode when no savings account is linked.

## Description

Introduced a new getter (`loansSavingsAccountLinked`) to determine if a savings account is linked. When this is `false`, charges with a payment mode of “Account transfer” are filtered out. This change ensures that charges requiring an account transfer are not selected if no savings account is linked, thereby preventing the internal server error at disbursement.

## Related issues and discussion

FIxes: [FINERACT-2205](https://issues.apache.org/jira/browse/FINERACT-2205)

## Screenshots, if any

https://github.com/user-attachments/assets/8a9c1271-ebb1-475b-b525-bca6df7c6cc1



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
