### PR TITLE
fix: Loan Product Cash accounting view

### DIFF
--- a/src/app/core/utils/accounting.ts
+++ b/src/app/core/utils/accounting.ts
@@ -41,7 +41,7 @@ export class Accounting {
         'ACCRUAL (UPFRONT)'
       ].includes(value)) {
       return 'Accrual (upfront)';
-    } else if (value === 'CASH BASED') {
+    } else if (value.startsWith('CASH')) {
       return 'Cash';
     } else if (value === 'NONE') {
       return 'NONE';

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
@@ -223,6 +223,7 @@ export class CreateLoanProductComponent implements OnInit {
       );
     } else {
       delete loanProduct['supportedInterestRefundTypes'];
+      delete loanProduct['daysInYearCustomStrategy'];
     }
     delete loanProduct['useDueForRepaymentsConfigurations'];
 

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
@@ -258,6 +258,7 @@ export class EditLoanProductComponent implements OnInit {
       );
     } else {
       delete loanProduct['supportedInterestRefundTypes'];
+      delete loanProduct['daysInYearCustomStrategy'];
     }
     delete loanProduct['useDueForRepaymentsConfigurations'];
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
@@ -190,7 +190,7 @@
       </mifosx-gl-account-selector>
 
       <mifosx-gl-account-selector
-        *ngIf="capitalizedIncome.enableIncomeCapitalization"
+        *ngIf="capitalizedIncome?.enableIncomeCapitalization"
         fxFlex="48%"
         [inputFormControl]="loanProductAccountingForm.controls.incomeFromCapitalizationAccountId"
         [glAccountList]="incomeAccountData"
@@ -253,7 +253,7 @@
       </mifosx-gl-account-selector>
 
       <mifosx-gl-account-selector
-        *ngIf="capitalizedIncome.enableIncomeCapitalization"
+        *ngIf="capitalizedIncome?.enableIncomeCapitalization"
         fxFlex="48%"
         [inputFormControl]="loanProductAccountingForm.controls.deferredIncomeLiabilityAccountId"
         [glAccountList]="liabilityAccountData"


### PR DESCRIPTION
## Description

In the Loan Product creation and edition we were having issues to display the right Loan accounting type when we are using `Cash` accounting

## Screenshots

<img width="1512" alt="Screenshot 2025-04-29 at 7 49 22 a m" src="https://github.com/user-attachments/assets/b942530a-aaf5-4c61-8692-4c7180f8541a" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
