### PR TITLE
WEB-354 Wrong markup in create-user.component.html

### DIFF
--- a/src/app/users/create-user/create-user.component.html
+++ b/src/app/users/create-user/create-user.component.html
@@ -17,7 +17,7 @@
             <input matInput [required]="userForm.controls.sendPasswordToEmail.value" formControlName="email" />
             <mat-error *ngIf="userForm.controls.email.hasError('email')">
               {{ 'labels.inputs.Email' | translate }} {{ 'labels.commons.is' | translate }}
-              <strong>{{"labels.commons.invalid' | translate}}</strong>
+              <strong>{{ 'labels.commons.invalid' | translate }}</strong>
             </mat-error>
             <mat-error *ngIf="userForm.controls.email.hasError('required')">
               {{ 'labels.inputs.Email' | translate }} {{ 'labels.commons.is' | translate }}


### PR DESCRIPTION
## Description

This PR fixes a minor markup error in the create-user.component.html template. A missing single quote in an Angular translate pipe ({{"labels.commons.invalid' | translate}}) was causing a rendering error.

This change corrects the syntax to {{ 'labels.commons.invalid' | translate }} to match the project's conventions and ensure the translation works correctly.
## Related issues and discussion

#{Issue Number}
Fixes #WEB-354
## Screenshots, if any
N/A
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x ] If you have multiple commits please combine them into one commit by squashing them.

- [ x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a translation binding issue in the email validation error message that was preventing proper display of localized text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->