### PR TITLE
WEB-135 expand git hub actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,11 @@ name: build-run
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
+  # Triggers the workflow on push or pull request events for specific branches
   push:
-    branches: [main]
+    branches: [main, dev, angular-update]
   pull_request:
-    branches: [main]
+    branches: [main, dev, angular-update]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/create-docker-hub-image.yml
+++ b/.github/workflows/create-docker-hub-image.yml
@@ -2,7 +2,7 @@ name: Publish Image in Docker Hub
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev, angular-update]
 
 jobs:
   build:
@@ -45,6 +45,8 @@ jobs:
 
           if [ "${{ steps.extract_branch.outputs.branch }}" == "main" ]; then
             TAGS="$TAGS --tag $DOCKER_ORGANIZATION/web-app:${{ steps.git_hashes.outputs.short_hash }} --tag $DOCKER_ORGANIZATION/web-app:${{ steps.git_hashes.outputs.long_hash }}"
+          else
+            TAGS="$TAGS --tag $DOCKER_ORGANIZATION/web-app:${{ steps.extract_branch.outputs.branch }}-${{ steps.git_hashes.outputs.short_hash }}"
           fi
 
           docker build --push --build-arg="PUPPETEER_SKIP_DOWNLOAD_ARG=true" --platform linux/amd64,linux/arm64 $TAGS .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev, angular-update]
   pull_request:
-    branches: [main]
+    branches: [main, dev, angular-update]
 
 jobs:
   testRigor:


### PR DESCRIPTION
## Description

The current GitHub Actions workflow is configured to run only on the **main** branch. We need to update the workflow file so that it also triggers on:

- **dev**
- **angular-update**

## Related issues and discussion

[WEB-135](https://mifosforge.jira.com/browse/WEB-135?atlOrigin=eyJpIjoiM2FjNThkNTE3MmY1NGRlMmJiNmFiZDkxNjY3YTU5ODAiLCJwIjoiaiJ9)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-135]: https://mifosforge.jira.com/browse/WEB-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ