### PR TITLE
WEB-321 MatCheckbox is not used warnings during startup of ng serve

### DIFF
--- a/src/app/login/login-form/login-form.component.ts
+++ b/src/app/login/login-form/login-form.component.ts
@@ -31,7 +31,6 @@ import { environment } from '../../../environments/environment';
     MatPrefix,
     FaIconComponent,
     MatIconButton,
-    MatCheckbox,
     MatProgressBar,
     MatProgressSpinner
   ]


### PR DESCRIPTION
**Changes Made :-** 
-Remove unused MatCheckbox import from LoginFormComponent to resolve Angular startup warning.

[WEB :- 321](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-321)