### PR TITLE
Resolution to Web-211, 2nd PR

### DIFF
--- a/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.html
+++ b/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.html
@@ -1,10 +1,12 @@
+<!-- Test re commit issue... Test 1 -->
+
 <mat-card class="container">
   <div class="layout-row-wrap gap-2px responsive-column">
     <div class="flex-fill" *ngIf="isFromClient">
       <span class="flex-40">
         <h3 class="mat-h3">{{ 'labels.heading.Client Type' | translate }}</h3>
       </span>
-      <span class="flex-60">
+      <span class="Client-Name">
         <h3 class="mat-h3">{{ clientName }}</h3>
       </span>
     </div>
@@ -20,7 +22,7 @@
 
     <mat-divider [inset]="true"></mat-divider>
 
-    <mat-form-field class="flex-30">
+    <mat-form-field class="type-field">
       <mat-label>{{ 'labels.inputs.Type' | translate }}</mat-label>
       <mat-select [formControl]="transferType">
         <mat-option *ngFor="let transferTypeData of transferTypeDatas" [value]="transferTypeData.id">
@@ -29,7 +31,7 @@
       </mat-select>
     </mat-form-field>
 
-    <mat-form-field class="flex-30">
+    <mat-form-field class="Account-Id-field">
       <input matInput placeholder="From Account Id" [formControl]="fromAccountId" />
     </mat-form-field>
 
@@ -40,7 +42,8 @@
       (click)="filterStandingInstructions()"
       class="filter-button"
     >
-      &nbsp;&nbsp;{{ 'labels.buttons.Filter' | translate }}
+      <!-- {{ 'labels.buttons.Filter' | translate }} -->
+      {{ 'labels.buttons.Filter' | translate | titlecase }}
     </button>
   </div>
 

--- a/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.html
+++ b/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.html
@@ -1,4 +1,4 @@
-<!-- Test re commit issue... Test 1 -->
+<!-- Test re commit issue... Test 22 -->
 
 <mat-card class="container">
   <div class="layout-row-wrap gap-2px responsive-column">

--- a/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.scss
+++ b/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.scss
@@ -1,7 +1,9 @@
+// Version 2
+
 .container {
   .filter-button {
     height: 2.5rem;
-    margin-top: 1rem;
+    margin-top: 2rem;
   }
 }
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,3 +1,5 @@
+// Test Version 1
+
 /*
  * Entry point of global application style.
  * Component-specific style should not go here and be included directly as part of the components.
@@ -268,7 +270,6 @@
 }
 
 .flex-40 {
-  //flex: 0 0 40%;
   flex: 1;
   width: 40%;
 }
@@ -313,7 +314,6 @@
 }
 
 .flex-60 {
-  // flex: 0 0 60%;
   flex: 1;
   width: 60%;
 }
@@ -590,4 +590,24 @@
 .content {
   display: contents;
   flex: 1;
+}
+
+//New!
+.type-field {
+  position: absolute;
+  left: 1px;
+  top: 20px;
+}
+
+//New!
+.Account-Id-field {
+  position: absolute;
+  left: 490px;
+  top: 20px;
+}
+
+//New!
+.Client-Name {
+  position: absolute;
+  left: 490px;
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,4 +1,4 @@
-// Test Version 1
+// Test Version 2
 
 /*
  * Entry point of global application style.


### PR DESCRIPTION
Web-211 Resolution, 2nd PR

This PR resolves the issues described in web-211. Filter button now has a capital F, regardless of which language is being used. Button formatting was further adjusted to give the page an overall better layout. Account ID, account-type field and client-name label have all been given specific formatting which greatly improves layout, even with a reduced window size.

![web-211 resolution, 3 July 2025](https://github.com/user-attachments/assets/5adb6e48-3553-485c-8ad7-b7acc66ad620)
![web-211 resolution 2, 3rd July 2025](https://github.com/user-attachments/assets/c315636a-25b6-4112-bbb4-06615d304f53)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [*] If you have multiple commits please combine them into one commit by squashing them.

- [*] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
