### PR TITLE
WEB-326 fix: mat-label text color in dashboard widgets for better visibility …

### DIFF
--- a/src/app/home/dashboard/amount-collected-pie/amount-collected-pie.component.scss
+++ b/src/app/home/dashboard/amount-collected-pie/amount-collected-pie.component.scss
@@ -3,12 +3,30 @@
   padding: 0;
 
   .header {
-    #office {
+    :where(#office) {
       margin-bottom: -1.2em;
+
+      // Make sure mat-label text is visible in light theme
+      :where(mat-label) {
+        color: rgb(0 0 0 / 87%); // Standard Material Design text color for light theme
+      }
     }
   }
 
   .fallback {
     height: 20rem;
+  }
+}
+
+// Dark theme specific styles
+:host-context(.dark-theme) {
+  .card {
+    .header {
+      :where(#office) {
+        :where(mat-label) {
+          color: white; // White text color for dark theme
+        }
+      }
+    }
   }
 }

--- a/src/app/home/dashboard/amount-disbursed-pie/amount-disbursed-pie.component.scss
+++ b/src/app/home/dashboard/amount-disbursed-pie/amount-disbursed-pie.component.scss
@@ -3,12 +3,30 @@
   padding: 0;
 
   .header {
-    #office {
+    :where(#office) {
       margin-bottom: -1.2em;
+
+      // Make sure mat-label text is visible in light theme
+      :where(mat-label) {
+        color: rgb(0 0 0 / 87%); // Standard Material Design text color for light theme
+      }
     }
   }
 
   .fallback {
     height: 20rem;
+  }
+}
+
+// Dark theme specific styles
+:host-context(.dark-theme) {
+  .card {
+    .header {
+      :where(#office) {
+        :where(mat-label) {
+          color: white; // White text color for dark theme
+        }
+      }
+    }
   }
 }

--- a/src/app/home/dashboard/client-trends-bar/client-trends-bar.component.scss
+++ b/src/app/home/dashboard/client-trends-bar/client-trends-bar.component.scss
@@ -3,12 +3,17 @@
   padding: 0;
 
   .header {
-    #office {
+    :where(#office) {
       margin-bottom: -1.2em;
+
+      // Make sure mat-label text is visible in light theme
+      :where(mat-label) {
+        color: rgb(0 0 0 / 87%); // Standard Material Design text color for light theme
+      }
     }
   }
 
-  #timescale {
+  :where(#timescale) {
     margin: 2% 50%;
     transform: translateX(-50%);
   }
@@ -17,5 +22,18 @@
     overflow-x: auto;
     max-width: 100%;
     min-height: 16.5rem;
+  }
+}
+
+// Dark theme specific styles
+:host-context(.dark-theme) {
+  .card {
+    .header {
+      :where(#office) {
+        :where(mat-label) {
+          color: white; // White text color for dark theme
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description
WEB-326 Fix office dropdown label color in light theme

This PR fixes an issue where the mat-label text for Office dropdown in several dashboard widgets was white on a white background in light theme, making it invisible to users.

## Changes Made
- Added specific styling for mat-label elements in the Office dropdown
- Set text color to rgba(0, 0, 0, 0.87) in light theme for better visibility
- Set text color to white in dark theme using :host-context(.dark-theme)
- Applied these changes to:
  - client-trends-bar component
  - amount-disbursed-pie component 
  - amount-collected-pie component

## Testing
The changes were tested in both light and dark themes to ensure proper visibility of the Office dropdown label text.

## Screenshots, if any
before applying changes
![before](https://github.com/user-attachments/assets/7d417db0-0245-4a80-9149-8b5fe9a5c25d)
after applying changes
![after](https://github.com/user-attachments/assets/0f2bcef1-e2be-4ab5-b4e2-4fae617ec846)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

- [x]  Added the Jira issue key (WEB-326) in the PR title and description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label visibility and contrast in dashboard charts for light and dark themes.
  * Ensured header labels display correctly across Amount Collected, Amount Disbursed, and Client Trends widgets.

* **Style**
  * Reduced CSS specificity to prevent style conflicts and improve maintainability.
  * Unified theming rules so labels render consistently in both light and dark modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->