### PR TITLE
WEB-352: Re-Amortization Interest Handling configuration

### DIFF
--- a/src/app/loans/common-resolvers/loan-action-button.resolver.ts
+++ b/src/app/loans/common-resolvers/loan-action-button.resolver.ts
@@ -81,6 +81,8 @@ export class LoanActionButtonResolver {
       return this.loansService.getLoanActionTemplate(loanId, 'buyDownFee');
     } else if (loanActionButton === 'Re-Age') {
       return this.loansService.getLoanActionTemplate(loanId, 'reAge');
+    } else if (loanActionButton === 'Re-Amortize') {
+      return this.loansService.getLoanActionTemplate(loanId, 'reAmortization');
     } else {
       return undefined;
     }

--- a/src/app/loans/loans-view/loan-account-actions/loan-reamortize/loan-reamortize.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/loan-reamortize/loan-reamortize.component.html
@@ -4,8 +4,32 @@
       <mat-card-content>
         <div class="layout-column">
           <mat-form-field>
+            <mat-label>{{ 'labels.inputs.Interest Handling' | translate }}</mat-label>
+            <mat-select formControlName="reAmortizationInterestHandling">
+              <mat-option
+                *ngFor="
+                  let reAmortizationInterestHandlingOption of reAmortizationInterestHandlingOptions;
+                  trackBy: trackByInterestHandlingOption
+                "
+                [value]="reAmortizationInterestHandlingOption.id"
+              >
+                {{ reAmortizationInterestHandlingOption.value | translateKey: 'catalogs' }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+        </div>
+
+        <div class="layout-column">
+          <mat-form-field>
             <mat-label>{{ 'labels.inputs.Reason' | translate }}</mat-label>
-            <input matInput formControlName="note" />
+            <mat-select formControlName="reasonCodeValueId">
+              <mat-option
+                *ngFor="let reAmortizationReasonOption of reAmortizationReasonOptions; trackBy: trackByReasonOption"
+                [value]="reAmortizationReasonOption.id"
+              >
+                {{ reAmortizationReasonOption.name }}
+              </mat-option>
+            </mat-select>
           </mat-form-field>
         </div>
 
@@ -13,6 +37,13 @@
           <mat-form-field>
             <mat-label>{{ 'labels.inputs.External Id' | translate }}</mat-label>
             <input matInput formControlName="externalId" />
+          </mat-form-field>
+        </div>
+
+        <div class="layout-column">
+          <mat-form-field>
+            <mat-label>{{ 'labels.inputs.Note' | translate }}</mat-label>
+            <input matInput formControlName="note" />
           </mat-form-field>
         </div>
 

--- a/src/app/loans/loans-view/loan-account-actions/loan-reamortize/loan-reamortize.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/loan-reamortize/loan-reamortize.component.ts
@@ -1,7 +1,9 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
 import { LoansService } from 'app/loans/loans.service';
+import { CodeValue } from 'app/shared/models/general.model';
+import { OptionData } from 'app/shared/models/option-data.model';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
 @Component({
@@ -18,6 +20,8 @@ export class LoanReamortizeComponent implements OnInit {
   loanId: string;
   /** ReAmortize Loan Form */
   reamortizeLoanForm: UntypedFormGroup;
+  reAmortizationReasonOptions: CodeValue[] = [];
+  reAmortizationInterestHandlingOptions: OptionData[] = [];
 
   constructor(
     private formBuilder: UntypedFormBuilder,
@@ -29,11 +33,18 @@ export class LoanReamortizeComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.reAmortizationReasonOptions = this.dataObject?.reAmortizationReasonOptions || [];
+    this.reAmortizationInterestHandlingOptions = this.dataObject?.reAmortizationInterestHandlingOptions || [];
+
     this.createReAmortizeLoanForm();
   }
 
   createReAmortizeLoanForm() {
     this.reamortizeLoanForm = this.formBuilder.group({
+      reAmortizationInterestHandling: [
+        this.reAmortizationInterestHandlingOptions[0] || null
+      ],
+      reasonCodeValueId: null,
       note: '',
       externalId: ''
     });
@@ -44,5 +55,13 @@ export class LoanReamortizeComponent implements OnInit {
     this.loanService.submitLoanActionButton(this.loanId, data, 'reAmortize').subscribe((response: any) => {
       this.router.navigate(['../../transactions'], { relativeTo: this.route });
     });
+  }
+
+  trackByInterestHandlingOption(index: number, option: OptionData): string | number {
+    return option.id ?? index;
+  }
+
+  trackByReasonOption(index: number, option: CodeValue): string | number {
+    return option.id ?? index;
   }
 }


### PR DESCRIPTION
## Description

User should be able to select the following Interest handling subtypes from the drop down during application of re-amortization to the loan account

- Default Behavior
- Waive Interest
- Equal Overdue Interest Split

## Related issues and discussion

[WEB-352](https://mifosforge.jira.com/browse/WEB-352)

## Screenshots, if any

<img width="1030" height="498" alt="Screenshot 2025-10-21 at 8 30 36 p m" src="https://github.com/user-attachments/assets/e66f61b8-d958-4789-bc04-2faf5223516f" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-352]: https://mifosforge.jira.com/browse/WEB-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled "Re‑Amortize" loan action so it appears and launches the re‑amortization flow.
  * Added interest‑handling selection to the re‑amortization form.
  * Replaced freeform reason input with a standardized reason dropdown.
  * Added a dedicated Note field.
  * Preserved External ID field and existing Cancel/Submit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->