### PR TITLE
Replace references to MatLegacyCardModule in Angular 15 project.

### DIFF
--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -7,7 +7,7 @@ import { MatLegacyAutocompleteModule as MatAutocompleteModule } from '@angular/m
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
-import { MatLegacyCardModule as MatCardModule } from '@angular/material/legacy-card';
+import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy-chips';
 import { MatNativeDateModule } from '@angular/material/core';


### PR DESCRIPTION
## Correct all references to

_MatLegacyCardModule_

in the angular-update branch and verify the result works by testing.


## Fixes issue [WEB-149](https://mifosforge.jira.com/browse/WEB-149)

Changes made:
Updated import of MatLegacyCardModule to a non-Legacy component.
There areno styling changes from angular 14 to 15 update in card component

[WEB-149]: https://mifosforge.jira.com/browse/WEB-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ