### PR TITLE
WEB-290: Introduce classification field on loan transactions

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.html
@@ -68,6 +68,15 @@
             <input matInput formControlName="externalId" />
           </mat-form-field>
 
+          <mat-form-field *ngIf="isCapitalizedIncome()">
+            <mat-label>{{ 'labels.inputs.Classification' | translate }}</mat-label>
+            <mat-select formControlName="classificationId">
+              <mat-option *ngFor="let classificationOption of classificationOptions" [value]="classificationOption.id">
+                {{ classificationOption.name }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+
           <mat-form-field>
             <mat-label>{{ 'labels.inputs.Payment Type' | translate }}</mat-label>
             <mat-select formControlName="paymentTypeId">

--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
@@ -47,6 +47,8 @@ export class MakeRepaymentComponent implements OnInit {
 
   command: string | null = null;
 
+  classificationOptions: any[] = [];
+
   /**
    * @param {FormBuilder} formBuilder Form Builder.
    * @param {LoansService} loanService Loan Service.
@@ -102,6 +104,7 @@ export class MakeRepaymentComponent implements OnInit {
           Validators.min(0.001),
           Validators.max(this.dataObject.amount)])
       );
+      this.repaymentLoanForm.addControl('classificationId', new UntypedFormControl(''));
     } else {
       this.repaymentLoanForm.addControl(
         'transactionAmount',
@@ -114,6 +117,7 @@ export class MakeRepaymentComponent implements OnInit {
 
   setRepaymentLoanDetails() {
     this.paymentTypes = this.dataObject.paymentTypeOptions;
+    this.classificationOptions = this.dataObject.classificationOptions;
     this.repaymentLoanForm.patchValue({
       transactionAmount: this.dataObject.amount
     });

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.html
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.html
@@ -82,6 +82,14 @@
           ></mifosx-external-identifier>
         </div>
 
+        <div class="flex-50 mat-body-strong" *ngIf="transactionData.classification">
+          {{ 'Classification' | translateKey: 'catalogs' }}
+        </div>
+
+        <div class="flex-50" *ngIf="transactionData.classification">
+          {{ transactionData.classification.name }}
+        </div>
+
         <mat-divider *ngIf="existTransactionRelations" [inset]="true"></mat-divider>
 
         <div class="mat-body-strong flex-100" *ngIf="existTransactionRelations">


### PR DESCRIPTION
## Description

When Capitalized Income / Buydown Fee transaction got created, user should be able to provide classification (optional field!), and Fineract store it on the transaction level!

If classification was not set, it remains null.
Fineract should check whether valid classification was provided:

Exists based on the relatedcodes (see above)

[WEB-290](https://mifosforge.jira.com/browse/WEB-290)

## Screenshots, if any
- Loan Transaction creation
<img width="1014" height="687" alt="Screenshot 2025-08-25 at 8 20 50 a m" src="https://github.com/user-attachments/assets/a926b1e3-3ca7-4d0c-9361-47195e7f4d8b" />

- Loan Transaction details
<img width="1005" height="608" alt="Screenshot 2025-08-25 at 8 20 15 a m" src="https://github.com/user-attachments/assets/e0c99882-c555-4fc9-8ab6-9e47eeeef747" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-290]: https://mifosforge.jira.com/browse/WEB-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ