### PR TITLE
WEB-(409)-fix: use strict equality (===) for status code checks to prevent acci…

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/client-approval/client-approval.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/client-approval/client-approval.component.ts
@@ -172,7 +172,7 @@ export class ClientApprovalComponent {
     });
     this.tasksService.submitBatchData(this.batchRequests).subscribe((response: any) => {
       response.forEach((responseEle: any) => {
-        if ((responseEle.statusCode = '200')) {
+        if (responseEle.statusCode === '200') {
           activatedAccounts++;
           responseEle.body = JSON.parse(responseEle.body);
           if (selectedAccounts === activatedAccounts) {

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component.ts
@@ -202,7 +202,7 @@ export class LoanApprovalComponent {
     });
     this.tasksService.submitBatchData(this.batchRequests).subscribe((response: any) => {
       response.forEach((responseEle: any) => {
-        if ((responseEle.statusCode = '200')) {
+        if (responseEle.statusCode === '200') {
           approvedAccounts++;
           responseEle.body = JSON.parse(responseEle.body);
           if (selectedAccounts === approvedAccounts) {

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component.ts
@@ -154,7 +154,7 @@ export class LoanDisbursalComponent {
     });
     this.tasksService.submitBatchData(this.batchRequests).subscribe((response: any) => {
       response.forEach((responseEle: any) => {
-        if ((responseEle.statusCode = '200')) {
+        if (responseEle.statusCode === '200') {
           approvedAccounts++;
           responseEle.body = JSON.parse(responseEle.body);
           if (selectedAccounts === approvedAccounts) {


### PR DESCRIPTION
…dental assignment

## Description

This PR fixes an issue where the responseEle.statusCode comparison used the assignment operator (=) instead of strict equality (===).

#{Issue Number}
WEB-409
## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Corrected batch response validation logic in approval and disbursal workflows. Status code checks in client approval, loan approval, and loan disbursal processes have been fixed to properly validate successful server responses (HTTP 200), ensuring accurate account approval counting, preventing transaction processing errors, and maintaining system data integrity during all approval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->