### PR TITLE
WEB-334: Fix translation for Transfer Details label

### DIFF
--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1134,6 +1134,7 @@
       "Transaction Details": "Detaily transakce",
       "Transaction Reverted": "Transakce vrácena",
       "Transactions": "Transakce",
+      "Transfer Details": "Podrobnosti o převodu",
       "Transferred From": "Převedeno z",
       "Transferred To": "Převeden k",
       "Transferring From Details": "Přenos z podrobností",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1135,6 +1135,7 @@
       "Transaction Details": "Transaktionsdetails",
       "Transaction Reverted": "Transaktion rückgängig gemacht",
       "Transactions": "Transaktionen",
+      "Transfer Details": "Transferdetails",
       "Transferred From": "Transferiert von",
       "Transferred To": "Übertragen auf",
       "Transferring From Details": "Von Details übertragen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1139,6 +1139,7 @@
       "Transaction Details": "Transaction Details",
       "Transaction Reverted": "Transaction Reverted",
       "Transactions": "Transactions",
+      "Transfer Details": "Transfer Details",
       "Transferred From": "Transferred From",
       "Transferred To": "Transferred To",
       "Transferring From Details": "Transferring From Details",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1134,6 +1134,7 @@
       "Transaction Details": "Detalles de la transacción",
       "Transaction Reverted": "Transacción revertida",
       "Transactions": "Transacciones",
+      "Transfer Details": "Detalles de la transferencia",
       "Transferred From": "Transferido desde",
       "Transferred To": "Transferido a",
       "Transferring From Details": "Transferir desde detalles",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1134,6 +1134,7 @@
       "Transaction Details": "Detalles de la transacción",
       "Transaction Reverted": "Transacción revertida",
       "Transactions": "Transacciones",
+      "Transfer Details": "Detalles de la transferencia",
       "Transferred From": "Transferido desde",
       "Transferred To": "Transferido a",
       "Transferring From Details": "Transferir desde detalles",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1135,6 +1135,7 @@
       "Transaction Details": "détails de la transaction",
       "Transaction Reverted": "Transaction annulée",
       "Transactions": "Transactions",
+      "Transfer Details": "Détails du transfert",
       "Transferred From": "Transféré de",
       "Transferred To": "Transféré à",
       "Transferring From Details": "Transfert depuis les détails",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1135,6 +1135,7 @@
       "Transaction Details": "Dettagli di Transazione",
       "Transaction Reverted": "Transazione annullata",
       "Transactions": "Transazioni",
+      "Transfer Details": "Dettagli del trasferimento",
       "Transferred From": "Trasferito da",
       "Transferred To": "Trasferito a",
       "Transferring From Details": "Trasferimento dai dettagli",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1136,6 +1136,7 @@
       "Transaction Details": "상세 거래 내역",
       "Transaction Reverted": "거래가 되돌려졌습니다.",
       "Transactions": "업무",
+      "Transfer Details": "전송 세부 정보",
       "Transferred From": "다음에서 전송됨",
       "Transferred To": "로 전송",
       "Transferring From Details": "세부정보에서 전송 중",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1135,6 +1135,7 @@
       "Transaction Details": "Pervedimo duomenys",
       "Transaction Reverted": "Sandoris grąžintas",
       "Transactions": "Sandoriai",
+      "Transfer Details": "Pervedimo informacija",
       "Transferred From": "Perkelta iš",
       "Transferred To": "Perkelta į",
       "Transferring From Details": "Perkėlimas iš detalių",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1135,6 +1135,7 @@
       "Transaction Details": "Darījuma informācija",
       "Transaction Reverted": "Darījums ir atsaukts",
       "Transactions": "Darījumi",
+      "Transfer Details": "Pārskaitījuma informācija",
       "Transferred From": "Pārsūtīts no",
       "Transferred To": "Pārsūtīts uz",
       "Transferring From Details": "Pārsūtīšana no detaļām",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1135,6 +1135,7 @@
       "Transaction Details": "लेनदेन विवरण",
       "Transaction Reverted": "कारोबार फिर्ता गरियो",
       "Transactions": "लेनदेन",
+      "Transfer Details": "स्थानान्तरण विवरणहरू",
       "Transferred From": "बाट स्थानान्तरण गरियो",
       "Transferred To": "मा हस्तान्तरण गरियो",
       "Transferring From Details": "विवरणहरूबाट स्थानान्तरण गर्दै",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1135,6 +1135,7 @@
       "Transaction Details": "Detalhes da transação",
       "Transaction Reverted": "Transação revertida",
       "Transactions": "Transações",
+      "Transfer Details": "Detalhes da transferência",
       "Transferred From": "Transferido de",
       "Transferred To": "Transferido para",
       "Transferring From Details": "Transferindo de detalhes",


### PR DESCRIPTION
## Description

WEB-334: Fix translation for Transfer Details label

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Transfer Details” label in the Transactions area across locales: en-US, de-DE, fr-FR, es-CL, es-MX, it-IT, pt-PT, cs-CS, ko-KO, lt-LT, lv-LV, ne-NE.

- Chores
  - Updated translations to include the new label; no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->