### PR TITLE
update angular-fontawesome for Angular 17 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@angular/router": "17.3.12",
         "@ckeditor/ckeditor5-angular": "6.0.1",
         "@ckeditor/ckeditor5-build-classic": "40.2.0",
-        "@fortawesome/angular-fontawesome": "^0.13.0",
+        "@fortawesome/angular-fontawesome": "0.14.1",
         "@fortawesome/fontawesome-free": "^6.7.2",
         "@fortawesome/fontawesome-svg-core": "6.2.1",
         "@fortawesome/free-brands-svg-icons": "6.7.2",
@@ -4852,15 +4852,15 @@
       }
     },
     "node_modules/@fortawesome/angular-fontawesome": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.13.0.tgz",
-      "integrity": "sha512-gzSPRdveOXNO7NIiMgTyB46aiHG0i98KinnAEqHXi8qzraM/kCcHn/0y3f4MhemX6kftwsFli0IU8RyHmtXlSQ==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-0.14.1.tgz",
+      "integrity": "sha512-Yb5HLiEOAxjSLEcaOM51CKIrzdfvoDafXVJERm9vufxfZkVZPZJgrZRgqwLVpejgq4/Ez6TqHZ6SqmJwdtRF6g==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.1"
+        "tslib": "^2.6.2"
       },
       "peerDependencies": {
-        "@angular/core": "^16.0.0",
+        "@angular/core": "^17.0.0",
         "@fortawesome/fontawesome-svg-core": "~1.2.27 || ~1.3.0-beta2 || ^6.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@angular/router": "17.3.12",
     "@ckeditor/ckeditor5-angular": "6.0.1",
     "@ckeditor/ckeditor5-build-classic": "40.2.0",
-    "@fortawesome/angular-fontawesome": "^0.13.0",
+    "@fortawesome/angular-fontawesome": "0.14.1",
     "@fortawesome/fontawesome-free": "^6.7.2",
     "@fortawesome/fontawesome-svg-core": "6.2.1",
     "@fortawesome/free-brands-svg-icons": "6.7.2",


### PR DESCRIPTION
## Description

update angular-fontawesome for Angular 17 compatibility

from  **"@fortawesome/angular-fontawesome": "0.13.0"**  to      **"@fortawesome/angular-fontawesome": "0.14.1",**

