### PR TITLE
fix: Use first API url from url list

### DIFF
--- a/src/app/accounting/chart-of-accounts/gl-account-tree.service.ts
+++ b/src/app/accounting/chart-of-accounts/gl-account-tree.service.ts
@@ -92,7 +92,6 @@ export class GlAccountTreeService {
     // and rest as children to respective parent nodes.
     for (const glAccount of glAccountData) {
       if (glAccount.parentId === 0) {
-        console.log(glAccount.type.value);
         if (glAccount.type.value === 'ASSET') {
           glAccountTree[0].children[0].children.push(glAccounts[glAccount.id]);
         } else if (glAccount.type.value === 'EQUITY') {

--- a/src/app/accounting/financial-activity-mappings/edit-financial-activity-mapping/edit-financial-activity-mapping.component.ts
+++ b/src/app/accounting/financial-activity-mappings/edit-financial-activity-mapping/edit-financial-activity-mapping.component.ts
@@ -46,7 +46,6 @@ export class EditFinancialActivityMappingComponent implements OnInit {
   ) {
     this.route.data.subscribe((data: { financialActivityAccountAndTemplate: any }) => {
       this.financialActivityAccountId = data.financialActivityAccountAndTemplate.id;
-      console.log(data.financialActivityAccountAndTemplate.financialActivityData);
       this.financialActivityId = data.financialActivityAccountAndTemplate.financialActivityData.id;
       this.glAccountId = data.financialActivityAccountAndTemplate.glAccountData.id;
       this.glAccountOptions = data.financialActivityAccountAndTemplate.glAccountOptions;

--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-terms-step/fixed-deposit-account-terms-step.component.ts
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-terms-step/fixed-deposit-account-terms-step.component.ts
@@ -68,7 +68,6 @@ export class FixedDepositAccountTermsStepComponent implements OnInit, OnChanges 
         depositPeriod: this.fixedDepositsAccountTemplate.depositPeriod,
         depositPeriodFrequencyId: this.fixedDepositsAccountTemplate.depositPeriodFrequency.id
       });
-      console.log(this.fixedDepositAccountTermsForm.value);
     }
   }
 

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
@@ -112,7 +112,6 @@ export class ViewTransactionComponent implements OnInit {
     });
     this.clientId = this.route.snapshot.params['clientId'];
     this.loanId = this.route.snapshot.params['loanId'];
-    console.log(this.transactionType);
   }
 
   ngOnInit(): void {

--- a/src/app/products/charges/create-charge/create-charge.component.html
+++ b/src/app/products/charges/create-charge/create-charge.component.html
@@ -217,7 +217,7 @@
 
             <mat-form-field fxFlex="48%" *ngIf="showMinMaxCap()">
               <mat-label>{{ 'labels.inputs.Maximum Charge Cap' | translate }}</mat-label>
-              <input matInput formControlName="maxCap" />
+              <input matInput [min]="chargeForm.value.minCap" formControlName="maxCap" />
             </mat-form-field>
 
             <div fxFlex="48%" fxLayout="row" fxLayoutGap="2%" fxLayout.lt-md="column">

--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
@@ -170,7 +170,6 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
             newCharge = { ...charge, feeOnMonthDay: dateMonthDay };
             break;
         }
-        console.log(newCharge);
         this.chargesDataSource.splice(this.chargesDataSource.indexOf(charge), 1, newCharge);
         this.chargesDataSource = this.chargesDataSource.concat([]);
       }

--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -157,7 +157,11 @@ export class SettingsService {
     if (localStorage.getItem('mifosXServerURL')) {
       return localStorage.getItem('mifosXServerURL');
     }
-    return environment.baseApiUrl;
+    if (environment.baseApiUrl && environment.baseApiUrl !== '') {
+      return environment.baseApiUrl;
+    } else {
+      return this.servers()[0];
+    }
   }
 
   /**

--- a/src/app/shared/tenant-selector/tenant-selector.component.html
+++ b/src/app/shared/tenant-selector/tenant-selector.component.html
@@ -3,12 +3,7 @@
     <fa-icon icon="building" size="lg"></fa-icon>
   </span>
   <mat-label>{{ 'labels.inputs.Tenant' | translate }}</mat-label>
-  <mat-select
-    [disabled]="!allowSelection()"
-    [formControl]="tenantSelector"
-    (selectionChange)="setTenantIdentifier()"
-    class="tenantselector"
-  >
+  <mat-select [formControl]="tenantSelector" (selectionChange)="setTenantIdentifier()" class="tenantselector">
     <mat-option *ngFor="let tenant of tenants" [value]="tenant">
       {{ tenant }}
     </mat-option>

--- a/src/app/shared/tenant-selector/tenant-selector.component.ts
+++ b/src/app/shared/tenant-selector/tenant-selector.component.ts
@@ -19,6 +19,11 @@ export class TenantSelectorComponent implements OnInit {
 
   ngOnInit(): void {
     this.tenantSelector.setValue(this.settingsService.tenantIdentifier);
+    if (this.tenants.length > 1) {
+      this.tenantSelector.enable;
+    } else {
+      this.tenantSelector.disable;
+    }
   }
 
   /**

--- a/src/app/shares/shares-account-view/charges-tab/charges-tab.component.ts
+++ b/src/app/shares/shares-account-view/charges-tab/charges-tab.component.ts
@@ -40,7 +40,6 @@ export class ChargesTabComponent implements OnInit {
       this.sharesAccountData = data.sharesAccountData;
       this.chargesData = this.sharesAccountData.charges;
     });
-    console.log(this.sharesAccountData);
   }
 
   ngOnInit() {

--- a/src/app/system/manage-hooks/create-hook/create-hook.component.ts
+++ b/src/app/system/manage-hooks/create-hook/create-hook.component.ts
@@ -141,7 +141,6 @@ export class CreateHookComponent implements OnInit {
     const addEventDialogRef = this.dialog.open(AddEventDialogComponent, {
       data: this.hooksTemplateData
     });
-    console.log(this.hooksTemplateData);
 
     addEventDialogRef.afterClosed().subscribe((response: any) => {
       if (response) {

--- a/src/app/system/roles-and-permissions/view-role/view-role.component.ts
+++ b/src/app/system/roles-and-permissions/view-role/view-role.component.ts
@@ -231,9 +231,7 @@ export class ViewRoleComponent implements OnInit {
     this.formGroup.controls.roster.disable();
     this.checkboxesChanged = false;
     this.isDisabled = true;
-    this.systemService.updateRolePermission(this.roleId, permissionData).subscribe((response: any) => {
-      console.log('response: ', response);
-    });
+    this.systemService.updateRolePermission(this.roleId, permissionData).subscribe((response: any) => {});
   }
 
   /**

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -18,7 +18,7 @@ export const environment = {
   // For connecting to server running elsewhere set the base API URL
   baseApiUrl:
     loadedEnv['fineractApiUrl'] ||
-    (loadedEnv['fineractApiUrls']?.length > 0 ? loadedEnv['fineractApiUrls'][0] : window.location.origin),
+    (loadedEnv['fineractApiUrls']?.length > 0 ? loadedEnv['fineractApiUrls'].split(',')[0] : window.location.origin),
   oauthServerUrl: loadedEnv['oauthServerUrl'] || loadedEnv['fineractApiUrl'] + loadedEnv['apiProvider'],
   allowServerSwitch: env.allow_switching_backend_instance,
   apiProvider: loadedEnv['apiProvider'] || '/fineract-provider/api',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -23,7 +23,7 @@ export const environment = {
   // For connecting to server running elsewhere set the base API URL
   baseApiUrl:
     loadedEnv['fineractApiUrl'] ||
-    (loadedEnv['fineractApiUrls']?.length > 0 ? loadedEnv['fineractApiUrls'][0] : window.location.origin),
+    (loadedEnv['fineractApiUrls']?.length > 0 ? loadedEnv['fineractApiUrls'].split(',')[0] : window.location.origin),
   allowServerSwitch: env.allow_switching_backend_instance,
   apiProvider: loadedEnv['apiProvider'] || '/fineract-provider/api',
   apiVersion: loadedEnv['apiVersion'] || '/v1',


### PR DESCRIPTION
## Description

Using the env settings like these ones:

`docker run -d --network bridge -p 4200:80  -e FINERACT_API_URLS=http://localhost:8080 -e FINERACT_PLATFORM_TENANTS_IDENTIFIER=default,test,live -e MIFOS_SESSION_IDLE_TIMEOUT=300000 openmf/web-app:main`

We must to use the first value in the API url list when there is not a default APU url set

## Screenshots
<img width="650" alt="Screenshot 2025-04-23 at 10 57 28 p m" src="https://github.com/user-attachments/assets/5375813f-8d09-42df-bdaa-c52a22e5e30b" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
