### PR TITLE
Fix unable to add product to an existing client due the PR #2340

### DIFF
--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.html
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.html
@@ -159,7 +159,11 @@
     <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
     {{ 'labels.buttons.Previous' | translate }}
   </button>
-  <button mat-raised-button matStepperNext [disabled]="selectedClientMembers.selectedMembers.length === 0">
+  <button
+    mat-raised-button
+    matStepperNext
+    [disabled]="activeClientMembers ? selectedClientMembers.selectedMembers.length === 0 : false"
+  >
     {{ 'labels.buttons.Next' | translate }}
     <fa-icon icon="arrow-right" class="m-l-10"></fa-icon>
   </button>

--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
@@ -228,7 +228,9 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
   }
 
   get selectedClientMembers() {
-    return { selectedMembers: this.activeClientMembers.filter((item: any) => item.selected) };
+    return {
+      selectedMembers: this.activeClientMembers ? this.activeClientMembers.filter((item: any) => item.selected) : []
+    };
   }
 
   /** Toggle all checks */


### PR DESCRIPTION
…2340

## Description
The implementation logic in the PR: #2340 introduced a `TypeError` due to accessing `.filter` on an undefined member list. That error has now been resolved by safely handling the member list before applying filters.

## Related issues and discussion

Fixes: #WEB-62

## Screenshots, if any

![image](https://github.com/user-attachments/assets/5e1b02dc-3a90-43a8-9bb3-3473f525f858)

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.