### PR TITLE
fix: Loan Product detail view using charges

### DIFF
--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -780,11 +780,7 @@
 
     <mat-divider [inset]="true"></mat-divider>
 
-    <table
-      class="mat-elevation-z1 flex-fill"
-      mat-table
-      [dataSource]="loanProduct.charges | chargesPenaltyFilter: false"
-    >
+    <table class="mat-elevation-z1 flex-100" mat-table [dataSource]="loanProduct.charges | chargesPenaltyFilter: false">
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Name' | translate }}</th>
         <td mat-cell *matCellDef="let charge">
@@ -821,7 +817,7 @@
 
     <mat-divider [inset]="true"></mat-divider>
 
-    <table class="mat-elevation-z1 flex-fill" mat-table [dataSource]="loanProduct.charges | chargesPenaltyFilter: true">
+    <table class="mat-elevation-z1 flex-100" mat-table [dataSource]="loanProduct.charges | chargesPenaltyFilter: true">
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Name' | translate }}</th>
         <td mat-cell *matCellDef="let overdueCharge">

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -148,7 +148,7 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
         this.loanProductAccountingForm.patchValue({
           enableAccrualActivityPosting: this.loanProductsTemplate.enableAccrualActivityPosting
         });
-        if (this.capitalizedIncome.enableIncomeCapitalization) {
+        if (this.capitalizedIncome && this.capitalizedIncome.enableIncomeCapitalization) {
           this.loanProductAccountingForm.patchValue({
             deferredIncomeLiabilityAccountId: accountingMappings.deferredIncomeLiabilityAccount.id,
             incomeFromCapitalizationAccountId: accountingMappings.incomeFromCapitalizationAccount.id
@@ -165,7 +165,7 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
           incomeFromPenaltyAccountId: accountingMappings.incomeFromPenaltyAccount.id,
           incomeFromRecoveryAccountId: accountingMappings.incomeFromRecoveryAccount.id,
           writeOffAccountId: accountingMappings.writeOffAccount.id,
-          goodwillCreditAccountId: accountingMappings.goodwillCreditAccount.id,
+          goodwillCreditAccountId: accountingMappings.goodwillCreditAccount?.id || null,
           overpaymentLiabilityAccountId: accountingMappings.overpaymentLiabilityAccount.id,
           chargeOffFraudExpenseAccountId: accountingMappings.chargeOffFraudExpenseAccount
             ? accountingMappings.chargeOffFraudExpenseAccount.id
@@ -591,7 +591,7 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
 
   setCapitalizedIncomeControls() {
     if (this.isAccountingAccrualBased) {
-      if (this.capitalizedIncome.enableIncomeCapitalization) {
+      if (this.capitalizedIncome && this.capitalizedIncome.enableIncomeCapitalization) {
         this.loanProductAccountingForm.addControl(
           'deferredIncomeLiabilityAccountId',
           new UntypedFormControl('', Validators.required)


### PR DESCRIPTION
## Description

There was a style layout issue in the Loan Product detail general tab when we are using Loan Charges 

#{Issue Number}

## Screenshots

- Issue
<img width="1486" alt="Screenshot 2025-06-22 at 10 56 09 p m" src="https://github.com/user-attachments/assets/b83e82ad-4161-40d2-838f-aad689917cde" />

- After fix
<img width="1476" alt="Screenshot 2025-06-22 at 10 56 49 p m" src="https://github.com/user-attachments/assets/066e6122-a680-4c10-9a6a-208a22fad288" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
