### PR TITLE
WEB-267 Remove tenant identifier for OAuth token requests

### DIFF
--- a/src/app/core/authentication/authentication.interceptor.ts
+++ b/src/app/core/authentication/authentication.interceptor.ts
@@ -36,6 +36,14 @@ export class AuthenticationInterceptor implements HttpInterceptor {
     if (this.settingsService.tenantIdentifier) {
       httpOptions.headers['Fineract-Platform-TenantId'] = this.settingsService.tenantIdentifier;
     }
+    if (
+      environment.oauth.enabled &&
+      (request.url.includes(`${environment.oauth.serverUrl}/token`) ||
+        request.url.includes(`${environment.oauth.serverUrl}/logout`))
+    ) {
+      // If the request is for OAuth token, we do not set the tenant identifier.
+      delete httpOptions.headers[authorizationTenantHeader];
+    }
     request = request.clone({ setHeaders: httpOptions.headers });
     return next.handle(request);
   }

--- a/src/app/core/authentication/authentication.service.ts
+++ b/src/app/core/authentication/authentication.service.ts
@@ -105,15 +105,12 @@ export class AuthenticationService {
       httpParams = httpParams.set('grant_type', 'password');
       let headers = new HttpHeaders();
       headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
-      return this.http
-        .disableApiPrefix()
-        .post(`${environment.oauth.serverUrl}/token`, httpParams.toString(), { headers: headers })
-        .pipe(
-          map((tokenResponse: OAuth2Token) => {
-            this.getUserDetails(tokenResponse);
-            return of(true);
-          })
-        );
+      return this.http.post(`${environment.oauth.serverUrl}/token`, httpParams.toString(), { headers: headers }).pipe(
+        map((tokenResponse: OAuth2Token) => {
+          this.getUserDetails(tokenResponse);
+          return of(true);
+        })
+      );
     } else {
       return this.http
         .post('/authentication', { username: loginContext.username, password: loginContext.password })
@@ -137,7 +134,6 @@ export class AuthenticationService {
     let headers = new HttpHeaders();
     headers = headers.set('Authorization', 'bearer ' + tokenResponse.access_token);
     this.http
-      .disableApiPrefix()
       .get(`${environment.serverUrl}/userdetails`, { headers: headers })
       .subscribe((credentials: Credentials) => {
         this.onLoginSuccess(credentials);
@@ -174,7 +170,6 @@ export class AuthenticationService {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
     return this.http
-      .disableApiPrefix()
       .post(`${environment.oauth.serverUrl}/token`, httpParams.toString(), { headers: headers })
       .subscribe((tokenResponse: OAuth2Token) => {
         this.storage.setItem(this.oAuthTokenDetailsStorageKey, JSON.stringify(tokenResponse));
@@ -241,7 +236,6 @@ export class AuthenticationService {
     let headers = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
     return this.http
-      .disableApiPrefix()
       .post(`${environment.oauth.serverUrl}/logout`, httpParams.toString(), { headers: headers })
       .subscribe();
   }


### PR DESCRIPTION
## Description

The problem is Fineract-Platform-TenantId header is rejected by CORS policy on the endpoints exposed by keycloak.
This is a fix to remove this header from the requests to keycloack oauth server.

## Related issues and discussion

WEB-267

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
