### PR TITLE
HTTP Cache service using environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ Available languages:
 | MIFOS_DEFAULT_CHAR_DELIMITER      | Character delimiter for CSV exports                  | ,             |
 | MIFOS_WAIT_TIME_FOR_NOTIFICATIONS | Wait time in seconds for reading notifications       | 60            |
 | MIFOS_WAIT_TIME_FOR_CATCHUP       | Wait time in seconds for reading COB Catch-Up status | 30            |
-| MIFOS_MIN_PASSWORD_LENGTH         | WMinimum length for user passwords                   | 12            |
+| MIFOS_MIN_PASSWORD_LENGTH         | Minimum length for user passwords                    | 12            |
+| MIFOS_HTTP_CACHE_ENABLED          | whether to use HTTP Get calls with cache             | false         |
 
 #### UI Display Settings
 

--- a/env.sample
+++ b/env.sample
@@ -29,3 +29,6 @@ MIFOS_OAUTH_SERVER_URL=https://{$URL_OAUTH_SERVER}
 
 #Set the application client id, only used while Oauth is enabled
 MIFOS_OAUTH_CLIENT_ID=web-app
+
+#Enable or Disable HTTP Cache
+MIFOS_HTTP_CACHE_ENABLED=true

--- a/src/app/core/http/cache.interceptor.ts
+++ b/src/app/core/http/cache.interceptor.ts
@@ -7,6 +7,7 @@ import { Observable, Subscriber } from 'rxjs';
 
 /** Custom Services */
 import { HttpCacheService } from './http-cache.service';
+import { environment } from 'environments/environment';
 
 /**
  * Caches HTTP requests.
@@ -45,7 +46,7 @@ export class CacheInterceptor implements HttpInterceptor {
       } else {
         next.handle(request).subscribe(
           (event) => {
-            if (event instanceof HttpResponse) {
+            if (environment.httpCacheEnabled && event instanceof HttpResponse) {
               this.httpCacheService.setCacheData(request.urlWithParams, event);
             }
             subscriber.next(event);

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -252,7 +252,6 @@
         </mat-option>
       </mat-select>
       <button
-        mat-button
         *ngIf="loanProductSettingsForm.controls.delinquencyBucketId"
         matSuffix
         mat-icon-button

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -47,6 +47,9 @@
   // Min Password length
   window['env']['minPasswordLength'] = '$MIFOS_MIN_PASSWORD_LENGTH';
 
+  // Enable or Disable HTTP Cache
+  window['env']['httpCacheEnabled'] = '$MIFOS_HTTP_CACHE_ENABLED';
+
   window['env']['vNextApiUrl'] = '$VNEXT_API_URL';
   window['env']['vNextApiProvider'] = '$VNEXT_API_PROVIDER';
   window['env']['vNextApiVersion'] = '$VNEXT_API_VERSION';

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -53,6 +53,7 @@ export const environment = {
       idleTimeout: loadedEnv['sessionIdleTimeout'] || 300000 // 5 minutes
     }
   },
+  httpCacheEnabled: loadedEnv.httpCacheEnabled || false,
 
   vNextApiUrl: window['env']['vNextApiUrl'] || 'https://apis.mifos.community',
   vNextApiProvider: window['env']['vNextApiProvider'] || '/vnext1',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -57,6 +57,7 @@ export const environment = {
       idleTimeout: loadedEnv.sessionIdleTimeout || 300000 // 5 minutes
     }
   },
+  httpCacheEnabled: loadedEnv.httpCacheEnabled || false,
 
   vNextApiUrl: window.env?.vNextApiUrl || 'https://apis.flexcore.mx',
   vNextApiProvider: window.env?.vNextApiProvider || '/vnext1',


### PR DESCRIPTION
## Description

Due a lack in the HTTP Cache service, we will be able to Enable or Disable using the env variable `MIFOS_HTTP_CACHE_ENABLED` the default value currently is `false` 

## Related issues and discussion

## Screenshots
<img width="2021" alt="Screenshot 2025-06-17 at 12 51 06 p m" src="https://github.com/user-attachments/assets/a22a93af-e5ac-498c-9bf1-61e93d39bc7a" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
