### PR TITLE
WEB-330-fix(ui): add background boxes for better layout

### DIFF
--- a/src/app/accounting/search-journal-entry/search-journal-entry.component.html
+++ b/src/app/accounting/search-journal-entry/search-journal-entry.component.html
@@ -1,4 +1,4 @@
-<div class="container layout-row-wrap gap-2px responsive-column">
+<div class="container layout-row-wrap gap-2px responsive-column filter-container">
   <mat-form-field class="flex-31">
     <mat-label>{{ 'labels.inputs.Office Name' | translate }}</mat-label>
     <input matInput [formControl]="officeName" [matAutocomplete]="officeNameAutocomplete" />
@@ -85,13 +85,12 @@
   </mat-option>
 </mat-autocomplete>
 
-<div class="mat-elevation-z8 container">
+<div class="mat-elevation-z8 container table-container">
   <table mat-table [dataSource]="dataSource" matSort>
     <ng-container matColumnDef="id">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Entry ID' | translate }}</th>
       <td mat-cell *matCellDef="let journalEntry">{{ journalEntry.id }}</td>
     </ng-container>
-
     <ng-container matColumnDef="officeName">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Office' | translate }}</th>
       <td mat-cell *matCellDef="let journalEntry">{{ journalEntry.officeName }}</td>

--- a/src/app/accounting/search-journal-entry/search-journal-entry.component.scss
+++ b/src/app/accounting/search-journal-entry/search-journal-entry.component.scss
@@ -1,7 +1,33 @@
 table {
   width: 100%;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: 8px;
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease;
 
   .select-row:hover {
     cursor: pointer;
   }
+}
+
+.filter-container {
+  margin-bottom: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: 8px;
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.table-container {
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: 8px;
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease;
 }


### PR DESCRIPTION
## Description

Added a background box to the first container on the Search Journal Entry page to improve layout and make it visually consistent with other containers. This change fixes the UI issue where the first container looked incomplete.

## Related issues and discussion

#{Issue Number}
WEB-330

## Screenshots, if any
before:
<img width="1559" height="802" alt="Screenshot 2025-09-28 155117" src="https://github.com/user-attachments/assets/bc64e532-6877-4ee0-b961-b51590df614a" />
after:
<img width="1555" height="798" alt="Screenshot 2025-09-28 160839" src="https://github.com/user-attachments/assets/83c52c4a-0e3e-4278-92c6-93b27fd66da9" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ X ] If you have multiple commits please combine them into one commit by squashing them.

- [ X ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refreshed the Journal Entry Search UI with updated styling for the filter panel and results table, including shadows, borders, and rounded corners.
  * Added subtle background-color and border-color transitions for smoother visual feedback.
  * Improved spacing, padding, and max-height in the filter area for better readability.
  * Applied consistent container styling across filter and table sections.
  * No changes to behavior or data; purely visual enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->