### PR TITLE
WEB-132: Replace `master` with `main` in GitHub Actions workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 - View the [README](../README.md) or [watch this video](https://youtu.be/OnxxC3K2oro) to get your development environment up and running.
 - Learn how to [format pull requests](#submitting-a-pull-request).
 - Read how to [rebase/merge upstream branches](#configuring-remotes).
-- Understand our [commit message conventions](https://github.com/openMF/web-app/blob/master/.github/COMMIT_MESSAGE.md).
+- Understand our [commit message conventions](https://github.com/openMF/web-app/blob/main/.github/COMMIT_MESSAGE.md).
 - Sign our [Mifos CLA](http://mifos.org/about-us/financial-legal/mifos-contributor-agreement/).
 - Follow our [code of conduct](CODE_OF_CONDUCT.md).
 - [Find an issue to work on](https://github.com/openMF/web-app/issues) and start smashing!
@@ -49,10 +49,10 @@ Remember that this is an inclusive community, committed to creating a safe, posi
 git clone https://github.com/your-username/web-app.git
 ```
 
-- Make sure you are in the `master` branch.
+- Make sure you are in the `main` branch.
 
 ```
-git checkout master
+git checkout main
 ```
 
 - Create a new branch with a meaningful name before adding and committing your changes.
@@ -97,7 +97,7 @@ git push origin branch-name
 git push origin remote-branch-name --force
 ```
 
-- Follow the Pull request template and submit a pull request with a motive for your change and the method you used to achieve it to be merged with the `master` branch.
+- Follow the Pull request template and submit a pull request with a motive for your change and the method you used to achieve it to be merged with the `main` branch.
 - If you can, please submit the pull request with the fix or improvements including tests.
 - During review, if you are requested to make changes, rebase your branch and squash the multiple commits into one. Once you push these changes the pull request will edit automatically.
 
@@ -120,18 +120,18 @@ git remote add upstream https://github.com/openMF/web-app.git
   > upstream  https://github.com/openMF/web-app.git (push)
 ```
 
-3. To update your local copy with remote changes, run the following: (This will give you an exact copy of the current remote. You should not have any local changes on your master branch, if you do, use rebase instead.)
+3. To update your local copy with remote changes, run the following: (This will give you an exact copy of the current remote. You should not have any local changes on your main branch, if you do, use rebase instead.)
 
 ```
 git fetch upstream
-git checkout master
-git merge upstream/master
+git checkout main
+git merge upstream/main
 ```
 
-4. Push these merged changes to the master branch on your fork. Ensure to pull in upstream changes regularly to keep your forked repository up to date.
+4. Push these merged changes to the main branch on your fork. Ensure to pull in upstream changes regularly to keep your forked repository up to date.
 
 ```
-git push origin master
+git push origin main
 ```
 
 5. Switch to the branch you are using for some piece of work.
@@ -143,7 +143,7 @@ git checkout branch-name
 6. Rebase your branch, which means, take in all latest changes and replay your work in the branch on top of this - this produces cleaner versions/history.
 
 ```
-git rebase master
+git rebase main
 ```
 
 7. Push the final changes when you're ready.
@@ -162,10 +162,10 @@ After your pull request is merged, you can safely delete your branch and pull th
 git push origin --delete branch-name
 ```
 
-2. Checkout the master branch.
+2. Checkout the main branch.
 
 ```
-git checkout master
+git checkout main
 ```
 
 3. Delete the local branch.
@@ -174,10 +174,10 @@ git checkout master
 git branch -D branch-name
 ```
 
-4. Update your master branch with the latest upstream version.
+4. Update your main branch with the latest upstream version.
 
 ```
-git pull upstream master
+git pull upstream main
 ```
 
 ## Skipping a Travis CI Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ name: build-run
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/create-docker-hub-image.yml
+++ b/.github/workflows/create-docker-hub-image.yml
@@ -2,7 +2,7 @@ name: Publish Image in Docker Hub
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:
@@ -43,7 +43,7 @@ jobs:
         run: |
           TAGS="--tag $DOCKER_ORGANIZATION/web-app:${{ steps.extract_branch.outputs.branch }}"
 
-          if [ "${{ steps.extract_branch.outputs.branch }}" == "master" ]; then
+          if [ "${{ steps.extract_branch.outputs.branch }}" == "main" ]; then
             TAGS="$TAGS --tag $DOCKER_ORGANIZATION/web-app:${{ steps.git_hashes.outputs.short_hash }} --tag $DOCKER_ORGANIZATION/web-app:${{ steps.git_hashes.outputs.long_hash }}"
           fi
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,5 @@
 # https://github.com/marketplace/actions/close-stale-issues
-# https://github.com/actions/stale/blob/master/action.yml
+# https://github.com/actions/stale/blob/main/action.yml
 # https://github.com/actions/stale
 name: Mark stale issues and pull requests
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   testRigor:


### PR DESCRIPTION
## Description

Updated GitHub Actions workflows to trigger on the main branch instead of master, reflecting the current default branch of the repository. To ensure workflows run correctly and consistently with the active development branch.

## Related issues and discussion

[WEB-132](https://mifosforge.jira.com/browse/WEB-132?atlOrigin=eyJpIjoiNjhlM2JhOGJlMGI1NGRhYzg3YWE0OGEwMmI4N2U1YzUiLCJwIjoiaiJ9)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-132]: https://mifosforge.jira.com/browse/WEB-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ