### PR TITLE
Replace references to MatLegacyRadioModule in Angular 15 project, style fixes as per radio module update

### DIFF
--- a/src/app/accounting/accounting-rules/create-rule/create-rule.component.html
+++ b/src/app/accounting/accounting-rules/create-rule/create-rule.component.html
@@ -27,7 +27,13 @@
 
           <div fxFlex="48%" fxLayout="row" fxLayout.lt-md="column" class="rule-wrapper">
             <mat-label fxFlex="50%">{{ 'labels.inputs.Affected GL Entry (Debit) Rule Type' | translate }} *</mat-label>
-            <mat-radio-group fxFlex="50%" fxLayout="row" fxLayoutGap="5%" formControlName="debitRuleType">
+            <mat-radio-group
+              fxFlex="50%"
+              fxLayout="row"
+              fxLayoutGap="5%"
+              formControlName="debitRuleType"
+              class="radio-group-spacing"
+            >
               <mat-radio-button value="fixedAccount">{{ 'labels.inputs.Fixed Account' | translate }}</mat-radio-button>
               <mat-radio-button value="listOfAccounts">{{
                 'labels.inputs.List of Accounts' | translate
@@ -69,7 +75,13 @@
 
           <div fxFlex="48%" fxLayout="row" fxLayout.lt-md="column" class="rule-wrapper">
             <mat-label fxFlex="50%">{{ 'labels.inputs.Affected GL Entry (Credit) Rule Type' | translate }} *</mat-label>
-            <mat-radio-group fxFlex="50%" fxLayout="row" fxLayoutGap="5%" formControlName="creditRuleType">
+            <mat-radio-group
+              fxFlex="50%"
+              fxLayout="row"
+              fxLayoutGap="5%"
+              formControlName="creditRuleType"
+              class="radio-group-spacing"
+            >
               <mat-radio-button value="fixedAccount">{{ 'labels.inputs.Fixed Account' | translate }}</mat-radio-button>
               <mat-radio-button value="listOfAccounts">{{
                 'labels.inputs.List of Accounts' | translate

--- a/src/app/accounting/accounting-rules/create-rule/create-rule.component.scss
+++ b/src/app/accounting/accounting-rules/create-rule/create-rule.component.scss
@@ -12,3 +12,15 @@
     right: 0;
   }
 }
+
+.radio-group-spacing {
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+}
+
+@media (width <= 768px) {
+  .radio-group-spacing {
+    flex-direction: column;
+  }
+}

--- a/src/app/accounting/accounting-rules/edit-rule/edit-rule.component.html
+++ b/src/app/accounting/accounting-rules/edit-rule/edit-rule.component.html
@@ -27,7 +27,13 @@
 
           <div fxFlex="48%" fxLayout="row" fxLayout.lt-md="column" class="rule-wrapper">
             <mat-label fxFlex="50%">{{ 'labels.inputs.Affected GL Entry (Debit) Rule Type' | translate }} *</mat-label>
-            <mat-radio-group fxFlex="50%" fxLayout="row" fxLayoutGap="5%" formControlName="debitRuleType">
+            <mat-radio-group
+              fxFlex="50%"
+              fxLayout="row"
+              fxLayoutGap="5%"
+              formControlName="debitRuleType"
+              class="radio-group-spacing"
+            >
               <mat-radio-button value="fixedAccount">{{ 'labels.inputs.Fixed Account' | translate }}</mat-radio-button>
               <mat-radio-button value="listOfAccounts">{{
                 'labels.inputs.List of Accounts' | translate
@@ -69,7 +75,13 @@
 
           <div fxFlex="48%" fxLayout="row" fxLayout.lt-md="column" class="rule-wrapper">
             <mat-label fxFlex="50%">{{ 'labels.inputs.Affected GL Entry (Credit) Rule Type' | translate }} *</mat-label>
-            <mat-radio-group fxFlex="50%" fxLayout="row" fxLayoutGap="5%" formControlName="creditRuleType">
+            <mat-radio-group
+              fxFlex="50%"
+              fxLayout="row"
+              fxLayoutGap="5%"
+              formControlName="creditRuleType"
+              class="radio-group-spacing"
+            >
               <mat-radio-button value="fixedAccount">{{ 'labels.inputs.Fixed Account' | translate }}</mat-radio-button>
               <mat-radio-button value="listOfAccounts">{{
                 'labels.inputs.List of Accounts' | translate

--- a/src/app/accounting/accounting-rules/edit-rule/edit-rule.component.scss
+++ b/src/app/accounting/accounting-rules/edit-rule/edit-rule.component.scss
@@ -12,3 +12,15 @@
     right: 0;
   }
 }
+
+.radio-group-spacing {
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+}
+
+@media (width <= 768px) {
+  .radio-group-spacing {
+    flex-direction: column;
+  }
+}

--- a/src/app/clients/clients-view/client-actions/take-survey/take-survey.component.html
+++ b/src/app/clients/clients-view/client-actions/take-survey/take-survey.component.html
@@ -20,7 +20,7 @@
             <div fxLayout="row" class="question">
               <mat-label fxFlex="40" class="question-text">{{ question.text }}</mat-label>
 
-              <mat-radio-group fxFlex="60" [(ngModel)]="question.answer">
+              <mat-radio-group fxFlex="60" [(ngModel)]="question.answer" class="radio-group-spacing">
                 <mat-radio-button
                   fxLayout="column"
                   class="radio-button"

--- a/src/app/clients/clients-view/client-actions/take-survey/take-survey.component.scss
+++ b/src/app/clients/clients-view/client-actions/take-survey/take-survey.component.scss
@@ -45,3 +45,15 @@
   align-items: normal;
   white-space: normal;
 }
+
+.radio-group-spacing {
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+}
+
+@media (width <= 768px) {
+  .radio-group-spacing {
+    flex-direction: column;
+  }
+}

--- a/src/app/login/two-factor-authentication/two-factor-authentication.component.html
+++ b/src/app/login/two-factor-authentication/two-factor-authentication.component.html
@@ -14,7 +14,12 @@
   class="two-factor-auth-form"
   (ngSubmit)="requestOTP()"
 >
-  <mat-radio-group fxLayout="column" fxFlexAlign="center" formControlName="twoFactorAuthenticationDeliveryMethod">
+  <mat-radio-group
+    fxLayout="column"
+    fxFlexAlign="center"
+    formControlName="twoFactorAuthenticationDeliveryMethod"
+    class="radio-group-spacing"
+  >
     <mat-radio-button
       *ngFor="let twoFactorAuthenticationDeliveryMethod of twoFactorAuthenticationDeliveryMethods"
       [value]="twoFactorAuthenticationDeliveryMethod"

--- a/src/app/login/two-factor-authentication/two-factor-authentication.component.scss
+++ b/src/app/login/two-factor-authentication/two-factor-authentication.component.scss
@@ -21,3 +21,15 @@
     margin: 0.5rem 0;
   }
 }
+
+.radio-group-spacing {
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+}
+
+@media (width <= 768px) {
+  .radio-group-spacing {
+    flex-direction: column;
+  }
+}

--- a/src/app/organization/password-preferences/password-preferences.component.html
+++ b/src/app/organization/password-preferences/password-preferences.component.html
@@ -2,7 +2,12 @@
   <mat-card>
     <form [formGroup]="passwordPreferencesForm" (ngSubmit)="submit()">
       <mat-card-content>
-        <mat-radio-group fxLayout="column" formControlName="validationPolicyId" fxLayoutGap="10px">
+        <mat-radio-group
+          fxLayout="column"
+          formControlName="validationPolicyId"
+          fxLayoutGap="10px"
+          class="radio-group-spacing"
+        >
           <mat-radio-button *ngFor="let passwordPreference of passwordPreferencesData" [value]="passwordPreference.id">
             <span class="description-wrap">{{ passwordPreference.description }}</span>
           </mat-radio-button>

--- a/src/app/organization/password-preferences/password-preferences.component.scss
+++ b/src/app/organization/password-preferences/password-preferences.component.scss
@@ -1,3 +1,15 @@
 .description-wrap {
   white-space: normal;
 }
+
+.radio-group-spacing {
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+}
+
+@media (width <= 768px) {
+  .radio-group-spacing {
+    flex-direction: column;
+  }
+}

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-accounting-step/fixed-deposit-product-accounting-step.component.html
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-accounting-step/fixed-deposit-product-accounting-step.component.html
@@ -6,6 +6,7 @@
       fxLayoutGap="5%"
       fxLayout.lt-md="column"
       formControlName="accountingRule"
+      class="radio-group-spacing"
     >
       <mat-radio-button *ngFor="let accountingRule of accountingRuleData; let i = index" [value]="i + 1">
         {{ 'labels.accounting.' + accountingRule | translate }}

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-accounting-step/fixed-deposit-product-accounting-step.component.scss
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-accounting-step/fixed-deposit-product-accounting-step.component.scss
@@ -23,3 +23,15 @@ mat-divider {
 .margin-t {
   margin-top: 1em;
 }
+
+.radio-group-spacing {
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+}
+
+@media (width <= 768px) {
+  .radio-group-spacing {
+    flex-direction: column;
+  }
+}

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
@@ -6,6 +6,7 @@
       fxLayoutGap="5%"
       fxLayout.lt-md="column"
       formControlName="accountingRule"
+      class="radio-group-spacing"
     >
       <mat-radio-button *ngFor="let accountingRule of accountingRuleData; let i = index" [value]="i + 1">
         {{ 'labels.accounting.' + accountingRule | translate }}

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.scss
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.scss
@@ -23,3 +23,15 @@ mat-divider {
 .margin-t {
   margin-top: 1em;
 }
+
+.radio-group-spacing {
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+}
+
+@media (width <= 768px) {
+  .radio-group-spacing {
+    flex-direction: column;
+  }
+}

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-accounting-step/recurring-deposit-product-accounting-step.component.html
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-accounting-step/recurring-deposit-product-accounting-step.component.html
@@ -6,6 +6,7 @@
       fxLayoutGap="5%"
       fxLayout.lt-md="column"
       formControlName="accountingRule"
+      class="radio-group-spacing"
     >
       <mat-radio-button *ngFor="let accountingRule of accountingRuleData; let i = index" [value]="i + 1">
         {{ 'labels.accounting.' + accountingRule | translate }}

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-accounting-step/recurring-deposit-product-accounting-step.component.scss
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-accounting-step/recurring-deposit-product-accounting-step.component.scss
@@ -23,3 +23,15 @@ mat-divider {
 .margin-t {
   margin-top: 1em;
 }
+
+.radio-group-spacing {
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+}
+
+@media (width <= 768px) {
+  .radio-group-spacing {
+    flex-direction: column;
+  }
+}

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-accounting-step/saving-product-accounting-step.component.html
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-accounting-step/saving-product-accounting-step.component.html
@@ -6,6 +6,7 @@
       fxLayoutGap="5%"
       fxLayout.lt-md="column"
       formControlName="accountingRule"
+      class="radio-group-spacing"
     >
       <mat-radio-button *ngFor="let accountingRule of accountingRuleData; let i = index" [value]="i + 1">
         {{ 'labels.accounting.' + accountingRule | translate }}

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-accounting-step/saving-product-accounting-step.component.scss
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-accounting-step/saving-product-accounting-step.component.scss
@@ -23,3 +23,15 @@ mat-divider {
 .margin-t {
   margin-top: 1em;
 }
+
+.radio-group-spacing {
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+}
+
+@media (width <= 768px) {
+  .radio-group-spacing {
+    flex-direction: column;
+  }
+}

--- a/src/app/products/share-products/share-product-stepper/share-product-accounting-step/share-product-accounting-step.component.html
+++ b/src/app/products/share-products/share-product-stepper/share-product-accounting-step/share-product-accounting-step.component.html
@@ -6,6 +6,7 @@
       fxLayoutGap="5%"
       fxLayout.lt-md="column"
       formControlName="accountingRule"
+      class="radio-group-spacing"
     >
       <mat-radio-button *ngFor="let accountingRule of accountingRuleData; let i = index" [value]="i + 1">
         {{ 'labels.accounting.' + accountingRule | translate }}

--- a/src/app/products/share-products/share-product-stepper/share-product-accounting-step/share-product-accounting-step.component.scss
+++ b/src/app/products/share-products/share-product-stepper/share-product-accounting-step/share-product-accounting-step.component.scss
@@ -14,3 +14,15 @@ mat-divider {
 .margin-t {
   margin-top: 1em;
 }
+
+.radio-group-spacing {
+  display: flex;
+  gap: 2rem;
+  flex-direction: row;
+}
+
+@media (width <= 768px) {
+  .radio-group-spacing {
+    flex-direction: column;
+  }
+}

--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -27,7 +27,8 @@ import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-m
 import { MatLegacyPaginatorModule as MatPaginatorModule } from '@angular/material/legacy-paginator';
 import { MatLegacyProgressBarModule as MatProgressBarModule } from '@angular/material/legacy-progress-bar';
 import { MatLegacyProgressSpinnerModule as MatProgressSpinnerModule } from '@angular/material/legacy-progress-spinner';
-import { MatLegacyRadioModule as MatRadioModule } from '@angular/material/legacy-radio';
+import { MatRadioModule } from '@angular/material/radio';
+
 import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatLegacySlideToggleModule as MatSlideToggleModule } from '@angular/material/legacy-slide-toggle';


### PR DESCRIPTION
## Fixes issues raised on ticket WEB-144

### Changes:
1.  Replace references to MatLegacyRadioModule in Angular 15 project : updated import import { MatRadioModule } from '@angular/material/radio';
2. In Angular 15, touch targets for radio buttons have been enhanced to improve accessibility, leading to increased spacing between them. This spacing is further customized using SCSS to maintain a clean layout, prevent overlap, and provide comfortable space for user interaction.
