### PR TITLE
fix: Loan undo contract termination pristine form due non required fi…

### DIFF
--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
@@ -189,7 +189,8 @@ export class ViewTransactionComponent implements OnInit {
       const data = {
         title: this.translateService.instant('labels.heading.Undo Transaction'),
         layout: { addButtonText: 'Undo' },
-        formfields: formfields
+        formfields: formfields,
+        pristine: false
       };
       const undoTransactionAccountDialogRef = this.dialog.open(FormDialogComponent, { data, width: '50rem' });
       undoTransactionAccountDialogRef.afterClosed().subscribe((response: any) => {


### PR DESCRIPTION
…elds

## Description

There was an issue when we try to apply the Loan Undo Contract Termination the form was not enabling the Submit button even if the input fields are not required 

## Related issues and discussion

## Screenshots
- Previous

![d0d26b97-27b4-46e8-a0a4-1acd40c4be56](https://github.com/user-attachments/assets/5c96bee0-9c2a-4c70-aa76-504d546810e7)

- After change
<img width="1429" alt="Screenshot 2025-06-19 at 5 46 42 p m" src="https://github.com/user-attachments/assets/2a119efd-48e3-4a6a-9c76-e240735aa4ec" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
