### PR TITLE
WEB-432-refactor(templates): align view template page with consistent UI pattern

### DIFF
--- a/src/app/templates/view-template/view-template.component.html
+++ b/src/app/templates/view-template/view-template.component.html
@@ -1,23 +1,22 @@
-<div class="container m-b-20 layout-row align-end gap-20px">
-  <button mat-raised-button color="primary" [routerLink]="['edit']" *mifosxHasPermission="'UPDATE_TEMPLATE'">
-    <fa-icon icon="edit" class="m-r-10"></fa-icon>
-    {{ 'labels.buttons.Edit' | translate }}
-  </button>
-
-  <button mat-raised-button color="warn" (click)="delete()" *mifosxHasPermission="'DELETE_TEMPLATE'">
-    <fa-icon icon="trash" class="m-r-10"></fa-icon>
-    {{ 'labels.buttons.Delete' | translate }}
-  </button>
-</div>
-
 <div class="container">
+  <div class="layout-row align-end gap-10px m-b-20">
+    <button mat-raised-button color="primary" [routerLink]="['edit']" *mifosxHasPermission="'UPDATE_TEMPLATE'">
+      <fa-icon icon="edit" class="m-r-10"></fa-icon>
+      {{ 'labels.buttons.Edit' | translate }}
+    </button>
+
+    <button mat-raised-button color="warn" (click)="delete()" *mifosxHasPermission="'DELETE_TEMPLATE'">
+      <fa-icon icon="trash" class="m-r-10"></fa-icon>
+      {{ 'labels.buttons.Delete' | translate }}
+    </button>
+  </div>
+
   <mat-card>
     <mat-card-content>
       <div class="layout-row-wrap">
         <div class="flex-50 mat-body-strong">
           {{ 'labels.inputs.name' | translate }}
         </div>
-
         <div class="flex-50">
           {{ templateData.name }}
         </div>
@@ -25,7 +24,6 @@
         <div class="flex-50 mat-body-strong">
           {{ 'labels.inputs.Entity' | translate }}
         </div>
-
         <div class="flex-50">
           {{ templateData.entity }}
         </div>
@@ -33,7 +31,6 @@
         <div class="flex-50 mat-body-strong">
           {{ 'labels.inputs.Type' | translate }}
         </div>
-
         <div class="flex-50">
           {{ templateData.type }}
         </div>
@@ -41,7 +38,6 @@
         <div class="flex-50 mat-body-strong">
           {{ 'labels.inputs.Text' | translate }}
         </div>
-
         <div class="flex-50" [innerHTML]="templateData.text"></div>
       </div>
     </mat-card-content>

--- a/src/app/templates/view-template/view-template.component.scss
+++ b/src/app/templates/view-template/view-template.component.scss
@@ -1,10 +1,44 @@
-.container {
-  max-width: 37rem;
+// Component-specific styles - minimal overrides to global styles
+// Follows existing patterns from general-tab components
 
-  .content {
-    div {
-      margin: 1rem 0;
-      word-wrap: break-word;
+.container {
+  max-width: 32rem;
+  margin: 0 auto;
+  width: 85%;
+}
+
+mat-card {
+  mat-card-content {
+    padding: 1.5rem;
+
+    .layout-row-wrap {
+      display: grid;
+      grid-template-columns: 50% 50%;
+
+      @media (width <= 768px) {
+        grid-template-columns: 100%;
+      }
+    }
+
+    .flex-50 {
+      padding: 0.625rem 0;
+      display: flex;
+      align-items: center;
+      font-size: 0.875rem;
+      overflow-wrap: break-word;
+      line-height: 1.6;
+
+      &.mat-body-strong {
+        font-weight: 600;
+      }
+
+      &:not(:last-child, :nth-last-child(2)) {
+        border-bottom: 1px solid #ddd;
+      }
+    }
+
+    @media (width <= 480px) {
+      padding: 1rem;
     }
   }
 }


### PR DESCRIPTION
## Description

This pr improve the template view page now has the same look, feel, and behavior as other detail/view pages in the application, providing a consistent user experience throughout the system.
#{Issue Number}
WEB-432
## Screenshots, if any
before:
<img width="1045" height="635" alt="Screenshot 2025-11-24 133154" src="https://github.com/user-attachments/assets/c6efedb0-39bb-438c-a178-252e8041329f" />
after:
<img width="932" height="538" alt="Screenshot 2025-11-24 134446" src="https://github.com/user-attachments/assets/fb762eed-1265-48f6-a083-01ad94717975" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reworked action area layout to improve button alignment and spacing while preserving buttons and permissions.
  * Adjusted container sizing and centering; increased card content padding for better presentation.
  * Introduced two-column responsive layout that collapses to one column on small screens.
  * Tuned text sizing, added a stronger emphasis style, field separators, and responsive padding for small viewports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->