### PR TITLE
WEB-261: Allow to create Interest Refund transaction manually

### DIFF
--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.html
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.html
@@ -159,6 +159,12 @@
               <span>{{ 'labels.text.View Transaction' | translate }}</span>
             </button>
           </span>
+          <span *ngIf="canCreateInterestRefund(transaction)">
+            <button mat-menu-item (click)="openInterestRefundDialog(transaction)">
+              <mat-icon><fa-icon icon="plus" size="sm"></fa-icon></mat-icon>
+              <span>{{ 'tooltips.Create Interest Refund' | translate }}</span>
+            </button>
+          </span>
           <span *ngIf="allowUndoTransaction(transaction)">
             <button mat-menu-item *mifosxHasPermission="'ADJUST_LOAN'" (click)="undoTransaction(transaction, $event)">
               <mat-icon><fa-icon icon="undo" size="sm"></fa-icon></mat-icon>

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -369,6 +369,7 @@
       "Create Group": "Vytvořit skupinu",
       "Create Holiday": "Vytvořte dovolenou",
       "Create Hook": "Vytvořte háček",
+      "Create Interest Refund": "Vytvořit vrácení úroků",
       "Create Journal Entries": "Vytvářejte záznamy deníku",
       "Create Loan Product": "Vytvořte produkt půjčky",
       "Create Office": "Vytvořit Office",
@@ -3517,6 +3518,7 @@
     "Yes": "Ano",
     "loan product will be active and available to clients": "Datum, kdy bude úvěrový produkt aktivní a dostupný klientům. Pokud nevyplníte, bude úvěrový produkt aktivní, jakmile bude vytvořen.",
     "loan product will become inactive and unavailable to clients": "Datum, kdy se úvěrový produkt stane neaktivním a nedostupným pro klienty. Pokud je prázdné, produkt zatížení se nikdy nestane neaktivním.",
-    "Refund transactions where interest refund will automatically be calculated": "Transakce s vrácením peněz, kde bude automaticky vypočítána refundace úroků"
+    "Refund transactions where interest refund will automatically be calculated": "Transakce s vrácením peněz, kde bude automaticky vypočítána refundace úroků",
+    "Create Interest Refund": "Vytvořit vrácení úroků"
   }
 }

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -369,6 +369,7 @@
       "Create Group": "Gruppe erstellen",
       "Create Holiday": "Urlaub erstellen",
       "Create Hook": "Hook erstellen",
+      "Create Interest Refund": "Zinsrückerstattung erstellen",
       "Create Journal Entries": "Erstellen Sie Journaleinträge",
       "Create Loan Product": "Darlehensprodukt erstellen",
       "Create Office": "Büro erstellen",
@@ -3516,6 +3517,7 @@
     "Yes": "Ja",
     "loan product will be active and available to clients": "Das Datum, an dem das Kreditprodukt aktiv und für Kunden verfügbar sein wird. Wenn das Feld leer ist, ist das Kreditprodukt aktiv, sobald es erstellt wird.",
     "loan product will become inactive and unavailable to clients": "Das Datum, an dem das Kreditprodukt inaktiv wird und für Kunden nicht mehr verfügbar ist. Wenn es leer ist, wird das Ladeprodukt niemals inaktiv.",
-    "Refund transactions where interest refund will automatically be calculated": "Rückerstattungstransaktionen, bei denen die Zinsrückerstattung automatisch berechnet wird"
+    "Refund transactions where interest refund will automatically be calculated": "Rückerstattungstransaktionen, bei denen die Zinsrückerstattung automatisch berechnet wird",
+    "Create Interest Refund": "Zinsrückerstattung erstellen"
   }
 }

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -370,6 +370,7 @@
       "Create Group": "Create Group",
       "Create Holiday": "Create Holiday",
       "Create Hook": "Create Hook",
+      "Create Interest Refund": "Create Interest Refund",
       "Create Journal Entries": "Create Journal Entries",
       "Create Loan Product": "Create Loan Product",
       "Create Office": "Create Office",
@@ -3622,6 +3623,7 @@
     "Yes": "Yes",
     "loan product will be active and available to clients": "The date that the loan product will be active and available to clients. If blank, the loan product will be active as soon as it is created.",
     "loan product will become inactive and unavailable to clients": "The date that the loan product will become inactive and unavailable to clients. If blank, the load product will never become inactive.",
-    "Refund transactions where interest refund will automatically be calculated": "Refund transactions where interest refund will automatically be calculated"
+    "Refund transactions where interest refund will automatically be calculated": "Refund transactions where interest refund will automatically be calculated",
+    "Create Interest Refund": "Create Interest Refund"
   }
 }

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -369,6 +369,7 @@
       "Create Group": "Crea un Grupo",
       "Create Holiday": "Crear Festivo",
       "Create Hook": "Crear gancho",
+      "Create Interest Refund": "Crear reembolso de intereses",
       "Create Journal Entries": "Crear entradas de diario",
       "Create Loan Product": "Crear producto de Crédito",
       "Create Office": "Crear Oficina",
@@ -3517,6 +3518,7 @@
     "Yes": "Sí",
     "loan product will be active and available to clients": "La fecha en que el producto de Crédito estará activo y disponible para los clientes. Si está en blanco, el producto de Crédito estará activo tan pronto como se cree.",
     "loan product will become inactive and unavailable to clients": "La fecha en que el producto de Crédito quedará inactivo y no estará disponible para los clientes. Si está en blanco, el producto de carga nunca quedará inactivo.",
-    "Refund transactions where interest refund will automatically be calculated": "Transacciones de reembolso en las que el reembolso de intereses se calculará automáticamente"
+    "Refund transactions where interest refund will automatically be calculated": "Transacciones de reembolso en las que el reembolso de intereses se calculará automáticamente",
+    "Create Interest Refund": "Crear reembolso de intereses"
   }
 }

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -369,6 +369,7 @@
       "Create Group": "Crea un Grupo",
       "Create Holiday": "Crear Festivo",
       "Create Hook": "Crear gancho",
+      "Create Interest Refund": "Crear reembolso de intereses",
       "Create Journal Entries": "Crear entradas de diario",
       "Create Loan Product": "Crear producto de Crédito",
       "Create Office": "Crear Oficina",
@@ -3517,6 +3518,7 @@
     "Yes": "Sí",
     "loan product will be active and available to clients": "La fecha en que el producto de Crédito estará activo y disponible para los clientes. Si está en blanco, el producto de Crédito estará activo tan pronto como se cree.",
     "loan product will become inactive and unavailable to clients": "La fecha en que el producto de Crédito quedará inactivo y no estará disponible para los clientes. Si está en blanco, el producto de carga nunca quedará inactivo.",
-    "Refund transactions where interest refund will automatically be calculated": "Transacciones de reembolso en las que el reembolso de intereses se calculará automáticamente"
+    "Refund transactions where interest refund will automatically be calculated": "Transacciones de reembolso en las que el reembolso de intereses se calculará automáticamente",
+    "Create Interest Refund": "Crear reembolso de intereses"
   }
 }

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -369,6 +369,7 @@
       "Create Group": "Créer un groupe",
       "Create Holiday": "Créer des vacances",
       "Create Hook": "Créer un crochet",
+      "Create Interest Refund": "Créer un remboursement d’intérêts",
       "Create Journal Entries": "Créer des entrées de journal",
       "Create Loan Product": "Créer un produit de prêt",
       "Create Office": "Créer un bureau",
@@ -3516,6 +3517,7 @@
     "Yes": "Oui",
     "loan product will be active and available to clients": "La date à laquelle le produit de prêt sera actif et disponible pour les clients. Si ce champ est vide, le produit de prêt sera actif dès sa création.",
     "loan product will become inactive and unavailable to clients": "Date à laquelle le produit de prêt deviendra inactif et indisponible pour les clients. S'il est vide, le produit chargé ne deviendra jamais inactif.",
-    "Refund transactions where interest refund will automatically be calculated": "Opérations de remboursement pour lesquelles le remboursement des intérêts sera automatiquement calculé"
+    "Refund transactions where interest refund will automatically be calculated": "Opérations de remboursement pour lesquelles le remboursement des intérêts sera automatiquement calculé",
+    "Create Interest Refund": "Créer un remboursement d’intérêts"
   }
 }

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -369,6 +369,7 @@
       "Create Group": "Creare un gruppo",
       "Create Holiday": "Crea vacanza",
       "Create Hook": "Crea gancio",
+      "Create Interest Refund": "Crea rimborso interessi",
       "Create Journal Entries": "Crea voci di diario",
       "Create Loan Product": "Crea prodotto di prestito",
       "Create Office": "Crea ufficio",
@@ -3517,6 +3518,7 @@
     "Yes": "SÌ",
     "loan product will be active and available to clients": "La data in cui il prodotto di prestito sarà attivo e disponibile per i clienti. Se vuoto, il prodotto di prestito sarà attivo non appena verrà creato.",
     "loan product will become inactive and unavailable to clients": "La data in cui il prodotto di prestito diventerà inattivo e non disponibile per i clienti. Se vuoto, il prodotto caricato non diventerà mai inattivo.",
-    "Refund transactions where interest refund will automatically be calculated": "Transazioni di rimborso in cui il rimborso degli interessi verrà calcolato automaticamente"
+    "Refund transactions where interest refund will automatically be calculated": "Transazioni di rimborso in cui il rimborso degli interessi verrà calcolato automaticamente",
+    "Create Interest Refund": "Crea rimborso interessi"
   }
 }

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -369,6 +369,7 @@
       "Create Group": "그룹 만들기",
       "Create Holiday": "공휴일 만들기",
       "Create Hook": "후크 생성",
+      "Create Interest Refund": "이자 환불 생성",
       "Create Journal Entries": "분개 항목 만들기",
       "Create Loan Product": "대출상품 생성",
       "Create Office": "사무실 만들기",
@@ -3517,6 +3518,7 @@
     "Yes": "예",
     "loan product will be active and available to clients": "대출 상품이 활성화되어 고객에게 제공되는 날짜입니다. 비어 있으면 대출 상품이 생성되자마자 활성화됩니다.",
     "loan product will become inactive and unavailable to clients": "대출 상품이 비활성화되어 고객이 사용할 수 없게 되는 날짜입니다. 비어 있으면 로드 제품이 비활성화되지 않습니다.",
-    "Refund transactions where interest refund will automatically be calculated": "이자 환불이 자동으로 계산되는 환불 거래"
+    "Refund transactions where interest refund will automatically be calculated": "이자 환불이 자동으로 계산되는 환불 거래",
+    "Create Interest Refund": "이자 환불 생성"
   }
 }

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -369,6 +369,7 @@
       "Create Group": "Sukurti grupę",
       "Create Holiday": "Sukurkite šventę",
       "Create Hook": "Sukurti kabliuką",
+      "Create Interest Refund": "Sukurti palūkanų grąžinimą",
       "Create Journal Entries": "Kurti žurnalo įrašus",
       "Create Loan Product": "Sukurti paskolos produktą",
       "Create Office": "Sukurkite biurą",
@@ -3517,6 +3518,7 @@
     "Yes": "Taip",
     "loan product will be active and available to clients": "Data, kada paskolos produktas bus aktyvus ir bus prieinamas klientams. Jei tuščia, paskolos produktas bus aktyvus, kai tik bus sukurtas.",
     "loan product will become inactive and unavailable to clients": "Data, kai paskolos produktas taps neaktyvus ir nepasiekiamas klientams. Jei tuščia, įkėlimo produktas niekada netaps neaktyvus.",
-    "Refund transactions where interest refund will automatically be calculated": "Atmaksas darījumi, kuros procentu atmaksa tiks aprēķināta automātiski"
+    "Refund transactions where interest refund will automatically be calculated": "Atmaksas darījumi, kuros procentu atmaksa tiks aprēķināta automātiski",
+    "Create Interest Refund": "Sukurti palūkanų grąžinimą"
   }
 }

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -369,6 +369,7 @@
       "Create Group": "Izveidot grupu",
       "Create Holiday": "Izveidojiet svētkus",
       "Create Hook": "Izveidojiet āķi",
+      "Create Interest Refund": "Izveidot procentu atmaksu",
       "Create Journal Entries": "Izveidojiet žurnāla ierakstus",
       "Create Loan Product": "Izveidojiet aizdevuma produktu",
       "Create Office": "Izveidojiet biroju",
@@ -3517,6 +3518,7 @@
     "Yes": "Jā",
     "loan product will be active and available to clients": "Datums, kad aizdevuma produkts būs aktīvs un pieejams klientiem. Ja lauks ir tukšs, aizdevuma produkts būs aktīvs, tiklīdz tas tiks izveidots.",
     "loan product will become inactive and unavailable to clients": "Datums, kad aizdevuma produkts kļūs neaktīvs un klientiem nebūs pieejams. Ja lauks ir tukšs, ielādes produkts nekad nekļūs neaktīvs.",
-    "Refund transactions where interest refund will automatically be calculated": "Grąžinimo operacijos, kai palūkanų grąžinimas bus skaičiuojamas automatiškai"
+    "Refund transactions where interest refund will automatically be calculated": "Grąžinimo operacijos, kai palūkanų grąžinimas bus skaičiuojamas automatiškai",
+    "Create Interest Refund": "Izveidot procentu atmaksu"
   }
 }

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -369,6 +369,7 @@
       "Create Group": "समूह सिर्जना गर्नुहोस्",
       "Create Holiday": "छुट्टी सिर्जना गर्नुहोस्",
       "Create Hook": "हुक सिर्जना गर्नुहोस्",
+      "Create Interest Refund": "ब्याज फिर्ता सिर्जना गर्नुहोस्",
       "Create Journal Entries": "जर्नल प्रविष्टिहरू सिर्जना गर्नुहोस्",
       "Create Loan Product": "ऋण उत्पादन सिर्जना गर्नुहोस्",
       "Create Office": "कार्यालय सिर्जना गर्नुहोस्",
@@ -3517,6 +3518,7 @@
     "Yes": "हो",
     "loan product will be active and available to clients": "ऋण उत्पादन सक्रिय र ग्राहकहरूको लागि उपलब्ध हुने मिति। खाली भएमा, ऋण उत्पादन सिर्जना हुने बित्तिकै सक्रिय हुनेछ।",
     "loan product will become inactive and unavailable to clients": "ऋण उत्पादन निष्क्रिय र ग्राहकहरु को लागी अनुपलब्ध हुने मिति। यदि खाली छ भने, लोड उत्पादन कहिल्यै निष्क्रिय हुनेछैन।",
-    "Refund transactions where interest refund will automatically be calculated": "फिर्ता लेनदेन जहाँ ब्याज फिर्ता स्वतः गणना हुनेछ"
+    "Refund transactions where interest refund will automatically be calculated": "फिर्ता लेनदेन जहाँ ब्याज फिर्ता स्वतः गणना हुनेछ",
+    "Create Interest Refund": "ब्याज फिर्ता सिर्जना गर्नुहोस्"
   }
 }

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -369,6 +369,7 @@
       "Create Group": "Criar grupo",
       "Create Holiday": "Criar feriado",
       "Create Hook": "Criar gancho",
+      "Create Interest Refund": "Criar reembolso de juros",
       "Create Journal Entries": "Criar lançamentos contábeis manuais",
       "Create Loan Product": "Criar produto de empréstimo",
       "Create Office": "Criar escritório",
@@ -3517,6 +3518,7 @@
     "Yes": "Sim",
     "loan product will be active and available to clients": "A data em que o produto de empréstimo estará ativo e disponível para os clientes. Se estiver em branco, o produto de empréstimo estará ativo assim que for criado.",
     "loan product will become inactive and unavailable to clients": "A data em que o produto de empréstimo ficará inativo e indisponível para os clientes. Se estiver em branco, o produto de carregamento nunca ficará inativo.",
-    "Refund transactions where interest refund will automatically be calculated": "Transações de reembolso em que o reembolso de juros será calculado automaticamente"
+    "Refund transactions where interest refund will automatically be calculated": "Transações de reembolso em que o reembolso de juros será calculado automaticamente",
+    "Create Interest Refund": "Criar reembolso de juros"
   }
 }

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -369,6 +369,7 @@
       "Create Group": "Unda Kikundi",
       "Create Holiday": "Unda Likizo",
       "Create Hook": "Unda Hook",
+      "Create Interest Refund": "Unda Marejesho ya Riba",
       "Create Journal Entries": "Unda Maingizo ya Jarida",
       "Create Loan Product": "Tengeneza Bidhaa ya Mkopo",
       "Create Office": "Unda Ofisi",
@@ -3517,6 +3518,7 @@
     "Yes": "Ndiyo",
     "loan product will be active and available to clients": "Tarehe ambayo bidhaa ya mkopo itaanza kutumika na inapatikana kwa wateja. Ikiwa tupu, bidhaa ya mkopo itaanza kutumika mara tu itakapoundwa.",
     "loan product will become inactive and unavailable to clients": "Tarehe ambayo bidhaa ya mkopo itaacha kutumika na haitapatikana kwa wateja. Ikiwa tupu, bidhaa ya kupakia haitafanya kazi kamwe.",
-    "Refund transactions where interest refund will automatically be calculated": "Shughuli za kurejesha pesa ambapo urejeshaji wa riba utahesabiwa kiotomatiki"
+    "Refund transactions where interest refund will automatically be calculated": "Shughuli za kurejesha pesa ambapo urejeshaji wa riba utahesabiwa kiotomatiki",
+    "Create Interest Refund": "Unda Marejesho ya Riba"
   }
 }


### PR DESCRIPTION
## Description

This PR adds the ability to manually create an Interest Refund transaction for Payout Refund and Merchant Issued Refund transactions.
A new menu action "Create Interest Refund" is available for eligible refund transactions.
The form is pre-filled with the calculated amount and available payment types.
The transaction date is not required and is not shown in the form.
All necessary validations are performed on the UI:
Only available for Payout Refund and Merchant Issued Refund types
Not available for reversed transactions
Not available if an Interest Refund already exists for the target transaction

## Related issues and discussion

#{[WEB-261](https://mifosforge.jira.com/browse/WEB-261)}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-261]: https://mifosforge.jira.com/browse/WEB-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ