### PR TITLE
Loan account Contract Termination undo

### DIFF
--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
@@ -196,7 +196,7 @@ export class TransactionsTabComponent implements OnInit {
    * INTEREST REFUND:33
    * CAPITALIZED INCOME:35
    * CAPITALIZED INCOME ADJUSTMENT:37
-   * CONTRACT_TERMINATION:90
+   * CONTRACT_TERMINATION:38
    */
   showTransaction(transactionsData: LoanTransaction): boolean {
     return [
@@ -216,7 +216,7 @@ export class TransactionsTabComponent implements OnInit {
       33,
       35,
       37,
-      90
+      38
     ].includes(transactionsData.type.id);
   }
 
@@ -228,7 +228,8 @@ export class TransactionsTabComponent implements OnInit {
       transaction.type.disbursement ||
       transaction.type.chargeoff ||
       this.isReAgoeOrReAmortize(transaction.type) ||
-      transaction.type.interestRefund
+      transaction.type.interestRefund ||
+      transaction.type.contractTermination
     );
   }
 

--- a/src/app/loans/models/loan-transaction-type.model.ts
+++ b/src/app/loans/models/loan-transaction-type.model.ts
@@ -36,4 +36,5 @@ export interface LoanTransactionType {
   capitalizedIncomeAdjustment: boolean;
   capitalizedIncomeAmortization: boolean;
   capitalizedIncomeAmortizationAdjustment: boolean;
+  contractTermination: boolean;
 }


### PR DESCRIPTION
## Description

Contract termination can be reversed. During reversal, notes and external id can be provided

## Related issues and discussion


## Screenshots

https://github.com/user-attachments/assets/0580f216-eaa6-4983-af72-a80781af4be3



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
