### PR TITLE
WEB-304: Accounting settings gets lost on Loan product edit screen

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -142,18 +142,18 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
           enableAccrualActivityPosting: this.loanProductsTemplate.enableAccrualActivityPosting
         });
         if (this.deferredIncomeRecognition) {
-          if (this.deferredIncomeRecognition.capitalizedIncome.enableIncomeCapitalization) {
+          if (this.deferredIncomeRecognition.capitalizedIncome?.enableIncomeCapitalization) {
             this.loanProductAccountingForm.patchValue({
               deferredIncomeLiabilityAccountId: accountingMappings.deferredIncomeLiabilityAccount.id,
               incomeFromCapitalizationAccountId: accountingMappings.incomeFromCapitalizationAccount.id
             });
           }
-          if (this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee) {
+          if (this.deferredIncomeRecognition.buyDownFee?.enableBuyDownFee) {
             this.loanProductAccountingForm.patchValue({
               deferredIncomeLiabilityAccountId: accountingMappings.deferredIncomeLiabilityAccount.id,
               incomeFromBuyDownAccountId: accountingMappings.incomeFromBuyDownAccount.id
             });
-            if (this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee) {
+            if (this.deferredIncomeRecognition.buyDownFee?.merchantBuyDownFee) {
               this.loanProductAccountingForm.patchValue({
                 buyDownExpenseAccountId: accountingMappings.buyDownExpenseAccount?.id
               });
@@ -599,8 +599,8 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
     if (this.isAccountingAccrualBased) {
       if (this.deferredIncomeRecognition) {
         if (
-          this.deferredIncomeRecognition.capitalizedIncome.enableIncomeCapitalization ||
-          this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee
+          this.deferredIncomeRecognition.capitalizedIncome?.enableIncomeCapitalization ||
+          this.deferredIncomeRecognition.buyDownFee?.enableBuyDownFee
         ) {
           this.loanProductAccountingForm.addControl(
             'deferredIncomeLiabilityAccountId',
@@ -609,7 +609,7 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
         } else {
           this.loanProductAccountingForm.removeControl('deferredIncomeLiabilityAccountId');
         }
-        if (this.deferredIncomeRecognition.capitalizedIncome.enableIncomeCapitalization) {
+        if (this.deferredIncomeRecognition.capitalizedIncome?.enableIncomeCapitalization) {
           this.loanProductAccountingForm.addControl(
             'incomeFromCapitalizationAccountId',
             new UntypedFormControl('', Validators.required)
@@ -617,8 +617,8 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
         } else {
           this.loanProductAccountingForm.removeControl('incomeFromCapitalizationAccountId');
         }
-        if (this.deferredIncomeRecognition.buyDownFee.enableBuyDownFee) {
-          if (this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee) {
+        if (this.deferredIncomeRecognition.buyDownFee?.enableBuyDownFee) {
+          if (this.deferredIncomeRecognition.buyDownFee?.merchantBuyDownFee) {
             this.loanProductAccountingForm.addControl(
               'buyDownExpenseAccountId',
               new UntypedFormControl('', Validators.required)


### PR DESCRIPTION
## Description

Expected result:

The accounting entries are filled with the actual GLs and ready to be saved if there’s no change

Actual result:

accounting entries are empty

## Related issues and discussion

[WEB-304](https://mifosforge.jira.com/browse/WEB-304)

## Screenshots

https://github.com/user-attachments/assets/4ae2df2a-9dd9-48fa-b14c-ff3ab42aad41


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-304]: https://mifosforge.jira.com/browse/WEB-304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ