### PR TITLE
WEB-347:No Interest Compoundig Option for Deposit,FD and RD accounts

### DIFF
--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -683,7 +683,7 @@
       "Reduce EMI amount": "Betrag reduzieren",
       "Reduce number of installments": "Reduzieren Sie die Anzahl der Raten",
       "Reschedule next repayments": "Planen Sie die nächsten Rückzahlungen neu",
-      "None": "Hauptstadt",
+      "None": "keiner",
       "Interest": "Interesse",
       "Fee and Interest": "Gebühr und Zinsen",
       "Creocore Unique": "Creocore Einzigartig",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -682,7 +682,7 @@
       "Reduce EMI amount": "Reducir Monto de Cuota",
       "Reduce number of installments": "Reducir el número de cuotas",
       "Reschedule next repayments": "Reprogramar próximos pagos",
-      "None": "Capital",
+      "None": "Ninguno",
       "Interest": "Interés",
       "Fee and Interest": "Comisión e interés",
       "Creocore Unique": "Creocore único",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -682,7 +682,7 @@
       "Reduce EMI amount": "Reducir Monto de Cuota",
       "Reduce number of installments": "Reducir el número de cuotas",
       "Reschedule next repayments": "Reprogramar próximos pagos",
-      "None": "Capital",
+      "None": "Ninguno",
       "Interest": "Interés",
       "Fee and Interest": "Comisión e interés",
       "Creocore Unique": "Creocore único",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -683,7 +683,7 @@
       "Reduce EMI amount": "Réduire le montant",
       "Reduce number of installments": "Réduire le nombre de versements",
       "Reschedule next repayments": "Reprogrammer les prochains remboursements",
-      "None": "Capital",
+      "None": "Aucune",
       "Interest": "Intérêt",
       "Fee and Interest": "Frais et intérêts",
       "Creocore Unique": "Créocore Unique",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -683,7 +683,7 @@
       "Reduce EMI amount": "Ridurre l'importo",
       "Reduce number of installments": "Ridurre il numero di rate",
       "Reschedule next repayments": "Riprogrammare i prossimi rimborsi",
-      "None": "Capitale",
+      "None": "Nessuno",
       "Interest": "Interesse",
       "Fee and Interest": "Commissione e interessi",
       "Creocore Unique": "Creocore unico",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -683,7 +683,7 @@
       "Reduce EMI amount": "Reduzir quantidade",
       "Reduce number of installments": "Reduza o número de parcelas",
       "Reschedule next repayments": "Reprogramar próximos pagamentos",
-      "None": "Capital",
+      "None": "Nenhum",
       "Interest": "Interesse",
       "Fee and Interest": "Taxa e juros",
       "Creocore Unique": "Creocore Único",


### PR DESCRIPTION
## Description

Currently in Deposit, FD and RD products/Account configuration, we could set the “Interest Compounding Period” to Daily/Weekly/Monthly/Yearly.  However, there is no option for of No-Interest Compounding for any of these products.  This is a GAP for organizations that Adapt No-Interest compounding products.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the displayed "None" label translation in German, Spanish (Chile and Mexico), French, Italian, and Portuguese to improve localization accuracy and ensure consistent wording in EMI/restructuring and repayment-related options across supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->