### PR TITLE
WEB-439 Show-validation-error-messages-beside-name-and-description-fields-in-create-fixed-deposit-product-form

### DIFF
--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.html
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.html
@@ -36,11 +36,19 @@
         <mat-form-field class="flex-28 m-r-5">
           <mat-label>{{ 'labels.inputs.Name' | translate }}</mat-label>
           <input matInput formControlName="name" required />
+          <mat-error *ngIf="chart.get('name')?.touched && chart.get('name')?.hasError('required')">
+            {{ 'labels.inputs.Name' | translate }} {{ 'labels.commons.is' | translate }}
+            <strong>{{ 'labels.commons.required' | translate }}</strong>
+          </mat-error>
         </mat-form-field>
 
         <mat-form-field class="flex-70">
           <mat-label>{{ 'labels.inputs.Description' | translate }}</mat-label>
           <textarea matInput formControlName="description" required></textarea>
+          <mat-error *ngIf="chart.get('description')?.touched && chart.get('description')?.hasError('required')">
+            {{ 'labels.inputs.Description' | translate }} {{ 'labels.commons.is' | translate }}
+            <strong>{{ 'labels.commons.required' | translate }}</strong>
+          </mat-error>
         </mat-form-field>
 
         <mat-form-field class="flex-48 m-r-5" (click)="validFromDatePicker.open()">


### PR DESCRIPTION
**Changes Made :-**

-Added required field validation and error messages for the "Name" and "Description" fields in the Interest Rate Chart step of the Fixed Deposit Product creation form to ensure consistent user feedback for missing required fields.

[WEB-439](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-439)

[WEB-439]: https://mifosforge.jira.com/browse/WEB-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation error messages for required fields in the fixed deposit interest rate chart form. Users will now see clear feedback when required fields are empty or invalid after interaction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->