### PR TITLE
WEB-221: Fix line under Language Selection dropdown to white

### DIFF
--- a/src/app/shared/language-selector/language-selector.component.scss
+++ b/src/app/shared/language-selector/language-selector.component.scss
@@ -1,3 +1,23 @@
 ::ng-deep .mat-form-field-underline {
-  background-color: transparent;
+  background-color: white;
+}
+
+::ng-deep .mat-mdc-form-field-bottom-align::before {
+  border-bottom-color: white;
+}
+
+::ng-deep .mdc-line-ripple::before {
+  border-bottom-color: white;
+}
+
+::ng-deep .mdc-line-ripple::after {
+  border-bottom-color: white;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-line-ripple::before {
+  border-bottom-color: white !important;
+}
+
+::ng-deep .mat-mdc-form-field .mdc-line-ripple::after {
+  border-bottom-color: white !important;
 }


### PR DESCRIPTION
## Description

This PR fixes the issue where the line under the Language Selection dropdown was black instead of white. Now, the line correctly appears white, improving the visual consistency of the UI.

## Related issues and discussion

#WEB-221

## Screenshots, if any

*Before:*  
<img width="228" height="75" alt="Screenshot 2025-06-22 134642 (1)" src="https://github.com/user-attachments/assets/e86f3a16-e4f2-4291-9066-12668b75eccb" />


*After:*  
<img width="522" height="90" alt="Screenshot 2025-08-31 124543" src="https://github.com/user-attachments/assets/2ce1d122-ed69-4e4c-9d4f-e9bfb367546e" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
