### PR TITLE
WEB-311: View Transaction Details screen - Classification field value…

### DIFF
--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.html
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.html
@@ -86,7 +86,7 @@
           {{ 'Classification' | translateKey: 'catalogs' }}
         </div>
 
-        <div class="flex-50 wrap-content" *ngIf="transactionData.classification">
+        <div class="flex-50 no-break-content" *ngIf="transactionData.classification">
           {{ transactionData.classification.name }}
         </div>
 

--- a/src/assets/styles/_text.scss
+++ b/src/assets/styles/_text.scss
@@ -255,3 +255,7 @@ body {
   overflow-wrap: break-word;
   word-wrap: break-word;
 }
+
+.no-break-content {
+  overflow-wrap: anywhere !important;
+}


### PR DESCRIPTION
… is misaligned

## Description

The Classification field value is not aligned properly with other field values

The text appears to be shifted/mispositioned compared to the standard field layout

[WEB-311](https://mifosforge.jira.com/browse/WEB-311)

## Screenshots
<img width="997" height="677" alt="Screenshot 2025-09-10 at 3 14 03 p m" src="https://github.com/user-attachments/assets/c55051d3-2ee1-4972-959b-f02ac919cc1c" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-311]: https://mifosforge.jira.com/browse/WEB-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ