### PR TITLE
WEB-433-fix:the login form icon overlap

### DIFF
--- a/src/app/login/login-form/login-form.component.html
+++ b/src/app/login/login-form/login-form.component.html
@@ -12,7 +12,7 @@
     </mat-form-field>
 
     <mat-form-field class="login-input flex-align-center">
-      <span matPrefix class="m-r-10">
+      <span matPrefix class="m-r-10" *ngIf="!loginForm.controls.password.value">
         <fa-icon icon="lock" size="lg"></fa-icon>
       </span>
       <mat-label>{{ 'labels.inputs.Password' | translate }}</mat-label>


### PR DESCRIPTION
## Description
this pr fixed overlapping icons in the login password field by conditionally showing the lock icon only when the field is empty, ensuring a clean swap with the eye icon 
#{Issue Number}
WEB-433
## Screenshots, if any
WEB-433
## Checklist
after:
<img width="364" height="288" alt="Screenshot 2025-11-24 144342" src="https://github.com/user-attachments/assets/1abb44c8-ea6c-44c6-8246-5d444a514f01" />
before:
<img width="571" height="971" alt="Screenshot 2025-11-24 150910" src="https://github.com/user-attachments/assets/785ab4e3-1c73-456f-84f7-1d1aba8745a6" />

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The lock icon in the password field now only displays when the field is empty, providing clearer visual feedback during the login process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->