### PR TITLE
Replace references to MatLegacyFormFieldModule, MatLegacyInput, MatLegacySelectModule and other modules necessary for form component

### DIFF
--- a/src/app/shared/language-selector/language-selector.component.scss
+++ b/src/app/shared/language-selector/language-selector.component.scss
@@ -1,4 +1,4 @@
 #language-selector,
 .languageselector {
-  max-width: 6rem;
+  // max-width: 6rem;
 }

--- a/src/app/shared/material.module.ts
+++ b/src/app/shared/material.module.ts
@@ -3,32 +3,29 @@ import { NgModule } from '@angular/core';
 import { LayoutModule } from '@angular/cdk/layout';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
-import { MatLegacyAutocompleteModule as MatAutocompleteModule } from '@angular/material/legacy-autocomplete';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatBadgeModule } from '@angular/material/badge';
-import { MatLegacyButtonModule as MatButtonModule } from '@angular/material/legacy-button';
+import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatLegacyChipsModule as MatChipsModule } from '@angular/material/legacy-chips';
+import { MatChipsModule } from '@angular/material/chips';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
-import { MatLegacyDialogModule as MatDialogModule } from '@angular/material/legacy-dialog';
+import { MatDialogModule } from '@angular/material/dialog';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
-import {
-  MAT_LEGACY_FORM_FIELD_DEFAULT_OPTIONS as MAT_FORM_FIELD_DEFAULT_OPTIONS,
-  MatLegacyFormFieldModule as MatFormFieldModule
-} from '@angular/material/legacy-form-field';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS, MatFormFieldModule } from '@angular/material/form-field';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatIconModule } from '@angular/material/icon';
-import { MatLegacyInputModule as MatInputModule } from '@angular/material/legacy-input';
-import { MatLegacyListModule as MatListModule } from '@angular/material/legacy-list';
-import { MatLegacyMenuModule as MatMenuModule } from '@angular/material/legacy-menu';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
+import { MatMenuModule } from '@angular/material/menu';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatRadioModule } from '@angular/material/radio';
-import { MatLegacySelectModule as MatSelectModule } from '@angular/material/legacy-select';
+import { MatSelectModule } from '@angular/material/select';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatSliderModule } from '@angular/material/slider';
@@ -38,7 +35,7 @@ import { MatStepperModule } from '@angular/material/stepper';
 import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatLegacyTooltipModule as MatTooltipModule } from '@angular/material/legacy-tooltip';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatTreeModule } from '@angular/material/tree';
 import { NgxMatSelectSearchModule } from 'ngx-mat-select-search';
 
@@ -90,7 +87,7 @@ import { NgxMatSelectSearchModule } from 'ngx-mat-select-search';
   providers: [
     {
       provide: MAT_FORM_FIELD_DEFAULT_OPTIONS,
-      useValue: { appearance: 'standard' }
+      useValue: { appearance: 'fill' }
     },
     {
       provide: STEPPER_GLOBAL_OPTIONS,

--- a/src/main.scss
+++ b/src/main.scss
@@ -510,6 +510,17 @@
   align-items: center;
 }
 
+.mat-mdc-form-field {
+  .mat-mdc-input-element::placeholder {
+    font-size: 14px !important;
+    color: #999 !important;
+  }
+
+  .mdc-floating-label {
+    font-size: 14px !important;
+  }
+}
+
 @media (width <= 768px) {
   .flex-lt-md-50 {
     flex: 0 0 50%;

--- a/src/theme/mifosx-theme.scss
+++ b/src/theme/mifosx-theme.scss
@@ -23,8 +23,8 @@
 //  If you don't need the default component typographies but still want the hierarchy styles,
 //  you can delete this line and instead use:
 //    `@include mat.legacy-typography-hierarchy(mat.define-legacy-typography-config());`
-@include mat.all-legacy-component-typographies();
-@include mat.legacy-core();
+@include mat.all-component-typographies();
+@include mat.core();
 
 /* ################################## Light theme ################################### */
 
@@ -43,7 +43,7 @@ $mifosx-app-theme: mat.define-light-theme($mifosx-app-primary, $mifosx-app-accen
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component
 // that you are using.
-@include mat.all-legacy-component-themes($mifosx-app-theme);
+@include mat.all-component-themes($mifosx-app-theme);
 @include groups-view-component-theme($mifosx-app-theme);
 @include centers-view-component-theme($mifosx-app-theme);
 @include dashboard-component-theme($mifosx-app-theme);
@@ -62,7 +62,7 @@ $mifosx-app-dark-theme: mat.define-dark-theme($mifosx-app-dark-primary, $mifosx-
 
 // Include theme styles for core and each component used in your app.
 .dark-theme {
-  @include mat.all-legacy-component-themes($mifosx-app-dark-theme);
+  @include mat.all-component-themes($mifosx-app-dark-theme);
   @include groups-view-component-theme($mifosx-app-dark-theme);
   @include centers-view-component-theme($mifosx-app-dark-theme);
   @include dashboard-component-theme($mifosx-app-dark-theme);


### PR DESCRIPTION
## Fixes issue on ticket [WEB-162](https://mifosforge.jira.com/browse/WEB-162)

## Replaces all references to 
1. MatLegacyFormFieldModule, 
2. MatLegacyInput, 
3. MatLegacySelectModule 
4. MAT_FORM_FIELD_DEFAULT_OPTIONS
5. Autocomplete
6. Dialogue

#### All the imports has been changed and styles for _**Form, input and select**_ only has been updated.

Before changes:
![image](https://github.com/user-attachments/assets/980ab25f-5346-44cd-860b-601c703c4fae)

After Changes:
![image](https://github.com/user-attachments/assets/13d202eb-0fe9-4aab-9878-613b4a925d36)

The style for _all_ components has been updated to use new MDC based default styling like:
![image](https://github.com/user-attachments/assets/012fad74-7310-4b87-9b88-5b865f1c7083)
![image](https://github.com/user-attachments/assets/e5abc3ee-a8bd-4d2c-99c9-998dd49754f5)

and all other modules from angular material.

The theme selector component has been updated to use new MDC based styles.
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-162]: https://mifosforge.jira.com/browse/WEB-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ