### PR TITLE
WEB-344 Remove .git from .dockerignore so git information is available on docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ npm-debug.log
 Dockerfile*
 docker-compose*
 .dockerignore
-.git
 .gitignore
 README.md
 LICENSE


### PR DESCRIPTION
## Description

This change makes git information available on docker and fixes the bug that the commit hash is not shown on the footer on cloud.

## Related issues and discussion

#WEB-344

## Screenshots, if any

Before
<img width="568" height="47" alt="image" src="https://github.com/user-attachments/assets/ee8ba8f9-283e-42af-b39e-167b7ba7524c" />

After

<img width="351" height="65" alt="image" src="https://github.com/user-attachments/assets/34ec85f8-895d-4125-abb7-3d3114e9fc31" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Docker ignore settings to allow repository metadata to be included in build contexts, improving compatibility with workflows that rely on version information inside containers. No runtime or user interface changes; application behavior remains unchanged. This may aid debugging and traceability of builds across environments, without affecting performance, stability, or existing configurations for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->