### PR TITLE
WEB-325-fix(css): update styles for manage-group-members page

### DIFF
--- a/src/app/groups/groups-view/group-actions/manage-group-members/manage-group-members.component.scss
+++ b/src/app/groups/groups-view/group-actions/manage-group-members/manage-group-members.component.scss
@@ -3,15 +3,18 @@
 
   .mat-table {
     display: block;
-    font-family: Tahoma, Verdana, sans-serif;
+    font-family: Roboto, 'Helvetica Neue', sans-serif;
     width: 100%;
+    margin-top: -2rem;
+    padding: 1.5rem;
   }
 
   .mat-row,
   .mat-header-row {
     display: flex;
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
+    border-bottom: 1px solid var(--border-color-light, #eee);
+    color: var(--text-color, inherit);
+    font-weight: 500;
     align-items: center;
     min-height: 48px;
     padding: 0 24px;
@@ -22,14 +25,52 @@
     flex: 1;
     overflow: hidden;
     word-wrap: break-word;
+    flex-direction: column;
   }
 
   h3 {
     padding-left: 0;
     margin-bottom: 0;
+    font-weight: 500;
+    border-bottom: 2px solid var(--border-color-light, #eee);
+  }
+
+  .p-t-10 {
+    font-weight: 500;
+    margin-left: 1rem;
   }
 
   .client-card {
     max-height: 20rem;
+    margin-bottom: 1rem;
+    padding: 1.5rem;
+    box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+    border: 1px solid var(--border-color, #ddd);
+    border-radius: 8px;
+    transition:
+      background-color 0.3s ease,
+      border-color 0.3s ease;
+  }
+
+  .flex-50 {
+    max-height: 20rem;
+    margin-bottom: 1rem;
+    padding: 1.5rem;
+    box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+    border: 1px solid var(--border-color, #ddd);
+    border-radius: 8px;
+    transition:
+      background-color 0.3s ease,
+      border-color 0.3s ease;
+  }
+
+  .flex-50 button {
+    left: 0;
+  }
+
+  .flex-fill {
+    margin-top: 0.5rem;
+    display: inline;
+    font-weight: 500;
   }
 }


### PR DESCRIPTION
#Description

Updated the manage-group-members page to fix spacing issues.
Adjusted padding and margin for better readability and consistent layout.

Fixes #{Issue Number}
WEB-325
Screenshots, if any
before:
<img width="1496" height="518" alt="Screenshot 2025-09-24 234907" src="https://github.com/user-attachments/assets/d48ca782-5def-411e-82de-0c30dcd7edb6" />
after:
<img width="1217" height="397" alt="Screenshot 2025-09-25 152333" src="https://github.com/user-attachments/assets/7b72a5e8-c79d-415a-b5c6-196b5daa092a" />

Checklist:
 [X] If you have multiple commits please combine them into one commit by squashing them.

 [X]Read and understood the contribution guidelines at web-app/.github/CONTRIBUTING.md.