### PR TITLE
fix: add capitalized income amount to loan summary view, remove capitalized income max amount validation

### DIFF
--- a/src/app/loans/loans-view/general-tab/general-tab.component.ts
+++ b/src/app/loans/loans-view/general-tab/general-tab.component.ts
@@ -82,7 +82,7 @@ export class GeneralTabComponent implements OnInit {
     this.loanSummaryTableData = [
       {
         property: 'Principal',
-        original: this.loanDetails.summary.principalDisbursed,
+        original: this.loanDetails.summary.totalPrincipal,
         adjustment: this.loanDetails.summary.principalAdjustments || 0,
         paid: this.loanDetails.summary.principalPaid,
         waived: this.loanDetails.summary.principalWaived || 0,

--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
@@ -82,22 +82,12 @@ export class MakeRepaymentComponent implements OnInit {
       note: ''
     });
 
-    if (this.isCapitalizedIncome()) {
-      this.repaymentLoanForm.addControl(
-        'transactionAmount',
-        new UntypedFormControl('', [
-          Validators.required,
-          Validators.min(0.001),
-          Validators.max(this.dataObject.amount)])
-      );
-    } else {
-      this.repaymentLoanForm.addControl(
-        'transactionAmount',
-        new UntypedFormControl('', [
-          Validators.required,
-          Validators.min(0.001)])
-      );
-    }
+    this.repaymentLoanForm.addControl(
+      'transactionAmount',
+      new UntypedFormControl('', [
+        Validators.required,
+        Validators.min(0.001)])
+    );
   }
 
   setRepaymentLoanDetails() {


### PR DESCRIPTION
## Description

Replaced Loan summary table data total principal value, as principalDisbursed does not cover the principal that comes from capitalized income transactions. Also removed the max value validator that was created especially for capitalized income transactions, as it is not needed capitalized income transactions can be sent in as long as the following is true: (principalDisbursed + capitalizedIncome <= approvedPrincipal)

## Related issues and discussion

[FINERACT-2232](https://issues.apache.org/jira/browse/FINERACT-2232)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
