### PR TITLE
fix: Loan Id updated in Loan views after url changed

### DIFF
--- a/src/app/loans/loans-view/datatable-tab/datatable-tab.component.ts
+++ b/src/app/loans/loans-view/datatable-tab/datatable-tab.component.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute } from '@angular/router';
   templateUrl: './datatable-tab.component.html',
   styleUrls: ['./datatable-tab.component.scss']
 })
-export class DatatableTabComponent {
+export class DatatableTabComponent implements OnInit {
   entityId: string;
   /** Loan Datatable */
   entityDatatable: any = null;
@@ -23,6 +23,12 @@ export class DatatableTabComponent {
     this.route.data.subscribe((data: { loanDatatable: any }) => {
       this.entityDatatable = data.loanDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
+    });
+  }
+
+  ngOnInit() {
+    this.route.parent.parent.params.subscribe((params) => {
+      this.entityId = params['loanId'];
     });
   }
 }

--- a/src/app/loans/loans-view/loan-documents-tab/loan-documents-tab.component.ts
+++ b/src/app/loans/loans-view/loan-documents-tab/loan-documents-tab.component.ts
@@ -1,5 +1,5 @@
 /** Angular Imports */
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -15,7 +15,7 @@ import { SettingsService } from 'app/settings/settings.service';
   templateUrl: './loan-documents-tab.component.html',
   styleUrls: ['./loan-documents-tab.component.scss']
 })
-export class LoanDocumentsTabComponent {
+export class LoanDocumentsTabComponent implements OnInit {
   /** Stores the resolved loan documents data */
   entityDocuments: any;
   /** Loan account Id */
@@ -35,6 +35,12 @@ export class LoanDocumentsTabComponent {
 
     this.route.data.subscribe((data: { loanDocuments: any }) => {
       this.getLoanDocumentsData(data.loanDocuments);
+    });
+  }
+
+  ngOnInit(): void {
+    this.route.parent.params.subscribe((params) => {
+      this.entityId = params['loanId'];
     });
   }
 

--- a/src/app/loans/loans-view/loans-view.component.ts
+++ b/src/app/loans/loans-view/loans-view.component.ts
@@ -82,6 +82,12 @@ export class LoansViewComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.route.params.subscribe((params) => {
+      if (this.loanId != params['loanId']) {
+        this.loanId = params['loanId'];
+        this.reload();
+      }
+    });
     this.recalculateInterest = this.loanDetailsData.recalculateInterest || true;
     this.status = this.loanDetailsData.status.value;
     if (this.loanStatus.active && this.loanDetailsData.multiDisburseLoan) {

--- a/src/app/loans/loans-view/notes-tab/notes-tab.component.ts
+++ b/src/app/loans/loans-view/notes-tab/notes-tab.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Components */
@@ -12,7 +12,7 @@ import { AuthenticationService } from '../../../core/authentication/authenticati
   templateUrl: './notes-tab.component.html',
   styleUrls: ['./notes-tab.component.scss']
 })
-export class NotesTabComponent {
+export class NotesTabComponent implements OnInit {
   entityId: string;
   username: string;
   entityNotes: any;
@@ -27,6 +27,12 @@ export class NotesTabComponent {
     this.entityId = this.route.parent.snapshot.params['loanId'];
     this.route.data.subscribe((data: { loanNotes: any }) => {
       this.entityNotes = data.loanNotes;
+    });
+  }
+
+  ngOnInit(): void {
+    this.route.parent.params.subscribe((params) => {
+      this.entityId = params['loanId'];
     });
   }
 


### PR DESCRIPTION
## Description

We were having an issue, after adding a loan datatable record (multi-entity loan datatable) for a specific loan, while trying to add a similar data for a different loan within the same browser window (_after manually updating the URL values for client and loan Id_), the new data is created for first loan, rather than second loan

## Screenshots


https://github.com/user-attachments/assets/d28fcc53-359a-4b24-8ae8-ffca252d65e7


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
