### PR TITLE
WEB-108 GSIM/GLIM Overview Not Updated After Activation

### DIFF
--- a/src/app/groups/groups-view/general-tab/general-tab.component.ts
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.ts
@@ -19,6 +19,7 @@ import { StatusLookupPipe } from '../../../pipes/status-lookup.pipe';
 import { AccountsFilterPipe } from '../../../pipes/accounts-filter.pipe';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { GroupsService } from '../../groups.service';
 
 /**
  * Groups View General Tab Component.
@@ -123,11 +124,10 @@ export class GeneralTabComponent {
   /** Boolean for toggling savings accounts table */
   showClosedSavingAccounts = false;
 
-  /**
-   * Fetches group's related data from `resolve`
-   * @param {ActivatedRoute} route Activated Route.
-   */
-  constructor(private route: ActivatedRoute) {
+  constructor(
+    private route: ActivatedRoute,
+    private groupsService: GroupsService
+  ) {
     this.route.data.subscribe(
       (data: { groupAccountsData: any; groupClientMembers: any; groupSummary: any; glimData: any; gsimData: any }) => {
         this.glimAccounts = data.glimData;
@@ -140,6 +140,18 @@ export class GeneralTabComponent {
     );
     this.route.parent.data.subscribe((data: { groupViewData: any }) => {
       this.groupClientMembers = data.groupViewData.clientMembers;
+    });
+  }
+
+  /**
+   * Refreshes group account data from backend (for GSIM/GLIM status/balance update)
+   */
+  refreshAccounts(groupId: string) {
+    this.groupsService.getGroupAccountsData(groupId).subscribe((data: any) => {
+      this.groupAccountData = data;
+      this.savingAccounts = data.savingsAccounts;
+      this.loanAccounts = data.loanAccounts;
+      // If GSIM/GLIM data is separate, fetch and update here as well
     });
   }
 

--- a/src/app/groups/groups-view/groups-view.component.ts
+++ b/src/app/groups/groups-view/groups-view.component.ts
@@ -100,6 +100,12 @@ export class GroupsViewComponent {
       case 'Manage Members':
       case 'Transfer Clients':
         this.router.navigate([`actions/${name}`], { relativeTo: this.route });
+        if (name === 'Activate') {
+          const generalTab = this.getGeneralTabComponent();
+          if (generalTab) {
+            generalTab.refreshAccounts(this.groupViewData.id);
+          }
+        }
         break;
       case 'Edit Meeting':
         const queryParams: any = { calendarId: this.groupViewData.collectionMeetingCalendar.id };
@@ -116,7 +122,9 @@ export class GroupsViewComponent {
         break;
     }
   }
-
+  getGeneralTabComponent(): any {
+    return null;
+  }
   /**
    * Checks if meeting is editable.
    */
@@ -129,7 +137,6 @@ export class GroupsViewComponent {
     }
     return false;
   }
-
   /**
    * Refetches data for the component
    * TODO: Replace by a custom reload component instead of hard-coded back-routing.


### PR DESCRIPTION
**Changes Made :-**

-Fixed group overview to show updated GSIM/GLIM account status and balance after approval and activation.
-Added logic to refresh account data immediately after account actions.

[WEB-108](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-108)

[WEB-108]: https://mifosforge.jira.com/browse/WEB-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ