### PR TITLE
WEB-(407)-fix: add null safety and type guard for ErrorDialogComponent data

### DIFF
--- a/src/app/shared/error-dialog/error-dialog.component.html
+++ b/src/app/shared/error-dialog/error-dialog.component.html
@@ -1,8 +1,8 @@
 <h1 mat-dialog-title>{{ 'Error Log' | translate }}</h1>
 
 <div mat-dialog-content>
-  <p *ngIf="!showAsCode">{{ data }}</p>
-  <span *ngIf="showAsCode" [innerHTML]="data"></span>
+  <p *ngIf="!showAsCode">{{ displayData }}</p>
+  <span *ngIf="showAsCode" [innerHTML]="displayData"></span>
 </div>
 
 <mat-dialog-actions align="left">

--- a/src/app/shared/error-dialog/error-dialog.component.ts
+++ b/src/app/shared/error-dialog/error-dialog.component.ts
@@ -28,12 +28,25 @@ export class ErrorDialogComponent {
   showAsCode = false;
   /**
    * @param {MatDialogRef} dialogRef Component reference to dialog.
-   * @param {any} data Provides any data.
+   * @param {unknown} data Provides any data.
    */
   constructor(
     public dialogRef: MatDialogRef<ErrorDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: string
+    @Inject(MAT_DIALOG_DATA) public data: unknown
   ) {
-    this.showAsCode = data.startsWith('<pre><code>');
+    // Guard for non-string data to avoid runtime error
+    this.showAsCode = typeof data === 'string' && data.startsWith('<pre><code>');
+  }
+
+  /**
+   * Get display data with proper type safety for template usage.
+   * @returns {string} Safe string representation of the data.
+   */
+  get displayData(): string {
+    if (typeof this.data === 'string') {
+      return this.data;
+    }
+    // Convert non-string data to string representation for display
+    return this.data != null ? JSON.stringify(this.data) : '';
   }
 }

--- a/src/app/system/manage-data-tables/column-dialog/column-dialog.component.html
+++ b/src/app/system/manage-data-tables/column-dialog/column-dialog.component.html
@@ -8,7 +8,7 @@
     <div class="layout-column">
       <mat-form-field>
         <mat-label>{{ 'labels.inputs.Column Name' | translate }}</mat-label>
-        <input matInput required formControlName="name" />
+        <input matInput required formControlName="name" placeholder="{{ 'labels.inputs.Column Name' | translate }}" />
         <mat-error *ngIf="columnForm.controls.name.hasError('required')">
           {{ 'labels.inputs.Column Name' | translate }} {{ 'labels.commons.is' | translate }}
           <strong>{{ 'labels.commons.required' | translate }}</strong>
@@ -22,11 +22,21 @@
             {{ columnType.displayValue | translateKey: 'inputs' }}
           </mat-option>
         </mat-select>
+        <mat-error *ngIf="columnForm.controls.type.hasError('required')">
+          {{ 'labels.inputs.Column Type' | translate }} {{ 'labels.commons.is' | translate }}
+          <strong>{{ 'labels.commons.required' | translate }}</strong>
+        </mat-error>
       </mat-form-field>
 
       <mat-form-field *ngIf="columnForm.value.type === 'String'">
         <mat-label> {{ 'labels.inputs.Column Length' | translate }}</mat-label>
-        <input matInput required type="number" formControlName="length" />
+        <input
+          matInput
+          required
+          type="number"
+          formControlName="length"
+          placeholder="{{ 'labels.inputs.Column Length' | translate }}"
+        />
       </mat-form-field>
 
       <mat-form-field *ngIf="columnForm.value.type === 'Dropdown'">


### PR DESCRIPTION
## Description
This PR improves the ErrorDialogComponent by adding proper type safety and null checks for the injected dialog data.
#{Issue Number}
WEB-407

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error dialog now safely handles non-string or unexpected data formats, preventing runtime errors.

* **New Features / UI**
  * Added placeholders for name and length inputs and a visible validation message for the type field in the column dialog.

* **Documentation**
  * Clarified JSDoc/comments to reflect the broader accepted data type for error dialog input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->