### PR TITLE
WEB-366 Opening Audit Trails page causes Javascript error

### DIFF
--- a/src/app/system/audit-trails/audit-trails.component.ts
+++ b/src/app/system/audit-trails/audit-trails.component.ts
@@ -358,9 +358,11 @@ export class AuditTrailsComponent implements OnInit, AfterViewInit {
 
     //this.sort.sortChange.subscribe(() => (this.paginator.pageIndex = 0));
 
-    merge(this.sort.sortChange, this.paginator.page)
-      .pipe(tap(() => this.loadAuditTrailsPage()))
-      .subscribe();
+    if (this.sort && this.paginator) {
+      merge(this.sort.sortChange, this.paginator.page)
+        .pipe(tap(() => this.loadAuditTrailsPage()))
+        .subscribe();
+    }
   }
 
   /**
@@ -381,7 +383,7 @@ export class AuditTrailsComponent implements OnInit, AfterViewInit {
    * Loads a page of audit trails.
    */
   loadAuditTrailsPage() {
-    if (!this.sort.direction) {
+    if (this.sort && !this.sort.direction) {
       delete this.sort.active;
     }
     this.getAuditTrails();
@@ -393,7 +395,9 @@ export class AuditTrailsComponent implements OnInit, AfterViewInit {
    * @param {string} property Property to filter data by.
    */
   applyFilter(filterValue: string, property: string) {
-    this.paginator.pageIndex = 0;
+    if (this.paginator) {
+      this.paginator.pageIndex = 0;
+    }
     const findIndex = this.filterAuditTrailsBy.findIndex((filter) => filter.type === property);
     this.filterAuditTrailsBy[findIndex].value = filterValue;
     this.loadAuditTrailsPage();
@@ -544,7 +548,7 @@ export class AuditTrailsComponent implements OnInit, AfterViewInit {
       'clientName'
     ];
     this.systemService
-      .getAuditTrails(this.filterAuditTrailsBy, this.sort.active ? this.sort.active : '', this.sort.direction, 0, -1)
+      .getAuditTrails(this.filterAuditTrailsBy, this.sort?.active ?? '', this.sort?.direction ?? '', 0, -1)
       .subscribe((response: any) => {
         if (response !== undefined) {
           let csv = response.pageItems.map((row: any) =>


### PR DESCRIPTION
**Changes Made :-**

-Fixed a JavaScript error on the Audit Trails page by adding a null check for sort and paginator .

[WEB-366](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-366)

[WEB-366]: https://mifosforge.jira.com/browse/WEB-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented runtime errors by ensuring sorting and pagination controls are initialized before use, improving stability when navigating audit trails.
  * Fixed filtering behavior so page resets only occur when pagination is available.
  * Made CSV export more robust by tolerating missing sort state, preventing failed downloads or incorrect sort metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->