### PR TITLE
Fixed survey section in clients

### DIFF
--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -282,7 +282,9 @@
         <button mat-menu-item (click)="doAction('Create Collateral')">
           {{ 'labels.buttons.Create Collateral' | translate }}
         </button>
-        <button mat-menu-item (click)="doAction('Survey')">{{ 'labels.buttons.Survey' | translate }}</button>
+        <button mat-menu-item (click)="doAction('Survey')" [disabled]="true">
+          {{ 'labels.buttons.Survey' | translate }}
+        </button>
         <button
           mat-menu-item
           (click)="doAction('Update Default Savings')"


### PR DESCRIPTION
## Description

Survey creation is currently not working on Fineract and therefore useless in Mifos. There is another reference of surveys in hamburger menu in clients, and hence has to be disabled.

## Related issues and discussion

Fixes WEB-94: https://mifosforge.jira.com/browse/WEB-94

## Screenshots, if any
Before:
![WhatsApp Image 2025-03-29 at 12 12 20_4310ce76](https://github.com/user-attachments/assets/3554c5b1-c3da-4546-80e9-c26e307d588b)

After: 
![WhatsApp Image 2025-03-29 at 12 13 01_3551429f](https://github.com/user-attachments/assets/c0139679-4308-4e5b-ad71-8ded8f16640a)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
