### PR TITLE
WEB-365 Utilizing Bulk Loan Reassignment does not work at all

### DIFF
--- a/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.html
+++ b/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.html
@@ -106,7 +106,9 @@
 
                   <tr *ngFor="let loans of groups.loans">
                     <td>
-                      <mat-checkbox>{{ loans.productName }}({{ loans.accountNo }})</mat-checkbox>
+                      <mat-checkbox (change)="getLoans($event, loans.id)"
+                        >{{ loans.productName }}({{ loans.accountNo }})</mat-checkbox
+                      >
                     </td>
                   </tr>
                 </table>

--- a/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.ts
+++ b/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.ts
@@ -107,10 +107,14 @@ export class BulkLoanReassignmnetComponent implements OnInit {
    * @param officerId Office Id.
    */
   getFromOfficers(officerId: any) {
-    this.toLoanOfficers = this.fromLoanOfficers.filter((officer: any) => officer.id !== officerId);
-    this.organizationSevice.getOfficerTemplate(officerId, this.officeTemplate.id).subscribe((response: any) => {
-      this.officerTemplate = response;
-    });
+    this.toLoanOfficers = this.fromLoanOfficers?.filter((officer: any) => officer.id !== officerId) || [];
+    if (officerId && this.officeTemplate && this.officeTemplate.id) {
+      this.organizationSevice.getOfficerTemplate(officerId, this.officeTemplate.id).subscribe((response: any) => {
+        this.officerTemplate = response;
+      });
+    } else {
+      this.officerTemplate = undefined;
+    }
   }
 
   /**


### PR DESCRIPTION
**Changes Made :-** 

-Fixed JS error and enabled loan selection in Bulk Loan Reassignment form by adding null checks and proper handlers.

[WEB-365](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-365)

[WEB-365]: https://mifosforge.jira.com/browse/WEB-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Group-loans checkbox now correctly responds to user toggles, matching client-loan behavior.
  * Added validation to avoid errors and unnecessary requests when required configuration/context is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->