### PR TITLE
Web-211 Resolution

### DIFF
--- a/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.html
+++ b/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.html
@@ -4,7 +4,7 @@
       <span class="flex-40">
         <h3 class="mat-h3">{{ 'labels.heading.Client Type' | translate }}</h3>
       </span>
-      <span class="flex-60">
+      <span class="Client-Name">
         <h3 class="mat-h3">{{ clientName }}</h3>
       </span>
     </div>
@@ -20,7 +20,7 @@
 
     <mat-divider [inset]="true"></mat-divider>
 
-    <mat-form-field class="flex-30">
+    <mat-form-field class="type-field">
       <mat-label>{{ 'labels.inputs.Type' | translate }}</mat-label>
       <mat-select [formControl]="transferType">
         <mat-option *ngFor="let transferTypeData of transferTypeDatas" [value]="transferTypeData.id">
@@ -29,7 +29,7 @@
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field class="flex-30">
+    <mat-form-field class="Account-Id-field">
       <input matInput placeholder="From Account Id" [formControl]="fromAccountId" />
     </mat-form-field>
 
@@ -40,7 +40,7 @@
       (click)="filterStandingInstructions()"
       class="filter-button"
     >
-      &nbsp;&nbsp;{{ 'labels.buttons.Filter' | translate }}
+      {{ 'labels.buttons.Filter' | translate | titlecase }}
     </button>
   </div>
 

--- a/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.scss
+++ b/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.scss
@@ -1,7 +1,7 @@
 .container {
   .filter-button {
     height: 2.5rem;
-    margin-top: 1rem;
+    margin-top: 2rem;
   }
 }
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -611,3 +611,23 @@ mifosx-notifications-page td {
   justify-content: flex-start;
   width: 100%;
 }
+
+//New!
+.type-field {
+  position: absolute;
+  left: 0px;
+  top: 20px;
+}
+
+//New!
+.Account-Id-field {
+  position: absolute;
+  left: 490px;
+  top: 20px;
+}
+
+//New!
+.Client-Name {
+  position: absolute;
+  left: 490px;
+}


### PR DESCRIPTION
This PR resolves the issues described in web-211.  Filter button now has a capital F, regardless of which language is being used.  Button formatting was further adjusted to give the page an overall better layout.  Account ID, account-type field and client-name label have all been given specific formatting which greatly improves layout, even with a reduced window size.

Web-211

![web-211 resolution, 3 July 2025](https://github.com/user-attachments/assets/aa512650-4f96-4e0e-9623-833a13226bc8)
![web-211 resolution 2, 3rd July 2025](https://github.com/user-attachments/assets/96df805f-23ec-490f-8eb6-4655d9217de0)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.  Sorry.  Not sure offhand how to do this - on my list of things to learn!

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
