### PR TITLE
Fix layout regression after Angular 18 migration: left align fields a…

### DIFF
--- a/src/app/clients/edit-client/edit-client.component.html
+++ b/src/app/clients/edit-client/edit-client.component.html
@@ -2,8 +2,9 @@
   <mat-card>
     <form [formGroup]="editClientForm">
       <mat-card-content>
-        <div class="layout-row-wrap gap-2px responsive-column">
-          <mat-form-field class="flex-fill flex-23">
+        <!-- First Row: Office, Legal Form, Account No, External ID -->
+        <div class="responsive-row">
+          <mat-form-field class="flex-24">
             <mat-label>{{ 'labels.inputs.Office' | translate }}</mat-label>
             <mat-select required formControlName="officeId">
               <mat-option *ngFor="let office of officeOptions" [value]="office.id">
@@ -16,7 +17,7 @@
             </mat-error>
           </mat-form-field>
 
-          <mat-form-field class="flex-fill flex-23">
+          <mat-form-field class="flex-24">
             <mat-label>{{ 'labels.inputs.Legal Form' | translate }}</mat-label>
             <mat-select formControlName="legalFormId">
               <mat-option *ngFor="let legalForm of legalFormOptions" [value]="legalForm.id">
@@ -25,16 +26,19 @@
             </mat-select>
           </mat-form-field>
 
-          <mat-form-field class="flex-fill flex-23">
+          <mat-form-field class="flex-24">
             <mat-label>{{ 'labels.inputs.Account No' | translate }}</mat-label>
             <input matInput formControlName="accountNo" />
           </mat-form-field>
 
-          <mat-form-field class="flex-fill flex-23">
+          <mat-form-field class="flex-24">
             <mat-label>{{ 'labels.inputs.External Id' | translate }}</mat-label>
             <input matInput formControlName="externalId" />
           </mat-form-field>
+        </div>
 
+        <!-- Name fields section -->
+        <div class="responsive-row">
           <mat-form-field *ngIf="editClientForm.contains('fullname')" class="flex-48">
             <mat-label>{{
               'labels.inputs.' + getDateLabel(legalFormId, ['Name', 'Entity Name']) | translate
@@ -46,7 +50,7 @@
             </mat-error>
           </mat-form-field>
 
-          <mat-form-field *ngIf="editClientForm.contains('firstname')" class="flex-48">
+          <mat-form-field *ngIf="editClientForm.contains('firstname')" class="flex-32">
             <mat-label>{{ 'labels.inputs.First Name' | translate }}</mat-label>
             <input matInput required formControlName="firstname" />
             <mat-error *ngIf="editClientForm.controls.firstname.hasError('required')">
@@ -55,12 +59,12 @@
             </mat-error>
           </mat-form-field>
 
-          <mat-form-field *ngIf="editClientForm.contains('middlename')" class="flex-48">
+          <mat-form-field *ngIf="editClientForm.contains('middlename')" class="flex-32">
             <mat-label>{{ 'labels.inputs.Middle Name' | translate }}</mat-label>
             <input matInput formControlName="middlename" />
           </mat-form-field>
 
-          <mat-form-field *ngIf="editClientForm.contains('lastname')" class="flex-48">
+          <mat-form-field *ngIf="editClientForm.contains('lastname')" class="flex-32">
             <mat-label>{{ 'labels.inputs.Last Name' | translate }}</mat-label>
             <input matInput required formControlName="lastname" />
             <mat-error *ngIf="editClientForm.controls.lastname.hasError('required')">
@@ -68,9 +72,12 @@
               <strong>{{ 'labels.commons.required' | translate }}</strong>
             </mat-error>
           </mat-form-field>
+        </div>
 
-          <mat-divider></mat-divider>
+        <mat-divider class="section-divider"></mat-divider>
 
+        <!-- Date of Birth and Gender Row -->
+        <div class="responsive-row">
           <mat-form-field class="flex-48" (click)="dateOfBirthDatePicker.open()">
             <mat-label>{{
               'labels.inputs.' + getDateLabel(legalFormId, ['Date of Birth', 'Incorporation Date']) | translate
@@ -88,7 +95,10 @@
               </mat-option>
             </mat-select>
           </mat-form-field>
+        </div>
 
+        <!-- Staff and Is Staff Row -->
+        <div class="responsive-row align-center">
           <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Staff' | translate }}</mat-label>
             <mat-select formControlName="staffId">
@@ -98,53 +108,6 @@
             </mat-select>
           </mat-form-field>
 
-          <div
-            class="flex-100 layout-row-wrap gap-2percent column-on-small"
-            formGroupName="clientNonPersonDetails"
-            *ngIf="editClientForm.contains('clientNonPersonDetails')"
-          >
-            <mat-form-field class="flex-48">
-              <mat-label>{{ 'labels.inputs.Constitution' | translate }}</mat-label>
-              <mat-select formControlName="constitutionId" required>
-                <mat-option *ngFor="let constitution of constitutionOptions" [value]="constitution.id">
-                  {{ constitution.name }}
-                </mat-option>
-              </mat-select>
-            </mat-form-field>
-
-            <mat-form-field class="flex-48">
-              <mat-label>{{ 'labels.inputs.Main Business Line' | translate }}</mat-label>
-              <mat-select formControlName="mainBusinessLineId">
-                <mat-option *ngFor="let business of businessLineOptions" [value]="business.id">
-                  {{ business.name }}
-                </mat-option>
-              </mat-select>
-            </mat-form-field>
-
-            <mat-form-field class="flex-48" (click)="incorpValidityTillDateDatePicker.open()">
-              <mat-label>{{ 'labels.inputs.Incorporation Validity Till Date' | translate }}</mat-label>
-              <input
-                matInput
-                [min]="minDate"
-                [max]="maxDate"
-                [matDatepicker]="incorpValidityTillDateDatePicker"
-                formControlName="incorpValidityTillDate"
-              />
-              <mat-datepicker-toggle matSuffix [for]="incorpValidityTillDateDatePicker"></mat-datepicker-toggle>
-              <mat-datepicker #incorpValidityTillDateDatePicker></mat-datepicker>
-            </mat-form-field>
-
-            <mat-form-field class="flex-48">
-              <mat-label>{{ 'labels.inputs.Incorporation No' | translate }}</mat-label>
-              <input matInput formControlName="incorpNumber" />
-            </mat-form-field>
-
-            <mat-form-field class="flex-98">
-              <mat-label>{{ 'labels.inputs.Remarks' | translate }}</mat-label>
-              <textarea matInput formControlName="remarks" cdkTextareaAutosize cdkAutosizeMinRows="2"></textarea>
-            </mat-form-field>
-          </div>
-
           <mat-checkbox
             *ngIf="legalFormId === 1"
             class="flex-48 margin-v"
@@ -153,7 +116,57 @@
           >
             {{ 'labels.inputs.Is staff' | translate }}?
           </mat-checkbox>
+        </div>
 
+        <div
+          class="flex-100 layout-row-wrap gap-2percent column-on-small"
+          formGroupName="clientNonPersonDetails"
+          *ngIf="editClientForm.contains('clientNonPersonDetails')"
+        >
+          <mat-form-field class="flex-48">
+            <mat-label>{{ 'labels.inputs.Constitution' | translate }}</mat-label>
+            <mat-select formControlName="constitutionId" required>
+              <mat-option *ngFor="let constitution of constitutionOptions" [value]="constitution.id">
+                {{ constitution.name }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field class="flex-48">
+            <mat-label>{{ 'labels.inputs.Main Business Line' | translate }}</mat-label>
+            <mat-select formControlName="mainBusinessLineId">
+              <mat-option *ngFor="let business of businessLineOptions" [value]="business.id">
+                {{ business.name }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field class="flex-48" (click)="incorpValidityTillDateDatePicker.open()">
+            <mat-label>{{ 'labels.inputs.Incorporation Validity Till Date' | translate }}</mat-label>
+            <input
+              matInput
+              [min]="minDate"
+              [max]="maxDate"
+              [matDatepicker]="incorpValidityTillDateDatePicker"
+              formControlName="incorpValidityTillDate"
+            />
+            <mat-datepicker-toggle matSuffix [for]="incorpValidityTillDateDatePicker"></mat-datepicker-toggle>
+            <mat-datepicker #incorpValidityTillDateDatePicker></mat-datepicker>
+          </mat-form-field>
+
+          <mat-form-field class="flex-48">
+            <mat-label>{{ 'labels.inputs.Incorporation No' | translate }}</mat-label>
+            <input matInput formControlName="incorpNumber" />
+          </mat-form-field>
+
+          <mat-form-field class="flex-98">
+            <mat-label>{{ 'labels.inputs.Remarks' | translate }}</mat-label>
+            <textarea matInput formControlName="remarks" cdkTextareaAutosize cdkAutosizeMinRows="2"></textarea>
+          </mat-form-field>
+        </div>
+
+        <!-- Mobile No and Email Address Row -->
+        <div class="responsive-row">
           <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Mobile No' | translate }}</mat-label>
             <input matInput type="text" formControlName="mobileNo" />
@@ -164,7 +177,10 @@
             <input matInput formControlName="emailAddress" />
             <mat-error *ngIf="editClientForm.controls.emailAddress.errors?.email"> Email not valid </mat-error>
           </mat-form-field>
+        </div>
 
+        <!-- Client Type and Client Classification Row -->
+        <div class="responsive-row">
           <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Client Type' | translate }}</mat-label>
             <mat-select formControlName="clientTypeId">
@@ -185,7 +201,10 @@
               </mat-option>
             </mat-select>
           </mat-form-field>
+        </div>
 
+        <!-- Submitted On and Activated On Row -->
+        <div class="responsive-row">
           <mat-form-field class="flex-48" (click)="submittedOnDatePicker.open()">
             <mat-label>{{ 'labels.inputs.Submitted On' | translate }}</mat-label>
             <input
@@ -219,11 +238,35 @@
         </div>
       </mat-card-content>
 
-      <mat-card-actions class="layout-row align-center gap-5px responsive-column">
-        <button type="button" mat-raised-button [routerLink]="['../general']">
+      <mat-card-actions
+        class="button-container"
+        style="
+          display: flex;
+          justify-content: center;
+          gap: 20px;
+          padding: 24px 0;
+          margin-top: 32px;
+          border-top: 1px solid rgba(0, 0, 0, 0.12);
+        "
+      >
+        <button
+          type="button"
+          mat-raised-button
+          [routerLink]="['../general']"
+          class="custom-button"
+          style="min-width: 100px; height: 36px; margin: 0 10px; padding: 0 20px; border-radius: 4px"
+        >
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
-        <button mat-raised-button color="primary" [disabled]="!editClientForm.valid" (click)="submit()">
+        <button
+          type="submit"
+          mat-raised-button
+          color="primary"
+          [disabled]="!editClientForm.valid"
+          (click)="submit()"
+          class="custom-button"
+          style="min-width: 100px; height: 36px; margin: 0 10px; padding: 0 20px; border-radius: 4px"
+        >
           {{ 'labels.buttons.Submit' | translate }}
         </button>
       </mat-card-actions>

--- a/src/app/clients/edit-client/edit-client.component.scss
+++ b/src/app/clients/edit-client/edit-client.component.scss
@@ -1,3 +1,196 @@
 .margin-v {
   margin: 2em 0 0;
 }
+
+.flex-32 {
+  flex: 0 1 32%;
+  max-width: 32%;
+}
+
+.gap-2percent {
+  gap: 2%;
+}
+
+.align-center {
+  align-items: center;
+}
+
+// Enhanced layout styles
+.container {
+  margin: 24px auto;
+  max-width: 1200px;
+  width: 100%;
+  padding: 0 24px;
+  box-sizing: border-box;
+}
+
+.mat-card {
+  padding: 32px;
+  margin: 16px 0;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 10%);
+}
+
+.mat-card-content {
+  padding: 0 !important;
+}
+
+.flex-24 {
+  flex: 0 1 calc(25% - 15px);
+  max-width: calc(25% - 15px);
+  margin-right: 0;
+}
+
+.flex-48 {
+  flex: 0 1 calc(50% - 10px);
+  max-width: calc(50% - 10px);
+  margin-right: 0;
+}
+
+.responsive-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  margin-bottom: 24px;
+  align-items: flex-start;
+}
+
+.responsive-row:last-child {
+  margin-bottom: 0;
+}
+
+.mat-form-field {
+  margin-bottom: 16px;
+}
+
+.mat-form-field:last-child {
+  margin-right: 0;
+}
+
+// Ensure all form fields in first row have consistent appearance
+.responsive-row .mat-form-field {
+  min-height: 56px; // Standard Material Design height
+}
+
+.responsive-row .mat-form-field .mat-form-field-wrapper {
+  padding-bottom: 1.3438em;
+}
+
+.section-divider {
+  margin: 32px 0 24px;
+  border-color: rgb(0 0 0 / 12%);
+}
+
+.mat-checkbox {
+  margin: 20px 0;
+}
+
+.mat-card-actions {
+  text-align: center !important;
+}
+
+.button-container {
+  display: flex !important;
+  justify-content: center !important;
+  gap: 20px !important;
+  padding: 24px 0 !important;
+  margin-top: 32px !important;
+  border-top: 1px solid rgb(0 0 0 / 12%) !important;
+}
+
+.custom-button {
+  min-width: 100px !important;
+  height: 36px !important;
+  margin: 0 10px !important;
+  padding: 0 20px !important;
+  border-radius: 4px !important;
+  font-weight: 500 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.3px !important;
+  font-size: 13px !important;
+}
+
+::ng-deep .mat-card-actions {
+  padding: 32px 0 0 !important;
+  margin-top: 40px !important;
+  border-top: 1px solid rgb(0 0 0 / 12%) !important;
+  display: flex !important;
+  gap: 32px !important;
+  justify-content: center !important;
+  align-items: center !important;
+  width: 100% !important;
+}
+
+::ng-deep .mat-card-actions button {
+  margin: 0 !important;
+  margin-left: 16px !important;
+  margin-right: 16px !important;
+}
+
+::ng-deep .mat-raised-button {
+  min-width: 140px !important;
+  height: 48px !important;
+  border-radius: 8px !important;
+  font-weight: 500 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.5px !important;
+  padding: 0 32px !important;
+  font-size: 14px !important;
+}
+
+@media (width <= 1024px) {
+  .flex-24 {
+    flex: 0 1 calc(50% - 10px);
+    max-width: calc(50% - 10px);
+  }
+}
+
+@media (width <= 768px) {
+  .flex-32 {
+    flex: 0 1 100%;
+    max-width: 100%;
+  }
+
+  .container {
+    margin: 16px;
+  }
+
+  .mat-card {
+    padding: 20px;
+  }
+
+  .responsive-row {
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .responsive-row .mat-form-field,
+  .flex-24,
+  .flex-32,
+  .flex-48 {
+    flex: 1 1 100%;
+    max-width: 100%;
+    margin-right: 0;
+  }
+
+  .mat-card-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .mat-raised-button {
+    margin-bottom: 8px;
+  }
+}
+
+@media (width <= 480px) {
+  .mat-card {
+    padding: 16px;
+    margin: 8px 0;
+  }
+
+  .responsive-row {
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+}


### PR DESCRIPTION
…nd move Date of Birth to new row

## Description

The "Date of Birth" field has been moved to a new row in the form layout. This change improves readability and ensures better alignment with other fields.
## Related issues and discussion
Fixes #210
#{Issue Number}
#210

## Screenshots, if any
before:
<img width="962" height="777" alt="Screenshot 2025-09-12 035125" src="https://github.com/user-attachments/assets/9e472433-3ade-4c1b-a5e1-ab15f667cb28" />
after:
<img width="1237" height="886" alt="Screenshot 2025-09-12 035003" src="https://github.com/user-attachments/assets/c0c03ffc-da41-4a08-bccc-96289b010bb7" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ X ] If you have multiple commits please combine them into one commit by squashing them.

- [ X ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
