### PR TITLE
WEB-232: Reset overAppliedCalculationType and overAppliedNumber fields when 'Allow approval / disbursal above loan applied amount' is unchecked

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -202,6 +202,8 @@ export class LoanProductTermsStepComponent implements OnInit, OnChanges {
       maxNumberOfRepayments: [''],
       isLinkedToFloatingInterestRates: [false],
       allowApprovedDisbursedAmountsOverApplied: [false],
+      overAppliedCalculationType: [{ value: null, disabled: true }],
+      overAppliedNumber: [{ value: null, disabled: true }],
       minInterestRatePerPeriod: [''],
       interestRatePerPeriod: [
         '',
@@ -236,12 +238,14 @@ export class LoanProductTermsStepComponent implements OnInit, OnChanges {
       .get('allowApprovedDisbursedAmountsOverApplied')
       .valueChanges.subscribe((allowApprovedDisbursedAmountsOverApplied) => {
         if (allowApprovedDisbursedAmountsOverApplied) {
-          this.loanProductTermsForm.addControl('overAppliedCalculationType', new UntypedFormControl(''));
-          this.loanProductTermsForm.addControl('overAppliedNumber', new UntypedFormControl(''));
+          this.loanProductTermsForm.get('overAppliedCalculationType').enable();
+          this.loanProductTermsForm.get('overAppliedNumber').enable();
           this.loanProductTermsForm.addControl('disallowExpectedDisbursements', new UntypedFormControl('true'));
         } else {
-          this.loanProductTermsForm.removeControl('overAppliedCalculationType');
-          this.loanProductTermsForm.removeControl('overAppliedNumber');
+          this.loanProductTermsForm.get('overAppliedCalculationType').disable();
+          this.loanProductTermsForm.get('overAppliedCalculationType').patchValue(null);
+          this.loanProductTermsForm.get('overAppliedNumber').disable();
+          this.loanProductTermsForm.get('overAppliedNumber').patchValue(null);
           this.loanProductTermsForm.removeControl('disallowExpectedDisbursements');
         }
       });


### PR DESCRIPTION
## Description

**Problem that was solved:**

Pre-condition: progressive loan, horizontal, 360/30, interest recalculation, multidisbursal loan that doesn’t expect tranches(with enabled 'Disallow expected tranches' setting) 
 - 'Allow approval / disbursal above loan applied amount' setting enabled with calculation type and amount: percentage, 50

Steps to reproduce:
1 - create loan product according configuration

2 - modify it with:

 disabled 'Allow approval / disbursal above loan applied amount' setting on loan product level

and disable 'Enable Multiple Disbursals' loan setting

Expected result: loan product is modified with disabled 'Allow approval / disbursal above loan applied amount' setting and disabled 'Enable Multiple Disbursals' loan setting

Actual result: 400 error is shown  with message 
"Allow Approved / Disbursed Amounts Over Applied is Not Set - Over Applied Calculation Type Can't Be Entered"

## Related issues and discussion

#{[WEB-232](https://mifosforge.jira.com/browse/WEB-232)}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-232]: https://mifosforge.jira.com/browse/WEB-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ