### PR TITLE
WEB-117 Loan Account Charge(Amount% charges) Doubling on Application Modification

### DIFF
--- a/src/app/loans/edit-loans-account/edit-loans-account.component.ts
+++ b/src/app/loans/edit-loans-account/edit-loans-account.component.ts
@@ -129,14 +129,29 @@ export class EditLoansAccountComponent {
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;
     const loanType = 'individual';
+    const uniqueCharges = new Map<number | string, any>();
+    (this.loansAccount.charges ?? []).forEach((charge: any) => {
+      const chargeId = charge.chargeId;
+      if (chargeId == null) {
+        return;
+      } // Skip malformed entries
+      uniqueCharges.set(chargeId, charge);
+    });
+
     const loansAccountData = {
       ...this.loansAccount,
       clientId: this.loansAccountAndTemplate.clientId,
-      charges: this.loansAccount.charges.map((charge: any) => ({
-        chargeId: charge.id,
-        amount: charge.amount,
-        dueDate: charge.dueDate && this.dateUtils.formatDate(charge.dueDate, dateFormat)
-      })),
+      charges: Array.from(uniqueCharges.values()).map((charge: any) => {
+        const result: any = {
+          chargeId: charge.chargeId,
+          amount: charge.amount,
+          dueDate: charge.dueDate && this.dateUtils.formatDate(charge.dueDate, dateFormat)
+        };
+        if (charge.id && charge.id !== charge.chargeId) {
+          result.id = charge.id;
+        }
+        return result;
+      }),
       collateral: this.loansAccount.collateral.map((collateralEle: any) => ({
         type: collateralEle.type,
         value: collateralEle.value,


### PR DESCRIPTION
**Changes Made :-** 

-Fixed issue where charges were doubling when editing a loan application.
-Added code to prevent duplicate charges by checking for existing ones.
-Updated how charges are handled during loan modifications to maintain correct values.

[WEB-117](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-117)

[WEB-117]: https://mifosforge.jira.com/browse/WEB-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate charges from being added or submitted on loan accounts, reducing double-charging and related errors.

* **Improvements**
  * Charges are deduplicated before saving so only a single entry per charge is stored.
  * Charge entries now preserve alternate identifiers and key fields when present.
  * Charge lists pre-populate more reliably from templates or existing loan data, improving edit flows and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->