### PR TITLE
WEB-111 GSIM-linked GLIM Application Does Not Show Account-Transfer Charges

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
@@ -152,8 +152,9 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
     if (this.loansAccountProductTemplate) {
       this.loanPurposeOptions = this.loansAccountProductTemplate.loanPurposeOptions;
       this.chargeData = this.loansAccountProductTemplate.chargeOptions;
-      // filter chargeData to have charges that have chargePaymentMode not 'Account Transfer' if loansSavingsAccountLinked is false
-      if (!this.loansSavingsAccountLinked) {
+      // filter chargeData to have charges that have chargePaymentMode not 'Account Transfer' if no savings account is linked
+      const hasLinkedGSIMAccount = this.loansAccountTemplate?.gsimData?.groupId != null;
+      if (!this.loansSavingsAccountLinked && !hasLinkedGSIMAccount) {
         this.chargeData = this.chargeData.filter(
           (charge: any) => charge.chargePaymentMode?.value != 'Account transfer'
         );


### PR DESCRIPTION
**Changes Made :-**  

-Fixed: Account-transfer charges now display in Charges step when GSIM account is linked to GLIM loan.
-Updated charge filtering logic to correctly include account-transfer charges for GSIM-linked applications.
-Verified dropdown shows all applicable charges when product and linkage conditions are met.

[WEB-111 ](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-111)