### PR TITLE
Misalignment of Add button client-identities page

### DIFF
--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.html
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.html
@@ -1,17 +1,21 @@
 <div class="tab-container mat-typography">
-  <h3>{{ 'labels.heading.Identities' | translate }}</h3>
+  <div class="header-row" fxLayout="row" fxLayoutAlign="space-between">
+    <h3 class="mat-subheading-2">
+      {{ 'labels.heading.Identities' | translate }}
+    </h3>
 
-  <button
-    mat-raised-button
-    class="f-right"
-    color="primary"
-    (click)="addIdentifier()"
-    *mifosxHasPermission="'CREATE_CLIENTIDENTIFIER'"
-  >
-    <fa-icon icon="plus" class="m-r-10"></fa-icon> {{ 'labels.buttons.Add' | translate }}
-  </button>
+    <button
+      mat-raised-button
+      color="primary"
+      (click)="addIdentifier()"
+      *mifosxHasPermission="'CREATE_CLIENTIDENTIFIER'"
+    >
+      <fa-icon icon="plus" class="m-r-10"></fa-icon>
+      {{ 'labels.buttons.Add' | translate }}
+    </button>
+  </div>
 
-  <table mat-table #identifiersTable [dataSource]="clientIdentities">
+  <table mat-table #identifiersTable [dataSource]="clientIdentities" [ngStyle]="{ 'margin-top': '3%' }">
     <ng-container matColumnDef="id">
       <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Id' | translate }}</th>
       <td mat-cell *matCellDef="let identity">{{ identity.id }}</td>

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.scss
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.scss
@@ -3,7 +3,7 @@
   margin: 1%;
 
   h3 {
-    margin: 1% auto;
+    margin: 0;
   }
 
   table {


### PR DESCRIPTION
## Description
Go to any client and under the identities section, the add button is misaligned, we can see the correct version of this being applied in the documents page. This issue is being caused because the heading and button isn’t wrapped in a div.

## Related issues and discussion

Fixes WEB-145: https://mifosforge.jira.com/browse/WEB-145

## Screenshots, if any
Identities page:
![WhatsApp Image 2025-04-18 at 14 58 11_5b60b4d0](https://github.com/user-attachments/assets/312c83a0-6550-4bf1-9fd2-aaec85c649a1)

Documents page:
![WhatsApp Image 2025-04-18 at 14 58 35_b9476243](https://github.com/user-attachments/assets/2a1806f4-6e38-414a-bc4f-dcd7ca3e42b6)

After:
![WhatsApp Image 2025-04-18 at 15 00 03_f6393770](https://github.com/user-attachments/assets/fcb0a39b-0ddc-4694-abdf-50ca591b4272)



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
