### PR TITLE
WEB-371 Cancelling the editing of an Accounting Rule leads to a 404

### DIFF
--- a/src/app/accounting/accounting-rules/edit-rule/edit-rule.component.html
+++ b/src/app/accounting/accounting-rules/edit-rule/edit-rule.component.html
@@ -121,7 +121,7 @@
       </mat-card-content>
 
       <mat-card-actions class="layout-row align-center gap-5px responsive-column">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button


### PR DESCRIPTION
**Changes Made :-**

-Fixed cancel button navigation in Accounting Rules edit form by changing routerLink from ['../../'] to ['../'] .
-Resolved 404 error by ensuring proper navigation to the specific accounting rule's view page instead of an invalid URL .

[WEB-371](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-371)

[WEB-371]: https://mifosforge.jira.com/browse/WEB-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Cancel button navigation in accounting rules editing to direct users to the correct parent page level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->