### PR TITLE
WEB-374 Create Charge page throws Javascript error

### DIFF
--- a/src/app/products/charges/create-charge/create-charge.component.ts
+++ b/src/app/products/charges/create-charge/create-charge.component.ts
@@ -75,13 +75,12 @@ export class CreateChargeComponent implements OnInit {
   ) {
     this.route.data.subscribe((data: { chargesTemplate: any }) => {
       this.chargesTemplateData = data.chargesTemplate;
-      if (data.chargesTemplate.incomeOrLiabilityAccountOptions.liabilityAccountOptions) {
-        this.incomeAndLiabilityAccountData =
-          data.chargesTemplate.incomeOrLiabilityAccountOptions.incomeAccountOptions.concat(
-            data.chargesTemplate.incomeOrLiabilityAccountOptions.liabilityAccountOptions
-          );
+      const incomeOptions = data.chargesTemplate.incomeOrLiabilityAccountOptions.incomeAccountOptions || [];
+      const liabilityOptions = data.chargesTemplate.incomeOrLiabilityAccountOptions.liabilityAccountOptions || [];
+      if (liabilityOptions.length > 0) {
+        this.incomeAndLiabilityAccountData = incomeOptions.concat(liabilityOptions);
       } else {
-        this.incomeAndLiabilityAccountData = data.chargesTemplate.incomeOrLiabilityAccountOptions.incomeAccountOptions;
+        this.incomeAndLiabilityAccountData = incomeOptions;
       }
     });
   }


### PR DESCRIPTION
**Changes Made :-**

-Fixed JS error on "Create Charge" by adding a null check for [incomeAccountOptions] before using .concat.

[WEB-374](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-374)

[WEB-374]: https://mifosforge.jira.com/browse/WEB-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account option handling when creating charges by refining how liability and income account options are combined, preventing the display of invalid options in specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->