### PR TITLE
Loan Product with Capitalized Income GL accounting mappings

### DIFF
--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -1011,6 +1011,14 @@
       [withTitle]="'47%'"
     >
     </mifosx-gl-account-display>
+    <mifosx-gl-account-display
+      fxFlex="100%"
+      *ngIf="accountingMappings.incomeFromCapitalizationAccount"
+      [accountTitle]="'Income capitalization'"
+      [glAccount]="accountingMappings.incomeFromCapitalizationAccount"
+      [withTitle]="'47%'"
+    >
+    </mifosx-gl-account-display>
 
     <h4 fxFlexFill class="mat-h4">{{ 'labels.heading.Expenses' | translate }}</h4>
 
@@ -1051,6 +1059,14 @@
         fxFlex="100%"
         [accountTitle]="'Over payment liability'"
         [glAccount]="accountingMappings.overpaymentLiabilityAccount"
+        [withTitle]="'47%'"
+      >
+      </mifosx-gl-account-display>
+      <mifosx-gl-account-display
+        fxFlex="100%"
+        *ngIf="accountingMappings.deferredIncomeLiabilityAccount"
+        [accountTitle]="'Deferred income'"
+        [glAccount]="accountingMappings.deferredIncomeLiabilityAccount"
         [withTitle]="'47%'"
       >
       </mifosx-gl-account-display>

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
@@ -152,6 +152,10 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
             this.loanProduct.incomeFromChargeOffPenaltyAccountId,
             incomeAccountData
           ),
+          incomeFromCapitalizationAccount: this.glAccountLookUp(
+            this.loanProduct.incomeFromCapitalizationAccountId,
+            incomeAccountData
+          ),
 
           writeOffAccount: this.glAccountLookUp(this.loanProduct.writeOffAccountId, expenseAccountData),
           goodwillCreditAccount: this.glAccountLookUp(this.loanProduct.goodwillCreditAccountId, expenseAccountData),
@@ -160,6 +164,10 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
 
           overpaymentLiabilityAccount: this.glAccountLookUp(
             this.loanProduct.overpaymentLiabilityAccountId,
+            liabilityAccountData
+          ),
+          deferredIncomeLiabilityAccount: this.glAccountLookUp(
+            this.loanProduct.deferredIncomeLiabilityAccountId,
             liabilityAccountData
           )
         };

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
@@ -113,6 +113,7 @@
         [loanProductsTemplate]="loanProductsTemplate"
         [accountingRuleData]="accountingRuleData"
         [loanProductFormValid]="loanProductFormValid"
+        [capitalizedIncome]="capitalizedIncome"
       >
       </mifosx-loan-product-accounting-step>
     </mat-step>

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
@@ -115,6 +115,7 @@
         [loanProductsTemplate]="loanProductAndTemplate"
         [accountingRuleData]="accountingRuleData"
         [loanProductFormValid]="loanProductFormValidAndNotPristine"
+        [capitalizedIncome]="capitalizedIncome"
       >
       </mifosx-loan-product-accounting-step>
     </mat-step>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
@@ -189,6 +189,16 @@
       >
       </mifosx-gl-account-selector>
 
+      <mifosx-gl-account-selector
+        *ngIf="capitalizedIncome.enableIncomeCapitalization"
+        fxFlex="48%"
+        [inputFormControl]="loanProductAccountingForm.controls.incomeFromCapitalizationAccountId"
+        [glAccountList]="incomeAccountData"
+        [required]="true"
+        [inputLabel]="'Income capitalization'"
+      >
+      </mifosx-gl-account-selector>
+
       <mat-divider fxFlex="98%"></mat-divider>
 
       <h4 fxFlex="98%" class="mat-h4">{{ 'labels.heading.Expenses' | translate }}</h4>
@@ -239,6 +249,16 @@
         [glAccountList]="liabilityAccountData"
         [required]="true"
         [inputLabel]="'Over payment liability'"
+      >
+      </mifosx-gl-account-selector>
+
+      <mifosx-gl-account-selector
+        *ngIf="capitalizedIncome.enableIncomeCapitalization"
+        fxFlex="48%"
+        [inputFormControl]="loanProductAccountingForm.controls.deferredIncomeLiabilityAccountId"
+        [glAccountList]="liabilityAccountData"
+        [required]="true"
+        [inputLabel]="'Deferred income'"
       >
       </mifosx-gl-account-selector>
 

--- a/src/app/products/loan-products/models/loan-product.model.ts
+++ b/src/app/products/loan-products/models/loan-product.model.ts
@@ -117,6 +117,7 @@ export interface LoanProduct {
   accountingMappings?: { [key: string]: AccountingMapping };
   fundSourceAccountId?: number;
   goodwillCreditAccountId?: number;
+  incomeFromCapitalizationAccountId?: number;
   incomeFromChargeOffFeesAccountId?: number;
   incomeFromChargeOffInterestAccountId?: number;
   incomeFromChargeOffPenaltyAccountId?: number;
@@ -134,6 +135,7 @@ export interface LoanProduct {
   receivablePenaltyAccountId?: number;
   transfersInSuspenseAccountId?: number;
   writeOffAccountId?: number;
+  deferredIncomeLiabilityAccountId?: number;
   // Advanced Accounting
   paymentChannelToFundSourceMappings?: PaymentChannelToFundSourceMapping[];
   feeToIncomeAccountMappings?: ChargeToIncomeAccountMapping[];

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1482,6 +1482,7 @@
       "Default Savings Account": "Výchozí spořicí účet",
       "Default Shares per Client": "Výchozí podíly na klienta",
       "Default Theme": "Výchozí motiv",
+      "Deferred income": "Výnosy příštích období",
       "Deleted": "Smazáno",
       "Delinquency Action": "Akce delikvence",
       "Delinquency Bucket": "Delikvence Bucket",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1482,6 +1482,7 @@
       "Default Savings Account": "Standardsparkonto",
       "Default Shares per Client": "Standardanteile pro Kunde",
       "Default Theme": "Standardthema",
+      "Deferred income": "Rechnungsabgrenzungsposten",
       "Deleted": "Gelöscht",
       "Delinquency Action": "Kriminalitätsaktion",
       "Delinquency Bucket": "Kriminalitätseimer",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1486,6 +1486,7 @@
       "Default Savings Account": "Default Savings Account",
       "Default Shares per Client": "Default Shares per Client",
       "Default Theme": "Default Theme",
+      "Deferred income": "Deferred income",
       "Deleted": "Deleted",
       "Delinquency Action": "Delinquency Action",
       "Delinquency Bucket": "Delinquency Bucket",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1481,6 +1481,7 @@
       "Default Savings Account": "Cuenta de Ahorros predeterminada",
       "Default Shares per Client": "Acciones predeterminadas por cliente",
       "Default Theme": "Tema predeterminado",
+      "Deferred income": "Ingresos diferidos",
       "Deleted": "Eliminado",
       "Delinquency Action": "Acción de morosidad",
       "Delinquency Bucket": "Clasificación de morosidad",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1481,6 +1481,7 @@
       "Default Savings Account": "Cuenta de Ahorros predeterminada",
       "Default Shares per Client": "Acciones predeterminadas por cliente",
       "Default Theme": "Tema predeterminado",
+      "Deferred income": "Ingresos diferidos",
       "Deleted": "Eliminado",
       "Delinquency Action": "Acción de morosidad",
       "Delinquency Bucket": "Clasificación de morosidad",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1482,6 +1482,7 @@
       "Default Savings Account": "Compte d'épargne par défaut",
       "Default Shares per Client": "Actions par défaut par client",
       "Default Theme": "Thème par défaut",
+      "Deferred income": "Produits différés",
       "Deleted": "Supprimé",
       "Delinquency Action": "Action de délinquance",
       "Delinquency Bucket": "Seau de délinquance",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1482,6 +1482,7 @@
       "Default Savings Account": "Conto di risparmio predefinito",
       "Default Shares per Client": "Condivisioni predefinite per cliente",
       "Default Theme": "Tema predefinito",
+      "Deferred income": "Ricavi differiti",
       "Deleted": "Eliminato",
       "Delinquency Action": "Azione di delinquenza",
       "Delinquency Bucket": "Il secchio della delinquenza",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1483,6 +1483,7 @@
       "Default Savings Account": "기본 저축 계좌",
       "Default Shares per Client": "클라이언트당 기본 공유",
       "Default Theme": "기본 테마",
+      "Deferred income": "이연소득",
       "Deleted": "삭제됨",
       "Delinquency Action": "연체 행동",
       "Delinquency Bucket": "연체 버킷",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1482,6 +1482,7 @@
       "Default Savings Account": "Numatytoji taupomoji sąskaita",
       "Default Shares per Client": "Numatytosios akcijos vienam klientui",
       "Default Theme": "Numatytoji tema",
+      "Deferred income": "Atidėtos pajamos",
       "Deleted": "Ištrinta",
       "Delinquency Action": "Deliktingumo veiksmas",
       "Delinquency Bucket": "Nusikaltimų kibiras",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1482,6 +1482,7 @@
       "Default Savings Account": "Noklusējuma krājkonts",
       "Default Shares per Client": "Noklusējuma akcijas vienam klientam",
       "Default Theme": "Noklusējuma motīvs",
+      "Deferred income": "Atliktie ienākumi",
       "Deleted": "Izdzēsts",
       "Delinquency Action": "Likumpārkāpums",
       "Delinquency Bucket": "Noziedzības spainis",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1482,6 +1482,7 @@
       "Default Savings Account": "पूर्वनिर्धारित बचत खाता",
       "Default Shares per Client": "प्रति ग्राहक पूर्वनिर्धारित शेयरहरू",
       "Default Theme": "पूर्वनिर्धारित विषयवस्तु",
+      "Deferred income": "स्थगित आय",
       "Deleted": "मेटाइयो",
       "Delinquency Action": "अपराध कार्य",
       "Delinquency Bucket": "अपराध बाल्टी",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1482,6 +1482,7 @@
       "Default Savings Account": "Conta poupança padrão",
       "Default Shares per Client": "Compartilhamentos padrão por cliente",
       "Default Theme": "Tema Padrão",
+      "Deferred income": "Renda diferida",
       "Deleted": "Excluído",
       "Delinquency Action": "Ação de inadimplência",
       "Delinquency Bucket": "Balde de inadimplência",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1482,6 +1482,7 @@
       "Default Savings Account": "Akaunti ya Akiba chaguomsingi",
       "Default Shares per Client": "Hisa Chaguomsingi kwa kila Mteja",
       "Default Theme": "Mandhari Chaguomsingi",
+      "Deferred income": "Mapato yaliyoahirishwa",
       "Deleted": "Imefutwa",
       "Delinquency Action": "Kitendo cha Delinquency",
       "Delinquency Bucket": "Ndoo ya Uhalifu",


### PR DESCRIPTION
## Description

In the Loan Product If capitalized income is enabled, a new `Liability` account and `Income` account ought to be configured for periodical accounting

“Deferred income” liability / “Income Capitalization” income GL mappings are beong added in the loan product

## Screenshots

https://github.com/user-attachments/assets/a4ea72c5-5f48-4e70-8140-5d7a5c42aac2


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
