### PR TITLE
WEB-448 Credit amount field allows invalid values zero and negative in journal entry creation

### DIFF
--- a/src/app/accounting/create-journal-entry/create-journal-entry.component.html
+++ b/src/app/accounting/create-journal-entry/create-journal-entry.component.html
@@ -51,7 +51,14 @@
 
               <mat-form-field class="flex-43">
                 <mat-label>{{ 'labels.inputs.Debit Amount' | translate }}</mat-label>
-                <input type="number" matInput required formControlName="amount" />
+                <input
+                  type="number"
+                  matInput
+                  required
+                  formControlName="amount"
+                  min="1"
+                  (input)="onAmountInput($event)"
+                />
                 <mat-error *ngIf="debits.at(i).controls.amount.hasError('required')">
                   {{ 'labels.inputs.Debit Amount' | translate }} {{ 'labels.commons.is' | translate }}
                   <strong>{{ 'labels.commons.required' | translate }}</strong>
@@ -92,7 +99,14 @@
 
               <mat-form-field class="flex-43">
                 <mat-label>{{ 'labels.inputs.Credit Amount' | translate }}</mat-label>
-                <input type="number" matInput required formControlName="amount" />
+                <input
+                  type="number"
+                  matInput
+                  required
+                  formControlName="amount"
+                  min="1"
+                  (input)="onAmountInput($event)"
+                />
                 <mat-error *ngIf="credits.at(i).controls.amount.hasError('required')">
                   {{ 'labels.inputs.Credit Amount' | translate }} {{ 'labels.commons.is' | translate }}
                   <strong>{{ 'labels.commons.required' | translate }}</strong>

--- a/src/app/accounting/create-journal-entry/create-journal-entry.component.ts
+++ b/src/app/accounting/create-journal-entry/create-journal-entry.component.ts
@@ -34,6 +34,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   ]
 })
 export class CreateJournalEntryComponent implements OnInit, AfterViewInit {
+  onCreditAmountInput(event: any) {
+    if (event.target.value < 1) {
+      event.target.value = 1;
+    }
+  }
   /** Minimum transaction date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum transaction date allowed. */
@@ -140,7 +145,9 @@ export class CreateJournalEntryComponent implements OnInit, AfterViewInit {
       ],
       amount: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(1)]
       ]
     });
   }


### PR DESCRIPTION
**Changes Made :-**

-Added validation to restrict credit amount field to values greater than zero in Journal Entry creation.

[WEB-448](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-448)

[WEB-448]: https://mifosforge.jira.com/browse/WEB-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for journal entry amount inputs to enforce a minimum value of 1, preventing zero or negative amounts from being entered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->