### PR TITLE
WEB-269: Buy-Down fees Accounting for non merchant product

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-active-client-members/loans-active-client-members.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-active-client-members/loans-active-client-members.component.ts
@@ -65,13 +65,10 @@ export class LoansActiveClientMembersComponent implements OnInit {
   ];
 
   ngOnInit(): void {
-    // console.log("Active Client Members in LoansActiveClientMembersComponent:", this.activeClientMembers);
-
     this.dataSource = new MatTableDataSource<any>(this.activeClientMembers);
   }
 
   get isValid() {
-    // console.log("LoansActiveClientMembersComponent isValid:", this.selectedClientMembers?.selectedMembers?.reduce((acc: any, cur: any) => acc + (cur.principal ?? 0), 0) > 0);
     return (
       !this.activeClientMembers ||
       this.selectedClientMembers?.selectedMembers?.reduce((acc: any, cur: any) => acc + (cur.principal ?? 0), 0) > 0

--- a/src/app/loans/loans-view/account-details/account-details.component.html
+++ b/src/app/loans/loans-view/account-details/account-details.component.html
@@ -123,6 +123,11 @@
       <span class="flex-50"> {{ loanDetails.buyDownFeeIncomeType?.value | translateKey: 'catalogs' }} </span>
     </div>
 
+    <div class="flex-fill layout-row" *ngIf="loanDetails.enableBuyDownFee">
+      <span class="flex-50"> {{ 'labels.inputs.Merchant Buy down fee' | translate }}</span>
+      <span class="flex-50"> {{ loanDetails.merchantBuyDownFee | yesNo }} </span>
+    </div>
+
     <div class="flex-fill layout-row">
       <span class="flex-50"> {{ 'labels.inputs.Grace: On Principal Payment' | translate }}</span>
       <span class="flex-50"> {{ loanDetails.graceOnPrincipalPayment }} </span>

--- a/src/app/loans/loans-view/loan-buy-down-fees-tab/loan-buy-down-fees-tab.component.html
+++ b/src/app/loans/loans-view/loan-buy-down-fees-tab/loan-buy-down-fees-tab.component.html
@@ -14,41 +14,41 @@
       <ng-container matColumnDef="buyDownFeeDate">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.heading.Date' | translate }}</th>
         <td mat-cell *matCellDef="let item">
-          {{ item.buyDownFeeDate | date: 'mediumDate' }}
+          {{ item.buyDownFeeDate | dateFormat }}
         </td>
       </ng-container>
 
       <ng-container matColumnDef="buyDownFeeAmount">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.heading.Fee Amount' | translate }}</th>
-        <td mat-cell *matCellDef="let item">
+        <td mat-cell class="r-amount" *matCellDef="let item">
           {{ item.buyDownFeeAmount | formatNumber: '0.00' }}
         </td>
       </ng-container>
 
       <ng-container matColumnDef="amortizedAmount">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.heading.Amortized Amount' | translate }}</th>
-        <td mat-cell *matCellDef="let item">
+        <td mat-cell class="r-amount" *matCellDef="let item">
           {{ item.amortizedAmount | formatNumber: '0.00' }}
         </td>
       </ng-container>
 
       <ng-container matColumnDef="notYetAmortizedAmount">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.heading.Not Yet Amortized Amount' | translate }}</th>
-        <td mat-cell *matCellDef="let item">
+        <td mat-cell class="r-amount" *matCellDef="let item">
           {{ item.notYetAmortizedAmount | formatNumber: '0.00' }}
         </td>
       </ng-container>
 
       <ng-container matColumnDef="adjustedAmount">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.heading.Adjusted Amount' | translate }}</th>
-        <td mat-cell *matCellDef="let item">
+        <td mat-cell class="r-amount" *matCellDef="let item">
           {{ item.adjustedAmount | formatNumber: '0.00' }}
         </td>
       </ng-container>
 
       <ng-container matColumnDef="chargedOffAmount">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.heading.Charged Off Amount' | translate }}</th>
-        <td mat-cell *matCellDef="let item">
+        <td mat-cell class="r-amount" *matCellDef="let item">
           {{ item.chargedOffAmount | formatNumber: '0.00' }}
         </td>
       </ng-container>

--- a/src/app/loans/loans-view/loan-buy-down-fees-tab/loan-buy-down-fees-tab.component.ts
+++ b/src/app/loans/loans-view/loan-buy-down-fees-tab/loan-buy-down-fees-tab.component.ts
@@ -16,7 +16,7 @@ import { FormatNumberPipe } from '@pipes/format-number.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { LoansService } from '../../loans.service';
 import { BuyDownFeeAmortizationDetails } from '../../models/loan-account.model';
-import { DatePipe } from '@angular/common';
+import { DateFormatPipe } from '@pipes/date-format.pipe';
 
 @Component({
   selector: 'mifosx-loan-buy-down-fees-tab',
@@ -35,7 +35,7 @@ import { DatePipe } from '@angular/common';
     MatRowDef,
     MatRow,
     FormatNumberPipe,
-    DatePipe
+    DateFormatPipe
   ]
 })
 export class LoanBuyDownFeesTabComponent implements OnInit {

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -930,6 +930,11 @@
       <span class="flex-40">{{ 'labels.inputs.Buy down fee income type' | translate }}:</span>
       <span class="flex-60">{{ loanProduct.buyDownFeeIncomeType?.value | translateKey: 'catalogs' }}</span>
     </div>
+
+    <div class="flex-100 layout-row">
+      <span class="flex-40">{{ 'labels.inputs.Merchant Buy down fee' | translate }}:</span>
+      <span class="flex-60">{{ loanProduct.merchantBuyDownFee | yesNo }}</span>
+    </div>
   </div>
 
   <h3 class="mat-h3 flex-100">{{ 'labels.heading.Accounting' | translate }}</h3>

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
@@ -110,12 +110,9 @@
         [buyDownFeeCalculationTypeOptions]="loanProductsTemplate.buyDownFeeCalculationTypeOptions"
         [buyDownFeeStrategyOptions]="loanProductsTemplate.buyDownFeeStrategyOptions"
         [buyDownFeeIncomeTypeOptions]="loanProductsTemplate.buyDownFeeIncomeTypeOptions"
-        (setDeferredIncomeRecognition)="setDeferredIncomeRecognition($event)"
         (setViewChildForm)="setViewChildForm($event)"
       >
       </mifosx-loan-product-capitalized-income-step>
-
-      <mifosx-stepper-buttons></mifosx-stepper-buttons>
     </mat-step>
 
     <mat-step [stepControl]="loanProductAccountingForm">

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
@@ -17,6 +17,8 @@ import { LoanProducts } from '../loan-products';
 import {
   AdvancedPaymentAllocation,
   AdvancedPaymentStrategy,
+  BuyDownFee,
+  CapitalizedIncome,
   DeferredIncomeRecognition,
   PaymentAllocation
 } from '../loan-product-stepper/loan-product-payment-strategy-step/payment-allocation-model';
@@ -159,7 +161,8 @@ export class CreateLoanProductComponent implements OnInit {
           enableBuyDownFee: true,
           buyDownFeeCalculationType: this.loanProductsTemplate.buyDownFeeCalculationTypeOptions[0],
           buyDownFeeStrategy: this.loanProductsTemplate.buyDownFeeStrategyOptions[0],
-          buyDownFeeIncomeType: this.loanProductsTemplate.buyDownFeeIncomeTypeOptions[0]
+          buyDownFeeIncomeType: this.loanProductsTemplate.buyDownFeeIncomeTypeOptions[0],
+          merchantBuyDownFee: true
         };
       } else {
         this.deferredIncomeRecognition.buyDownFee = {
@@ -195,6 +198,28 @@ export class CreateLoanProductComponent implements OnInit {
 
   setViewChildForm(viewChildForm: UntypedFormGroup): void {
     this.loanDeferredIncomeRecognitionForm = viewChildForm;
+    const formValues: any = this.loanDeferredIncomeRecognitionForm.getRawValue();
+    const capitalizedIncome: CapitalizedIncome = formValues.enableIncomeCapitalization
+      ? {
+          enableIncomeCapitalization: true,
+          capitalizedIncomeCalculationType: formValues.capitalizedIncomeCalculationType,
+          capitalizedIncomeStrategy: formValues.capitalizedIncomeStrategy,
+          capitalizedIncomeType: formValues.capitalizedIncomeType
+        }
+      : { enableIncomeCapitalization: false };
+    const buyDownFee: BuyDownFee = formValues.enableBuyDownFee
+      ? {
+          enableBuyDownFee: true,
+          buyDownFeeCalculationType: formValues.buyDownFeeCalculationType,
+          buyDownFeeStrategy: formValues.buyDownFeeStrategy,
+          buyDownFeeIncomeType: formValues.buyDownFeeIncomeType,
+          merchantBuyDownFee: formValues.merchantBuyDownFee
+        }
+      : { enableBuyDownFee: false };
+    this.setDeferredIncomeRecognition({
+      capitalizedIncome: capitalizedIncome,
+      buyDownFee: buyDownFee
+    });
   }
 
   get loanProductSettingsForm() {
@@ -257,6 +282,7 @@ export class CreateLoanProductComponent implements OnInit {
             this.deferredIncomeRecognition.buyDownFee.buyDownFeeCalculationType;
           loanProduct['buyDownFeeStrategy'] = this.deferredIncomeRecognition.buyDownFee.buyDownFeeStrategy;
           loanProduct['buyDownFeeIncomeType'] = this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType;
+          loanProduct['merchantBuyDownFee'] = this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee;
         }
       }
     }

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
@@ -110,12 +110,9 @@
         [buyDownFeeCalculationTypeOptions]="loanProductAndTemplate.buyDownFeeCalculationTypeOptions"
         [buyDownFeeStrategyOptions]="loanProductAndTemplate.buyDownFeeStrategyOptions"
         [buyDownFeeIncomeTypeOptions]="loanProductAndTemplate.buyDownFeeIncomeTypeOptions"
-        (setDeferredIncomeRecognition)="setDeferredIncomeRecognition($event)"
         (setViewChildForm)="setViewChildForm($event)"
       >
       </mifosx-loan-product-capitalized-income-step>
-
-      <mifosx-stepper-buttons></mifosx-stepper-buttons>
     </mat-step>
 
     <mat-step [stepControl]="loanProductAccountingForm" completed>

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
@@ -20,7 +20,9 @@ import {
   AdvancedPaymentStrategy,
   DeferredIncomeRecognition,
   CreditAllocation,
-  PaymentAllocation
+  PaymentAllocation,
+  CapitalizedIncome,
+  BuyDownFee
 } from '../loan-product-stepper/loan-product-payment-strategy-step/payment-allocation-model';
 import { Accounting } from 'app/core/utils/accounting';
 import { LoanProductInterestRefundStepComponent } from '../loan-product-stepper/loan-product-interest-refund-step/loan-product-interest-refund-step.component';
@@ -119,13 +121,13 @@ export class EditLoanProductComponent implements OnInit {
     this.accountingRuleData = this.accounting.getAccountingRulesForLoans();
     this.buildAdvancedPaymentAllocation();
     this.advancePaymentStrategy(this.loanProductAndTemplate.transactionProcessingStrategyCode);
+    if (this.deferredIncomeRecognition == null) {
+      this.deferredIncomeRecognition = {};
+    }
     if (this.isAdvancedPaymentStrategy) {
       this.paymentAllocation = this.loanProductAndTemplate.paymentAllocation;
       this.creditAllocation = this.loanProductAndTemplate.creditAllocation;
       this.supportedInterestRefundTypes = this.loanProductAndTemplate.supportedInterestRefundTypes;
-      if (this.deferredIncomeRecognition == null) {
-        this.deferredIncomeRecognition = {};
-      }
       if (this.loanProductAndTemplate.enableIncomeCapitalization) {
         this.deferredIncomeRecognition.capitalizedIncome = {
           enableIncomeCapitalization: true,
@@ -143,7 +145,8 @@ export class EditLoanProductComponent implements OnInit {
           enableBuyDownFee: true,
           buyDownFeeCalculationType: this.loanProductAndTemplate.buyDownFeeCalculationType.id,
           buyDownFeeStrategy: this.loanProductAndTemplate.buyDownFeeStrategy.id,
-          buyDownFeeIncomeType: this.loanProductAndTemplate.buyDownFeeIncomeType.id
+          buyDownFeeIncomeType: this.loanProductAndTemplate.buyDownFeeIncomeType.id,
+          merchantBuyDownFee: this.loanProductAndTemplate.merchantBuyDownFee
         };
       } else {
         this.deferredIncomeRecognition.buyDownFee = {
@@ -177,6 +180,28 @@ export class EditLoanProductComponent implements OnInit {
 
   setViewChildForm(viewChildForm: UntypedFormGroup): void {
     this.loanIncomeCapitalizationForm = viewChildForm;
+    const formValues: any = this.loanIncomeCapitalizationForm.getRawValue();
+    const capitalizedIncome: CapitalizedIncome = formValues.enableIncomeCapitalization
+      ? {
+          enableIncomeCapitalization: true,
+          capitalizedIncomeCalculationType: formValues.capitalizedIncomeCalculationType,
+          capitalizedIncomeStrategy: formValues.capitalizedIncomeStrategy,
+          capitalizedIncomeType: formValues.capitalizedIncomeType
+        }
+      : { enableIncomeCapitalization: false };
+    const buyDownFee: BuyDownFee = formValues.enableBuyDownFee
+      ? {
+          enableBuyDownFee: true,
+          buyDownFeeCalculationType: formValues.buyDownFeeCalculationType,
+          buyDownFeeStrategy: formValues.buyDownFeeStrategy,
+          buyDownFeeIncomeType: formValues.buyDownFeeIncomeType,
+          merchantBuyDownFee: formValues.merchantBuyDownFee
+        }
+      : { enableBuyDownFee: false };
+    this.setDeferredIncomeRecognition({
+      capitalizedIncome: capitalizedIncome,
+      buyDownFee: buyDownFee
+    });
   }
 
   advancePaymentStrategy(value: string): void {
@@ -294,6 +319,7 @@ export class EditLoanProductComponent implements OnInit {
               this.deferredIncomeRecognition.buyDownFee.buyDownFeeCalculationType;
             loanProduct['buyDownFeeStrategy'] = this.deferredIncomeRecognition.buyDownFee.buyDownFeeStrategy;
             loanProduct['buyDownFeeIncomeType'] = this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType;
+            loanProduct['merchantBuyDownFee'] = this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee;
           }
         }
       }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
@@ -242,7 +242,10 @@
 
       <mifosx-gl-account-selector
         class="flex-48"
-        *ngIf="deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee"
+        *ngIf="
+          deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee &&
+          deferredIncomeRecognition?.buyDownFee?.merchantBuyDownFee
+        "
         [inputFormControl]="loanProductAccountingForm.controls.buyDownExpenseAccountId"
         [glAccountList]="expenseAccountData"
         [required]="true"

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -1,12 +1,5 @@
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
-import {
-  UntypedFormArray,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  UntypedFormGroup,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { UntypedFormArray, UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
@@ -21,7 +14,7 @@ import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 import { MatDivider } from '@angular/material/divider';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { GlAccountSelectorComponent } from '../../../../shared/accounting/gl-account-selector/gl-account-selector.component';
-import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatIconButton } from '@angular/material/button';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import {
   MatTable,
@@ -158,9 +151,13 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
           if (this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee) {
             this.loanProductAccountingForm.patchValue({
               deferredIncomeLiabilityAccountId: accountingMappings.deferredIncomeLiabilityAccount.id,
-              buyDownExpenseAccountId: accountingMappings.buyDownExpenseAccount.id,
               incomeFromBuyDownAccountId: accountingMappings.incomeFromBuyDownAccount.id
             });
+            if (this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee) {
+              this.loanProductAccountingForm.patchValue({
+                buyDownExpenseAccountId: accountingMappings.buyDownExpenseAccount?.id
+              });
+            }
           }
         }
       /* falls through */
@@ -621,10 +618,12 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
           this.loanProductAccountingForm.removeControl('incomeFromCapitalizationAccountId');
         }
         if (this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee) {
-          this.loanProductAccountingForm.addControl(
-            'buyDownExpenseAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
+          if (this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee) {
+            this.loanProductAccountingForm.addControl(
+              'buyDownExpenseAccountId',
+              new UntypedFormControl('', Validators.required)
+            );
+          }
           this.loanProductAccountingForm.addControl(
             'incomeFromBuyDownAccountId',
             new UntypedFormControl('', Validators.required)

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component.html
@@ -70,5 +70,20 @@
         </mat-option>
       </mat-select>
     </mat-form-field>
+
+    <mat-checkbox class="flex-48" *ngIf="enableBuyDownFee" labelPosition="before" formControlName="merchantBuyDownFee">
+      {{ 'labels.inputs.Merchant Buy down fee' | translate }}
+    </mat-checkbox>
+  </div>
+
+  <div class="layout-row responsive-column align-center gap-2px margin-t">
+    <button mat-raised-button matStepperPrevious>
+      <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
+      {{ 'labels.buttons.Previous' | translate }}
+    </button>
+    <button mat-raised-button matStepperNext>
+      {{ 'labels.buttons.Next' | translate }}
+      <fa-icon icon="arrow-right" class="m-l-10"></fa-icon>
+    </button>
   </div>
 </form>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import {
   UntypedFormBuilder,
   UntypedFormControl,
@@ -14,6 +14,7 @@ import {
 import { StringEnumOptionData } from 'app/shared/models/option-data.model';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
 @Component({
   selector: 'mifosx-loan-product-capitalized-income-step',
@@ -21,10 +22,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   styleUrls: ['./loan-product-deferred-income-recognition-step.component.scss'],
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
-    MatCheckbox
+    MatCheckbox,
+    FaIconComponent
   ]
 })
-export class LoanProductDeferredIncomeRecognitionStepComponent implements OnChanges {
+export class LoanProductDeferredIncomeRecognitionStepComponent implements OnInit {
   @Input() deferredIncomeRecognition: DeferredIncomeRecognition;
   @Input() capitalizedIncomeCalculationTypeOptions: StringEnumOptionData[];
   @Input() capitalizedIncomeStrategyOptions: StringEnumOptionData[];
@@ -38,7 +40,6 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnChan
   enableIncomeCapitalization: boolean;
   enableBuyDownFee: boolean;
 
-  @Output() setDeferredIncomeRecognition = new EventEmitter<DeferredIncomeRecognition>();
   @Output() setViewChildForm = new EventEmitter<UntypedFormGroup>();
 
   constructor(private formBuilder: UntypedFormBuilder) {
@@ -84,11 +85,13 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnChan
         this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType,
         Validators.required
       ]);
+      this.loanDeferredIncomeRecognitionForm.addControl('merchantBuyDownFee', [
+        this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee
+      ]);
     }
-    this.setViewChildForm.emit(this.loanDeferredIncomeRecognitionForm);
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
+  ngOnInit(): void {
     this.enableIncomeCapitalization = this.deferredIncomeRecognition.capitalizedIncome
       ? this.deferredIncomeRecognition.capitalizedIncome.enableIncomeCapitalization
       : false;
@@ -109,10 +112,10 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnChan
         enableBuyDownFee: this.enableBuyDownFee,
         buyDownFeeCalculationType: this.deferredIncomeRecognition.buyDownFee.buyDownFeeCalculationType,
         buyDownFeeStrategy: this.deferredIncomeRecognition.buyDownFee.buyDownFeeStrategy,
-        buyDownFeeIncomeType: this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType
+        buyDownFeeIncomeType: this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType,
+        merchantBuyDownFee: this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee
       });
     }
-    this.setViewChildForm.emit(this.loanDeferredIncomeRecognitionForm);
   }
 
   setConditionalControls() {
@@ -206,6 +209,10 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnChan
           'buyDownFeeIncomeType',
           new UntypedFormControl(buyDownFeeIncomeType, Validators.required)
         );
+        this.loanDeferredIncomeRecognitionForm.addControl(
+          'merchantBuyDownFee',
+          new UntypedFormControl(this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee)
+        );
 
         this.loanDeferredIncomeRecognitionForm
           .get('buyDownFeeCalculationType')
@@ -220,38 +227,21 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnChan
           .valueChanges.subscribe((newValue: string) => {
             this.emitValuesChange();
           });
+        this.loanDeferredIncomeRecognitionForm.get('merchantBuyDownFee').valueChanges.subscribe((newValue: boolean) => {
+          this.emitValuesChange();
+        });
       } else {
         this.loanDeferredIncomeRecognitionForm.removeControl('buyDownFeeCalculationType');
         this.loanDeferredIncomeRecognitionForm.removeControl('buyDownFeeStrategy');
         this.loanDeferredIncomeRecognitionForm.removeControl('buyDownFeeIncomeType');
+        this.loanDeferredIncomeRecognitionForm.removeControl('merchantBuyDownFee');
       }
 
       this.emitValuesChange();
-      this.setViewChildForm.emit(this.loanDeferredIncomeRecognitionForm);
     });
   }
 
   emitValuesChange(): void {
-    const capitalizedIncome: CapitalizedIncome = this.enableIncomeCapitalization
-      ? {
-          enableIncomeCapitalization: true,
-          capitalizedIncomeCalculationType:
-            this.loanDeferredIncomeRecognitionForm.value.capitalizedIncomeCalculationType,
-          capitalizedIncomeStrategy: this.loanDeferredIncomeRecognitionForm.value.capitalizedIncomeStrategy,
-          capitalizedIncomeType: this.loanDeferredIncomeRecognitionForm.value.capitalizedIncomeType
-        }
-      : { enableIncomeCapitalization: false };
-    const buyDownFee: BuyDownFee = this.enableBuyDownFee
-      ? {
-          enableBuyDownFee: true,
-          buyDownFeeCalculationType: this.loanDeferredIncomeRecognitionForm.value.buyDownFeeCalculationType,
-          buyDownFeeStrategy: this.loanDeferredIncomeRecognitionForm.value.buyDownFeeStrategy,
-          buyDownFeeIncomeType: this.loanDeferredIncomeRecognitionForm.value.buyDownFeeIncomeType
-        }
-      : { enableBuyDownFee: false };
-    this.setDeferredIncomeRecognition.emit({
-      capitalizedIncome: capitalizedIncome,
-      buyDownFee: buyDownFee
-    });
+    this.setViewChildForm.emit(this.loanDeferredIncomeRecognitionForm);
   }
 }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-payment-strategy-step/payment-allocation-model.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-payment-strategy-step/payment-allocation-model.ts
@@ -54,6 +54,7 @@ export interface BuyDownFee {
   buyDownFeeCalculationType?: string;
   buyDownFeeStrategy?: string;
   buyDownFeeIncomeType?: string;
+  merchantBuyDownFee?: boolean;
 }
 
 export interface DeferredIncomeRecognition {

--- a/src/app/products/manage-tax-groups/view-tax-group/view-tax-group.component.html
+++ b/src/app/products/manage-tax-groups/view-tax-group/view-tax-group.component.html
@@ -8,7 +8,7 @@
 <div class="container">
   <mat-card>
     <mat-card-content>
-      <div class="layout-row-wrap">
+      <div class="layout-row-wrap card-content">
         <div class="mat-body-strong flex-33">
           {{ 'labels.inputs.Name' | translate }}
         </div>

--- a/src/app/products/manage-tax-groups/view-tax-group/view-tax-group.component.scss
+++ b/src/app/products/manage-tax-groups/view-tax-group/view-tax-group.component.scss
@@ -1,9 +1,9 @@
 .container {
   max-width: 37rem;
 
-  .content {
+  .card-content {
     div {
-      margin: 0.8rem 0;
+      margin: 1rem 0;
       word-wrap: break-word;
     }
   }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "Typ kapitalizace příjmu",
       "DEFERRED INCOME RECOGNITION": "Vykazování odložených výnosů",
       "Enable Buy down fee": "Povolit poplatek za odkup",
+      "Merchant Buy down fee": "Poplatek za odkup obchodníka",
       "Buy down fee calculation type": "Typ výpočtu poplatku za odkup",
       "Buy down fee strategy": "Strategie poplatku za odkup",
       "Buy down fee income type": "Typ příjmu z poplatku za odkup",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "Art der Ertragskapitalisierung",
       "DEFERRED INCOME RECOGNITION": "Erfassung abgegrenzter Erträge",
       "Enable Buy down fee": "Buy-Down-Gebühr aktivieren",
+      "Merchant Buy down fee": "Händler-Buy-Down-Gebühr",
       "Buy down fee calculation type": "Berechnungsart der Buy-Down-Gebühr",
       "Buy down fee strategy": "Strategie für Buy-Down-Gebühr",
       "Buy down fee income type": "Einnahmeart der Buy-Down-Gebühr",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2500,6 +2500,7 @@
       "Income capitalization type": "Income capitalization type",
       "DEFERRED INCOME RECOGNITION": "DEFERRED INCOME RECOGNITION",
       "Enable Buy down fee": "Enable Buy down fee",
+      "Merchant Buy down fee": "Merchant Buy down fee",
       "Buy down fee calculation type": "Buy down fee calculation type",
       "Buy down fee strategy": "Buy down fee strategy",
       "Buy down fee income type": "Buy down fee income type",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "Tipo de capitalización de ingresos",
       "DEFERRED INCOME RECOGNITION": "Reconocimiento de ingresos diferidos",
       "Enable Buy down fee": "Habilitar comisión de compra anticipada",
+      "Merchant Buy down fee": "Tarifa de compra inicial del comerciante",
       "Buy down fee calculation type": "Tipo de cálculo de comisión de compra anticipada",
       "Buy down fee strategy": "Estrategia de comisión de compra anticipada",
       "Buy down fee income type": "Tipo de ingreso de comisión de compra anticipada",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "Tipo de capitalización de ingresos",
       "DEFERRED INCOME RECOGNITION": "INGRESOS DIFERIDOS",
       "Enable Buy down fee": "Habilitar comisión de compra anticipada",
+      "Merchant Buy down fee": "Tarifa de compra inicial del comerciante",
       "Buy down fee calculation type": "Tipo de cálculo de comisión de compra anticipada",
       "Buy down fee strategy": "Estrategia de comisión de compra anticipada",
       "Buy down fee income type": "Tipo de ingreso de comisión de compra anticipada",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "Type de capitalisation des revenus",
       "DEFERRED INCOME RECOGNITION": "Comptabilisation des produits différés",
       "Enable Buy down fee": "Activer les frais de rachat",
+      "Merchant Buy down fee": "Frais d'achat du commerçant",
       "Buy down fee calculation type": "Type de calcul des frais de rachat",
       "Buy down fee strategy": "Stratégie des frais de rachat",
       "Buy down fee income type": "Type de revenu des frais de rachat",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "Tipo di capitalizzazione del reddito",
       "DEFERRED INCOME RECOGNITION": "Rilevazione dei risconti passivi",
       "Enable Buy down fee": "Abilita commissione di buy down",
+      "Merchant Buy down fee": "Commissione di acquisto del commerciante",
       "Buy down fee calculation type": "Tipo di calcolo della commissione di buy down",
       "Buy down fee strategy": "Strategia per la commissione di buy down",
       "Buy down fee income type": "Tipo di ricavo da commissione di buy down",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -2494,6 +2494,7 @@
       "Income capitalization type": "소득 자본화 유형",
       "DEFERRED INCOME RECOGNITION": "이연수익 인식",
       "Enable Buy down fee": "매수 수수료 활성화",
+      "Merchant Buy down fee": "상인 구매 선불 수수료",
       "Buy down fee calculation type": "매수 수수료 계산 유형",
       "Buy down fee strategy": "매수 수수료 전략",
       "Buy down fee income type": "매수 수수료 수익 유형",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "Pajamų kapitalizacijos tipas",
       "DEFERRED INCOME RECOGNITION": "Atidėtųjų pajamų pripažinimas",
       "Enable Buy down fee": "Įjungti supirkimo mokestį",
+      "Merchant Buy down fee": "Prekybininko pirkimo mokestis",
       "Buy down fee calculation type": "Supirkimo mokesčio skaičiavimo tipas",
       "Buy down fee strategy": "Supirkimo mokesčio strategija",
       "Buy down fee income type": "Supirkimo mokesčio pajamų tipas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "Ienākumu kapitalizācijas veids",
       "DEFERRED INCOME RECOGNITION": "Atliktā ienākuma atzīšana",
       "Enable Buy down fee": "Iespējot atpirkšanas maksu",
+      "Merchant Buy down fee": "Merchant Buy down maksa",
       "Buy down fee calculation type": "Atpirkšanas maksas aprēķina veids",
       "Buy down fee strategy": "Atpirkšanas maksas stratēģija",
       "Buy down fee income type": "Atpirkšanas maksas ienākumu veids",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "आय पूँजीकरण प्रकार",
       "DEFERRED INCOME RECOGNITION": "स्थगित आय पहिचान",
       "Enable Buy down fee": "बाइ डाउन शुल्क सक्षम गर्नुहोस्",
+      "Merchant Buy down fee": "मर्चेन्ट बाइ डाउन शुल्क",
       "Buy down fee calculation type": "बाइ डाउन शुल्क गणना प्रकार",
       "Buy down fee strategy": "बाइ डाउन शुल्क रणनीति",
       "Buy down fee income type": "बाइ डाउन शुल्क आय प्रकार",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "Tipo de capitalização de renda",
       "DEFERRED INCOME RECOGNITION": "Reconhecimento de receita diferida",
       "Enable Buy down fee": "Habilitar taxa de aquisição",
+      "Merchant Buy down fee": "Taxa de compra inicial do comerciante",
       "Buy down fee calculation type": "Tipo de cálculo de taxa de aquisição",
       "Buy down fee strategy": "Estratégia de taxa de aquisição",
       "Buy down fee income type": "Tipo de receita de taxa de aquisição",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -2493,6 +2493,7 @@
       "Income capitalization type": "Aina ya mtaji wa mapato",
       "DEFERRED INCOME RECOGNITION": "Utambuzi wa mapato ulioahirishwa",
       "Enable Buy down fee": "Washa ada ya Kununua chini",
+      "Merchant Buy down fee": "Mfanyabiashara Nunua ada ya chini",
       "Buy down fee calculation type": "Nunua aina ya hesabu ya ada ya chini",
       "Buy down fee strategy": "Nunua mkakati wa ada ya chini",
       "Buy down fee income type": "Nunua aina ya mapato ya chini",


### PR DESCRIPTION
## Description

BuyDown fees accounting is currently configured to support merchant lending where merchant accounting is handling outside Fineract system. Hence the system has been configured to affect the EXPENSE account.

However, for non-merchant products the system should affect the ASSET account.

[WEB-269](https://mifosforge.jira.com/browse/WEB-269)

## Screenshots, if any

- Loan Product details
<img width="1510" height="234" alt="Screenshot 2025-08-13 at 12 45 25 p m" src="https://github.com/user-attachments/assets/e6f1dc26-6dac-4bad-98d3-f82c075b7081" />

- Loan Product creation / edition (new input field)

<img width="1474" height="597" alt="Screenshot 2025-08-13 at 6 17 38 p m" src="https://github.com/user-attachments/assets/8c4e98c4-8243-4c9c-88c5-bb472296a4d6" />


- Loan account details
<img width="1494" height="879" alt="Screenshot 2025-08-13 at 6 02 32 p m" src="https://github.com/user-attachments/assets/06ee9992-3921-4def-b6c2-d899b340104a" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-269]: https://mifosforge.jira.com/browse/WEB-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ