### PR TITLE
WEB-382: Fix runtime error in SettingsService.getBusinessDates

### DIFF
--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -248,7 +248,7 @@ export class SettingsService {
         this.setBusinessDate(this.dateUtils.formatDate(dateVal, SettingsService.businessDateFormat));
         this.alertService.alert({
           type: dateType + ' Set',
-          message: this.dateUtils.formatDate(dateVal, this.dateFormat())
+          message: this.dateUtils.formatDate(dateVal, this.dateFormat)
         });
         return;
       }


### PR DESCRIPTION
## Description

This update fixes a runtime error in SettingsService.getBusinessDates.
The issue happened because dateFormat was being called like a function, even though it’s actually a getter.
This caused the error “this.dateFormat is not a function” when the code ran, which broke business date notifications.

#{Issue Number}
WEB-382

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ X  ] If you have multiple commits please combine them into one commit by squashing them.

- [ X ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency in settings functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->