### PR TITLE
WEB-213: Loan product config - buy down fees accounting

### DIFF
--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -1042,6 +1042,14 @@
       [withTitle]="'47%'"
     >
     </mifosx-gl-account-display>
+    <mifosx-gl-account-display
+      class="flex-100"
+      *ngIf="accountingMappings.incomeFromBuyDownAccount"
+      [accountTitle]="'Income from Buy down fees'"
+      [glAccount]="accountingMappings.incomeFromBuyDownAccount"
+      [withTitle]="'47%'"
+    >
+    </mifosx-gl-account-display>
 
     <h4 class="mat-h4 flex-100">{{ 'labels.heading.Expenses' | translate }}</h4>
 
@@ -1073,6 +1081,14 @@
         *ngIf="accountingMappings.chargeOffFraudExpenseAccount"
         [accountTitle]="'ChargeOff Fraud Expense'"
         [glAccount]="accountingMappings.chargeOffFraudExpenseAccount"
+        [withTitle]="'47%'"
+      >
+      </mifosx-gl-account-display>
+      <mifosx-gl-account-display
+        class="flex-100"
+        *ngIf="accountingMappings.buyDownExpenseAccount"
+        [accountTitle]="'Buy down fee Expense'"
+        [glAccount]="accountingMappings.buyDownExpenseAccount"
         [withTitle]="'47%'"
       >
       </mifosx-gl-account-display>

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
@@ -202,11 +202,16 @@ export class LoanProductSummaryComponent implements OnInit, OnChanges {
             this.loanProduct.incomeFromCapitalizationAccountId,
             incomeAccountData
           ),
+          incomeFromBuyDownAccount: this.glAccountLookUp(
+            this.loanProduct.incomeFromBuyDownAccountId,
+            incomeAccountData
+          ),
 
           writeOffAccount: this.glAccountLookUp(this.loanProduct.writeOffAccountId, expenseAccountData),
           goodwillCreditAccount: this.glAccountLookUp(this.loanProduct.goodwillCreditAccountId, expenseAccountData),
           chargeOffExpenseAccount: this.glAccountLookUp(this.loanProduct.writeOffAccountId, expenseAccountData),
           chargeOffFraudExpenseAccount: this.glAccountLookUp(this.loanProduct.writeOffAccountId, expenseAccountData),
+          buyDownExpenseAccount: this.glAccountLookUp(this.loanProduct.buyDownExpenseAccountId, expenseAccountData),
 
           overpaymentLiabilityAccount: this.glAccountLookUp(
             this.loanProduct.overpaymentLiabilityAccountId,

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
@@ -190,6 +190,16 @@
       >
       </mifosx-gl-account-selector>
 
+      <mifosx-gl-account-selector
+        class="flex-48"
+        *ngIf="deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee"
+        [inputFormControl]="loanProductAccountingForm.controls.incomeFromBuyDownAccountId"
+        [glAccountList]="incomeAccountData"
+        [required]="true"
+        [inputLabel]="'Income from Buy down fees'"
+      >
+      </mifosx-gl-account-selector>
+
       <mat-divider class="flex-98"></mat-divider>
 
       <h4 class="mat-h4 flex-98">{{ 'labels.heading.Expenses' | translate }}</h4>
@@ -227,6 +237,16 @@
         [glAccountList]="expenseAccountData"
         [required]="true"
         [inputLabel]="'ChargeOff Fraud Expense'"
+      >
+      </mifosx-gl-account-selector>
+
+      <mifosx-gl-account-selector
+        class="flex-48"
+        *ngIf="deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee"
+        [inputFormControl]="loanProductAccountingForm.controls.buyDownExpenseAccountId"
+        [glAccountList]="expenseAccountData"
+        [required]="true"
+        [inputLabel]="'Buy down fee Expense'"
       >
       </mifosx-gl-account-selector>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -155,6 +155,12 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
               incomeFromCapitalizationAccountId: accountingMappings.incomeFromCapitalizationAccount.id
             });
           }
+          if (this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee) {
+            this.loanProductAccountingForm.patchValue({
+              buyDownExpenseAccountId: accountingMappings.buyDownExpenseAccount.id,
+              incomeFromBuyDownAccountId: accountingMappings.incomeFromBuyDownAccount.id
+            });
+          }
         }
       /* falls through */
       case 2:
@@ -606,6 +612,19 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
         } else {
           this.loanProductAccountingForm.removeControl('deferredIncomeLiabilityAccountId');
           this.loanProductAccountingForm.removeControl('incomeFromCapitalizationAccountId');
+        }
+        if (this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee) {
+          this.loanProductAccountingForm.addControl(
+            'buyDownExpenseAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromBuyDownAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+        } else {
+          this.loanProductAccountingForm.removeControl('buyDownExpenseAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromBuyDownAccountId');
         }
       }
     }

--- a/src/app/products/loan-products/models/loan-product.model.ts
+++ b/src/app/products/loan-products/models/loan-product.model.ts
@@ -121,8 +121,10 @@ export interface LoanProduct {
   // Accounting
   accountingRule: any;
   accountingMappings?: { [key: string]: AccountingMapping };
+  buyDownExpenseAccountId?: number;
   fundSourceAccountId?: number;
   goodwillCreditAccountId?: number;
+  incomeFromBuyDownAccountId?: number;
   incomeFromCapitalizationAccountId?: number;
   incomeFromChargeOffFeesAccountId?: number;
   incomeFromChargeOffInterestAccountId?: number;

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "Typ výpočtu poplatku za odkup",
       "Buy down fee strategy": "Strategie poplatku za odkup",
       "Buy down fee income type": "Typ příjmu z poplatku za odkup",
-      "Buy down fees": "Poplatky za odkup"
+      "Buy down fees": "Poplatky za odkup",
+      "Income from Buy down fees": "Příjmy z poplatků za odkup",
+      "Buy down fee Expense": "Náklady na poplatek za odkup"
     },
     "links": {
       "Community": "Společenství",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "Berechnungsart der Buy-Down-Gebühr",
       "Buy down fee strategy": "Strategie für Buy-Down-Gebühr",
       "Buy down fee income type": "Einnahmeart der Buy-Down-Gebühr",
-      "Buy down fees": "Buy-Down-Gebühren"
+      "Buy down fees": "Buy-Down-Gebühren",
+      "Income from Buy down fees": "Einnahmen aus Buy-Down-Gebühren",
+      "Buy down fee Expense": "Aufwendungen aus Buy-Down-Gebühren"
     },
     "links": {
       "Community": "Gemeinschaft",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2484,7 +2484,9 @@
       "Buy down fee calculation type": "Buy down fee calculation type",
       "Buy down fee strategy": "Buy down fee strategy",
       "Buy down fee income type": "Buy down fee income type",
-      "Buy down fees": "Buy down fees"
+      "Buy down fees": "Buy down fees",
+      "Income from Buy down fees": "Income from Buy down fees",
+      "Buy down fee Expense": "Buy down fee Expense"
     },
     "links": {
       "Community": "Community",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "Tipo de cálculo de comisión de compra anticipada",
       "Buy down fee strategy": "Estrategia de comisión de compra anticipada",
       "Buy down fee income type": "Tipo de ingreso de comisión de compra anticipada",
-      "Buy down fees": "Tarifas de compra anticipada"
+      "Buy down fees": "Tarifas de compra anticipada",
+      "Income from Buy down fees": "Ingresos por comisiones de compra inicial",
+      "Buy down fee Expense": "Gastos por comisiones de compra inicial"
     },
     "links": {
       "Community": "Comunidad",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "Tipo de cálculo de comisión de compra anticipada",
       "Buy down fee strategy": "Estrategia de comisión de compra anticipada",
       "Buy down fee income type": "Tipo de ingreso de comisión de compra anticipada",
-      "Buy down fees": "Tarifas de compra anticipada"
+      "Buy down fees": "Tarifas de compra anticipada",
+      "Income from Buy down fees": "Ingresos por comisiones de compra inicial",
+      "Buy down fee Expense": "Gastos por comisiones de compra inicial"
     },
     "links": {
       "Community": "Comunidad",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "Type de calcul des frais de rachat",
       "Buy down fee strategy": "Stratégie des frais de rachat",
       "Buy down fee income type": "Type de revenu des frais de rachat",
-      "Buy down fees": "Frais d'achat"
+      "Buy down fees": "Frais d'achat",
+      "Income from Buy down fees": "Revenus des commissions de rachat",
+      "Buy down fee Expense": "Charges des commissions de rachat"
     },
     "links": {
       "Community": "Communauté",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "Tipo di calcolo della commissione di buy down",
       "Buy down fee strategy": "Strategia per la commissione di buy down",
       "Buy down fee income type": "Tipo di ricavo da commissione di buy down",
-      "Buy down fees": "Commissioni di acquisto"
+      "Buy down fees": "Commissioni di acquisto",
+      "Income from Buy down fees": "Proventi da commissioni di buy down",
+      "Buy down fee Expense": "Spese da commissioni di buy down"
     },
     "links": {
       "Community": "Comunità",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -2478,7 +2478,9 @@
       "Buy down fee calculation type": "매수 수수료 계산 유형",
       "Buy down fee strategy": "매수 수수료 전략",
       "Buy down fee income type": "매수 수수료 수익 유형",
-      "Buy down fees": "매수 수수료"
+      "Buy down fees": "매수 수수료",
+      "Income from Buy down fees": "매입 수수료 수입",
+      "Buy down fee Expense": "매입 수수료 비용"
     },
     "links": {
       "Community": "지역 사회",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "Supirkimo mokesčio skaičiavimo tipas",
       "Buy down fee strategy": "Supirkimo mokesčio strategija",
       "Buy down fee income type": "Supirkimo mokesčio pajamų tipas",
-      "Buy down fees": "Išpirkimo mokesčiai"
+      "Buy down fees": "Išpirkimo mokesčiai",
+      "Income from Buy down fees": "Pajamos iš supirkimo mokesčių",
+      "Buy down fee Expense": "Supirkimo mokesčio išlaidos"
     },
     "links": {
       "Community": "bendruomenė",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "Atpirkšanas maksas aprēķina veids",
       "Buy down fee strategy": "Atpirkšanas maksas stratēģija",
       "Buy down fee income type": "Atpirkšanas maksas ienākumu veids",
-      "Buy down fees": "Iepirkuma maksas"
+      "Buy down fees": "Iepirkuma maksas",
+      "Income from Buy down fees": "Ienākumi no akciju izpirkšanas komisijas maksām",
+      "Buy down fee Expense": "Akciju izpirkšanas komisijas izdevumi"
     },
     "links": {
       "Community": "kopiena",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "बाइ डाउन शुल्क गणना प्रकार",
       "Buy down fee strategy": "बाइ डाउन शुल्क रणनीति",
       "Buy down fee income type": "बाइ डाउन शुल्क आय प्रकार",
-      "Buy down fees": "खरिद शुल्क"
+      "Buy down fees": "खरिद शुल्क",
+      "Income from Buy down fees": "खरिद शुल्कबाट हुने आम्दानी",
+      "Buy down fee Expense": "खरीद शुल्क खर्च"
     },
     "links": {
       "Community": "समुदाय",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "Tipo de cálculo de taxa de aquisição",
       "Buy down fee strategy": "Estratégia de taxa de aquisição",
       "Buy down fee income type": "Tipo de receita de taxa de aquisição",
-      "Buy down fees": "Taxas de compra antecipada"
+      "Buy down fees": "Taxas de compra antecipada",
+      "Income from Buy down fees": "Receita com taxas de recompra",
+      "Buy down fee Expense": "Despesa com taxas de recompra"
     },
     "links": {
       "Community": "Comunidade",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -2477,7 +2477,9 @@
       "Buy down fee calculation type": "Nunua aina ya hesabu ya ada ya chini",
       "Buy down fee strategy": "Nunua mkakati wa ada ya chini",
       "Buy down fee income type": "Nunua aina ya mapato ya chini",
-      "Buy down fees": "Nunua ada za chini"
+      "Buy down fees": "Nunua ada za chini",
+      "Income from Buy down fees": "Mapato kutoka kwa ada ya Kununua",
+      "Buy down fee Expense": "Kununua ada ya chini Gharama"
     },
     "links": {
       "Community": "Jumuiya",


### PR DESCRIPTION
## Description

#### If Buy Down fees is enabled on loan product,

1. A new Expense account to be configured for periodical accounting

**Type: Expense**
**Name: Buy Down Expense**
Available: **Only for progressive loans if Buy Down fees is enabled**

2. A new Income account to be configured for periodical accounting

**Type: Income**
**Name:  Income from Buy Down fees**
Available: **Only for progressive loans if Buy Down fees is enabled**

## Related issues and discussion

[WEB-213](https://mifosforge.jira.com/browse/WEB-213)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-213]: https://mifosforge.jira.com/browse/WEB-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ