### PR TITLE
Stop read notifications after user logouts

### DIFF
--- a/src/app/core/shell/sidenav/sidenav.component.ts
+++ b/src/app/core/shell/sidenav/sidenav.component.ts
@@ -101,7 +101,7 @@ export class SidenavComponent implements OnInit, AfterViewInit {
    */
   getFrequentActivities() {
     const frequencyCounts: any = {};
-    let index = this.userActivity.length;
+    let index = this.userActivity?.length;
     while (index) {
       frequencyCounts[this.userActivity[--index]] = (frequencyCounts[this.userActivity[index]] || 0) + 1;
     }

--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -66,7 +66,7 @@
   </button>
 
   <div #notifications>
-    <mifosx-notifications-tray fxHide.lt-md></mifosx-notifications-tray>
+    <mifosx-notifications-tray #notificationsTray fxHide.lt-md></mifosx-notifications-tray>
   </div>
 
   <div #themeToggle>

--- a/src/app/core/shell/toolbar/toolbar.component.ts
+++ b/src/app/core/shell/toolbar/toolbar.component.ts
@@ -28,6 +28,7 @@ import { ConfigurationWizardService } from '../../../configuration-wizard/config
 
 /** Custom Components */
 import { ConfigurationWizardComponent } from '../../../configuration-wizard/configuration-wizard.component';
+import { NotificationsTrayComponent } from 'app/shared/notifications-tray/notifications-tray.component';
 
 /**
  * Toolbar component.
@@ -46,6 +47,7 @@ export class ToolbarComponent implements OnInit, AfterViewInit, AfterContentChec
   @ViewChild('appMenu') appMenu: ElementRef<any>;
   /* Template for popover on appMenu */
   @ViewChild('templateAppMenu') templateAppMenu: TemplateRef<any>;
+  @ViewChild('notificationsTray') notificationsTray: NotificationsTrayComponent;
 
   /** Subscription to breakpoint observer for handset. */
   isHandset$: Observable<boolean> = this.breakpointObserver
@@ -112,7 +114,10 @@ export class ToolbarComponent implements OnInit, AfterViewInit, AfterContentChec
    * Logs out the authenticated user and redirects to login page.
    */
   logout() {
-    this.authenticationService.logout().subscribe(() => this.router.navigate(['/login'], { replaceUrl: true }));
+    this.authenticationService.logout().subscribe(() => {
+      this.notificationsTray.destroy();
+      this.router.navigate(['/login'], { replaceUrl: true });
+    });
   }
 
   /**

--- a/src/app/home/dashboard/dashboard.component.ts
+++ b/src/app/home/dashboard/dashboard.component.ts
@@ -69,7 +69,7 @@ export class DashboardComponent implements OnInit {
    */
   getFrequentActivities() {
     const frequencyCounts: any = {};
-    let index = this.userActivity.length;
+    let index = this.userActivity?.length;
     while (index) {
       frequencyCounts[this.userActivity[--index]] = (frequencyCounts[this.userActivity[index]] || 0) + 1;
     }

--- a/src/app/shared/notifications-tray/notifications-tray.component.ts
+++ b/src/app/shared/notifications-tray/notifications-tray.component.ts
@@ -64,6 +64,10 @@ export class NotificationsTrayComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.destroy();
+  }
+
+  public destroy() {
     clearTimeout(this.timer);
   }
 


### PR DESCRIPTION
## Description

We were calling the Notification API continuously, even if the user is not even logged in. The fix is call the `clearTimeout` method as part of the `logout` method

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
