### PR TITLE
fix: buttons with both mat-button and mat-icon-button spec

### DIFF
--- a/src/app/login/login-form/login-form.component.html
+++ b/src/app/login/login-form/login-form.component.html
@@ -18,7 +18,6 @@
     <input matInput type="{{ passwordInputType }}" formControlName="password" />
     <button
       type="button"
-      mat-button
       matSuffix
       *ngIf="loginForm.controls.password.value && !loading"
       mat-icon-button

--- a/src/app/shared/dropdown/dropdown.component.html
+++ b/src/app/shared/dropdown/dropdown.component.html
@@ -5,7 +5,7 @@
       {{ option.value | translateKey: 'catalogs' }}
     </mat-option>
   </mat-select>
-  <button mat-button *ngIf="controlSelect" matSuffix mat-icon-button aria-label="Clear" (click)="clearProperty($event)">
+  <button *ngIf="controlSelect" matSuffix mat-icon-button aria-label="Clear" (click)="clearProperty($event)">
     <mat-icon>{{ 'labels.buttons.Close' | translate }}</mat-icon>
   </button>
 </mat-form-field>


### PR DESCRIPTION
Specifying both mat-button and mat-icon-button in a <button…> tag appears in markup of 2 files.

FIXES: WEB-163