### PR TITLE
WEB-322: Re-aging: Interest handling configuration with id

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.html
@@ -45,7 +45,7 @@
             <mat-select formControlName="reAgeInterestHandling">
               <mat-option
                 *ngFor="let reAgeInterestHandlingOption of reAgeInterestHandlingOptions"
-                [value]="reAgeInterestHandlingOption.code"
+                [value]="reAgeInterestHandlingOption.id"
               >
                 {{ reAgeInterestHandlingOption.value | translateKey: 'catalogs' }}
               </mat-option>


### PR DESCRIPTION
## Description

Re-aging: Interest handling configuration with id value instead of code value 

## Related issues and discussion

[WEB-322](https://mifosforge.jira.com/browse/WEB-322)

## Screenshots

<img width="1019" height="803" alt="Screenshot 2025-10-10 at 2 51 25 p m" src="https://github.com/user-attachments/assets/e4ebbaa0-5809-43a0-92ef-f93557078628" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-322]: https://mifosforge.jira.com/browse/WEB-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the mapping of interest handling options in the Loan Re-Aging form. Selections now reliably apply the intended option, preventing mismatches between the displayed choice and the saved value.
  - Ensures consistent behavior when selecting or updating interest handling during re-aging, improving accuracy in both new selections and edits.
  - Enhances overall reliability of the loan re-aging workflow without altering the user interface or introducing new steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->