### PR TITLE
fix: revert font size to 14px

### DIFF
--- a/src/theme/mifosx-theme.scss
+++ b/src/theme/mifosx-theme.scss
@@ -16,7 +16,7 @@
 $mifosx-typography-level: mat.m2-define-typography-level(
   $font-family: Roboto,
   $font-weight: 400,
-  $font-size: 1rem,
+  $font-size: 14px,
   $line-height: 1.5,
   $letter-spacing: normal
 );


### PR DESCRIPTION
The Angular updates from 14 to 19 have caused
the font size to change. This was not intended.

FIXES: WEB-247