### PR TITLE
WEB-444 Display required validation message for selected products field on create provisioning criteria page

### DIFF
--- a/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.html
+++ b/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.html
@@ -19,6 +19,10 @@
                 {{ product.name }}
               </mat-option>
             </mat-select>
+            <mat-error *ngIf="provisioningCriteriaForm.controls.loanProducts.hasError('required')">
+              {{ 'labels.inputs.Selected Products' | translate }} {{ 'labels.commons.is' | translate }}
+              <strong>{{ 'labels.commons.required' | translate }}</strong>
+            </mat-error>
           </mat-form-field>
         </div>
       </form>


### PR DESCRIPTION
**Changes Made :-**

-Added required field validation and error message for the "Selected Products" field in the Create Provisioning Criteria form .

[WEB-444](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-444)

[WEB-444]: https://mifosforge.jira.com/browse/WEB-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Before :- 
![WhatsApp Image 2025-11-29 at 14 28 42_61a2e940](https://github.com/user-attachments/assets/021e8b40-b363-4176-af65-265ddbf39042)

After :- 
<img width="1365" height="720" alt="image" src="https://github.com/user-attachments/assets/7ceb9378-869e-430c-8293-b04372333e46" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation error message display for the required loan products field in the loan provisioning criteria form, providing users with clearer feedback when submitting incomplete forms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->