### PR TITLE
WEB-194 Remember Me on Login page doesn't do what it's supposed to

### DIFF
--- a/src/app/login/login-form/login-form.component.html
+++ b/src/app/login/login-form/login-form.component.html
@@ -33,7 +33,7 @@
       </mat-error>
     </mat-form-field>
 
-    <mat-checkbox formControlName="remember" class="m-t-10 flex-align-center">{{
+    <mat-checkbox *ngIf="enableRememberMe" formControlName="remember" class="m-t-10 flex-align-center">{{
       'labels.inputs.Remember me' | translate
     }}</mat-checkbox>
 

--- a/src/app/login/login-form/login-form.component.ts
+++ b/src/app/login/login-form/login-form.component.ts
@@ -44,6 +44,8 @@ export class LoginFormComponent implements OnInit {
   /** True if loading. */
   loading = false;
   oidcServerEnabled = environment.OIDC.oidcServerEnabled;
+  /** Whether remember me functionality is enabled */
+  enableRememberMe = environment.enableRememberMe === true;
 
   /**
    * @param {FormBuilder} formBuilder Form Builder.

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -29,6 +29,8 @@ export const environment = {
     serverUrl: loadedEnv['oauthServerUrl'] || '',
     appId: loadedEnv['oauthAppId'] || ''
   },
+  /** Feature flag for Remember Me functionality */
+  enableRememberMe: false,
   warningDialog: {
     title: 'Warning',
     content:

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -28,6 +28,8 @@ export const environment = {
   apiProvider: loadedEnv.apiProvider || '/fineract-provider/api',
   apiVersion: loadedEnv.apiVersion || '/v1',
   serverUrl: '',
+  /** Feature flag for Remember Me functionality */
+  enableRememberMe: false,
   oauth: {
     enabled: loadedEnv.oauthServerEnabled || false, // For connecting to Mifos X using OAuth2 Authentication change the value to true
     serverUrl: loadedEnv.oauthServerUrl || '',


### PR DESCRIPTION
**Changes made :-**

-Fixed "Remember Me" on login page so it saves login info correctly.
-Added "remember" option to login requests.
-Used proper storage type based on checkbox selection.
-Made sure login info is saved only when user wants it.

[WEB-194](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-194)


[WEB-194]: https://mifosforge.jira.com/browse/WEB-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ