### PR TITLE
Fix: Align buttons with title on Client General tab (208)

### DIFF
--- a/src/app/clients/clients-view/general-tab/general-tab.component.scss
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.scss
@@ -32,10 +32,19 @@
 }
 
 .heading-content {
+  display: flex; /* Use flexbox for alignment */
+  align-items: center; /* Align items vertically */
+  justify-content: space-between; /* Space out title and buttons */
   margin-bottom: 1%;
   margin-top: 1%;
 }
 
 .heading-name {
-  display: block;
+  margin: 0; /* Reset margin to avoid misalignment */
+}
+
+.layout-row.align-flex-end {
+  display: flex;
+  align-items: center; /* Ensure buttons are vertically aligned */
+  gap: 0.5rem; /* Add spacing between buttons if needed */
 }


### PR DESCRIPTION
## Description
Fixed layout regression introduced during Angular 14 → 18 migration.  
On the Client page (208), the action buttons were misaligned and placed below the title.  
This PR ensures that buttons remain vertically aligned with the page title, consistent with the old layout.

## Related issues and discussion
Fixes #208


#{Issue Number}
208

## Screenshots, if any
Before:
<img width="3788" height="2118" alt="Screenshot 2025-06-18 145039" src="https://github.com/user-attachments/assets/d991523e-ed38-409c-9aba-3eac4d770c2b" />
After:
<img width="989" height="933" alt="Screenshot 2025-09-09 143632" src="https://github.com/user-attachments/assets/7c76b298-dd51-42e0-bc5f-295267830bf5" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ X ] If you have multiple commits please combine them into one commit by squashing them.

- [ X ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
