### PR TITLE
fix fetching SavingsAccountTemplate when groupId present

### DIFF
--- a/src/app/savings/savings-account-stepper/savings-account-details-step/savings-account-details-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-details-step/savings-account-details-step.component.ts
@@ -93,7 +93,7 @@ export class SavingsAccountDetailsStepComponent implements OnInit {
    * Fetches savings account product template on productId value changes
    */
   buildDependencies() {
-    const entityId = this.savingsAccountTemplate.clientId || this.savingsAccountTemplate.groupId;
+    const entityId = this.savingsAccountTemplate.groupId || this.savingsAccountTemplate.clientId;
     this.savingsAccountDetailsForm.get('productId').valueChanges.subscribe((productId: string) => {
       this.savingsService
         .getSavingsAccountTemplate(entityId, productId, this.savingsAccountTemplate.groupId ? true : false)


### PR DESCRIPTION
## Description

Corrected the logic used to determine the entityId, prioritizing the groupId over the clientId. Previously, the logic incorrectly prioritized the clientId, causing requests associated with group-based savings applications to use the wrong identifier.

## Related issues and discussion

#{Issue Number}

[WEB-119](https://mifosforge.jira.com/jira/software/c/projects/WEB/issues/WEB-119)

## Screenshots, if any

https://github.com/user-attachments/assets/0d82f9e7-442e-4b9b-bf86-d55d77481de0



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-119]: https://mifosforge.jira.com/browse/WEB-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ