### PR TITLE
WEB-424 "MatGridList is not used" and "MatGridTile is not used" warnings during startup of "ng serve"

### DIFF
--- a/src/app/configuration-wizard/configuration-wizard.component.ts
+++ b/src/app/configuration-wizard/configuration-wizard.component.ts
@@ -25,8 +25,6 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatDialogTitle,
     CdkScrollable,
     MatDialogContent,
-    MatGridList,
-    MatGridTile,
     MatDialogClose,
     MatProgressBar,
     MatDialogActions


### PR DESCRIPTION
**Changes Made :-**

Remove unused MatGridList and MatGridTile imports from ConfigurationWizardComponent to resolve Angular startup warnings.

[WEB :- 424](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-424)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused component dependencies to improve code cleanliness and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->