### PR TITLE
WEB-89 List of currencies on the collateral page is astonishingly long

### DIFF
--- a/src/app/products/collaterals/create-collateral/create-collateral.component.ts
+++ b/src/app/products/collaterals/create-collateral/create-collateral.component.ts
@@ -1,5 +1,6 @@
 /** Angular Imports */
 import { Component, OnInit } from '@angular/core';
+import { OrganizationService } from 'app/organization/organization.service';
 import { UntypedFormGroup, UntypedFormBuilder, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
@@ -39,10 +40,19 @@ export class CreateCollateralComponent implements OnInit {
     private productsService: ProductsService,
     private route: ActivatedRoute,
     private router: Router,
-    private settingsService: SettingsService
+    private settingsService: SettingsService,
+    private organizationService: OrganizationService
   ) {
     this.route.data.subscribe((data: { collateralTemplate: any }) => {
-      this.collateralTemplateData = data.collateralTemplate;
+      this.organizationService.getCurrencies().subscribe((orgCurrencies: any) => {
+        console.log('Organization currencies response:', orgCurrencies);
+        let orgCurrencyList = Array.isArray(orgCurrencies.selectedCurrencyOptions)
+          ? orgCurrencies.selectedCurrencyOptions
+          : [];
+        this.collateralTemplateData = data.collateralTemplate.filter((currency: any) =>
+          orgCurrencyList.some((orgCurrency: any) => orgCurrency.code === currency.code)
+        );
+      });
     });
   }
 


### PR DESCRIPTION
**Changes Made :-**

-Filtered the currency dropdown in Collateral Management to show only organization-configured currencies, matching the Loan Product form.
-Used [selectedCurrencyOptions] from the API response for accurate currency filtering.

[WEB-89](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?selectedIssue=WEB-89)

[WEB-89]: https://mifosforge.jira.com/browse/WEB-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ