### PR TITLE
WEB-378-improve the css office-navigation-page

### DIFF
--- a/src/app/navigation/navigation.component.scss
+++ b/src/app/navigation/navigation.component.scss
@@ -1,0 +1,54 @@
+:host {
+  display: block;
+}
+
+.container {
+  width: 100%;
+}
+
+.layout-row-wrap.responsive-column {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.flex-48 {
+  flex: 1 1 48%;
+  min-width: 320px;
+}
+
+mat-card {
+  padding: 16px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+mat-card-content {
+  display: grid;
+  grid-template-columns: 100%;
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+mat-label {
+  letter-spacing: 0.2px;
+}
+
+@media (768px <= width) {
+  mat-card-content {
+    grid-template-columns: 50% 50%;
+  }
+}
+
+@media (1200px <= width) {
+  .flex-48 {
+    flex-basis: 48%;
+  }
+
+  mat-card-content {
+    grid-template-columns: 50% 50%;
+    gap: 16px;
+  }
+}

--- a/src/app/navigation/office-navigation/office-navigation.component.html
+++ b/src/app/navigation/office-navigation/office-navigation.component.html
@@ -1,4 +1,4 @@
-<mat-card-header class="layout-row gap-5percent header">
+<mat-card-header class="layout-row header">
   <fa-icon class="main-icon" icon="building" size="3x"></fa-icon>
   <mat-card-title-group>
     <div class="mat-typography">
@@ -7,19 +7,20 @@
           {{ officeData.name }}
         </h2>
       </mat-card-title>
-      <mat-card-subtitle>
-        <p *ngIf="officeData.externalId">
-          {{ 'labels.inputs.External Id' | translate }}:<mifosx-external-identifier
-            externalId="{{ officeData.externalId }}"
-          ></mifosx-external-identifier>
-        </p>
-      </mat-card-subtitle>
     </div>
   </mat-card-title-group>
 </mat-card-header>
 
 <mat-card-content>
   <div class="layout-row-wrap">
+    <div class="flex-50 mat-body-strong" *ngIf="officeData.externalId">
+      {{ 'labels.inputs.External Id' | translate }}
+    </div>
+
+    <div class="flex-50" *ngIf="officeData.externalId">
+      <mifosx-external-identifier externalId="{{ officeData.externalId }}"></mifosx-external-identifier>
+    </div>
+
     <div class="flex-50 mat-body-strong">
       {{ 'labels.inputs.Opened On' | translate }}
     </div>

--- a/src/app/navigation/office-navigation/office-navigation.component.scss
+++ b/src/app/navigation/office-navigation/office-navigation.component.scss
@@ -1,14 +1,76 @@
-h2 {
-  font-weight: 500;
+:host {
+  --border-color: #ddd;
 }
 
-.content {
-  div {
-    margin: 1rem 0;
-    word-wrap: break-word;
+.header {
+  padding: 1.5rem 1.5rem 1rem;
+  align-items: center;
+  gap: 1rem;
+
+  .main-icon {
+    margin: 0;
+  }
+
+  mat-card-title-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    flex: 1;
+  }
+
+  mat-card-title h2 {
+    font-weight: 500;
+    font-size: 1.5rem;
+    margin: 0;
+    line-height: 1.4;
   }
 }
 
-.main-icon {
-  margin: 7px 0 0;
+mat-card-content {
+  padding: 1.5rem;
+
+  .layout-row-wrap {
+    display: grid;
+    grid-template-columns: 50% 50%;
+
+    @media (width <= 768px) {
+      grid-template-columns: 100%;
+    }
+  }
+
+  .flex-50 {
+    padding: 0.625rem 0;
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid #ddd;
+  }
+
+  .mat-body-strong {
+    font-weight: 600;
+    font-size: 0.875rem;
+  }
+
+  div:not(.mat-body-strong) {
+    font-size: 0.875rem;
+    word-wrap: break-word;
+    line-height: 1.6;
+  }
+}
+
+@media (width <= 480px) {
+  .header {
+    padding: 1rem;
+
+    .main-icon {
+      margin-bottom: 0.5rem;
+    }
+
+    mat-card-title h2 {
+      font-size: 1.25rem;
+    }
+  }
+
+  mat-card-content {
+    padding: 1rem;
+  }
 }

--- a/src/app/navigation/office-navigation/office-navigation.component.ts
+++ b/src/app/navigation/office-navigation/office-navigation.component.ts
@@ -1,12 +1,6 @@
 /** Angular Imports */
 import { Component, Input } from '@angular/core';
-import {
-  MatCardHeader,
-  MatCardTitleGroup,
-  MatCardTitle,
-  MatCardSubtitle,
-  MatCardContent
-} from '@angular/material/card';
+import { MatCardHeader, MatCardTitleGroup, MatCardTitle, MatCardContent } from '@angular/material/card';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ExternalIdentifierComponent } from '../../shared/external-identifier/external-identifier.component';
 import { DateFormatPipe } from '../../pipes/date-format.pipe';
@@ -22,7 +16,6 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     FaIconComponent,
     MatCardTitleGroup,
     MatCardTitle,
-    MatCardSubtitle,
     ExternalIdentifierComponent,
     DateFormatPipe
   ]


### PR DESCRIPTION
## Description

Improved the CSS styling of the Office Navigation page to ensure proper alignment of icon.
This change enhances the visual consistency and layout across the navigation section, improving user experience.

#{Issue Number}
WEB-378
## Screenshots, if any
before:
<img width="1695" height="357" alt="Screenshot 2025-10-28 012441" src="https://github.com/user-attachments/assets/fc000cf1-f023-4936-b481-00665b0baa9e" />
after:
<img width="1618" height="555" alt="Screenshot 2025-11-01 231630" src="https://github.com/user-attachments/assets/286aa437-2b69-4da5-9d8e-09771db4ca30" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [ X ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced responsive layouts: new flex/grid behavior, breakpoints at 768px and 1200px, improved spacing and small-screen adjustments.
  * Refined header and card typography with a stronger body style and adjusted sizing; improved dark-theme color overrides.

* **Refactor**
  * Moved external identifier out of the header into the card content for clearer presentation and simplified header structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->