### PR TITLE
Fixed Amazon S3 Issue (WEB-15)

### DIFF
--- a/src/app/system/external-services/amazon-s3/amazon-s3.component.ts
+++ b/src/app/system/external-services/amazon-s3/amazon-s3.component.ts
@@ -54,7 +54,7 @@ export class AmazonS3Component implements OnInit {
   getConfigurationValue(configuration: any): string {
     const value = configuration.value;
     if (configuration.name === 's3_access_key' || configuration.name === 's3_secret_key') {
-      return value.replace(value.substr(1, value.length - 3), value.substr(1, value.length - 3).replace(/./g, '*'));
+      return value ? value.replace(value.substr(1, value.length - 3), value.substr(1, value.length - 3).replace(/./g, '*')) : '';
     }
     return value;
   }


### PR DESCRIPTION
## Description

This PR fixes a JavaScript error that occurs when the Amazon S3 configuration page is opened without any configuration value.

## Related issues and discussion

WEB -15: Amazon S3 page causes Javascript error

### Fix:
- Added a null check using a ternary operator to handle undefined `value` gracefully.
- Ensures the UI doesn't crash and logs remain clean.

## Screenshots
Before:
![web-15-before](https://github.com/user-attachments/assets/14a21080-baed-4e99-be37-4ee0f2c985c8)

After: 
![web-15-after](https://github.com/user-attachments/assets/ff52c123-ce85-465c-9add-f1361ee295ab)

### Jira Ticket:
[WEB-15] (https://mifosforge.jira.com/browse/WEB-15)


[WEB-15]: https://mifosforge.jira.com/browse/WEB-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ