### PR TITLE
WEB-19 Clicking on account list part in bread crumbs can cause error

### DIFF
--- a/src/app/savings/savings-routing.module.ts
+++ b/src/app/savings/savings-routing.module.ts
@@ -48,7 +48,7 @@ import { GeneralTabComponent } from './savings-account-view/general-tab/general-
 const routes: Routes = [
   {
     path: '',
-    data: { title: 'All Savings', breadcrumb: 'Savings', routeParamBreadcrumb: false },
+    data: { title: 'All Savings', breadcrumb: 'Savings', routeParamBreadcrumb: false, addBreadcrumbLink: false },
     children: [
       {
         path: 'create',

--- a/src/app/shares/shares-routing.module.ts
+++ b/src/app/shares/shares-routing.module.ts
@@ -22,7 +22,7 @@ import { GeneralTabComponent } from './shares-account-view/general-tab/general-t
 const routes: Routes = [
   {
     path: '',
-    data: { title: 'Shares', breadcrumb: 'Shares', routeParamBreadcrumb: false },
+    data: { title: 'Shares', breadcrumb: 'Shares', routeParamBreadcrumb: false, addBreadcrumbLink: false },
     children: [
       {
         path: 'create',


### PR DESCRIPTION
**Changes made :-** 

-Fixed issue where clicking on "Shares" or "Savings" in breadcrumbs was causing 404 errors.
-Added [addBreadcrumbLink: false] to both shares and savings routing modules.
-Made breadcrumb elements render as plain text instead of clickable links.
-Ensured navigation works correctly without causing request errors.

[WEB-19](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?selectedIssue=WEB-19)

[WEB-19]: https://mifosforge.jira.com/browse/WEB-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ