### PR TITLE
WEB-405-fix(find-pipe): sanitize HTML output to prevent XSS vulnerability

### DIFF
--- a/src/app/pipes/find.pipe.ts
+++ b/src/app/pipes/find.pipe.ts
@@ -1,12 +1,22 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, SecurityContext } from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 @Pipe({ name: 'find' })
 export class FindPipe implements PipeTransform {
-  transform(value: any, options: any, key: string, property: string): any {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value: any, options: any, key: string, property: string): SafeHtml | string {
     let optionFound;
-    if (options) {
-      optionFound = options.find((option: any) => option[key] === value);
+    if (options && Array.isArray(options)) {
+      optionFound = options.find((option: any) => option && option[key] === value);
     }
-    return optionFound ? optionFound[property] : '';
+
+    const result = optionFound ? optionFound[property] : '';
+
+    if (typeof result === 'string') {
+      return this.sanitizer.sanitize(SecurityContext.HTML, result) || '';
+    }
+
+    return String(result || '');
   }
 }


### PR DESCRIPTION
## Description

This PR improves the FindPipe by making it more secure and reliable.
Earlier, the pipe displayed raw HTML content without cleaning it, which could lead to security issues like XSS attacks.
#{Issue Number}
WEB-405
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer content handling: HTML content is now sanitized to prevent unsafe markup from rendering.
  * More robust data lookup: improved validation when selecting items so missing or unexpected values are handled gracefully, reducing display errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->