### PR TITLE
WEB-437-fix(charges): resolve chargeId undefined issue breaking disbursement date

### DIFF
--- a/src/app/loans/glim-account/create-glim-account/create-glim-account.component.ts
+++ b/src/app/loans/glim-account/create-glim-account/create-glim-account.component.ts
@@ -183,10 +183,31 @@ export class CreateGlimAccountComponent {
     // const monthDayFormat = 'dd MMMM';
     const data = {
       ...this.loansAccount,
-      charges: this.loansAccount.charges.map((charge: any) => ({
-        chargeId: charge.id,
-        amount: charge.amount
-      })),
+      charges: (this.loansAccount.charges ?? [])
+        .map((charge: any) => {
+          const chargeId = charge.chargeId ?? charge.id;
+          if (chargeId == null) {
+            return null;
+          }
+          const mappedCharge: any = {
+            chargeId,
+            amount: charge.amount
+          };
+          if (charge.id && charge.id !== chargeId) {
+            mappedCharge.id = charge.id;
+          }
+          if (charge.dueDate) {
+            mappedCharge.dueDate = this.dateUtils.formatDate(charge.dueDate, dateFormat);
+          }
+          if (charge.feeInterval !== undefined) {
+            mappedCharge.feeInterval = charge.feeInterval;
+          }
+          if (charge.feeOnMonthDay !== undefined) {
+            mappedCharge.feeOnMonthDay = charge.feeOnMonthDay;
+          }
+          return mappedCharge;
+        })
+        .filter(Boolean),
       clientId: client.id,
       totalLoan: totalLoan,
       loanType: 'glim',

--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.html
@@ -24,7 +24,7 @@
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.name' | translate }}</th>
       <td mat-cell *matCellDef="let charge">
-        {{ charge.name + ', ' + charge.currency.displaySymbol }}
+        {{ charge.name + ', ' + (charge.currency?.displaySymbol || '') }}
       </td>
     </ng-container>
 
@@ -110,7 +110,7 @@
   <table mat-table class="mat-elevation-z1" [dataSource]="overDueChargesDataSource">
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.name' | translate }}</th>
-      <td mat-cell *matCellDef="let charge">{{ charge.name }},{{ charge.currency.displaySymbol }}</td>
+      <td mat-cell *matCellDef="let charge">{{ charge.name + ', ' + (charge.currency?.displaySymbol || '') }}</td>
     </ng-container>
 
     <ng-container matColumnDef="type">

--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
@@ -338,32 +338,21 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
   get loansAccountCharges() {
     const uniqueCharges = this.getUniqueCharges(this.chargesDataSource);
     return {
-      charges: uniqueCharges.map((charge: any) => {
-        const result: any = {};
-        result.chargeId = charge.chargeId;
-
-        if (charge.id && charge.id !== charge.chargeId) {
-          result.id = charge.id;
-        }
-
-        if (charge.amount !== undefined) result.amount = charge.amount;
-        if (charge.dueDate !== undefined) result.dueDate = charge.dueDate;
-        if (charge.feeInterval !== undefined) result.feeInterval = charge.feeInterval;
-        if (charge.feeOnMonthDay !== undefined) result.feeOnMonthDay = charge.feeOnMonthDay;
-
-        return result;
-      })
+      charges: uniqueCharges.map((charge: any) => ({
+        ...charge,
+        chargeId: charge.chargeId ?? charge.id
+      }))
     };
   }
   private getUniqueCharges<T extends { id?: number | string; chargeId?: number | string }>(charges: T[]): T[] {
     const uniqueChargesMap = new Map<number | string, T>();
 
     for (const charge of charges ?? []) {
-      const chargeId = charge.chargeId;
+      const chargeId = charge.chargeId ?? charge.id;
       if (chargeId == null) {
         continue;
       }
-      uniqueChargesMap.set(chargeId, charge);
+      uniqueChargesMap.set(chargeId, { ...charge, chargeId });
     }
 
     return Array.from(uniqueChargesMap.values());

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
@@ -262,7 +262,7 @@
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.name' | translate }}</th>
         <td mat-cell *matCellDef="let charge">
-          {{ charge.name + ', ' + charge.currency.displaySymbol }}
+          {{ charge.name + ', ' + (charge.currency?.displaySymbol || '') }}
         </td>
       </ng-container>
 
@@ -329,7 +329,7 @@
     <table mat-table class="mat-elevation-z1" [dataSource]="loansAccountProductTemplate.overdueCharges">
       <ng-container matColumnDef="name">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.name' | translate }}</th>
-        <td mat-cell *matCellDef="let charge">{{ charge.name }},{{ charge.currency.displaySymbol }}</td>
+        <td mat-cell *matCellDef="let charge">{{ charge.name + ', ' + (charge.currency?.displaySymbol || '') }}</td>
       </ng-container>
 
       <ng-container matColumnDef="type">

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -642,11 +642,31 @@ export class LoansService {
   ): any {
     const loansAccountData = {
       ...loansAccount,
-      charges: loansAccount.charges.map((charge: any) => ({
-        chargeId: charge.id,
-        amount: charge.amount,
-        dueDate: charge.dueDate && this.dateUtils.formatDate(charge.dueDate, dateFormat)
-      })),
+      charges: (loansAccount.charges ?? [])
+        .map((charge: any) => {
+          const chargeId = charge.chargeId ?? charge.id;
+          if (chargeId == null) {
+            return null;
+          }
+          const mappedCharge: any = {
+            chargeId,
+            amount: charge.amount
+          };
+          if (charge.id && charge.id !== chargeId) {
+            mappedCharge.id = charge.id;
+          }
+          if (charge.dueDate) {
+            mappedCharge.dueDate = this.dateUtils.formatDate(charge.dueDate, dateFormat);
+          }
+          if (charge.feeInterval !== undefined) {
+            mappedCharge.feeInterval = charge.feeInterval;
+          }
+          if (charge.feeOnMonthDay !== undefined) {
+            mappedCharge.feeOnMonthDay = charge.feeOnMonthDay;
+          }
+          return mappedCharge;
+        })
+        .filter(Boolean),
       disbursementData: loansAccount.disbursementData.map((item: any) => ({
         expectedDisbursementDate: this.dateUtils.formatDate(item.expectedDisbursementDate, dateFormat),
         principal: item.principal


### PR DESCRIPTION

## Description
This PR fixes an issue where loan applications could not be submitted when a product already contained default charges.
The frontend was sending id instead of chargeId, causing the payload to include chargeId: undefined for product charges (which do not have an id)
This resulted in invalid payloads, blocked disbursement date updates, and prevented adding or removing charges.

#{Issue Number}
WEB-437
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rendering errors when charge currency is missing by using safe fallbacks.
  * Filtered out incomplete charge entries to avoid null-related issues.

* **Refactor / Improvements**
  * Normalized and standardized charge identifiers and expanded charge fields handling for more reliable loan charge processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->