### PR TITLE
WEB-229: Edit Client charge was broken

### DIFF
--- a/src/app/products/charges/create-charge/create-charge.component.html
+++ b/src/app/products/charges/create-charge/create-charge.component.html
@@ -23,7 +23,7 @@
 
           <div
             *ngIf="chargeForm.controls.chargeAppliesTo.value"
-            class="flex-fill layout-row-wrap gap-2percent responsive-column"
+            class="layout-row-wrap gap-2percent layout-lt-md-column form-section"
           >
             <mat-form-field class="flex-48">
               <mat-label>{{ 'labels.inputs.Charge Name' | translate }}</mat-label>
@@ -216,20 +216,6 @@
               </mat-error>
             </mat-form-field>
 
-            <div class="flex-48 layout-row gap-2percent layout-lt-md-column">
-              <div class="flex-50 active-wrapper">
-                <mat-checkbox labelPosition="before" formControlName="active">
-                  {{ 'labels.status.Active' | translate }}
-                </mat-checkbox>
-              </div>
-
-              <div class="flex-50 penalty-wrapper">
-                <mat-checkbox labelPosition="before" formControlName="penalty">
-                  {{ 'labels.commons.Is' | translate }} {{ 'labels.inputs.Penalty' | translate }}
-                </mat-checkbox>
-              </div>
-            </div>
-
             <mifosx-gl-account-selector
               class="flex-48"
               *ngIf="chargeForm.controls.chargeAppliesTo.value === 3"
@@ -247,6 +233,20 @@
                 </mat-option>
               </mat-select>
             </mat-form-field>
+
+            <div class="flex-48 layout-row gap-2percent layout-lt-md-column">
+              <div class="flex-50 active-wrapper">
+                <mat-checkbox labelPosition="before" formControlName="active">
+                  {{ 'labels.status.Active' | translate }}
+                </mat-checkbox>
+              </div>
+
+              <div class="flex-50 penalty-wrapper">
+                <mat-checkbox labelPosition="before" formControlName="penalty">
+                  {{ 'labels.commons.Is' | translate }} {{ 'labels.inputs.Penalty' | translate }}
+                </mat-checkbox>
+              </div>
+            </div>
           </div>
         </div>
       </mat-card-content>

--- a/src/app/products/charges/edit-charge/edit-charge.component.ts
+++ b/src/app/products/charges/edit-charge/edit-charge.component.ts
@@ -161,7 +161,7 @@ export class EditChargeComponent implements OnInit {
         this.addFeeFrequency = false;
         this.chargeForm.addControl(
           'incomeAccountId',
-          this.formBuilder.control(this.chargeData.incomeOrLiabilityAccount.id, Validators.required)
+          this.formBuilder.control(this.chargeData.incomeOrLiabilityAccount?.id, Validators.required)
         );
         break;
       }


### PR DESCRIPTION
## Description

Once the customer created a new Client Charge and tries to edit it, the layout is broken

## Related issues and discussion

[WEB-229](https://mifosforge.jira.com/browse/WEB-229)

## Screenshots
<img width="1310" alt="Screenshot 2025-06-24 at 11 56 33 a m" src="https://github.com/user-attachments/assets/96d1c60e-cef3-4104-832f-be715fa75ea3" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-229]: https://mifosforge.jira.com/browse/WEB-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ