### PR TITLE
fix(client-profile): handle missing profile image and remove skipErrorHandler 

### DIFF
--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -90,12 +90,21 @@ export class ClientsViewComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.clientsService.getClientProfileImage(this.clientViewData.id).subscribe(
-      (base64Image: any) => {
+    this.clientsService.getClientProfileImage(this.clientViewData.id).subscribe({
+      next: (base64Image: any) => {
         this.clientImage = this._sanitizer.bypassSecurityTrustResourceUrl(base64Image);
       },
-      (error: any) => {}
-    );
+      error: (error: any) => {
+        // 404 is expected when client has no profile image - not an error
+        if (error.status === 404) {
+          this.clientImage = null;
+        } else {
+          // Log other unexpected errors
+          console.error('Error loading client profile image:', error);
+          this.clientImage = null;
+        }
+      }
+    });
   }
 
   isActive(): boolean {

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -4,6 +4,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 
 /** rxjs Imports */
 import { Observable } from 'rxjs';
+
 /**
  * Clients service.
  */
@@ -170,9 +171,7 @@ export class ClientsService {
 
   getClientProfileImage(clientId: string) {
     const httpParams = new HttpParams().set('maxHeight', '150');
-    return this.http
-      .skipErrorHandler()
-      .get(`/clients/${clientId}/images`, { params: httpParams, responseType: 'text' });
+    return this.http.get(`/clients/${clientId}/images`, { params: httpParams, responseType: 'text' });
   }
 
   uploadClientProfileImage(clientId: string, image: File) {


### PR DESCRIPTION
Updated clients-view.component.ts and component.service.ts to handle cases where a client does not have a profile image and removed the use of skipErrorHandler to prevent runtime errors.

Related issues and discussion
[WEB-268](https://mifosforge.jira.com/browse/WEB-268?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)


[WEB-268]: https://mifosforge.jira.com/browse/WEB-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ