### PR TITLE
WEB-381: Fix dark mode preference not persisting after reload

### DIFF
--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -255,11 +255,11 @@ export class SettingsService {
     });
   }
 
-  setThemeDarkEnabled(enabled: string) {
-    localStorage.setItem('mifosXThemeDarkEnabled', enabled);
+  setThemeDarkEnabled(enabled: boolean) {
+    localStorage.setItem('mifosXThemeDarkEnabled', JSON.stringify(enabled));
   }
 
-  get themeDarkEnabled() {
+  get themeDarkEnabled(): boolean {
     return JSON.parse(localStorage.getItem('mifosXThemeDarkEnabled'));
   }
 }

--- a/src/app/shared/theme-toggle/theme-toggle.component.ts
+++ b/src/app/shared/theme-toggle/theme-toggle.component.ts
@@ -24,16 +24,16 @@ export class ThemeToggleComponent implements OnInit, OnChanges {
   ) {}
 
   ngOnInit(): void {
-    this.darkModeOn = this.settingsService.themeDarkEnabled === 'true';
+    this.darkModeOn = !!this.settingsService.themeDarkEnabled;
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    this.darkModeOn = this.settingsService.themeDarkEnabled === 'true';
+    this.darkModeOn = !!this.settingsService.themeDarkEnabled;
   }
 
   toggleTheme() {
     this.darkModeOn = !this.darkModeOn;
-    this.settingsService.setThemeDarkEnabled(this.darkModeOn ? 'true' : 'false');
+    this.settingsService.setThemeDarkEnabled(this.darkModeOn);
     this.themingService.setDarkMode(this.darkModeOn);
   }
 }

--- a/src/app/web-app.component.ts
+++ b/src/app/web-app.component.ts
@@ -148,7 +148,7 @@ export class WebAppComponent implements OnInit {
       this.cssClass = value;
     });
     this.themingService.setInitialDarkMode();
-    this.themingService.setDarkMode(this.settingsService.themeDarkEnabled === 'true');
+    this.themingService.setDarkMode(!!this.settingsService.themeDarkEnabled);
 
     // Setup logger
     if (environment.production) {


### PR DESCRIPTION
This update fixes the issue where dark mode resets to light mode after reloading the page.
The problem occurred because the theme value stored in localStorage was saved as a boolean but compared as a string ('true'), which caused the check to fail.

The fix ensures that the saved theme preference is read correctly on startup, so the user’s chosen mode (dark or light) now stays consistent after a reload.
#{Issue Number}
WEB-381
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ X ] If you have multiple commits please combine them into one commit by squashing them.

- [ X ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the theme preference system to improve consistency and maintainability of dark mode state handling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->