### PR TITLE
WEB-348:Fix Unable to configure maker checker task

### DIFF
--- a/src/app/system/configure-maker-checker-tasks/configure-maker-checker-tasks.component.html
+++ b/src/app/system/configure-maker-checker-tasks/configure-maker-checker-tasks.component.html
@@ -31,12 +31,11 @@
         </div>
 
         <mat-divider [vertical]="true"></mat-divider>
-
         <div class="list-permission layout-column flex-70">
           <form [formGroup]="formGroup" (submit)="submit()">
-            <div *ngFor="let permission of permissions.permissions" class="display-permissions">
-              <div formArrayName="roster">
-                <div [formGroupName]="permission.id">
+            <div formArrayName="roster">
+              <div *ngFor="let permission of permissions.permissions; let i = index" class="display-permissions">
+                <div [formGroupName]="i">
                   <mat-checkbox name="cp" id="{{ permission.code }}" formControlName="selected">
                     {{ permissionName(permission.code) }}
                   </mat-checkbox>


### PR DESCRIPTION
## Description
When the admin attempted to set up maker-checker permissions for the Accounting module, the required checkbox was selected and the Submit button was clicked. After submission, the system navigated away from the Accounting permission list to another module. Upon returning, the previously selected permissions were not retained. The same behavior was observed when the scenario was tested using the API , the permission changes did not persist.


## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the form control binding mechanism to use index-based references instead of ID-based references for improved form handling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->