### PR TITLE
WEB-411: Improve alignment of Debit and Credit Amount fields

### DIFF
--- a/src/app/accounting/create-journal-entry/create-journal-entry.component.html
+++ b/src/app/accounting/create-journal-entry/create-journal-entry.component.html
@@ -49,7 +49,7 @@
               >
               </mifosx-gl-account-selector>
 
-              <mat-form-field class="flex-43">
+              <mat-form-field class="flex-24">
                 <mat-label>{{ 'labels.inputs.Debit Amount' | translate }}</mat-label>
                 <input type="number" matInput required formControlName="amount" />
                 <mat-error *ngIf="debits.at(i).controls.amount.hasError('required')">
@@ -58,7 +58,7 @@
                 </mat-error>
               </mat-form-field>
 
-              <span class="flex-fill">
+              <span class="flex-24">
                 <button *ngIf="i !== 0" type="button" mat-icon-button (click)="removeAffectedGLEntry(debits, i)">
                   <fa-icon icon="minus-circle" size="lg"></fa-icon>
                 </button>
@@ -90,7 +90,7 @@
               >
               </mifosx-gl-account-selector>
 
-              <mat-form-field class="flex-43">
+              <mat-form-field class="flex-24">
                 <mat-label>{{ 'labels.inputs.Credit Amount' | translate }}</mat-label>
                 <input type="number" matInput required formControlName="amount" />
                 <mat-error *ngIf="credits.at(i).controls.amount.hasError('required')">
@@ -99,7 +99,7 @@
                 </mat-error>
               </mat-form-field>
 
-              <span class="flex-fill">
+              <span class="flex-24">
                 <button *ngIf="i !== 0" type="button" mat-icon-button (click)="removeAffectedGLEntry(credits, i)">
                   <fa-icon icon="minus-circle" size="lg"></fa-icon>
                 </button>


### PR DESCRIPTION
On the Create Journal Entry page, the alignment of the Debit Amount and Credit Amount fields is inconsistent. These fields leave unnecessary empty space and are not aligned with the corresponding GL Entry fields, which affects the visual balance of the form.

This update adjusts only the alignment of these two fields so they fill the vacant space appropriately. No other UI elements or layout sections were changed.

### What Was Improved

Aligned Debit Amount field next to “Affected GL Entry (Debit)” by removing the empty gap.

Aligned Credit Amount field next to “Affected GL Entry (Credit)” in the same way.

Ensured no other form layout, spacing, or styling was modified.
### Related Issues and Discussion

Fixes: #WEB-411

### Before:
<img width="1336" height="283" alt="Screenshot 2025-11-05 at 11 57 09 PM" src="https://github.com/user-attachments/assets/d700af1f-8981-45cd-89cf-8fdf6f6c6011" />



### After:

<img width="1278" height="225" alt="Screenshot 2025-11-06 at 12 37 06 AM" src="https://github.com/user-attachments/assets/ea5a5932-4128-4fb7-9ee4-db3f5b1709e3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Made Debit and Credit amount fields more compact and better aligned for improved form layout and easier data entry.

* **New Features**
  * Added an explicit add-entry button for the first row in both Debit and Credit sections; remove-entry controls remain available on subsequent rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->