### PR TITLE
WEB-373 Javascript error message opening the first step of  Create Loans Account 

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -204,7 +204,7 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
         isEqualAmortization: this.loansAccountTermsData.isEqualAmortization,
         interestType: this.loansAccountTermsData.interestType.id,
         // TODO: 2025-03-17: Is this correct?
-        isFloatingInterestRate: this.loansAccountTermsData.isLoanProductLinkedToFloatingRate ? false : '',
+        isFloatingInterestRate: this.loansAccountTermsData.isLoanProductLinkedToFloatingRate ? false : null,
         interestCalculationPeriodType: this.loansAccountTermsData.interestCalculationPeriodType.id,
         allowPartialPeriodInterestCalculation: this.loansAccountTermsData.allowPartialPeriodInterestCalculation,
         inArrearsTolerance: this.loansAccountTermsData.inArrearsTolerance,
@@ -291,12 +291,12 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
       if (this.allowAddDisbursementDetails()) {
         this.loansAccountTermsForm.addControl(
           'maxOutstandingLoanBalance',
-          new UntypedFormControl(this.loansAccountTermsData.maxOutstandingLoanBalance, Validators.required)
+          new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null, Validators.required)
         );
       } else {
         this.loansAccountTermsForm.addControl(
           'maxOutstandingLoanBalance',
-          new UntypedFormControl(this.loansAccountTermsData.maxOutstandingLoanBalance)
+          new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null)
         );
       }
     }
@@ -330,7 +330,7 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
         amortizationType: this.loansAccountTermsData.amortizationType.id,
         isEqualAmortization: this.loansAccountTermsData.isEqualAmortization,
         interestType: this.loansAccountTermsData.interestType.id,
-        isFloatingInterestRate: this.loansAccountTermsData.isLoanProductLinkedToFloatingRate ? false : '',
+        isFloatingInterestRate: this.loansAccountTermsData.isLoanProductLinkedToFloatingRate ? false : null,
         interestCalculationPeriodType: this.loansAccountTermsData.interestCalculationPeriodType.id,
         allowPartialPeriodInterestCalculation: this.loansAccountTermsData.allowPartialPeriodInterestCalculation,
         inArrearsTolerance: this.loansAccountTermsData.inArrearsTolerance,
@@ -358,12 +358,12 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
       this.loansAccountTermsForm.removeControl('maxOutstandingLoanBalance');
       this.loansAccountTermsForm.addControl(
         'maxOutstandingLoanBalance',
-        new UntypedFormControl(this.loansAccountTermsData.maxOutstandingLoanBalance, Validators.required)
+        new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null, Validators.required)
       );
     } else {
       this.loansAccountTermsForm.addControl(
         'maxOutstandingLoanBalance',
-        new UntypedFormControl(this.loansAccountTermsData.maxOutstandingLoanBalance)
+        new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null)
       );
     }
   }
@@ -492,7 +492,7 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
       interestChargedFromDate: [''],
       interestRatePerPeriod: [''],
       interestType: [''],
-      isFloatingInterestRate: [''],
+      isFloatingInterestRate: [null],
       isEqualAmortization: [''],
       amortizationType: [
         '',


### PR DESCRIPTION
**Changes Made :-**

-Fixed a JavaScript error when opening the first step of "Create Loans Account" by adding a null check for [maxOutstandingLoanBalance]

[WEB-373
](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-373)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized loan account form defaults so missing numeric and flag fields (e.g., max outstanding balance and floating interest indicator) initialize as null instead of empty strings.
  * Ensures consistent behavior during initial load, re-initialization and control re-addition so required validation and form controls behave predictably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->