### PR TITLE
fix: broken flex calc style directive

### DIFF
--- a/src/app/centers/centers-view/notes-tab/notes-tab.component.html
+++ b/src/app/centers/centers-view/notes-tab/notes-tab.component.html
@@ -7,7 +7,7 @@
       class="layout-row align-start-baseline gap-20px"
       (ngSubmit)="submit()"
     >
-      <mat-form-field class="flex-fill" ="calc(90%-20px)">
+      <mat-form-field class="flex-90-minus-20px">
         <textarea
           formControlName="note"
           matInput

--- a/src/app/clients/clients-view/family-members-tab/add-family-member/add-family-member.component.html
+++ b/src/app/clients/clients-view/family-members-tab/add-family-member/add-family-member.component.html
@@ -1,7 +1,7 @@
 <div class="add-family-member-container">
   <form [formGroup]="addFamilyMemberForm" (ngSubmit)="submit()">
     <div class="layout-row-wrap responsive-column align-start-center">
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.First Name' | translate }}</mat-label>
         <input formControlName="firstName" required matInput />
         <mat-error *ngIf="addFamilyMemberForm.controls.firstName.hasError('required')">
@@ -10,12 +10,12 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Middle Name' | translate }}</mat-label>
         <input formControlName="middleName" matInput />
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Last Name' | translate }}</mat-label>
         <input formControlName="lastName" required matInput />
         <mat-error *ngIf="addFamilyMemberForm.controls.lastName.hasError('required')">
@@ -24,12 +24,12 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Qualification' | translate }}</mat-label>
         <input formControlName="qualification" matInput />
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Age' | translate }}</mat-label>
         <input type="number" formControlName="age" required matInput [min]="minAge" />
         <mat-error *ngIf="addFamilyMemberForm.controls.age.hasError('required')">
@@ -42,7 +42,7 @@
         >{{ 'labels.inputs.Is Dependent' | translate }}?
       </mat-checkbox>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Relationship' | translate }}</mat-label>
         <mat-select formControlName="relationshipId" required>
           <mat-option *ngFor="let relation of addFamilyMemberTemplate.relationshipIdOptions" [value]="relation.id">
@@ -55,7 +55,7 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Gender' | translate }}</mat-label>
         <mat-select formControlName="genderId" required>
           <mat-option *ngFor="let gender of addFamilyMemberTemplate.genderIdOptions" [value]="gender.id">
@@ -68,7 +68,7 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Profession' | translate }}</mat-label>
         <mat-select formControlName="professionId">
           <mat-option *ngFor="let profession of addFamilyMemberTemplate.professionIdOptions" [value]="profession.id">
@@ -77,7 +77,7 @@
         </mat-select>
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Marital Status' | translate }}</mat-label>
         <mat-select formControlName="maritalStatusId">
           <mat-option

--- a/src/app/clients/clients-view/family-members-tab/edit-family-member/edit-family-member.component.html
+++ b/src/app/clients/clients-view/family-members-tab/edit-family-member/edit-family-member.component.html
@@ -1,7 +1,7 @@
 <div class="add-family-member-container">
   <form [formGroup]="editFamilyMemberForm" (ngSubmit)="submit()">
     <div class="layout-row-wrap responsive-column align-start-center">
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.First Name' | translate }}</mat-label>
         <input formControlName="firstName" required matInput />
         <mat-error *ngIf="editFamilyMemberForm.controls.firstName.hasError('required')">
@@ -10,12 +10,12 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Middle Name' | translate }}</mat-label>
         <input formControlName="middleName" matInput />
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Last Name' | translate }}</mat-label>
         <input formControlName="lastName" required matInput />
         <mat-error *ngIf="editFamilyMemberForm.controls.lastName.hasError('required')">
@@ -24,12 +24,12 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Qualification' | translate }}</mat-label>
         <input formControlName="qualification" matInput />
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Age' | translate }}</mat-label>
         <input type="number" formControlName="age" required matInput />
         <mat-error *ngIf="editFamilyMemberForm.controls.age.hasError('required')">
@@ -42,7 +42,7 @@
         >Is Dependent?
       </mat-checkbox>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Relationship' | translate }}</mat-label>
         <mat-select formControlName="relationshipId" required>
           <mat-option *ngFor="let relation of addFamilyMemberTemplate.relationshipIdOptions" [value]="relation.id">
@@ -55,7 +55,7 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Gender' | translate }}</mat-label>
         <mat-select formControlName="genderId" required>
           <mat-option *ngFor="let gender of addFamilyMemberTemplate.genderIdOptions" [value]="gender.id">
@@ -68,7 +68,7 @@
         </mat-error>
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Profession' | translate }}</mat-label>
         <mat-select formControlName="professionId">
           <mat-option *ngFor="let profession of addFamilyMemberTemplate.professionIdOptions" [value]="profession.id">
@@ -77,7 +77,7 @@
         </mat-select>
       </mat-form-field>
 
-      <mat-form-field class="flex-fill" ="calc(50% - 25px)">
+      <mat-form-field class="flex-50-minus-25px">
         <mat-label>{{ 'labels.inputs.Marital Status' | translate }}</mat-label>
         <mat-select formControlName="maritalStatusId">
           <mat-option

--- a/src/app/shared/tabs/entity-notes-tab/entity-notes-tab.component.html
+++ b/src/app/shared/tabs/entity-notes-tab/entity-notes-tab.component.html
@@ -8,7 +8,7 @@
       class="layout-row align-start-baseline gap-20px"
       (ngSubmit)="addNote()"
     >
-      <mat-form-field class="flex-fill" ="calc(85%-20px)">
+      <mat-form-field class="flex-85-minus-20px">
         <textarea
           required
           formControlName="note"

--- a/src/main.scss
+++ b/src/main.scss
@@ -487,6 +487,14 @@
   flex: 1 1 calc(50% - 25px);
 }
 
+.flex-85-minus-20px {
+  flex: 1 1 calc(85% - 20px);
+}
+
+.flex-90-minus-20px {
+  flex: 1 1 calc(90% - 20px);
+}
+
 .layout-lt-md-column {
   @media (width <= 768px) {
     flex-direction: column;


### PR DESCRIPTION
There were quite a few broken element attributes like
   ="calc(90%-20px)"
which got replaced by CSS classes now.
FIXES: WEB-150