### PR TITLE
WEB-369-fix(oauth2): replace localStorage with sessionStorage in callback com…

### DIFF
--- a/src/app/zitadel/callback/callback.component.ts
+++ b/src/app/zitadel/callback/callback.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from '../auth.service';
 
 @Component({
@@ -9,15 +9,27 @@ import { AuthService } from '../auth.service';
 export class CallbackComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
+    private router: Router,
     private authService: AuthService
   ) {}
 
-  ngOnInit(): void {
-    let code = localStorage.getItem('auth_code');
-
-    if (code) {
-      const codeVerifier = localStorage.getItem('code_verifier');
-      this.authService.exchangeCodeForTokens(code, codeVerifier);
+  async ngOnInit(): Promise<void> {
+    try {
+      const code = sessionStorage.getItem('auth_code');
+      if (code) {
+        const codeVerifier = sessionStorage.getItem('code_verifier');
+        try {
+          await this.authService.exchangeCodeForTokens(code, codeVerifier);
+        } finally {
+          // Clean up sensitive data immediately after use
+          sessionStorage.removeItem('auth_code');
+          sessionStorage.removeItem('code_verifier');
+        }
+      }
+    } catch (error) {
+      console.error('Authentication failed:', error);
+      // Navigate to login page
+      this.router.navigate(['/login']);
     }
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,7 @@
       }
       const code = getQueryParam('code');
       if (code) {
-        localStorage.setItem('auth_code', code);
+        sessionStorage.setItem('auth_code', code);
         window.location.href = '/#/callback';
       }
     </script>


### PR DESCRIPTION
…ponent

## Description

The pr resolves a security issue in the OAuth2 callback flow where sensitive authentication details (auth_code and code_verifier) were previously stored in localStorage, which is persistent and can be accessed by client-side scripts.

Now, these values are stored temporarily in sessionStorage, which is automatically cleared when the browser tab closes. This update ensures compliance with OAuth2 + PKCE (Proof Key for Code Exchange) best practices.

#{Issue Number}
WEB-369

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication security by limiting sensitive token storage to the current session instead of persistent storage, reducing exposure on shared devices
  * Improved error handling and recovery during the authentication callback process with better error feedback and automatic redirection
  * Implemented automatic cleanup of temporary authentication credentials and data after session completion to minimize security exposure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->