### PR TITLE
WEB-426 Checkbox Alignment Issue in Bulk Loan Reassignment UI

### DIFF
--- a/src/app/system/manage-hooks/create-hook/create-hook.component.html
+++ b/src/app/system/manage-hooks/create-hook/create-hook.component.html
@@ -24,12 +24,6 @@
               <strong>{{ 'labels.commons.required' | translate }}</strong>
             </mat-error>
           </mat-form-field>
-
-          <div class="is-active-wrapper">
-            <mat-checkbox class="is-active flex-10" labelPosition="before" formControlName="isActive">
-              {{ 'labels.inputs.Is Active' | translate }}?
-            </mat-checkbox>
-          </div>
         </div>
 
         <div class="layout-row-wrap responsive-column gap-4percent">
@@ -107,13 +101,15 @@
 
         <br />
 
-        <div class="layout-row-wrap responsive-column">
+        <div class="layout-row-wrap responsive-column align-center">
           <p class="mat-title flex-20">{{ 'labels.inputs.Events' | translate }}<span class="red">*</span></p>
-
           <button mat-raised-button class="AddEventButton flex-20" type="button" color="primary" (click)="addEvent()">
             <fa-icon icon="plus" class="m-r-10"></fa-icon>
             {{ 'labels.buttons.Add' | translate }} {{ 'labels.inputs.Events' | translate }}
           </button>
+          <mat-checkbox class="is-active flex-10 m-l-20" labelPosition="before" formControlName="isActive">
+            {{ 'labels.inputs.Is Active' | translate }}?
+          </mat-checkbox>
         </div>
 
         <table mat-table [dataSource]="dataSource" matSort>


### PR DESCRIPTION
**Changes Made :-**

-Moved the "Is Active?" checkbox to the right of the "Add Events" button on the Create Hook page .

[WEB-426](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?selectedIssue=WEB-426)

[WEB-426]: https://mifosforge.jira.com/browse/WEB-426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized form layout by repositioning the "Is Active" checkbox to align inline with the events section, improving visual alignment and organization in the hook creation interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->