### PR TITLE
WEB-364 Deleting of a Loan Provisioning Criteria leads to a 404

### DIFF
--- a/src/app/organization/loan-provisioning-criteria/view-loan-provisioning-criteria/view-loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/view-loan-provisioning-criteria/view-loan-provisioning-criteria.component.ts
@@ -115,9 +115,14 @@ export class ViewLoanProvisioningCriteriaComponent implements OnInit {
     });
     deleteCriteriaDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
-        this.organizationService.deleteProvisioningCriteria(this.provisioningData.criteriaId).subscribe(() => {
-          this.router.navigate(['/organization/provisioningcriteria']);
-        });
+        this.organizationService.deleteProvisioningCriteria(this.provisioningData.criteriaId).subscribe(
+          () => {
+            this.router.navigate(['/organization/provisioning-criteria']);
+          },
+          (error) => {
+            console.error('Failed to delete provisioning criteria:', error);
+          }
+        );
       }
     });
   }


### PR DESCRIPTION
Changes Made :-

-Fixed redirect after deleting a Loan Provisioning Criteria to prevent 404 error.
-Now redirects user to the correct Loan Provisioning Criteria list page after deletion.

[WEB-364](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-364)

[WEB-364]: https://mifosforge.jira.com/browse/WEB-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the redirect destination after deleting loan provisioning criteria so users are sent to the proper section.
  * Added error handling and logging for delete operations to surface failures and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->