### PR TITLE
WEB-434-fix: add visible hover effect for table rows in dark mode

### DIFF
--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -267,4 +267,11 @@ body.dark-theme {
       content: url('../assets/images/white-mifos.png');
     }
   }
+
+  // Table row hover effect for dark mode
+  .mat-mdc-row:hover,
+  tr.select-row:hover,
+  .select-row:hover {
+    background-color: rgb(255 255 255 / 8%) !important;
+  }
 }


### PR DESCRIPTION
## Description

 this pr added a dark mode-specific hover effect that applies a subtle white overlay (rgb(255 255 255 / 8%)) to table rows when hovered, making the hover state clearly visible in dark mode.
## Related issues and discussion

#{Issue Number}
WEB-434
## Screenshots, if any
before:
<img width="1436" height="221" alt="Screenshot 2025-11-24 152510" src="https://github.com/user-attachments/assets/a9005db0-1e85-4a18-a618-657b9f5eb518" />
after:
<img width="1368" height="493" alt="Screenshot 2025-11-24 153518" src="https://github.com/user-attachments/assets/a616fef5-63e4-4e06-9d17-3f18daf48f33" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode hover effects for table and row elements to enhance visual feedback and usability when navigating data tables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->