### PR TITLE
WEB-335-proper implementation of dark mode

### DIFF
--- a/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.scss
+++ b/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.scss
@@ -107,7 +107,6 @@
     width: 100%;
 
     th {
-      background-color: #f5f5f5;
       font-weight: 500;
       padding: 16px 12px;
     }

--- a/src/app/shared/styles/list-layout.scss
+++ b/src/app/shared/styles/list-layout.scss
@@ -3,7 +3,6 @@ $bar: 150px;
 $foo: $bar * 8;
 $color: #e2e4ec;
 
-// Container styles
 .container {
   padding: 24px;
 
@@ -84,7 +83,6 @@ $color: #e2e4ec;
   // Table styling
   .bordered-table {
     width: 100%;
-    background: white;
     border: 1px solid #e0e0e0;
     border-radius: 4px;
     overflow: hidden;
@@ -104,7 +102,6 @@ $color: #e2e4ec;
     }
 
     th {
-      background-color: #fafafa;
       font-weight: 500;
       border-bottom: 1px solid #e0e0e0;
     }
@@ -121,7 +118,6 @@ $color: #e2e4ec;
   // Paginator styling
   mat-paginator {
     border-top: 1px solid #e0e0e0;
-    background: white;
     margin-top: 0;
   }
 


### PR DESCRIPTION
## Description

proper  implemenation of dark mode

#{Issue Number}
WEB-335
## Screenshots, if any
before:
<img width="1193" height="826" alt="Screenshot 2025-10-02 183915" src="https://github.com/user-attachments/assets/5b8c4096-8e21-4833-aefd-eb1713e1c5fc" />
after:
<img width="1184" height="833" alt="Screenshot 2025-10-02 184051" src="https://github.com/user-attachments/assets/ed5f1811-93f2-4a28-9650-72e862ceb4b1" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X ] If you have multiple commits please combine them into one commit by squashing them.

- [X ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed background shading from table headers in bulk import views, resulting in a flatter, cleaner header appearance.
  * Simplified backgrounds across list layouts: tables and pagination no longer force white or gray backgrounds, allowing them to inherit the surrounding container’s styling for a more consistent look.
  * Minor cleanup of style comments with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->