### PR TITLE
WEB-138-replace-references-to-mat-legacy-input-module-in-angular-15-project

### DIFF
--- a/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.ts
+++ b/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.ts
@@ -2,10 +2,7 @@
 import { Component, ViewChild } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
-import {
-  MatLegacyTableDataSource as MatTableDataSource,
-  MatLegacyTable as MatTable
-} from '@angular/material/legacy-table';
+import { MatTableDataSource, MatTable } from '@angular/material/table';
 import { ActivatedRoute } from '@angular/router';
 import { UntypedFormControl } from '@angular/forms';
 

--- a/src/app/account-transfers/make-account-interbank-transfers/make-account-interbank-transfers.component.ts
+++ b/src/app/account-transfers/make-account-interbank-transfers/make-account-interbank-transfers.component.ts
@@ -1,8 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
-import { MatLegacyInput as MatInput } from '@angular/material/legacy-input';
-
 @Component({
   selector: 'mifosx-make-account-interbank-transfers',
   templateUrl: './make-account-interbank-transfers.component.html',

--- a/src/app/account-transfers/make-account-transfers/make-account-transfers.component.ts
+++ b/src/app/account-transfers/make-account-transfers/make-account-transfers.component.ts
@@ -15,7 +15,6 @@ import { AccountTransfersService } from '../account-transfers.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { ClientsService } from 'app/clients/clients.service';
 import { Dates } from 'app/core/utils/dates';
-import { MatLegacyInput as MatInput } from '@angular/material/legacy-input';
 
 /** Environment Configuration */
 import { environment } from 'environments/environment';

--- a/src/app/shared/input-password/input-password.component.ts
+++ b/src/app/shared/input-password/input-password.component.ts
@@ -7,7 +7,7 @@ import {
   NgForm,
   Validators
 } from '@angular/forms';
-import { MatLegacyInput as MatInput } from '@angular/material/legacy-input';
+import { MatInput } from '@angular/material/input';
 import { ErrorStateMatcher } from '@angular/material/core';
 
 @Component({


### PR DESCRIPTION
## Description

Correct all references to 

- MatLegacyInputModule 
- MatLegacyInput
- MatLegacyTableDataSource
- MatLegacyTable

remove unsused MatInput from 2files

## Related issues and discussion

[WEB-138](https://mifosforge.jira.com/browse/WEB-138?atlOrigin=eyJpIjoiMjczYjU4MzBhMjEwNGQwN2JiMmJlZjljZmYwMDVkMDkiLCJwIjoiaiJ9)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-138]: https://mifosforge.jira.com/browse/WEB-138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ