### PR TITLE
Resolution to Web-109: Update gsim-account.component.html

### DIFF
--- a/src/app/savings/gsim-account/gsim-account.component.html
+++ b/src/app/savings/gsim-account/gsim-account.component.html
@@ -59,7 +59,7 @@
             mat-raised-button
             color="primary"
             (click)="routeEdit($event)"
-            [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Approve']"
+            [routerLink]="['../../../', 'savings-accounts', element.id, 'actions', 'Approve']"
           >
             <i class="fa fa-check" matTooltip="{{ 'tooltips.Approve' | translate }}"></i>
           </button>


### PR DESCRIPTION
This is the resolution to the ticket Web-109. Clicking on the checkbox on the GSIM Account Overview page at:

http://localhost:4200/#/groups/1/savings-accounts/gsim-account/000000004

would previously result in an 404 error. It now successfully redirects to an approval dialog at:

http://localhost:4200/#/groups/1/savings-accounts/4/actions/Approve