### PR TITLE
WEB-431 MatCardSubtitle is not used warning during startup of ng serve

### DIFF
--- a/src/app/navigation/office-navigation/office-navigation.component.ts
+++ b/src/app/navigation/office-navigation/office-navigation.component.ts
@@ -1,12 +1,6 @@
 /** Angular Imports */
 import { Component, Input } from '@angular/core';
-import {
-  MatCardHeader,
-  MatCardTitleGroup,
-  MatCardTitle,
-  MatCardSubtitle,
-  MatCardContent
-} from '@angular/material/card';
+import { MatCardHeader, MatCardTitleGroup, MatCardTitle, MatCardContent } from '@angular/material/card';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ExternalIdentifierComponent } from '../../shared/external-identifier/external-identifier.component';
 import { DateFormatPipe } from '../../pipes/date-format.pipe';
@@ -22,7 +16,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     FaIconComponent,
     MatCardTitleGroup,
     MatCardTitle,
-    MatCardSubtitle,
+    MatCardContent,
     ExternalIdentifierComponent,
     DateFormatPipe
   ]


### PR DESCRIPTION
**Changes Made :-**

-Removed unused MatCardSubtitle import from OfficeNavigationComponent to resolve Angular startup warning.

[[WEB-431]](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-431)

[WEB-431]: https://mifosforge.jira.com/browse/WEB-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cleaned up and consolidated UI imports, removing an unused card subtitle import. No user-facing behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->