### PR TITLE
WEB-385-improve the css of create-loan-provisioning

### DIFF
--- a/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.scss
+++ b/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.scss
@@ -1,0 +1,62 @@
+.container {
+  padding: 0.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.layout-row {
+  display: flex;
+  flex-direction: row;
+}
+
+mat-card {
+  padding: 1rem;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 10%) !important;
+  border-radius: 8px;
+
+  .layout-row {
+    margin-bottom: 0.5rem;
+  }
+}
+
+.mat-elevation-z1 {
+  padding: 1rem;
+  margin-top: 0.5rem;
+  border-radius: 4px;
+}
+
+table {
+  width: 100%;
+
+  th {
+    font-weight: 600;
+  }
+}
+
+.m-t-20 {
+  margin-top: 2rem;
+}
+
+.layout-align-center {
+  align-items: center;
+  justify-content: center;
+}
+
+@media (width <= 768px) {
+  .container {
+    padding: 0.5rem;
+  }
+
+  mat-card {
+    padding: 1rem;
+  }
+
+  .layout-row {
+    flex-direction: column;
+  }
+
+  .gap-20px {
+    flex-direction: column;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Adds proper spacing between the two columns to improve the overall visual balance 

[WEB-385](https://mifosforge.jira.com/browse/WEB-385)

before:
<img width="1414" height="567" alt="Screenshot 2025-10-30 002321" src="https://github.com/user-attachments/assets/be892d6d-55cb-422b-966a-d4e37973320f" />
after:
<img width="1418" height="740" alt="Screenshot 2025-10-30 002620" src="https://github.com/user-attachments/assets/a1fc6e65-28ea-454e-bb10-1fb5976366e4" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [  X ] If you have multiple commits please combine them into one commit by squashing them.

- [ X ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual styling for the loan provisioning criteria interface with improved spacing, shadows, and card layouts.
  * Optimized responsive design for mobile devices (screens 768px and below) with adjusted spacing and vertical layout adjustments.
  * Improved table presentation with refined header styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WEB-385]: https://mifosforge.jira.com/browse/WEB-385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ