### PR TITLE
WEB-307: Fix error when accessing client without profile picture

### DIFF
--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -92,17 +92,17 @@ export class ClientsViewComponent implements OnInit {
   ngOnInit() {
     this.clientsService.getClientProfileImage(this.clientViewData.id).subscribe({
       next: (base64Image: any) => {
-        this.clientImage = this._sanitizer.bypassSecurityTrustResourceUrl(base64Image);
-      },
-      error: (error: any) => {
-        // 404 is expected when client has no profile image - not an error
-        if (error.status === 404) {
-          this.clientImage = null;
+        // If base64Image is null, client has no profile image
+        if (base64Image) {
+          this.clientImage = this._sanitizer.bypassSecurityTrustResourceUrl(base64Image);
         } else {
-          // Log other unexpected errors
-          console.error('Error loading client profile image:', error);
           this.clientImage = null;
         }
+      },
+      error: (error: any) => {
+        // Handle any unexpected errors
+        console.error('Error loading client profile image:', error);
+        this.clientImage = null;
       }
     });
   }


### PR DESCRIPTION
## Changes made
- Updated clients-view.component.ts to better handle cases where a client does not have a profile image.
- Modified clients.service.ts to properly handle 404 responses for missing images.
- Updated error-handler.interceptor.ts to suppress error alerts for expected 404 responses on image requests.
- Eliminated HTTP 404 error alerts when accessing clients without profile pictures.

## Related issues
[WEB-307](https://mifosforge.jira.com/browse/WEB-307)


[WEB-307]: https://mifosforge.jira.com/browse/WEB-307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ