### PR TITLE
Fix: reset accrual-specific form fields on accounting rule change

### DIFF
--- a/src/app/products/saving-products/saving-product-stepper/saving-product-accounting-step/saving-product-accounting-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-accounting-step/saving-product-accounting-step.component.ts
@@ -206,6 +206,11 @@ export class SavingProductAccountingStepComponent implements OnInit {
             new UntypedFormControl('', Validators.required)
           );
         }
+        if (accountingRule === 2) {
+          this.savingProductAccountingForm.removeControl('feesReceivableAccountId');
+          this.savingProductAccountingForm.removeControl('penaltiesReceivableAccountId');
+          this.savingProductAccountingForm.removeControl('interestPayableAccountId');
+        }
 
         if (this.isDormancyTrackingActive.value) {
           this.savingProductAccountingForm.addControl(


### PR DESCRIPTION
## Description
- Accrual-specific form fields (feesReceivableAccountId, penaltiesReceivableAccountId, interestPayableAccountId) are properly removed when switching away from Accrual, ensuring correct form validation.

## Related issues and discussion

Fixes: [WEB-50](https://mifosforge.jira.com/jira/software/c/projects/WEB/issues/WEB-50)

## Screenshots, if any

https://github.com/user-attachments/assets/11fa829c-f07b-4156-bf25-afcfcb584b77


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-50]: https://mifosforge.jira.com/browse/WEB-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ