### PR TITLE
fix: Get rid of browser warning when starting up ng serve

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -6,5 +6,7 @@ last 2 versions
 > 0.5%
 Firefox ESR
 not dead
+not kaios 2.5
+not op_mini all
 # For IE 9-11 support, please uncomment the next line and adjust as needed
 # IE 9-11


### PR DESCRIPTION
We've got a browser warning due to the Angular 15 update that says kaios 2.5, op_mini all are not supported.

FIXES: WEB-140