### PR TITLE
fix: client list no longer loading due to preloadClients default

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -42,7 +42,7 @@ export const environment = {
   defaultLanguage: loadedEnv.defaultLanguage || 'en-US',
   supportedLanguages:
     loadedEnv.supportedLanguages || 'cs-CS,de-DE,en-US,es-MX,fr-FR,it-IT,ko-KO,lt-LT,lv-LV,ne-NE,pt-PT,sw-SW',
-  preloadClients: loadedEnv.preloadClients !== undefined ? loadedEnv.preloadClients : true,
+  preloadClients: loadedEnv['preloadClients'] || true,
 
   defaultCharDelimiter: loadedEnv.defaultCharDelimiter || ',',
 


### PR DESCRIPTION
## Description

This fix resolves an issue where the client list was not loading by default on the Clients page. Previously, users had to manually search for clients to see any results because the preloadClients flag was not set correctly. This update ensures that the client list now loads automatically when navigating to the Clients page, improving user experience and restoring expected functionality.

before
![Screenshot 2025-06-02 215105](https://github.com/user-attachments/assets/604893c5-6c36-423d-a7b5-cd238156f716)

after
![image](https://github.com/user-attachments/assets/c4854db4-5a04-43a2-812b-5e856745bc5a)
