### PR TITLE
WEB-445 Position field should accept only numeric input in create payment type form

### DIFF
--- a/src/app/organization/payment-types/create-payment-type/create-payment-type.component.html
+++ b/src/app/organization/payment-types/create-payment-type/create-payment-type.component.html
@@ -23,10 +23,13 @@
 
           <mat-form-field>
             <mat-label>{{ 'labels.inputs.Position' | translate }}</mat-label>
-            <input required matInput formControlName="position" />
+            <input required matInput type="number" min="1" formControlName="position" />
             <mat-error *ngIf="paymentTypeForm.controls.position.hasError('required')">
               {{ 'labels.inputs.Position' | translate }} {{ 'labels.commons.is' | translate }}
               <strong>{{ 'labels.commons.required' | translate }}</strong>
+            </mat-error>
+            <mat-error *ngIf="paymentTypeForm.controls.position.hasError('min')">
+              {{ 'labels.inputs.Position' | translate }} must be a positive number.
             </mat-error>
           </mat-form-field>
         </div>

--- a/src/app/organization/payment-types/create-payment-type/create-payment-type.component.ts
+++ b/src/app/organization/payment-types/create-payment-type/create-payment-type.component.ts
@@ -59,7 +59,9 @@ export class CreatePaymentTypeComponent implements OnInit {
       isCashPayment: [false],
       position: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(1)]
       ]
     });
   }

--- a/src/app/organization/payment-types/edit-payment-type/edit-payment-type.component.html
+++ b/src/app/organization/payment-types/edit-payment-type/edit-payment-type.component.html
@@ -23,7 +23,10 @@
 
           <mat-form-field>
             <mat-label>{{ 'labels.inputs.Position' | translate }}</mat-label>
-            <input required matInput formControlName="position" />
+            <input required matInput type="number" min="1" formControlName="position" />
+            <mat-error *ngIf="paymentTypeForm.controls.position.hasError('min')">
+              {{ 'labels.inputs.Position' | translate }} must be a positive number.
+            </mat-error>
             <mat-error *ngIf="paymentTypeForm.controls.position.hasError('required')">
               {{ 'labels.inputs.Position' | translate }} {{ 'labels.commons.is' | translate }}
               <strong>{{ 'labels.commons.required' | translate }}</strong>

--- a/src/app/organization/payment-types/edit-payment-type/edit-payment-type.component.ts
+++ b/src/app/organization/payment-types/edit-payment-type/edit-payment-type.component.ts
@@ -66,7 +66,9 @@ export class EditPaymentTypeComponent implements OnInit {
       isCashPayment: [this.paymentTypeData.isCashPayment],
       position: [
         this.paymentTypeData.position,
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(1)]
       ]
     });
   }


### PR DESCRIPTION
**Changes Made :-**

-Updated the "Position" field in the Create and Edit Payment Type forms to accept only numeric values, ensuring correct ordering and preventing invalid data entry.

[WEB-445](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-445)

Before :-
![WhatsApp Image 2025-11-29 at 14 59 10_dd0c52f8](https://github.com/user-attachments/assets/00b66894-16d2-4250-b12c-2876992aa2bd)

After :- 
<img width="1365" height="718" alt="image" src="https://github.com/user-attachments/assets/16ce28a3-ffe7-4e05-9765-ae6f529e650a" />

<img width="1365" height="719" alt="image" src="https://github.com/user-attachments/assets/5bccd963-c815-4bad-bff9-7ff9fe43c8a4" />



[WEB-445]: https://mifosforge.jira.com/browse/WEB-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Create and edit payment type forms now require numeric positions and enforce a minimum value of 1.
  * New validation message displays when position is below the minimum.
* **UI Improvements**
  * Position inputs now use numeric input controls for clearer user entry and validation feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->