### PR TITLE
fix: Enables entry of datetime in Angular 17

### DIFF
--- a/src/app/shared/form-dialog/formfield/formfield.component.html
+++ b/src/app/shared/form-dialog/formfield/formfield.component.html
@@ -50,14 +50,12 @@
     <mat-label>{{ formfield.label }}</mat-label>
     <input
       matInput
-      [ngxMatDatetimePicker]="datetimePicker"
+      type="datetime-local"
       [min]="formfield.minDate"
       [max]="formfield.maxDate"
       [formControlName]="formfield.controlName"
       [required]="formfield.required"
     />
-    <mat-datepicker-toggle matSuffix [for]="datetimePicker"></mat-datepicker-toggle>
-    <ngx-mat-datetime-picker #datetimePicker [enableMeridian]="true"></ngx-mat-datetime-picker>
     <mat-error *ngIf="form.controls[formfield.controlName].hasError('required')">
       {{ formfield.label }} {{ 'labels.commons.is' | translate }}
       <strong>{{ 'labels.commons.required' | translate }}</strong>


### PR DESCRIPTION
Angular 17 doesn't come with a datetime picker. We therefore need a workaround for entering date times. This provides such a workaround for the web app versions up to Angular 19, where we can combine date time pickers.

https://github.com/user-attachments/assets/a42dabf9-93d8-42c1-b583-1ccea47bc077


FIXES: WEB-187