### PR TITLE
WEB-255: Disable automatic Interest Refund calculation

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.html
@@ -118,6 +118,10 @@
             <mat-label> {{ 'labels.inputs.Note' | translate }}</mat-label>
             <textarea matInput formControlName="note" cdkTextareaAutosize cdkAutosizeMinRows="2"></textarea>
           </mat-form-field>
+
+          <mat-checkbox formControlName="skipInterestRefund" *ngIf="showInterestRefundCheckbox()">
+            {{ 'labels.inputs.Skip Interest Refund Transaction Posting' | translate }}
+          </mat-checkbox>
         </div>
 
         <mat-card-actions class="layout-row align-center gap-5px responsive-column">

--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
@@ -92,7 +92,8 @@ export class MakeRepaymentComponent implements OnInit {
       ],
       externalId: '',
       paymentTypeId: '',
-      note: ''
+      note: '',
+      skipInterestRefund: [false]
     });
 
     if (this.isCapitalizedIncome()) {
@@ -157,6 +158,11 @@ export class MakeRepaymentComponent implements OnInit {
     ].includes(this.command);
   }
 
+  showInterestRefundCheckbox(): boolean {
+    const code = this.dataObject?.type?.code?.toLowerCase() || '';
+    return code.includes('merchantissuedrefund') || code.includes('payoutrefund');
+  }
+
   /** Submits the repayment form */
   submit() {
     const repaymentLoanFormData = this.repaymentLoanForm.value;
@@ -166,12 +172,16 @@ export class MakeRepaymentComponent implements OnInit {
     if (repaymentLoanFormData.transactionDate instanceof Date) {
       repaymentLoanFormData.transactionDate = this.dateUtils.formatDate(prevTransactionDate, dateFormat);
     }
-    const data = {
+    const data: any = {
       ...repaymentLoanFormData,
       dateFormat,
       locale
     };
     data['transactionAmount'] = data['transactionAmount'] * 1;
+    if (repaymentLoanFormData.skipInterestRefund) {
+      data.interestRefundCalculation = false;
+    }
+    delete data.skipInterestRefund;
     this.loanService.submitLoanActionButton(this.loanId, data, this.command).subscribe((response: any) => {
       this.router.navigate(['../../transactions'], { relativeTo: this.route });
     });

--- a/src/app/standalone-shared.module.ts
+++ b/src/app/standalone-shared.module.ts
@@ -12,6 +12,7 @@ import { MatSelect } from '@angular/material/select';
 import { MatOption } from '@angular/material/core';
 import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular/material/datepicker';
 import { MatButton } from '@angular/material/button';
+import { MatCheckbox } from '@angular/material/checkbox';
 import { DateFormatPipe } from '@pipes/date-format.pipe';
 import { TranslatePipe as NgxTranslatePipe } from '@ngx-translate/core';
 import { TranslatePipe } from '@pipes/translate.pipe';
@@ -39,6 +40,7 @@ export const STANDALONE_SHARED_IMPORTS = [
   MatDatepickerToggle,
   MatDatepicker,
   MatButton,
+  MatCheckbox,
   DateFormatPipe,
   HasPermissionDirective,
 

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "Typ příjmu z poplatku za odkup",
       "Buy down fees": "Poplatky za odkup",
       "Income from Buy down fees": "Příjmy z poplatků za odkup",
-      "Buy down fee Expense": "Náklady na poplatek za odkup"
+      "Buy down fee Expense": "Náklady na poplatek za odkup",
+      "Skip Interest Refund Transaction Posting": "Přeskočit zaúčtování vrácení úroků"
     },
     "links": {
       "Community": "Společenství",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "Einnahmeart der Buy-Down-Gebühr",
       "Buy down fees": "Buy-Down-Gebühren",
       "Income from Buy down fees": "Einnahmen aus Buy-Down-Gebühren",
-      "Buy down fee Expense": "Aufwendungen aus Buy-Down-Gebühren"
+      "Buy down fee Expense": "Aufwendungen aus Buy-Down-Gebühren",
+      "Skip Interest Refund Transaction Posting": "Buchung der Zinsrückerstattung überspringen"
     },
     "links": {
       "Community": "Gemeinschaft",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2494,7 +2494,8 @@
       "Buy down fee income type": "Buy down fee income type",
       "Buy down fees": "Buy down fees",
       "Income from Buy down fees": "Income from Buy down fees",
-      "Buy down fee Expense": "Buy down fee Expense"
+      "Buy down fee Expense": "Buy down fee Expense",
+      "Skip Interest Refund Transaction Posting": "Skip Interest Refund Transaction Posting"
     },
     "links": {
       "Community": "Community",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "Tipo de ingreso de comisión de compra anticipada",
       "Buy down fees": "Tarifas de compra anticipada",
       "Income from Buy down fees": "Ingresos por comisiones de compra inicial",
-      "Buy down fee Expense": "Gastos por comisiones de compra inicial"
+      "Buy down fee Expense": "Gastos por comisiones de compra inicial",
+      "Skip Interest Refund Transaction Posting": "Omitir el registro de la devolución de intereses"
     },
     "links": {
       "Community": "Comunidad",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "Tipo de ingreso de comisión de compra anticipada",
       "Buy down fees": "Tarifas de compra anticipada",
       "Income from Buy down fees": "Ingresos por comisiones de compra inicial",
-      "Buy down fee Expense": "Gastos por comisiones de compra inicial"
+      "Buy down fee Expense": "Gastos por comisiones de compra inicial",
+      "Skip Interest Refund Transaction Posting": "Omitir el registro de la devolución de intereses"
     },
     "links": {
       "Community": "Comunidad",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "Type de revenu des frais de rachat",
       "Buy down fees": "Frais d'achat",
       "Income from Buy down fees": "Revenus des commissions de rachat",
-      "Buy down fee Expense": "Charges des commissions de rachat"
+      "Buy down fee Expense": "Charges des commissions de rachat",
+      "Skip Interest Refund Transaction Posting": "Ignorer la comptabilisation du remboursement des intérêts"
     },
     "links": {
       "Community": "Communauté",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "Tipo di ricavo da commissione di buy down",
       "Buy down fees": "Commissioni di acquisto",
       "Income from Buy down fees": "Proventi da commissioni di buy down",
-      "Buy down fee Expense": "Spese da commissioni di buy down"
+      "Buy down fee Expense": "Spese da commissioni di buy down",
+      "Skip Interest Refund Transaction Posting": "Salta la registrazione del rimborso degli interessi"
     },
     "links": {
       "Community": "Comunità",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -2488,7 +2488,8 @@
       "Buy down fee income type": "매수 수수료 수익 유형",
       "Buy down fees": "매수 수수료",
       "Income from Buy down fees": "매입 수수료 수입",
-      "Buy down fee Expense": "매입 수수료 비용"
+      "Buy down fee Expense": "매입 수수료 비용",
+      "Skip Interest Refund Transaction Posting": "이자 환불 거래 게시 건너뛰기"
     },
     "links": {
       "Community": "지역 사회",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "Supirkimo mokesčio pajamų tipas",
       "Buy down fees": "Išpirkimo mokesčiai",
       "Income from Buy down fees": "Pajamos iš supirkimo mokesčių",
-      "Buy down fee Expense": "Supirkimo mokesčio išlaidos"
+      "Buy down fee Expense": "Supirkimo mokesčio išlaidos",
+      "Skip Interest Refund Transaction Posting": "Praleisti palūkanų grąžinimo įrašą"
     },
     "links": {
       "Community": "bendruomenė",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "Atpirkšanas maksas ienākumu veids",
       "Buy down fees": "Iepirkuma maksas",
       "Income from Buy down fees": "Ienākumi no akciju izpirkšanas komisijas maksām",
-      "Buy down fee Expense": "Akciju izpirkšanas komisijas izdevumi"
+      "Buy down fee Expense": "Akciju izpirkšanas komisijas izdevumi",
+      "Skip Interest Refund Transaction Posting": "Izlaist procentu atmaksas ierakstu"
     },
     "links": {
       "Community": "kopiena",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "बाइ डाउन शुल्क आय प्रकार",
       "Buy down fees": "खरिद शुल्क",
       "Income from Buy down fees": "खरिद शुल्कबाट हुने आम्दानी",
-      "Buy down fee Expense": "खरीद शुल्क खर्च"
+      "Buy down fee Expense": "खरीद शुल्क खर्च",
+      "Skip Interest Refund Transaction Posting": "ब्याज फिर्ता पोस्टिङ्ग छोड्नुहोस्"
     },
     "links": {
       "Community": "समुदाय",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "Tipo de receita de taxa de aquisição",
       "Buy down fees": "Taxas de compra antecipada",
       "Income from Buy down fees": "Receita com taxas de recompra",
-      "Buy down fee Expense": "Despesa com taxas de recompra"
+      "Buy down fee Expense": "Despesa com taxas de recompra",
+      "Skip Interest Refund Transaction Posting": "Ignorar o lançamento do reembolso de juros"
     },
     "links": {
       "Community": "Comunidade",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -2487,7 +2487,8 @@
       "Buy down fee income type": "Nunua aina ya mapato ya chini",
       "Buy down fees": "Nunua ada za chini",
       "Income from Buy down fees": "Mapato kutoka kwa ada ya Kununua",
-      "Buy down fee Expense": "Kununua ada ya chini Gharama"
+      "Buy down fee Expense": "Kununua ada ya chini Gharama",
+      "Skip Interest Refund Transaction Posting": "Ruka uchapishaji wa muamala wa kurejesha riba"
     },
     "links": {
       "Community": "Jumuiya",


### PR DESCRIPTION
## Description

Adds a checkbox “Skip Interest Refund Transaction Posting” to Merchant Issued Refund and Payout Refund screens.
When enabled, this option prevents automatic Interest Refund transaction creation for the current refund, overriding the loan product configuration.
By default, the checkbox is disabled.

## Related issues and discussion

#{[WEB-255](https://mifosforge.jira.com/browse/WEB-255)}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-255]: https://mifosforge.jira.com/browse/WEB-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ