### PR TITLE
fix(profile-page): improve layout and fix formatting/lint issues

### DIFF
--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -1,4 +1,4 @@
-<div class="container m-b-20 layout-row layout-lt-md-column align-end gap-2percent">
+<div class="container m-b-10 layout-row layout-lt-md-column align-end gap-1percent">
   <button mat-raised-button color="primary" [routerLink]="['/system', 'roles-and-permissions']">
     <fa-icon icon="check" class="m-r-10"></fa-icon>
     {{ 'labels.buttons.Permissions' | translate }}
@@ -8,72 +8,65 @@
     {{ 'labels.buttons.Change Password' | translate }}
   </button>
 </div>
-
-<div class="container layout-column gap-2percent">
+<div class="container layout-column gap-1percent">
   <mat-card>
     <div class="layout-row-wrap">
       <div class="flex-50 header">
         {{ 'labels.inputs.Tenant Id' | translate }}
       </div>
-
       <div class="flex-50">
         {{ tenantIdentifier }}
       </div>
-
       <div class="flex-50 header">
         {{ 'labels.inputs.User Id' | translate }}
       </div>
-
       <div class="flex-50">
         {{ profileData.userId }}
       </div>
-
       <div class="flex-50 header">
         {{ 'labels.inputs.User Name' | translate }}
       </div>
-
       <div class="flex-50">
         {{ profileData.username }}
       </div>
-
       <div class="flex-50 header">
         {{ 'labels.inputs.Office' | translate }}
       </div>
-
       <div class="flex-50">
         {{ profileData.officeName }}
       </div>
-
       <div class="flex-50 header">
         {{ 'labels.inputs.Status' | translate }}
       </div>
-
       <div class="flex-50">
         {{ profileData.authenticated ? 'Authenticated' : 'Not Authenticated' }}
       </div>
-
       <div class="flex-50 header">
         {{ 'labels.inputs.Language' | translate }}
       </div>
-
       <div class="flex-50">
         {{ language }}
       </div>
     </div>
   </mat-card>
-
   <mat-card>
     <table class="mat-elevation-z1" mat-table [dataSource]="dataSource">
       <ng-container matColumnDef="role">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Role' | translate }}</th>
-        <td mat-cell *matCellDef="let role">{{ role.name }}</td>
+        <th mat-header-cell *matHeaderCellDef>
+          {{ 'labels.inputs.Role' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let role">
+          {{ role.name }}
+        </td>
       </ng-container>
-
       <ng-container matColumnDef="description">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Description' | translate }}</th>
-        <td mat-cell *matCellDef="let role">{{ role.description }}</td>
+        <th mat-header-cell *matHeaderCellDef>
+          {{ 'labels.inputs.Description' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let role">
+          {{ role.description }}
+        </td>
       </ng-container>
-
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
     </table>

--- a/src/app/profile/profile.component.scss
+++ b/src/app/profile/profile.component.scss
@@ -1,5 +1,16 @@
 .container {
   max-width: 37rem;
+  padding: 0.5rem;
+
+  mat-card {
+    margin-bottom: 1rem;
+    padding: 1rem;
+    box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+
+    .layout-row-wrap {
+      padding: 0.5rem 0;
+    }
+  }
 
   .content {
     div {
@@ -8,7 +19,28 @@
 
       &.header {
         font-weight: 500;
+        margin-bottom: 0.5rem;
       }
     }
+  }
+
+  table {
+    width: 100%;
+    margin-top: 1rem;
+  }
+}
+
+.mat-elevation-z1 {
+  margin: 0.5rem 0;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 12%);
+
+  th,
+  td {
+    border-top: 1px solid rgb(0 0 0 / 12%);
+  }
+
+  th.mat-header-cell:not(:first-of-type),
+  td.mat-cell:not(:first-of-type) {
+    border-left: 1px solid rgb(0 0 0 / 12%);
   }
 }


### PR DESCRIPTION
## Description
This PR fixes the layout issue on the Profile Page that appeared after the Angular upgrade (14 → 19).
The margin below the Language section and the visual separation between Language and Role were missing.

The changes restore proper spacing and add a divider to match the layout from v1.0.0.
This improves the readability and UI consistency of the Profile Page.

Changes made:

Restored proper margin below the Language section.

Added a visual divider between Language and Role sections to improve readability.

Fixed formatting and resolved lint issues to ensure consistent coding style.

Why these changes were made:

The previous layout lacked proper spacing, causing visual clutter and making it harder for users to distinguish sections.

Fixing lint/formatting issues maintains code quality and adheres to project standards.

Dependencies:

No new dependencies were introduced; changes only involve existing CSS/Angular Material styling.


## Related issues and discussion

#{Fixes: WEB-236}

## Screenshots, if any
Before (dev branch):

<img width="935" height="582" alt="Screenshot 2025-08-22 153526" src="https://github.com/user-attachments/assets/e9860dab-a075-4150-ae88-e60334880b35" />

After (this PR):
<img width="1403" height="817" alt="Screenshot 2025-08-22 161504" src="https://github.com/user-attachments/assets/87f33e0f-f8c4-4c9b-98ed-6dff307ec5ff" />



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ x ] If you have multiple commits please combine them into one commit by squashing them.

- [  x ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
