### PR TITLE
WEB-375-fix: suppress console logs for expected 404 client image requests

### DIFF
--- a/src/app/core/http/error-handler.interceptor.ts
+++ b/src/app/core/http/error-handler.interceptor.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpErrorResponse } from '@angular/common/http';
 
 /** rxjs Imports */
-import { Observable } from 'rxjs';
+import { EMPTY, Observable } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 /** Environment Configuration */
@@ -50,7 +50,9 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
       }
     }
 
-    if (!environment.production) {
+    const isClientImage404 = status === 404 && request.url.includes('/clients/') && request.url.includes('/images');
+
+    if (!environment.production && !isClientImage404) {
       log.error(`Request Error: ${errorMessage}`);
     }
 
@@ -70,10 +72,10 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
       });
     } else if (status === 404) {
       // Check if this is an image request that should be silently handled (client profile image)
-      if (request.url.includes('/clients/') && request.url.includes('/images')) {
+      if (isClientImage404) {
         // Don't show alerts for missing client images
         // This is an expected condition, not an error
-        return new Observable<HttpEvent<any>>();
+        return EMPTY;
       } else {
         this.alertService.alert({
           type: this.translate.instant('error.resource.not.found'),


### PR DESCRIPTION
## Description
This pr fix the issue where 404 errors for missing client images were showing in the console.  
These 404s are expected because not all clients have profile images.
Now, the error handler skips logging these specific 404s while keeping other errors as usual.  

#{Issue Number}
WEB-375
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Client image 404 errors no longer trigger alerts and are handled silently.

* **Improvements**
  * Error messages now support localization for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->