### PR TITLE
WEB-363-missing-field-validation-for-selected-products-in-provisioning-criteria

### DIFF
--- a/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.ts
@@ -131,7 +131,10 @@ export class CreateLoanProvisioningCriteriaComponent implements OnInit {
         '',
         Validators.required
       ],
-      loanProducts: ['']
+      loanProducts: [
+        [],
+        Validators.required
+      ]
     });
   }
 
@@ -234,9 +237,10 @@ export class CreateLoanProvisioningCriteriaComponent implements OnInit {
    */
   submit() {
     const locale = this.settingsService.language.code;
+    const products = this.provisioningCriteriaForm.get('loanProducts').value;
     const loanProvisioningCriteria = {
       ...this.provisioningCriteriaForm.value,
-      loanProducts: this.provisioningCriteriaForm.get('loanProducts').value.map((product: any) => ({
+      loanProducts: products.map((product: any) => ({
         id: product.id,
         name: product.name,
         includeInBorrowerCycle: product.includeInBorrowerCycle


### PR DESCRIPTION
**Changes Made :-**

-Added required validation for the Selected Products field in Provisioning Criteria creation.
-Disabled the submit button when no product is selected.
-Displayed a validation error if the user tries to submit without selecting a product.
-Prevented JavaScript errors by ensuring .map is only called on arrays.

[WEB-363](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-363)

[WEB-363]: https://mifosforge.jira.com/browse/WEB-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Form now requires selecting loan products before submission, preventing incomplete submissions.
  * Submission reliably captures and submits the selected loan products to ensure correct provisioning criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->