### PR TITLE
fix: Loan Product capitalized income with Income Type

### DIFF
--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -878,6 +878,11 @@
       <span fxFlex="47%">{{ 'labels.inputs.Income capitalization strategy' | translate }}:</span>
       <span fxFlex="53%">{{ loanProduct.capitalizedIncomeStrategy?.value | translateKey: 'catalogs' }}</span>
     </div>
+
+    <div fxFlexFill *ngIf="loanProduct.enableIncomeCapitalization">
+      <span fxFlex="47%">{{ 'labels.inputs.Income type' | translate }}:</span>
+      <span fxFlex="53%">{{ loanProduct.capitalizedIncomeType?.value | translateKey: 'catalogs' }}</span>
+    </div>
   </div>
 
   <h3 class="mat-h3" fxFlexFill>{{ 'labels.heading.Accounting' | translate }}</h3>

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
@@ -293,6 +293,11 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
           this.loanProductsTemplate.capitalizedIncomeStrategyOptions
         );
         this.loanProduct.capitalizedIncomeStrategy = optionValue;
+        optionValue = this.optionDataLookUp(
+          this.loanProduct.capitalizedIncomeType,
+          this.loanProductsTemplate.capitalizedIncomeTypeOptions
+        );
+        this.loanProduct.capitalizedIncomeType = optionValue;
       }
       optionValue = this.optionDataLookUp(
         this.loanProduct.interestRateFrequencyType,

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
@@ -98,6 +98,7 @@
         [capitalizedIncome]="capitalizedIncome"
         [capitalizedIncomeCalculationTypeOptions]="loanProductsTemplate.capitalizedIncomeCalculationTypeOptions"
         [capitalizedIncomeStrategyOptions]="loanProductsTemplate.capitalizedIncomeStrategyOptions"
+        [capitalizedIncomeTypeOptions]="loanProductsTemplate.capitalizedIncomeTypeOptions"
         (setCapitalizedIncome)="setCapitalizedIncome($event)"
         (setViewChildForm)="setViewChildForm($event)"
       >

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
@@ -117,8 +117,9 @@ export class CreateLoanProductComponent implements OnInit {
       if (this.loanProductsTemplate.enableIncomeCapitalization) {
         this.capitalizedIncome = {
           enableIncomeCapitalization: true,
-          incomeCapitalizationCalculationType: this.loanProductsTemplate.capitalizedIncomeCalculationTypeOptions[0],
-          incomeCapitalizationStrategy: this.loanProductsTemplate.capitalizedIncomeStrategyOptions[0]
+          capitalizedIncomeCalculationType: this.loanProductsTemplate.capitalizedIncomeCalculationTypeOptions[0],
+          capitalizedIncomeStrategy: this.loanProductsTemplate.capitalizedIncomeStrategyOptions[0],
+          capitalizedIncomeType: this.loanProductsTemplate.capitalizedIncomeTypeOptions[0]
         };
       } else {
         this.capitalizedIncome = {
@@ -201,8 +202,9 @@ export class CreateLoanProductComponent implements OnInit {
       if (this.capitalizedIncome != null) {
         loanProduct['enableIncomeCapitalization'] = this.capitalizedIncome.enableIncomeCapitalization;
         if (this.capitalizedIncome.enableIncomeCapitalization) {
-          loanProduct['capitalizedIncomeCalculationType'] = this.capitalizedIncome.incomeCapitalizationCalculationType;
-          loanProduct['capitalizedIncomeStrategy'] = this.capitalizedIncome.incomeCapitalizationStrategy;
+          loanProduct['capitalizedIncomeCalculationType'] = this.capitalizedIncome.capitalizedIncomeCalculationType;
+          loanProduct['capitalizedIncomeStrategy'] = this.capitalizedIncome.capitalizedIncomeStrategy;
+          loanProduct['capitalizedIncomeType'] = this.capitalizedIncome.capitalizedIncomeType;
         }
       }
     }

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
@@ -100,6 +100,7 @@
         [capitalizedIncome]="capitalizedIncome"
         [capitalizedIncomeCalculationTypeOptions]="loanProductAndTemplate.capitalizedIncomeCalculationTypeOptions"
         [capitalizedIncomeStrategyOptions]="loanProductAndTemplate.capitalizedIncomeStrategyOptions"
+        [capitalizedIncomeTypeOptions]="loanProductAndTemplate.capitalizedIncomeTypeOptions"
         (setCapitalizedIncome)="setCapitalizedIncome($event)"
         (setViewChildForm)="setViewChildForm($event)"
       >

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
@@ -101,8 +101,9 @@ export class EditLoanProductComponent implements OnInit {
       if (this.loanProductAndTemplate.enableIncomeCapitalization) {
         this.capitalizedIncome = {
           enableIncomeCapitalization: true,
-          incomeCapitalizationCalculationType: this.loanProductAndTemplate.capitalizedIncomeCalculationType.id,
-          incomeCapitalizationStrategy: this.loanProductAndTemplate.capitalizedIncomeStrategy.id
+          capitalizedIncomeCalculationType: this.loanProductAndTemplate.capitalizedIncomeCalculationType.id,
+          capitalizedIncomeStrategy: this.loanProductAndTemplate.capitalizedIncomeStrategy.id,
+          capitalizedIncomeType: this.loanProductAndTemplate.capitalizedIncomeType.id
         };
       } else {
         this.capitalizedIncome = {
@@ -236,8 +237,9 @@ export class EditLoanProductComponent implements OnInit {
       if (this.capitalizedIncome != null) {
         loanProduct['enableIncomeCapitalization'] = this.capitalizedIncome.enableIncomeCapitalization;
         if (this.capitalizedIncome.enableIncomeCapitalization) {
-          loanProduct['capitalizedIncomeCalculationType'] = this.capitalizedIncome.incomeCapitalizationCalculationType;
-          loanProduct['capitalizedIncomeStrategy'] = this.capitalizedIncome.incomeCapitalizationStrategy;
+          loanProduct['capitalizedIncomeCalculationType'] = this.capitalizedIncome.capitalizedIncomeCalculationType;
+          loanProduct['capitalizedIncomeStrategy'] = this.capitalizedIncome.capitalizedIncomeStrategy;
+          loanProduct['capitalizedIncomeType'] = this.capitalizedIncome.capitalizedIncomeType;
         }
       }
     }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-capitalized-income-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-capitalized-income-step.component.html
@@ -6,7 +6,7 @@
 
     <mat-form-field fxFlex="48%" *ngIf="enableIncomeCapitalization">
       <mat-label>{{ 'labels.inputs.Income capitalization calculation type' | translate }}</mat-label>
-      <mat-select formControlName="incomeCapitalizationCalculationType" required>
+      <mat-select formControlName="capitalizedIncomeCalculationType" required>
         <mat-option
           *ngFor="let capitalizedIncomeCalculationType of capitalizedIncomeCalculationTypeOptions"
           [value]="capitalizedIncomeCalculationType.id"
@@ -17,12 +17,23 @@
     </mat-form-field>
     <mat-form-field fxFlex="48%" *ngIf="enableIncomeCapitalization">
       <mat-label>{{ 'labels.inputs.Income capitalization strategy' | translate }}</mat-label>
-      <mat-select formControlName="incomeCapitalizationStrategy" required>
+      <mat-select formControlName="capitalizedIncomeStrategy" required>
         <mat-option
           *ngFor="let capitalizedIncomeStrategy of capitalizedIncomeStrategyOptions"
           [value]="capitalizedIncomeStrategy.id"
         >
           {{ capitalizedIncomeStrategy.value | translateKey: 'catalogs' }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field fxFlex="48%" *ngIf="enableIncomeCapitalization">
+      <mat-label>{{ 'labels.inputs.Income type' | translate }}</mat-label>
+      <mat-select formControlName="capitalizedIncomeType" required>
+        <mat-option
+          *ngFor="let capitalizedIncomeType of capitalizedIncomeTypeOptions"
+          [value]="capitalizedIncomeType.id"
+        >
+          {{ capitalizedIncomeType.value | translateKey: 'catalogs' }}
         </mat-option>
       </mat-select>
     </mat-form-field>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-capitalized-income-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-capitalized-income-step.component.ts
@@ -12,6 +12,7 @@ export class LoanProductCapitalizedIncomeStepComponent implements OnChanges {
   @Input() capitalizedIncome: CapitalizedIncome;
   @Input() capitalizedIncomeCalculationTypeOptions: StringEnumOptionData[];
   @Input() capitalizedIncomeStrategyOptions: StringEnumOptionData[];
+  @Input() capitalizedIncomeTypeOptions: StringEnumOptionData[];
 
   loanIncomeCapitalizationForm: UntypedFormGroup;
 
@@ -31,12 +32,16 @@ export class LoanProductCapitalizedIncomeStepComponent implements OnChanges {
     if (this.enableIncomeCapitalization) {
       this.loanIncomeCapitalizationForm = this.formBuilder.group({
         enableIncomeCapitalization: [this.enableIncomeCapitalization],
-        incomeCapitalizationCalculationType: [
-          this.capitalizedIncome.incomeCapitalizationCalculationType,
+        capitalizedIncomeCalculationType: [
+          this.capitalizedIncome.capitalizedIncomeCalculationType,
           Validators.required
         ],
-        incomeCapitalizationStrategy: [
-          this.capitalizedIncome.incomeCapitalizationStrategy,
+        capitalizedIncomeStrategy: [
+          this.capitalizedIncome.capitalizedIncomeStrategy,
+          Validators.required
+        ],
+        capitalizedIncomeType: [
+          this.capitalizedIncome.capitalizedIncomeType,
           Validators.required
         ]
       });
@@ -53,8 +58,9 @@ export class LoanProductCapitalizedIncomeStepComponent implements OnChanges {
     if (this.enableIncomeCapitalization) {
       this.loanIncomeCapitalizationForm.patchValue({
         enableIncomeCapitalization: this.enableIncomeCapitalization,
-        incomeCapitalizationCalculationType: this.capitalizedIncome.incomeCapitalizationCalculationType,
-        incomeCapitalizationStrategy: this.capitalizedIncome.incomeCapitalizationStrategy
+        capitalizedIncomeCalculationType: this.capitalizedIncome.capitalizedIncomeCalculationType,
+        capitalizedIncomeStrategy: this.capitalizedIncome.capitalizedIncomeStrategy,
+        capitalizedIncomeType: this.capitalizedIncome.capitalizedIncomeType
       });
     }
     this.setViewChildForm.emit(this.loanIncomeCapitalizationForm);
@@ -64,54 +70,71 @@ export class LoanProductCapitalizedIncomeStepComponent implements OnChanges {
     this.loanIncomeCapitalizationForm.get('enableIncomeCapitalization').valueChanges.subscribe((enabled: boolean) => {
       this.enableIncomeCapitalization = enabled;
       if (this.enableIncomeCapitalization) {
-        const incomeCapitalizationCalculationType =
-          this.capitalizedIncome.incomeCapitalizationCalculationType == ''
-            ? ''
-            : this.capitalizedIncome.incomeCapitalizationCalculationType;
+        const capitalizedIncomeCalculationType =
+          !this.capitalizedIncome.capitalizedIncomeCalculationType ||
+          this.capitalizedIncome.capitalizedIncomeCalculationType == ''
+            ? this.capitalizedIncomeCalculationTypeOptions[0].id
+            : this.capitalizedIncome.capitalizedIncomeCalculationType;
         this.loanIncomeCapitalizationForm.addControl(
-          'incomeCapitalizationCalculationType',
-          new UntypedFormControl(
-            this.capitalizedIncome.incomeCapitalizationCalculationType ||
-              this.capitalizedIncomeCalculationTypeOptions[0].id,
-            Validators.required
-          )
+          'capitalizedIncomeCalculationType',
+          new UntypedFormControl(capitalizedIncomeCalculationType, Validators.required)
         );
-        const incomeCapitalizationStrategy =
-          this.capitalizedIncome.incomeCapitalizationStrategy == ''
-            ? ''
-            : this.capitalizedIncome.incomeCapitalizationStrategy;
+        const capitalizedIncomeStrategy =
+          !this.capitalizedIncome.capitalizedIncomeStrategy || this.capitalizedIncome.capitalizedIncomeStrategy == ''
+            ? this.capitalizedIncomeStrategyOptions[0].id
+            : this.capitalizedIncome.capitalizedIncomeStrategy;
         this.loanIncomeCapitalizationForm.addControl(
-          'incomeCapitalizationStrategy',
-          new UntypedFormControl(incomeCapitalizationStrategy, Validators.required)
+          'capitalizedIncomeStrategy',
+          new UntypedFormControl(capitalizedIncomeStrategy, Validators.required)
+        );
+        const capitalizedIncomeType =
+          !this.capitalizedIncome.capitalizedIncomeType || this.capitalizedIncome.capitalizedIncomeType == ''
+            ? this.capitalizedIncomeTypeOptions[0].id
+            : this.capitalizedIncome.capitalizedIncomeType;
+        this.loanIncomeCapitalizationForm.addControl(
+          'capitalizedIncomeType',
+          new UntypedFormControl(capitalizedIncomeType, Validators.required)
         );
         this.setCapitalizedIncome.emit({
           enableIncomeCapitalization: true,
-          incomeCapitalizationCalculationType: incomeCapitalizationCalculationType,
-          incomeCapitalizationStrategy: incomeCapitalizationStrategy
+          capitalizedIncomeCalculationType: capitalizedIncomeCalculationType,
+          capitalizedIncomeStrategy: capitalizedIncomeStrategy,
+          capitalizedIncomeType: capitalizedIncomeType
         });
 
         this.loanIncomeCapitalizationForm
-          .get('incomeCapitalizationCalculationType')
+          .get('capitalizedIncomeCalculationType')
           .valueChanges.subscribe((newValue: string) => {
             this.setCapitalizedIncome.emit({
               enableIncomeCapitalization: true,
-              incomeCapitalizationCalculationType: newValue,
-              incomeCapitalizationStrategy: this.loanIncomeCapitalizationForm.value.incomeCapitalizationStrategy
+              capitalizedIncomeCalculationType: newValue,
+              capitalizedIncomeStrategy: this.loanIncomeCapitalizationForm.value.capitalizedIncomeStrategy,
+              capitalizedIncomeType: this.loanIncomeCapitalizationForm.value.capitalizedIncomeType
             });
           });
         this.loanIncomeCapitalizationForm
-          .get('incomeCapitalizationStrategy')
+          .get('capitalizedIncomeStrategy')
           .valueChanges.subscribe((newValue: string) => {
             this.setCapitalizedIncome.emit({
               enableIncomeCapitalization: true,
-              incomeCapitalizationCalculationType:
-                this.loanIncomeCapitalizationForm.value.incomeCapitalizationCalculationType,
-              incomeCapitalizationStrategy: newValue
+              capitalizedIncomeCalculationType:
+                this.loanIncomeCapitalizationForm.value.capitalizedIncomeCalculationType,
+              capitalizedIncomeStrategy: newValue,
+              capitalizedIncomeType: this.loanIncomeCapitalizationForm.value.capitalizedIncomeType
             });
           });
+        this.loanIncomeCapitalizationForm.get('capitalizedIncomeType').valueChanges.subscribe((newValue: string) => {
+          this.setCapitalizedIncome.emit({
+            enableIncomeCapitalization: true,
+            capitalizedIncomeCalculationType: this.loanIncomeCapitalizationForm.value.capitalizedIncomeCalculationType,
+            capitalizedIncomeStrategy: this.loanIncomeCapitalizationForm.value.capitalizedIncomeStrategy,
+            capitalizedIncomeType: newValue
+          });
+        });
       } else {
-        this.loanIncomeCapitalizationForm.removeControl('incomeCapitalizationCalculationType');
-        this.loanIncomeCapitalizationForm.removeControl('incomeCapitalizationStrategy');
+        this.loanIncomeCapitalizationForm.removeControl('capitalizedIncomeCalculationType');
+        this.loanIncomeCapitalizationForm.removeControl('capitalizedIncomeStrategy');
+        this.loanIncomeCapitalizationForm.removeControl('capitalizedIncomeType');
         this.setCapitalizedIncome.emit({ enableIncomeCapitalization: false });
       }
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-payment-strategy-step/payment-allocation-model.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-payment-strategy-step/payment-allocation-model.ts
@@ -44,8 +44,9 @@ export interface CreditAllocation {
 
 export interface CapitalizedIncome {
   enableIncomeCapitalization: boolean;
-  incomeCapitalizationCalculationType?: string;
-  incomeCapitalizationStrategy?: string;
+  capitalizedIncomeCalculationType?: string;
+  capitalizedIncomeStrategy?: string;
+  capitalizedIncomeType?: string;
 }
 
 export class PaymentAllocationTransactionTypes {

--- a/src/app/products/loan-products/models/loan-product.model.ts
+++ b/src/app/products/loan-products/models/loan-product.model.ts
@@ -69,6 +69,7 @@ export interface LoanProduct {
   enableIncomeCapitalization?: boolean;
   capitalizedIncomeCalculationType?: OptionData;
   capitalizedIncomeStrategy?: OptionData;
+  capitalizedIncomeType?: OptionData;
 
   canDefineInstallmentAmount: boolean;
   graceOnArrearsAgeing?: number;

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1709,6 +1709,7 @@
       "Income from fees": "Příjem z poplatků",
       "Income from fees Repayments": "Příjmy z poplatků Splátky",
       "Income from penalties": "Příjem z penále",
+      "Income type": "Typ příjmu",
       "Incorporation No": "Čís",
       "Incorporation Number": "Číslo zápisu",
       "Incorporation Validity Till Date": "Platnost založení do data",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1709,6 +1709,7 @@
       "Income from fees": "Einnahmen aus Gebühren",
       "Income from fees Repayments": "Einnahmen aus Gebührenrückzahlungen",
       "Income from penalties": "Einnahmen aus Strafen",
+      "Income type": "Einkommensart",
       "Incorporation No": "Gründungsnr",
       "Incorporation Number": "Gründungsnummer",
       "Incorporation Validity Till Date": "Gültigkeit der Gründung bis zum Datum",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1713,6 +1713,7 @@
       "Income from fees": "Income from fees",
       "Income from fees Repayments": "Income from fees Repayments",
       "Income from penalties": "Income from penalties",
+      "Income type": "Income type",
       "Incorporation No": "Incorporation No",
       "Incorporation Number": "Incorporation Number",
       "Incorporation Date": "Incorporation Date",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1708,6 +1708,7 @@
       "Income from fees": "Ingresos por Comisiones",
       "Income from fees Repayments": "Ingresos por comisiones Amortizaciones",
       "Income from penalties": "Ingresos por penalizaciones",
+      "Income type": "Tipo de ingreso",
       "Incorporation No": "Número de constitución",
       "Incorporation Number": "Número de constitución",
       "Incorporation Validity Till Date": "Validez de constitución hasta la fecha",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1708,6 +1708,7 @@
       "Income from fees": "Ingresos por Comisiones",
       "Income from fees Repayments": "Ingresos por comisiones Amortizaciones",
       "Income from penalties": "Ingresos por penalizaciones",
+      "Income type": "Tipo de ingreso",
       "Incorporation No": "Número de constitución",
       "Incorporation Number": "Número de constitución",
       "Incorporation Validity Till Date": "Validez de constitución hasta la fecha",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1709,6 +1709,7 @@
       "Income from fees": "Revenus d'honoraires",
       "Income from fees Repayments": "Revenus de taxes Remboursements",
       "Income from penalties": "Revenus des pénalités",
+      "Income type": "Type de revenu",
       "Incorporation No": "Numéro de constitution",
       "Incorporation Number": "Numéro de constitution",
       "Incorporation Validity Till Date": "Validité de la constitution jusqu'à la date",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1709,6 +1709,7 @@
       "Income from fees": "Proventi da commissioni",
       "Income from fees Repayments": "Proventi da commissioni Rimborsi",
       "Income from penalties": "Proventi da sanzioni",
+      "Income type": "Tipo di reddito",
       "Incorporation No": "Costituzione n",
       "Incorporation Number": "Numero di costituzione",
       "Incorporation Validity Till Date": "Validità della costituzione fino alla data",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1710,6 +1710,7 @@
       "Income from fees": "수수료 수입",
       "Income from fees Repayments": "수수료 수익 상환",
       "Income from penalties": "벌금으로 인한 소득",
+      "Income type": "소득 유형",
       "Incorporation No": "법인설립번호",
       "Incorporation Number": "법인번호",
       "Incorporation Validity Till Date": "법인설립 유효일까지",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1709,6 +1709,7 @@
       "Income from fees": "Pajamos iš mokesčių",
       "Income from fees Repayments": "Pajamos iš mokesčių Grąžinimai",
       "Income from penalties": "Pajamos iš baudų",
+      "Income type": "Pajamų rūšis",
       "Incorporation No": "Įmonės Nr",
       "Incorporation Number": "Įmonės numeris",
       "Incorporation Validity Till Date": "Įkūrimo galiojimas iki datos",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1709,6 +1709,7 @@
       "Income from fees": "Ienākumi no honorāriem",
       "Income from fees Repayments": "Ienākumi no nodevām Atmaksas",
       "Income from penalties": "Ienākumi no sodiem",
+      "Income type": "Ienākumu veids",
       "Incorporation No": "Dibināšanas Nr",
       "Incorporation Number": "Uzņēmuma numurs",
       "Incorporation Validity Till Date": "Reģistrācijas derīguma termiņš līdz datumam",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1709,6 +1709,7 @@
       "Income from fees": "शुल्कबाट आम्दानी",
       "Income from fees Repayments": "शुल्क भुक्तानीबाट आय",
       "Income from penalties": "दण्डबाट आम्दानी",
+      "Income type": "आय प्रकार",
       "Incorporation No": "निगम नं",
       "Incorporation Number": "निगमन नम्बर",
       "Incorporation Validity Till Date": "मिति सम्म सम्मिलित वैधता",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1709,6 +1709,7 @@
       "Income from fees": "Renda de taxas",
       "Income from fees Repayments": "Reembolsos de taxas",
       "Income from penalties": "Renda de penalidades",
+      "Income type": "Tipo de renda",
       "Incorporation No": "Incorporação Não",
       "Incorporation Number": "Número de Incorporação",
       "Incorporation Validity Till Date": "Validade de incorporação até a data",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1709,6 +1709,7 @@
       "Income from fees": "Mapato kutoka kwa ada",
       "Income from fees Repayments": "Mapato kutokana na Malipo ya ada",
       "Income from penalties": "Mapato kutoka kwa adhabu",
+      "Income type": "Aina ya mapato",
       "Incorporation No": "Incorporation No",
       "Incorporation Number": "Nambari ya Kuingiza",
       "Incorporation Validity Till Date": "Uhalali wa Ujumuishaji Hadi Tarehe",


### PR DESCRIPTION
## Description

We are able to configure `Capitalized income` on loan product, select **calculation mode**, **calculation strategy** and **Income type**

## Screenshots
<img width="1482" alt="Screenshot 2025-04-24 at 12 42 43 p m" src="https://github.com/user-attachments/assets/c7af2340-24e5-4f49-b46e-da9173c2a087" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
