### PR TITLE
WEB-303: Invalid general input field background transparent

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.scss
+++ b/src/app/core/shell/toolbar/toolbar.component.scss
@@ -78,6 +78,7 @@
   color: white !important;
   /* stylelint-disable-next-line selector-max-universal */
   * {
+    background-color: transparent !important;
     color: white !important;
   }
 }
@@ -86,6 +87,8 @@
   color: white !important;
   /* stylelint-disable-next-line selector-max-universal */
   * {
+    background-color: transparent !important;
     color: white !important;
+    margin-bottom: 0;
   }
 }

--- a/src/app/shared/language-selector/language-selector.component.scss
+++ b/src/app/shared/language-selector/language-selector.component.scss
@@ -1,7 +1,3 @@
-::ng-deep .mat-form-field-underline {
-  background-color: white;
-}
-
 ::ng-deep .mat-mdc-form-field-bottom-align::before {
   border-bottom-color: white;
 }

--- a/src/app/shared/search-tool/search-tool.component.scss
+++ b/src/app/shared/search-tool/search-tool.component.scss
@@ -7,10 +7,12 @@
   }
 
   .resource {
-    max-width: 90px;
+    min-width: 100px;
+    max-width: 100px;
     width: 100%;
     font-size: 1rem;
     color: white;
+    padding-left: 5px;
   }
 }
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -561,10 +561,6 @@
   }
 }
 
-.mdc-text-field--filled:not(.mdc-text-field--disabled) {
-  background-color: transparent !important;
-}
-
 .menu-explanation {
   font-size: 14px;
   margin: 0;


### PR DESCRIPTION
## Description

Due to set the background-color as transparent for the Input fields in general all of them have a weird style

We are removing that global style and use this only in the toolbar components where It is needed

[WEB-303](https://mifosforge.jira.com/browse/WEB-303)

## Screenshots

- Before the change

<img width="1417" height="638" alt="image" src="https://github.com/user-attachments/assets/96ff5a0b-4a36-4151-bb07-4e005ae122ae" />

- After the change

<img width="1856" height="764" alt="Screenshot 2025-09-03 at 4 00 12 p m" src="https://github.com/user-attachments/assets/4eeeba59-e886-4293-903a-42a486c18971" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-303]: https://mifosforge.jira.com/browse/WEB-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ