### PR TITLE
WEB-449 Translation key displayed instead of error message for percentage field in create tax component form

### DIFF
--- a/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.html
+++ b/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.html
@@ -16,7 +16,7 @@
             <mat-label>{{ 'labels.inputs.Percentage' | translate }}</mat-label>
             <input type="number" matInput required formControlName="percentage" />
             <mat-error *ngIf="taxComponentForm.controls.percentage.hasError('required')">
-              {{ 'labels.inputs.Percentage ' | translate }} {{ 'labels.commons.is' | translate }}
+              {{ 'labels.inputs.Percentage' | translate }} {{ 'labels.commons.is' | translate }}
               <strong>{{ 'labels.commons.required' | translate }}</strong>
             </mat-error>
             <mat-error

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1196,6 +1196,7 @@
         "EXPENSE": "NÁKLADY"
       },
       "ACCOUNTING": "ÚČETNICTVÍ",
+      "Percentage is required": "Je vyžadováno procento",
       "ADDRESS": "ADRESA",
       "Above Changes are Effective from": "Výše uvedené změny jsou účinné od",
       "Absent": "Chybí",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1196,6 +1196,7 @@
         "INCOME": "EINKOMMEN",
         "EXPENSE": "KOSTEN"
       },
+      "Percentage is required": "Prozentsatz ist erforderlich",
       "ACCOUNTING": "BUCHHALTUNG",
       "ADDRESS": "ADRESSE",
       "Above Changes are Effective from": "Die oben genannten Änderungen gelten ab",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1200,6 +1200,7 @@
         "INCOME": "INCOME",
         "EXPENSE": "EXPENSE"
       },
+      "Percentage is required": "Percentage is required",
       "ACCOUNTING": "ACCOUNTING",
       "ADDRESS": "ADDRESS",
       "Above Changes are Effective from": "Above Changes are Effective from",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1196,6 +1196,7 @@
         "EXPENSE": "EGRESO"
       },
       "ACCOUNTING": "CONTABILIDAD",
+      "Percentage is required": "Se requiere porcentaje",
       "ADDRESS": "DOMICILIO",
       "Above Changes are Effective from": "Los cambios anteriores son efectivos desde",
       "Absent": "Ausente",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1196,6 +1196,7 @@
         "EXPENSE": "EGRESO"
       },
       "ACCOUNTING": "CONTABILIDAD",
+      "Percentage is required": "Se requiere porcentaje",
       "ADDRESS": "DOMICILIO",
       "Above Changes are Effective from": "Los cambios anteriores son efectivos desde",
       "Absent": "Ausente",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1196,6 +1196,7 @@
         "INCOME": "REVENU",
         "EXPENSE": "FRAIS"
       },
+      "Percentage is required": "Le pourcentage est requis",
       "ACCOUNTING": "COMPTABILITÉ",
       "ADDRESS": "ADRESSE",
       "Above Changes are Effective from": "Les modifications ci-dessus entrent en vigueur à partir de",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1196,6 +1196,7 @@
         "INCOME": "REDDITO",
         "EXPENSE": "SPESE"
       },
+      "Percentage is required": "Percentuale richiesta",
       "ACCOUNTING": "CONTABILITÀ",
       "ADDRESS": "INDIRIZZO",
       "Above Changes are Effective from": "Le modifiche di cui sopra entrano in vigore a partire dal",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1197,6 +1197,7 @@
         "INCOME": "소득",
         "EXPENSE": "비용"
       },
+      "Percentage is required": "백분율이 필요합니다",
       "ACCOUNTING": "회계",
       "ADDRESS": "주소",
       "Above Changes are Effective from": "위 변경사항은 다음부터 적용됩니다.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1196,6 +1196,7 @@
         "INCOME": "PAJAMOS",
         "EXPENSE": "IŠLAIDOS"
       },
+      "Percentage is required": "Reikalingas procentas",
       "ACCOUNTING": "APSKAITA",
       "ADDRESS": "ADRESAS",
       "Above Changes are Effective from": "Aukščiau pateikti pakeitimai galioja nuo",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1196,6 +1196,7 @@
         "INCOME": "IENĀKUMI",
         "EXPENSE": "IZDEVUMI"
       },
+      "Percentage is required": "Nepieciešams procents",
       "ACCOUNTING": "GRĀMATVEDĪBA",
       "ADDRESS": "ADRESE",
       "Above Changes are Effective from": "Iepriekš minētās izmaiņas ir spēkā no",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1196,6 +1196,7 @@
         "INCOME": "आय",
         "EXPENSE": "खर्च"
       },
+      "Percentage is required": "प्रतिशत आवश्यक छ",
       "ACCOUNTING": "लेखा",
       "ADDRESS": "ठेगाना",
       "Above Changes are Effective from": "माथिका परिवर्तनहरू बाट प्रभावकारी छन्",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1196,6 +1196,7 @@
         "INCOME": "RENDA",
         "EXPENSE": "DESPESA"
       },
+      "Percentage is required": "Percentual é obrigatório",
       "ACCOUNTING": "CONTABILIDADE",
       "ADDRESS": "ENDEREÇO",
       "Above Changes are Effective from": "As alterações acima entram em vigor a partir de",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1196,6 +1196,7 @@
         "EXPENSE": "GHARAMA"
       },
       "ACCOUNTING": "UHASIBU",
+      "Percentage is required": "Asilimia inahitajika",
       "ADDRESS": "ANWANI",
       "Above Changes are Effective from": "Mabadiliko Hapo Juu yanatumika kutoka",
       "Absent": "Haipo",


### PR DESCRIPTION
**Changes Made :-**

-Fixed translation key issue for Percentage field error message in Create Tax Component form.
-Now displays the correct validation message instead of the translation key.

[WEB-449](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-449)

[WEB-449]: https://mifosforge.jira.com/browse/WEB-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Before :- 
<img width="1365" height="719" alt="image-20251201-082158" src="https://github.com/user-attachments/assets/b15fb760-24a4-44c1-ac7e-783149f80aa2" />

After :-
<img width="1365" height="721" alt="image" src="https://github.com/user-attachments/assets/18a3f548-e104-4338-821d-c3b5715c7940" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a translation key formatting issue so the percentage-required validation message displays consistently.
  * Added the missing "Percentage is required" translation across multiple locales, ensuring localized validation feedback for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->