### PR TITLE
WEB-309 @fineract/client services bypass server selection and make requests to localhost

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -41,8 +41,7 @@ import { ProfileModule } from './profile/profile.module';
 import { TasksModule } from './tasks/tasks.module';
 import { ConfigurationWizardModule } from './configuration-wizard/configuration-wizard.module';
 import { PortalModule } from '@angular/cdk/portal';
-import { ApiModule } from '@fineract/client';
-import { BASE_PATH } from '@fineract/client';
+import { ApiModule, Configuration, BASE_PATH } from '@fineract/client';
 import { SettingsService } from './settings/settings.service';
 
 /** Main Routing Module */
@@ -121,6 +120,12 @@ export function HttpLoaderFactory(http: HttpClient) {
     CollectionsModule,
     TasksModule,
     ConfigurationWizardModule,
+    ApiModule.forRoot(
+      () =>
+        new Configuration({
+          basePath: '' // Empty so ApiPrefixInterceptor handles all URL construction
+        })
+    ),
     AppRoutingModule,
     NotFoundComponent,
     CallbackComponent
@@ -133,6 +138,10 @@ export function HttpLoaderFactory(http: HttpClient) {
       provide: HTTP_INTERCEPTORS,
       useClass: !environment.OIDC.oidcServerEnabled ? TokenInterceptor : ZitadelTokenInterceptor,
       multi: true
+    },
+    {
+      provide: BASE_PATH,
+      useValue: '' // Empty so ApiPrefixInterceptor handles all URL construction
     }
   ]
 })


### PR DESCRIPTION
## Description

After logging in with a selected server (sandbox/demo), the notification service and other @fineract/client services continue making API requests to localhost instead of the selected server URL.


## Related issues and discussion
[WEB-309](https://mifosforge.jira.com/browse/WEB-309?atlOrigin=eyJpIjoiZDJjY2JiZGYwNjJlNDNiODg1NmZiZjI2NTg5MmE1YzAiLCJwIjoiaiJ9)



[WEB-309]: https://mifosforge.jira.com/browse/WEB-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ