### PR TITLE
WEB-(410)-fix: correct type comparison in view-history-scheduler-job filter logic

### DIFF
--- a/src/app/system/manage-jobs/scheduler-jobs/view-history-scheduler-job/view-history-scheduler-job.component.ts
+++ b/src/app/system/manage-jobs/scheduler-jobs/view-history-scheduler-job/view-history-scheduler-job.component.ts
@@ -113,9 +113,9 @@ export class ViewHistorySchedulerJobComponent implements OnInit {
       const filters = JSON.parse(filtersJson);
       filters.forEach((filter: any) => {
         const val = data[filter.id] === null ? '' : data[filter.id];
-        if (filter.value !== '') {
-          matchFilter.push(val === parseInt(filter.value, 10));
-        } else if (filter.value === '') {
+        if (filter.value !== '' && val !== '') {
+          matchFilter.push(parseInt(val.toString(), 10) === parseInt(filter.value, 10));
+        } else if (filter.value === '' || val === '') {
           matchFilter.push(val.toString().toLowerCase().includes(filter.value.toLowerCase()));
         }
       });


### PR DESCRIPTION
## Description
This PR fixes a type comparison bug in the view-history-scheduler-job component’s filter logic.
Previously, the code compared a string (val) with a number (parseInt(filter.value, 10)) using strict equality (===), which caused filtering by numeric values (like version numbers) to always return false

#{Issue Number}
WEB-(410)
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering behavior: numeric comparisons are now applied only when both the filter and the item value are present and numeric; otherwise the filter falls back to a case-insensitive text match. This prevents incorrect numeric comparisons and yields more intuitive results when fields or filter inputs are empty or non-numeric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->