### PR TITLE
Replace a dependecy in version.js

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,6 +1,6 @@
 const { gitDescribeSync } = require('git-describe');
 const { resolve, relative } = require('path');
-const { writeFileSync } = require('fs-extra');
+const { writeFileSync } = require('node:fs');
 const moment = require('moment');
 
 const gitInfo = gitDescribeSync({


### PR DESCRIPTION
version.js had a dependency on fs-extra, which is
unnecessary, because we can use the built-in
Node functionality.

FIXES: WEB-351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency management by leveraging Node.js built-in modules instead of external packages, improving resource efficiency without user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->