### PR TITLE
Fix: Remove unused Material components to resolve warnings during ng serve

### DIFF
--- a/src/app/collections/collection-sheet/collection-sheet.component.ts
+++ b/src/app/collections/collection-sheet/collection-sheet.component.ts
@@ -5,20 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { SettingsService } from 'app/settings/settings.service';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import {
-  MatCell,
-  MatCellDef,
-  MatColumnDef,
-  MatHeaderCell,
-  MatHeaderCellDef,
-  MatHeaderRow,
-  MatHeaderRowDef,
-  MatRow,
-  MatRowDef,
-  MatTable
-} from '@angular/material/table';
-import { MatSort, MatSortHeader } from '@angular/material/sort';
-import { MatPaginator } from '@angular/material/paginator';
+
 import { OrganizationService } from 'app/organization/organization.service';
 import { CentersService } from 'app/centers/centers.service';
 import { GroupsService } from 'app/groups/groups.service';
@@ -31,20 +18,7 @@ import { CollectionSheetData, JLGGroupData, MeetingFallCenter } from '../models/
   styleUrl: './collection-sheet.component.scss',
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
-    FaIconComponent,
-    MatTable,
-    MatSort,
-    MatColumnDef,
-    MatHeaderCellDef,
-    MatHeaderCell,
-    MatSortHeader,
-    MatCellDef,
-    MatCell,
-    MatHeaderRowDef,
-    MatHeaderRow,
-    MatRowDef,
-    MatRow,
-    MatPaginator
+    FaIconComponent
   ]
 })
 export class CollectionSheetComponent implements OnInit {


### PR DESCRIPTION
**Changes made :-** 
-Removed unused Material table components from CollectionSheetComponent imports to fix compiler warnings during ng serve startup .
-Eliminated MatIcon-related warnings by simplifying component dependencies related issue .

[WEB-283](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-283)

[WEB-283]: https://mifosforge.jira.com/browse/WEB-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ