### PR TITLE
WEB-342: Advance Accounting rule can not be edited for classification type

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component.html
@@ -24,8 +24,8 @@
 
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-      <td mat-cell *matCellDef="let chargeOffReasonExpense; let i = index">
-        <button mat-icon-button color="primary" (click)="edit(i)">
+      <td mat-cell *matCellDef="let item; let i = index">
+        <button mat-icon-button color="primary" (click)="edit(item, i)">
           <fa-icon icon="edit"></fa-icon>
         </button>
         <button mat-icon-button color="warn" (click)="delete(i)">


### PR DESCRIPTION
## Description

Advance Accounting rule can not be edited for classification type in the Buy Down Fee and Capitalized Income due the Edit button has not functionality linked

## Related issues and discussion

[WEB-342](https://mifosforge.jira.com/browse/WEB-342)

## Screenshots

https://github.com/user-attachments/assets/7bb54f52-8fa8-410c-a696-2a00ba22dd6c


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-342]: https://mifosforge.jira.com/browse/WEB-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit now opens a form dialog, accepts the full item for editing, and updates the selected row immediately.

* **Bug Fixes**
  * Edit dialog preselects classification and account fields correctly.
  * Editing updates only the intended row without mutating others.
  * More reliable launch of edits from the actions menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->