### PR TITLE
WEB-336: Fix translation view inactive charges button for Savings

### DIFF
--- a/src/app/savings/savings-account-view/charges-tab/charges-tab.component.html
+++ b/src/app/savings/savings-account-view/charges-tab/charges-tab.component.html
@@ -8,10 +8,7 @@
         {{
           showInactiveCharges
             ? viewAllChargeButtons('View Active Charges')
-            : viewAllChargeButtons(
-                'View Inactive
-        Charges'
-              )
+            : viewAllChargeButtons('View Inactive Charges')
         }}
       </button>
     </div>


### PR DESCRIPTION
## Description

WEB-336: Fix translation view inactive charges button for Savings

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the charges tab header button label to a single-line “View Inactive Charges,” replacing the previous split-line text. This improves readability, consistency, and reduces awkward wrapping in tighter layouts.
  * Visual/wording-only update; no functional or behavioral changes to interactions or data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->