### PR TITLE
 WEB-362-correct-position-and-trailing-comma-in-provisioning-criteria-loan-product

### DIFF
--- a/src/app/organization/loan-provisioning-criteria/view-loan-provisioning-criteria/view-loan-provisioning-criteria.component.html
+++ b/src/app/organization/loan-provisioning-criteria/view-loan-provisioning-criteria/view-loan-provisioning-criteria.component.html
@@ -12,15 +12,16 @@
 <div class="container">
   <mat-card>
     <mat-card-content>
-      <div class="layout-row-wrap">
-        <h2 class="mat-h2 flex-fill">{{ provisioningData.criteriaName }}</h2>
-        <mat-divider [inset]="true"></mat-divider>
-
-        <div class="loanProduct flex-fill">
-          <span class="flex-40">{{ 'labels.inputs.Loan Product' | translate }}:</span>
-          <span class="flex-60">{{ loanProducts }}</span>
-        </div>
+      <div class="layout-row-wrap align-center">
+        <h2 class="mat-h2 criteria-title">
+          {{ provisioningData.criteriaName }}
+        </h2>
+        <span class="loan-product-label">
+          <strong>{{ 'labels.inputs.Loan Product' | translate }}:</strong>
+          <span>{{ loanProducts }}</span>
+        </span>
       </div>
+      <mat-divider [inset]="true"></mat-divider>
 
       <div>
         <table mat-table class="mat-elevation-z1" [dataSource]="dataSource">

--- a/src/app/organization/loan-provisioning-criteria/view-loan-provisioning-criteria/view-loan-provisioning-criteria.component.scss
+++ b/src/app/organization/loan-provisioning-criteria/view-loan-provisioning-criteria/view-loan-provisioning-criteria.component.scss
@@ -1,3 +1,15 @@
+.criteria-title {
+  margin-bottom: 0;
+  display: inline;
+  vertical-align: middle;
+}
+
+.loan-product-label {
+  margin-left: 24px;
+  font-size: 1.1em;
+  vertical-align: middle;
+}
+
 table {
   width: 100%;
 }

--- a/src/app/organization/loan-provisioning-criteria/view-loan-provisioning-criteria/view-loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/view-loan-provisioning-criteria/view-loan-provisioning-criteria.component.ts
@@ -25,6 +25,8 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatDivider } from '@angular/material/divider';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
+import { LoanProduct } from 'app/products/loan-products/models/loan-product.model';
+
 /**
  * View Loan Provisioning
  */
@@ -93,9 +95,14 @@ export class ViewLoanProvisioningCriteriaComponent implements OnInit {
   setLoanProvisioningSelectedCriteria() {
     this.dataSource = new MatTableDataSource(this.provisioningData.definitions);
 
-    /** Get load products as a string. */
-    for (let _id = 0; _id < this.provisioningData.loanProducts.length; _id++) {
-      this.loanProducts += this.provisioningData.loanProducts[_id].name + ',';
+    // Get loan products as a comma-separated string, no trailing comma, with type safety
+    if (this.provisioningData.loanProducts && this.provisioningData.loanProducts.length > 0) {
+      this.loanProducts = (this.provisioningData.loanProducts as LoanProduct[])
+        .filter((p) => p && p.name)
+        .map((p) => p.name)
+        .join(', ');
+    } else {
+      this.loanProducts = '';
     }
   }
 


### PR DESCRIPTION
Changes Made :-

-Fixed layout and removed trailing comma for Loan Product display in Provisioning Criteria view.
-Ensured Loan Product names appear inline with the criteria name as requested.

[WEB-362](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-362)

[WEB-362]: https://mifosforge.jira.com/browse/WEB-362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loan product listing to remove trailing commas and handle missing or undefined items gracefully.

* **Style**
  * Simplified header into a single centered row, moved the divider below the header, and repositioned loan product info as a compact inline label beside the title for clearer layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->