### PR TITLE
WEB-133 Fix GitHub Actions workflow to use main branch instead of master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ name: build-run
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/create-docker-hub-image.yml
+++ b/.github/workflows/create-docker-hub-image.yml
@@ -2,7 +2,7 @@ name: Publish Image in Docker Hub
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:
@@ -43,7 +43,7 @@ jobs:
         run: |
           TAGS="--tag $DOCKER_ORGANIZATION/web-app:${{ steps.extract_branch.outputs.branch }}"
 
-          if [ "${{ steps.extract_branch.outputs.branch }}" == "master" ]; then
+          if [ "${{ steps.extract_branch.outputs.branch }}" == "main" ]; then
             TAGS="$TAGS --tag $DOCKER_ORGANIZATION/web-app:${{ steps.git_hashes.outputs.short_hash }} --tag $DOCKER_ORGANIZATION/web-app:${{ steps.git_hashes.outputs.long_hash }}"
           fi
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,5 @@
 # https://github.com/marketplace/actions/close-stale-issues
-# https://github.com/actions/stale/blob/master/action.yml
+# https://github.com/actions/stale/blob/main/action.yml
 # https://github.com/actions/stale
 name: Mark stale issues and pull requests
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   testRigor:


### PR DESCRIPTION
## Description

Updated GitHub Actions workflows to trigger on the main branch instead of master, reflecting the current default branch of the repository. To ensure workflows run correctly and consistently with the active development branch.

## Related issues and discussion

[WEB-133](https://mifosforge.jira.com/browse/WEB-133?atlOrigin=eyJpIjoiZDNjMTUyZmZiMTkyNDc3Y2JmMmY3NDk1M2NhNjM3NmIiLCJwIjoiaiJ9)



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-133]: https://mifosforge.jira.com/browse/WEB-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ