### PR TITLE
replace datetime-picker with stub and remove suppressImplicitAnyIndexErrors

### DIFF
--- a/src/app/shared/datetime-picker-stub/datetime-picker-stub.component.ts
+++ b/src/app/shared/datetime-picker-stub/datetime-picker-stub.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+
+/* eslint-disable @angular-eslint/component-selector */
+/* eslint-disable @angular-eslint/prefer-standalone */
+@Component({
+  selector: 'ngx-mat-datetime-picker',
+  template: `
+    <mat-datepicker-toggle [for]="picker"></mat-datepicker-toggle>
+    <mat-datepicker #picker></mat-datepicker>
+  `,
+  standalone: false
+})
+export class DatetimePickerStubComponent {
+  @Input() enableMeridian: boolean = true;
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -36,7 +36,7 @@ import { EntityDatatableTabComponent } from './tabs/entity-datatable-tab/entity-
 import { DatatableSingleRowComponent } from './tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component';
 import { DatatableMultiRowComponent } from './tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component';
 import { SvgIconComponent } from './svg-icon/svg-icon.component';
-import { NgxMatDatetimePickerModule, NgxMatNativeDateModule } from '@angular-material-components/datetime-picker';
+// import { NgxMatDatetimePickerModule, NgxMatNativeDateModule } from '@angular-material-components/datetime-picker';
 import { ViewJournalEntryComponent } from './accounting/view-journal-entry/view-journal-entry.component';
 import { ViewJournalEntryTransactionComponent } from './accounting/view-journal-entry-transaction/view-journal-entry-transaction.component';
 import { AccountNumberComponent } from './account-number/account-number.component';
@@ -51,6 +51,7 @@ import { LongTextComponent } from './long-text/long-text.component';
 import { DropdownComponent } from './dropdown/dropdown.component';
 import { InputAmountComponent } from './input-amount/input-amount.component';
 import { InputPasswordComponent } from './input-password/input-password.component';
+import { DatetimePickerStubComponent } from './datetime-picker-stub/datetime-picker-stub.component'; // import Datetime Picker Stub
 
 /**
  * Shared Module
@@ -65,9 +66,9 @@ import { InputPasswordComponent } from './input-password/input-password.componen
     ReactiveFormsModule,
     TranslateModule,
     PipesModule,
-    DirectivesModule,
-    NgxMatDatetimePickerModule,
-    NgxMatNativeDateModule
+    DirectivesModule
+    // NgxMatDatetimePickerModule,
+    // NgxMatNativeDateModule
   ],
   declarations: [
     FormfieldComponent,
@@ -108,7 +109,9 @@ import { InputPasswordComponent } from './input-password/input-password.componen
     LongTextComponent,
     DropdownComponent,
     InputAmountComponent,
-    InputPasswordComponent
+    InputPasswordComponent,
+    DatetimePickerStubComponent // temporarily added stub for datetime picker
+
   ],
   exports: [
     FileUploadComponent,
@@ -143,7 +146,9 @@ import { InputPasswordComponent } from './input-password/input-password.componen
     ThemeToggleComponent,
     LongTextComponent,
     DropdownComponent,
-    InputAmountComponent
+    InputAmountComponent,
+    DatetimePickerStubComponent // Export stub for datetime picker
+
   ]
 })
 export class SharedModule {}

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -28,7 +28,8 @@ import '@angular/localize/init';
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js/dist/zone'; // Included with Angular CLI.
+import 'zone.js';
+// Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true,
     "target": "ES2022",
     "typeRoots": [
       "node_modules/@types",


### PR DESCRIPTION
## Description

- Introduced `DatetimePickerStubComponent` to replace `ngx-mat-datetime-picker` for now (temporary)
- Removed `suppressImplicitAnyIndexErrors` no longer needed with updated typings
- Updated `zone.js` import in `polyfills.ts` from `zone.js/dist/zone` to `zone.js`