### PR TITLE
Web-161 replace references to mat legacy chips module in angular 15 project

### DIFF
--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -9,7 +9,7 @@ import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/lega
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy-chips';
+import { MatChipsModule } from '@angular/material/chips';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';


### PR DESCRIPTION
## Description

Correct all references to 

-   MatLegacyChipsModule

## Related issues and discussion

[WEB-161](https://mifosforge.jira.com/browse/WEB-161?atlOrigin=eyJpIjoiZTIyYzU2OTY2NmMzNGU0MGE2MDVlOGQyYjliMDg4YTQiLCJwIjoiaiJ9)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-161]: https://mifosforge.jira.com/browse/WEB-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ