### PR TITLE
WEB-425 Field validation for required field missing in "Bulk Loan Reassignment" page

### DIFF
--- a/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.html
+++ b/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.html
@@ -5,11 +5,15 @@
         <div class="layout-row-wrap gap-2px responsive-column">
           <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Office' | translate }}</mat-label>
-            <mat-select required (selectionChange)="getOffice($event.value)">
+            <mat-select required formControlName="officeId" (selectionChange)="getOffice($event.value)">
               <mat-option *ngFor="let office of offices" [value]="office.id">
                 {{ office.name }}
               </mat-option>
             </mat-select>
+            <mat-error *ngIf="bulkLoanForm.controls.officeId.hasError('required')">
+              {{ 'labels.inputs.Office' | translate }} {{ 'labels.commons.is' | translate }}
+              <strong>{{ 'labels.commons.required' | translate }}</strong>
+            </mat-error>
           </mat-form-field>
         </div>
 
@@ -23,6 +27,7 @@
               [matDatepicker]="assignmentDatePicker"
               required
               formControlName="assignmentDate"
+              placeholder="{{ 'labels.inputs.Assignment Date' | translate }}"
             />
             <mat-datepicker-toggle matSuffix [for]="assignmentDatePicker"></mat-datepicker-toggle>
             <mat-datepicker #assignmentDatePicker></mat-datepicker>
@@ -123,6 +128,7 @@
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button
+          type="submit"
           mat-raised-button
           color="primary"
           [disabled]="!bulkLoanForm.valid"

--- a/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.ts
+++ b/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.ts
@@ -79,8 +79,12 @@ export class BulkLoanReassignmnetComponent implements OnInit {
    */
   setBulkLoanForm() {
     this.bulkLoanForm = this.formBuilder.group({
+      officeId: [
+        '',
+        Validators.required
+      ],
       assignmentDate: [
-        new Date(),
+        this.settingsService.businessDate,
         Validators.required
       ],
       toLoanOfficerId: [


### PR DESCRIPTION
**Changes Made :-**

Added required field validation and error message for the "Office" field on the Bulk Loan Reassignment page to ensure consistent user feedback for missing required fields.

[WEB-425](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-425)

Before :- 
<img width="910" height="477" alt="image" src="https://github.com/user-attachments/assets/7ee0bddc-6d89-41ca-914d-518583de1e13" />

After :- 
<img width="1365" height="720" alt="image" src="https://github.com/user-attachments/assets/a428a924-5f22-4139-bb19-faf2554d81c7" />


[WEB-425]: https://mifosforge.jira.com/browse/WEB-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Office selection is now required when reassigning bulk loans; validation errors display if omitted.
  * Assignment Date now shows a helpful placeholder and defaults to the current business date.
  * Submit button is explicitly set as a form submit and remains disabled until the form is valid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->