### PR TITLE
WEB-246: add deferred income liability account handling for buy-down fee in loan product accounting form

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
@@ -264,7 +264,10 @@
       </mifosx-gl-account-selector>
 
       <mifosx-gl-account-selector
-        *ngIf="deferredIncomeRecognition?.capitalizedIncome?.enableIncomeCapitalization"
+        *ngIf="
+          deferredIncomeRecognition?.capitalizedIncome?.enableIncomeCapitalization ||
+          deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee
+        "
         class="flex-48"
         [inputFormControl]="loanProductAccountingForm.controls.deferredIncomeLiabilityAccountId"
         [glAccountList]="liabilityAccountData"

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -157,6 +157,7 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
           }
           if (this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee) {
             this.loanProductAccountingForm.patchValue({
+              deferredIncomeLiabilityAccountId: accountingMappings.deferredIncomeLiabilityAccount.id,
               buyDownExpenseAccountId: accountingMappings.buyDownExpenseAccount.id,
               incomeFromBuyDownAccountId: accountingMappings.incomeFromBuyDownAccount.id
             });
@@ -600,17 +601,23 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
   setDeferredIncomeRecognitionControls() {
     if (this.isAccountingAccrualBased) {
       if (this.deferredIncomeRecognition) {
-        if (this.deferredIncomeRecognition.capitalizedIncome.enableIncomeCapitalization) {
+        if (
+          this.deferredIncomeRecognition.capitalizedIncome.enableIncomeCapitalization ||
+          this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee
+        ) {
           this.loanProductAccountingForm.addControl(
             'deferredIncomeLiabilityAccountId',
             new UntypedFormControl('', Validators.required)
           );
+        } else {
+          this.loanProductAccountingForm.removeControl('deferredIncomeLiabilityAccountId');
+        }
+        if (this.deferredIncomeRecognition.capitalizedIncome.enableIncomeCapitalization) {
           this.loanProductAccountingForm.addControl(
             'incomeFromCapitalizationAccountId',
             new UntypedFormControl('', Validators.required)
           );
         } else {
-          this.loanProductAccountingForm.removeControl('deferredIncomeLiabilityAccountId');
           this.loanProductAccountingForm.removeControl('incomeFromCapitalizationAccountId');
         }
         if (this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee) {


### PR DESCRIPTION
## Description

The deferred income liability option must show up in the accounting tab if any deferred income types are enabled. currently it only shows up for Capitalized Income. In this PR I'm fixing that behaviour, the deferred income option now shows up in the accounting tab even if the user only sets buy down fees.

## Related issues and discussion

[WEB-246](https://mifosforge.jira.com/browse/WEB-246)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-246]: https://mifosforge.jira.com/browse/WEB-246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ