### PR TITLE
WEB-323-Fix CSS for Client Screen Report layout

### DIFF
--- a/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.html
+++ b/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.html
@@ -18,7 +18,7 @@
         </div>
       </mat-card-content>
 
-      <mat-card-actions class="layout-row align-center gap-5px responsive-column">
+      <mat-card-actions class="layout-row align-center gap-5px actions-spacing responsive-column">
         <button type="button" mat-raised-button [routerLink]="['../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
@@ -30,7 +30,7 @@
   </mat-card>
 </div>
 
-<div #output class="container">
+<div #output class="container m-t-20">
   <mat-card class="layout-column gap-3percent">
     <div class="layout-align-end">
       <button mat-stroked-button color="primary" [disabled]="!template" (click)="print()">

--- a/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.scss
+++ b/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.scss
@@ -5,3 +5,34 @@
     align-self: flex-end;
   }
 }
+
+::ng-deep mat-card {
+  margin-bottom: 1rem;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: 8px;
+  background-color: var(--card-background, #fff);
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease;
+  height: 10rem;
+}
+
+.m-t-20 button {
+  background-color: #1976d2;
+  color: white;
+}
+
+::ng-deep .container.m-t-20 mat-card p {
+  display: block;
+  margin-top: -1.9rem;
+}
+
+.m-b-20 form {
+  margin-top: -1.5rem;
+}
+
+.actions-spacing {
+  margin-top: 24px;
+}


### PR DESCRIPTION
## Description
#Description:
Fixed padding and margin inside the Client Screen Reports box.

Reduced width of the report display box for better alignment.

Centered content horizontally and improved spacing around buttons and text.

#{Issue Number}
WEB-323

## Screenshots, if any
before:
<img width="638" height="301" alt="Screenshot 2025-09-23 115923" src="https://github.com/user-attachments/assets/c63cbfab-8bde-4875-a1c6-7b97bb702683" />
after:
<img width="802" height="393" alt="Screenshot 2025-09-24 120030" src="https://github.com/user-attachments/assets/232b36f8-41b9-46a9-8868-cd8581cf7894" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X ] If you have multiple commits please combine them into one commit by squashing them.

- [ X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
