### PR TITLE
WEB-369 It must not be possible to save an Account despite unpopulated required fields

### DIFF
--- a/src/app/accounting/chart-of-accounts/edit-gl-account/edit-gl-account.component.html
+++ b/src/app/accounting/chart-of-accounts/edit-gl-account/edit-gl-account.component.html
@@ -90,7 +90,7 @@
         <button
           mat-raised-button
           color="primary"
-          [disabled]="glAccountForm.pristine"
+          [disabled]="glAccountForm.invalid || glAccountForm.pristine"
           *mifosxHasPermission="'UPDATE_GLACCOUNT'"
         >
           {{ 'labels.buttons.Submit' | translate }}


### PR DESCRIPTION
**Changes Made :-**

-Disabled Submit button when required fields are empty or form is pristine, ensuring users cannot save or update a GL Account with missing required fields and validation messages are shown.

[WEB-369](https://mifosforge.jira.com/jira/software/c/projects/GSBX/boards/364?selectedIssue=WEB-369)

[WEB-369]: https://mifosforge.jira.com/browse/WEB-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The Submit button on the GL Account edit form now prevents submission when the form contains invalid data, ensuring data integrity before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->