### PR TITLE
WEB-387: Loan repayment installment style color overdue

### DIFF
--- a/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.ts
+++ b/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.ts
@@ -11,8 +11,8 @@ import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
 
 import { jsPDF, jsPDFOptions } from 'jspdf';
 import autoTable from 'jspdf-autotable';
-import { NgIf, NgClass, CurrencyPipe } from '@angular/common';
-import { MatButton, MatIconButton } from '@angular/material/button';
+import { NgClass, CurrencyPipe } from '@angular/common';
+import { MatIconButton } from '@angular/material/button';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import {
   MatTable,
@@ -172,6 +172,7 @@ export class RepaymentScheduleTabComponent implements OnInit, OnChanges {
     if (!installment.fromDate) {
       return '';
     } else {
+      this.businessDate = this.settingsService.businessDate;
       const fromDate = this.dateUtils.parseDate(installment.fromDate);
       const dueDate = this.dateUtils.parseDate(installment.dueDate);
       if (fromDate <= this.businessDate && this.businessDate < dueDate) {


### PR DESCRIPTION
## Description

Loan repayment installment style color overdue when the Business Date is before the Installment due date

(WEB-387)[https://mifosforge.jira.com/browse/WEB-387]

## Screenshots

- Before
<img width="1171" height="1222" alt="4689520b-d527-4d08-8e30-8b2af03c2984" src="https://github.com/user-attachments/assets/3f730028-92a8-40b9-81f3-7642604609c6" />


- After

<img width="1504" height="1044" alt="Screenshot 2025-10-30 at 3 04 22 p m" src="https://github.com/user-attachments/assets/e91677be-81ad-4d11-a16e-cbfd829e3869" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Changes**
  * Updated button components to icon buttons for improved interface consistency.

* **Bug Fixes**
  * Enhanced data refresh logic to ensure current date information is properly maintained during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->