### PR TITLE
WEB-361 'Fund Mapping' search page doesn't send proper JSON to Fineract

### DIFF
--- a/src/app/organization/fund-mapping/fund-mapping.component.ts
+++ b/src/app/organization/fund-mapping/fund-mapping.component.ts
@@ -20,7 +20,9 @@ import {
   UntypedFormBuilder,
   UntypedFormControl,
   Validators,
-  ReactiveFormsModule
+  ReactiveFormsModule,
+  AbstractControl,
+  ValidationErrors
 } from '@angular/forms';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
@@ -113,13 +115,35 @@ export class FundMappingComponent implements OnInit {
   }
 
   /**
+   * Custom validator to ensure array fields are not empty.
+   * @param {AbstractControl} control - the form control to validate.
+   * @returns {ValidationErrors | null} - validation errors or null if valid.
+   */
+  private nonEmptyArrayValidator(control: AbstractControl): ValidationErrors | null {
+    const value = control.value;
+    if (!value || !Array.isArray(value) || value.length === 0) {
+      return { required: true };
+    }
+    if (value.every((item: any) => item === '' || item === null || item === undefined)) {
+      return { required: true };
+    }
+    return null;
+  }
+
+  /**
    * Creates the Fund Mapping Form
    */
   createFundMappingForm() {
     this.fundMappingForm = this.formBuilder.group({
-      loanStatus: [''],
-      loanProducts: [''],
-      offices: [''],
+      loanStatus: [
+        [],
+        this.nonEmptyArrayValidator.bind(this)],
+      loanProducts: [
+        [],
+        this.nonEmptyArrayValidator.bind(this)],
+      offices: [
+        [],
+        this.nonEmptyArrayValidator.bind(this)],
       loanDateOption: [
         '',
         Validators.required
@@ -223,6 +247,10 @@ export class FundMappingComponent implements OnInit {
     const prevLoanToDate: Date = this.fundMappingForm.value.loanToDate;
     if (fundMappingFormData.loanFromDate instanceof Date) {
       fundMappingFormData.loanFromDate = this.dateUtils.formatDate(prevLoanFromDate, dateFormat);
+    }
+    if (this.fundMappingForm.invalid) {
+      this.fundMappingForm.markAllAsTouched();
+      return;
     }
     if (fundMappingFormData.loanToDate instanceof Date) {
       fundMappingFormData.loanToDate = this.dateUtils.formatDate(prevLoanToDate, dateFormat);


### PR DESCRIPTION
## Description
Fixed the "Fund Mapping" search functionality that was sending empty strings instead of empty arrays to the fineract backend api . when users submitted a search with empty 'loanStatus', 'loanProduct' or 'offices' fields  the backend threw a 500 Internal server error due to malformed JSON 

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.
To fix the issue i checked the form fields if they are empty strings i converted them to empty arrays and also made these fields required because the fineract  backend required these fields otherwise it showed this error :
 {
    "developerMessage": "The request was invalid. This typically will happen due to validation errors which are provided.",
    "httpStatusCode": "400",
    "defaultUserMessage": "Validation errors exist.",
    "userMessageGlobalisationCode": "validation.msg.validation.errors.exist",
    "errors": [
        {
            "defaultUserMessage": "The parameter `loanStatus` cannot be empty. You must select at least one.",
            "parameterName": "loanStatus",
            "developerMessage": "The parameter `loanStatus` cannot be empty. You must select at least one.",
            "userMessageGlobalisationCode": "validation.msg.adHocQuery.loanStatus.cannot.be.empty",
            "args": []
        },
        {
            "defaultUserMessage": "The parameter `loanProducts` cannot be empty. You must select at least one.",
            "parameterName": "loanProducts",
            "developerMessage": "The parameter `loanProducts` cannot be empty. You must select at least one.",
            "userMessageGlobalisationCode": "validation.msg.adHocQuery.loanProducts.cannot.be.empty",
            "args": []
        },
        {
            "defaultUserMessage": "The parameter `offices` cannot be empty. You must select at least one.",
            "parameterName": "offices",
            "developerMessage": "The parameter `offices` cannot be empty. You must select at least one.",
            "userMessageGlobalisationCode": "validation.msg.adHocQuery.offices.cannot.be.empty",
            "args": []
        }
    ]
} 

## Related issues and discussion

#{Issue Number}
WEB-361
## Screenshots, if any
Before: 
<img width="1057" height="586" alt="Screenshot 2025-11-11 014211" src="https://github.com/user-attachments/assets/79f453c1-06a2-4f0d-8b6a-b3517bc73a58" />
After : 
<img width="1096" height="682" alt="image" src="https://github.com/user-attachments/assets/b1e3cee1-c740-45b3-9448-5a0a8fa3b275" />
 

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved fund-mapping form validation and submission flow to enforce non-empty selections for array fields and normalize data before payload creation.
* **Bug Fixes**
  * Prevents form submission when validation fails and ensures invalid controls are marked for user correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->