### PR TITLE
Fixes : WEB-203 Button position on Identities tab should be right aligned

### DIFF
--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.html
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.html
@@ -1,5 +1,5 @@
 <div class="tab-container mat-typography">
-  <div class="header-row layout-row align-space-between">
+  <div class="header-row">
     <h3 class="mat-subheading-2">
       {{ 'labels.heading.Identities' | translate }}
     </h3>

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.scss
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.scss
@@ -2,6 +2,12 @@
   padding: 1%;
   margin: 1%;
 
+  .header-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
   h3 {
     margin: 0;
   }


### PR DESCRIPTION
## Description

Aligned the button on the **"Identities"** tab to the right by converting hardcoded layout classes into a custom `.header-row` class.  
This change moves layout responsibility from the HTML to SCSS using `display: flex` and `justify-content: space-between`, improving readability and maintainability.  
No new dependencies were introduced.

## Related issues and discussion
#web-203
## Screenshots, if any

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/594a423b-626c-4be3-bfef-53d6c22d1e66" />


## Checklist

- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
