### PR TITLE
WEB-357 Editing a holiday fails due to failure to parse from date format

### DIFF
--- a/src/app/organization/holidays/edit-holiday/edit-holiday.component.ts
+++ b/src/app/organization/holidays/edit-holiday/edit-holiday.component.ts
@@ -134,17 +134,17 @@ export class EditHolidayComponent implements OnInit {
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;
     if (!this.isActiveHoliday) {
-      if (this.reSchedulingType === 2) {
-        const repaymentScheduledTo: Date = this.holidayForm.value.repaymentsRescheduledTo;
-        holidayFormData.repaymentsRescheduledTo = this.dateUtils.formatDate(repaymentScheduledTo, dateFormat);
+      if (holidayFormData.fromDate instanceof Date) {
+        holidayFormData.fromDate = this.dateUtils.formatDate(holidayFormData.fromDate, dateFormat);
       }
-      const prevFromDate: Date = this.holidayForm.value.fromDate;
-      const prevToDate: Date = this.holidayForm.value.toDate;
-      if (holidayFormData.closureDate instanceof Date) {
-        holidayFormData.fromDate = this.dateUtils.formatDate(prevFromDate, dateFormat);
+      if (holidayFormData.toDate instanceof Date) {
+        holidayFormData.toDate = this.dateUtils.formatDate(holidayFormData.toDate, dateFormat);
       }
-      if (holidayFormData.closureDate instanceof Date) {
-        holidayFormData.toDate = this.dateUtils.formatDate(prevToDate, dateFormat);
+      if (this.reSchedulingType === 2 && holidayFormData.repaymentsRescheduledTo instanceof Date) {
+        holidayFormData.repaymentsRescheduledTo = this.dateUtils.formatDate(
+          holidayFormData.repaymentsRescheduledTo,
+          dateFormat
+        );
       }
     }
     const data = {


### PR DESCRIPTION
**Changes Made :-** 

-Fixed date formatting for [fromDate], [toDate],and [repaymentsRescheduledTo] fields in the Edit Holiday form.

[WEB-357](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-357)

[WEB-357]: https://mifosforge.jira.com/browse/WEB-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date field processing in the holiday edit interface to ensure consistent and reliable formatting when updating holiday schedules and rescheduled repayment dates. Date values are now directly validated and formatted based on their type, eliminating previous dependencies on cached form values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->