### PR TITLE
WEB-383: Improve layout consistency on bulk-loan-reassignment page

### DIFF
--- a/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.scss
+++ b/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.scss
@@ -1,3 +1,29 @@
+.container {
+  display: flex;
+  justify-content: center;
+  padding: 16px 12px;
+}
+
+.container > mat-card {
+  width: 100%;
+  max-width: 560px;
+  margin: 0 auto;
+  border-radius: 4px;
+  padding: 16px 20px;
+  box-shadow:
+    0 1px 3px rgb(16 24 40 / 10%),
+    0 1px 2px rgb(16 24 40 / 6%);
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+.flex-48 {
+  flex: 1 1 100%;
+  min-width: 100%;
+}
+
 table {
-  border: none;
+  width: 100%;
 }


### PR DESCRIPTION
## Description
This update fixes the layout inconsistency on the bulk-loan-reassignment page.
The box  width is now consistent with other pages, and each form row fits properly inside the box.
The box stays centered, tables fill the width correctly, and the overall layout looks cleaner and more balanced.
#{Issue Number}
WEB-383
## Screenshots, if any
before:
<img width="1689" height="571" alt="Screenshot 2025-10-29 163024" src="https://github.com/user-attachments/assets/3680b1e4-7c03-4dd7-8093-fc6265ca0b75" />
after:
<img width="1616" height="846" alt="Screenshot 2025-10-29 164425" src="https://github.com/user-attachments/assets/48e535e1-73e1-4cc1-87e4-84a4cfb9cd7a" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ X ] If you have multiple commits please combine them into one commit by squashing them.

- [  X ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual presentation of the bulk loan reassignment interface with improved layout, spacing, and card styling for better visual hierarchy and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->