### PR TITLE
chore: disable @angular-eslint/prefer-standalone rule and clean up ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,50 +10,50 @@ module.exports = [
     ignores: ['projects/**/*']
   },
 
-  // TS files configuration (commented out)
-  // {
-  //   files: ['**/*.ts'],
-  //   languageOptions: {
-  //     parser: tsParser,
-  //     parserOptions: {
-  //       project: [
-  //         'tsconfig.json',
-  //         'e2e/tsconfig.json'
-  //       ],
-  //       createDefaultProgram: true
-  //     }
-  //   },
-  //   plugins: {
-  //     '@angular-eslint': angularEslintPlugin,
-  //     '@angular-eslint/template': angularEslintTemplatePlugin,
-  //     '@typescript-eslint': tseslint
-  //   },
-  //   rules: {
-  //     // Angular recommended rules
-  //     ...angularEslintPlugin.configs.recommended.rules,
+  // TS files configuration
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: [
+          'tsconfig.json',
+          'e2e/tsconfig.json'
+        ],
+        createDefaultProgram: true
+      }
+    },
+    plugins: {
+      '@angular-eslint': angularEslintPlugin,
+      '@angular-eslint/template': angularEslintTemplatePlugin,
+      '@typescript-eslint': tseslint
+    },
+    rules: {
+      // Angular recommended rules
+      ...angularEslintPlugin.configs.recommended.rules,
 
-  //     // Angular template inline rules
-  //     ...angularEslintTemplatePlugin.configs['process-inline-templates'].rules,
+      // Angular template inline rules
+      ...angularEslintTemplatePlugin.configs['process-inline-templates'].rules,
 
-  //     // Component selector rules
-  //     '@angular-eslint/component-selector': [
-  //       'error',
-  //       {
-  //         prefix: 'mifosx',
-  //         style: 'kebab-case',
-  //         type: 'element'
-  //       }
-  //     ],
-  //     '@angular-eslint/directive-selector': [
-  //       'error',
-  //       {
-  //         prefix: 'mifosx',
-  //         style: 'camelCase',
-  //         type: 'attribute'
-  //       }
-  //     ]
-  //   }
-  // },
+      // Component selector rules
+      '@angular-eslint/component-selector': [
+        'error',
+        {
+          prefix: 'mifosx',
+          style: 'kebab-case',
+          type: 'element'
+        }
+      ],
+      '@angular-eslint/directive-selector': [
+        'error',
+        {
+          prefix: 'mifosx',
+          style: 'camelCase',
+          type: 'attribute'
+        }
+      ]
+    }
+  },
 
   // HTML files configuration
   {

--- a/src/app/home/timeout-dialog/idle-timeout.service.ts
+++ b/src/app/home/timeout-dialog/idle-timeout.service.ts
@@ -27,7 +27,7 @@ export class IdleTimeoutService {
     const $signal = merge(...events.map((eventName) => fromEvent(document, eventName)));
     this.$onSessionTimeout = interval(this.timeoutDelay).pipe(
       takeUntil($signal),
-      map(() => undefined),
+      map((): void => undefined),
       repeat()
     );
   }

--- a/src/app/products/products-mix/create-product-mix/create-product-mix.component.ts
+++ b/src/app/products/products-mix/create-product-mix/create-product-mix.component.ts
@@ -12,7 +12,9 @@ import { ProductsService } from '../../products.service';
 @Component({
   selector: 'mifosx-create-product-mix',
   templateUrl: './create-product-mix.component.html',
-  styleUrls: ['./create-product-mix.component.scss']
+  styleUrls: ['./create-product-mix.component.scss'],
+  // eslint-disable-next-line @angular-eslint/prefer-standalone
+  standalone: false
 })
 export class CreateProductMixComponent implements OnInit {
   /** Product mix form. */

--- a/src/app/shares/shares-account-view/charges-tab/charges-tab.component.ts
+++ b/src/app/shares/shares-account-view/charges-tab/charges-tab.component.ts
@@ -9,7 +9,9 @@ import { ActivatedRoute } from '@angular/router';
 @Component({
   selector: 'mifosx-charges-tab',
   templateUrl: './charges-tab.component.html',
-  styleUrls: ['./charges-tab.component.scss']
+  styleUrls: ['./charges-tab.component.scss'],
+  // eslint-disable-next-line @angular-eslint/prefer-standalone
+  standalone: false
 })
 export class ChargesTabComponent implements OnInit {
   /** Shares Account Data */

--- a/src/app/system/manage-jobs/scheduler-jobs/custom-parameters-popover/custom-parameters-popover.component.ts
+++ b/src/app/system/manage-jobs/scheduler-jobs/custom-parameters-popover/custom-parameters-popover.component.ts
@@ -45,6 +45,7 @@ interface JobDataType {
   selector: 'mifosx-custom-parameters-popover',
   templateUrl: './custom-parameters-popover.component.html',
   styleUrls: ['./custom-parameters-popover.component.scss'],
+  // eslint-disable-next-line @angular-eslint/prefer-standalone
   standalone: false
 })
 export class CustomParametersPopoverComponent implements OnInit {
@@ -66,7 +67,7 @@ export class CustomParametersPopoverComponent implements OnInit {
   ngOnInit(): void {
     this.selectedJobs = this.data.selectedJobs.selected.map((jobJSON) => ({
       ...jobJSON,
-      jobParameters: []
+      jobParameters: [] as JobParameterType[]
     }));
   }
 


### PR DESCRIPTION
## Description

Added standalone: false and disabled the ESLint rule @angular-eslint/prefer-standalone using 
// eslint-disable-next-line @angular-eslint/prefer-standalone above the @Component decorator in:

- src/app/products/products-mix/create-product-mix/create-product-mix.component.ts
- src/app/shares/shares-account-view/charges-tab/charges-tab.component.ts
- src/app/system/manage-jobs/scheduler-jobs/custom-parameters-popover/custom-parameters-popover.component.ts
- Cleaned up comment formatting in eslint.config.js