### PR TITLE
Web 392 fix bulk import button alignment

### DIFF
--- a/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.html
+++ b/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.html
@@ -66,13 +66,13 @@
         'labels.text.Please retain the value Entity/Person in the filename.' | translate
       }}</mat-hint>
 
+      <div class="flex-spacer"></div>
+
       <div class="flex-13">
         <button mat-raised-button color="primary" [disabled]="!template" (click)="uploadTemplate()">
           <i class="fa fa-upload"></i>&nbsp;&nbsp;{{ 'labels.buttons.Upload' | translate }}
         </button>
       </div>
-
-      <div *ngIf="bulkImport.formFields >= 2" class="flex cover"></div>
     </mat-card>
   </div>
 

--- a/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.scss
+++ b/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.scss
@@ -20,6 +20,7 @@
       display: flex;
       flex-direction: column;
       border-radius: 20px;
+      min-height: 400px;
 
       h3 {
         margin: 0 0 20px;
@@ -36,7 +37,6 @@
       mat-card-content {
         padding: 0;
         margin-bottom: 20px;
-        flex-grow: 1;
 
         mat-form-field {
           width: 100%;
@@ -53,6 +53,11 @@
           font-weight: 500;
           width: 100%;
         }
+      }
+
+      .flex-spacer {
+        flex: 1;
+        min-height: 20px;
       }
 
       mifosx-file-upload {


### PR DESCRIPTION
On the Home → Organisation → Bulk Import → Loan Account page, the Download and Upload buttons were misaligned.
The buttons appeared uneven and did not follow the standard UI layout, resulting in an inconsistent look and feel compared to other pages.

Steps to Reproduce:

Navigate to Home → Organisation → Bulk Import → Loan Account.

Observe the Download and Upload buttons.

Notice that their alignment and spacing are not consistent.

Expected Behavior:
Both buttons should be properly aligned on the same line with consistent spacing and padding, following the UI design standards.

Actual Behavior:
Buttons appeared misaligned and unevenly spaced.

### BEFORE
<img width="1315" height="544" alt="Screenshot 2025-11-03 at 1 23 09 AM" src="https://github.com/user-attachments/assets/62d442ef-aefd-4a81-882d-92fded28a6a4" />

### AFTER
<img width="1296" height="551" alt="Screenshot 2025-11-03 at 1 41 12 AM" src="https://github.com/user-attachments/assets/579d485a-525d-45e5-8886-9be466604ef8" />

### Fix Implemented

Adjusted the CSS layout to ensure both buttons are aligned horizontally.

Used flexbox and consistent spacing (gap / margin) for better alignment.

Verified that the layout remains responsive across different screen sizes.

Result:
**The Download and Upload buttons are now properly aligned, creating a uniform and visually consistent UI.**




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted layout spacing and alignment in the bulk import view component.
  * Set fixed minimum height for the card container.
  * Improved vertical spacing using a spacer utility class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->