### PR TITLE
WEB-279 fix null reference error

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component.ts
@@ -90,7 +90,7 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnChan
 
   ngOnChanges(changes: SimpleChanges): void {
     this.enableIncomeCapitalization = this.deferredIncomeRecognition.capitalizedIncome
-      ? this.deferredIncomeRecognition.capitalizedIncome.enableIncomeCapitalization
+      ? this.deferredIncomeRecognition.capitalizedIncome?.enableIncomeCapitalization
       : false;
     this.enableBuyDownFee = this.deferredIncomeRecognition.buyDownFee
       ? this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee
@@ -99,9 +99,9 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnChan
       this.loanDeferredIncomeRecognitionForm.patchValue({
         enableIncomeCapitalization: this.enableIncomeCapitalization,
         capitalizedIncomeCalculationType:
-          this.deferredIncomeRecognition.capitalizedIncome.capitalizedIncomeCalculationType,
-        capitalizedIncomeStrategy: this.deferredIncomeRecognition.capitalizedIncome.capitalizedIncomeStrategy,
-        capitalizedIncomeType: this.deferredIncomeRecognition.capitalizedIncome.capitalizedIncomeType
+          this.deferredIncomeRecognition.capitalizedIncome?.capitalizedIncomeCalculationType,
+        capitalizedIncomeStrategy: this.deferredIncomeRecognition.capitalizedIncome?.capitalizedIncomeStrategy,
+        capitalizedIncomeType: this.deferredIncomeRecognition.capitalizedIncome?.capitalizedIncomeType
       });
     }
     if (this.enableBuyDownFee) {


### PR DESCRIPTION
## Description  

This PR fixes a runtime error that occurs in the Loan Product creation workflow when switching the loan schedule type from **Cumulative** to **Progressive**.  

The issue was caused by a null reference in the `LoanProductDeferredIncomeRecognitionStepComponent`, where the property `capitalizedIncome` was being accessed without verifying whether `deferredIncomeRecognition` was initialized.  

**Fix applied:**  
A null-safe access check (`?.`) was introduced to safely handle uninitialized objects and avoid runtime exceptions.  

This ensures that the UI behaves correctly and no errors are thrown when switching between schedule types.  

@alberto-art3ch @therajanmaurya @vidakovic @bharathcgowda 
Please can you help me with the revision, thank you.
## Screenshots 

**Before (error in console):**  

<img width="451" height="171" alt="imagen" src="https://github.com/user-attachments/assets/7163b5bf-01de-4daa-be3a-ae696dc59526" />

<img width="733" height="85" alt="imagen" src="https://github.com/user-attachments/assets/de3bd74c-51c1-4de6-aa0c-a545b2d085c2" />