### PR TITLE
WEB-(414)-Fixed the typo: recheduleLoansData → rescheduleLoansData (added missi…

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component.ts
@@ -96,8 +96,8 @@ export class RescheduleLoanComponent {
     private translateService: TranslateService,
     private tasksService: TasksService
   ) {
-    this.route.data.subscribe((data: { recheduleLoansData: any }) => {
-      this.loans = data.recheduleLoansData;
+    this.route.data.subscribe((data: { rescheduleLoansData: any }) => {
+      this.loans = data.rescheduleLoansData;
       this.dataSource = new MatTableDataSource(this.loans);
       this.selection = new SelectionModel(true, []);
     });

--- a/src/app/tasks/tasks-routing.module.ts
+++ b/src/app/tasks/tasks-routing.module.ts
@@ -71,7 +71,7 @@ const routes: Routes = [
           component: RescheduleLoanComponent,
           data: { title: 'Reschedule Loan' },
           resolve: {
-            recheduleLoansData: GetRescheduleLoans
+            rescheduleLoansData: GetRescheduleLoans
           }
         }
       ]


### PR DESCRIPTION
…ng 's')

## Description
Fixed the typo: recheduleLoansData → rescheduleLoansData (added missing 's')
#{Issue Number}
WEB-414

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing rescheduled loan data from loading properly in the loan rescheduling workflow, ensuring the feature functions correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->