### PR TITLE
WEB-192 fixed all errors encountered while running ng serve after upgrading to Angular 18

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,8 @@
             "index": "src/index.html",
             "tsConfig": "src/tsconfig.app.json",
             "polyfills": [
-              "src/polyfills.ts"
+              "src/polyfills.ts",
+              "@angular/localize/init"
             ],
             "assets": [
               "src/favicon.ico",
@@ -51,7 +52,12 @@
               "@ckeditor/ckeditor5-build-classic",
               "moment"
             ],
-            "browser": "src/main.ts"
+            "browser": "src/main.ts",
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src"
+              ]
+            }
           },
           "configurations": {
             "production": {
@@ -117,7 +123,10 @@
             "browsers": "ChromeHeadless",
             "main": "src/test.ts",
             "karmaConfig": "src/karma.conf.ts",
-            "polyfills": "src/polyfills.ts",
+            "polyfills": [
+              "src/polyfills.ts",
+              "@angular/localize/init"
+            ],
             "tsConfig": "src/tsconfig.spec.json",
             "scripts": [],
             "styles": [

--- a/src/app/core/utils/dates.ts
+++ b/src/app/core/utils/dates.ts
@@ -1,6 +1,6 @@
 import { DatePipe } from '@angular/common';
 import { Injectable } from '@angular/core';
-import * as moment from 'moment';
+import moment from 'moment';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/pipes/date-format.pipe.ts
+++ b/src/app/pipes/date-format.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { SettingsService } from 'app/settings/settings.service';
-import * as moment from 'moment';
+import moment from 'moment';
 
 @Pipe({
   name: 'dateFormat'

--- a/src/app/pipes/datetime-format.pipe.ts
+++ b/src/app/pipes/datetime-format.pipe.ts
@@ -1,6 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { SettingsService } from 'app/settings/settings.service';
-import * as moment from 'moment';
+import moment from 'moment';
 
 @Pipe({
   name: 'datetimeFormat'


### PR DESCRIPTION
## Description

This commit addresses and resolves all errors encountered when running ng serve after upgrading the project from Angular 17 to Angular 18. 

Two key issues were resolved as documented in the Jira ticket [WEB-192](https://mifosforge.jira.com/browse/WEB-192?atlOrigin=eyJpIjoiNzAxNmZmZDI2OGM3NDkzNzkwODZkMDQyODM0YmI1YTIiLCJwIjoiaiJ9):

- Included @angular/localize/init in the polyfills array to support Angular’s internationalization features.
- Configured stylePreprocessorOptions to ensure SCSS paths are correctly resolved, avoiding style compilation errors.

These changes were required to align the build and serve processes with Angular 18’s expectations.

[WEB-192]: https://mifosforge.jira.com/browse/WEB-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ