### PR TITLE
WEB-92 Click on GSIM application in GSIM application list causes Javascript error

### DIFF
--- a/src/app/core/shell/breadcrumb/breadcrumb.component.ts
+++ b/src/app/core/shell/breadcrumb/breadcrumb.component.ts
@@ -141,11 +141,9 @@ export class BreadcrumbComponent implements AfterViewInit {
                   routeData.loanDetailsData.accountNo +
                   ')';
               } else if (routeData.breadcrumb === 'Savings') {
-                breadcrumbLabel =
-                  this.printableValue(routeData.savingsAccountData.savingsProductName) +
-                  ' (' +
-                  routeData.savingsAccountData.accountNo +
-                  ')';
+                const savingsProductName = routeData.savingsAccountData?.savingsProductName ?? '';
+                const accountNo = routeData.savingsAccountData?.accountNo ?? '';
+                breadcrumbLabel = this.printableValue(savingsProductName) + (accountNo ? ' (' + accountNo + ')' : '');
               } else if (routeData.breadcrumb === 'Fixed Deposits') {
                 breadcrumbLabel =
                   this.printableValue(routeData.fixedDepositsAccountData.depositProductName) +


### PR DESCRIPTION
**Changes Made:**

-Added null checks for savings account data in the breadcrumb component to prevent JavaScript errors.
-Improved error handling for GSIM account breadcrumb rendering when data is missing.

Fixes: [WEB-92](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?selectedIssue=WEB-92)



[WEB-92]: https://mifosforge.jira.com/browse/WEB-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ