### PR TITLE
WEB-450 Days from field allows negative and zero values in delinquency range creation form

### DIFF
--- a/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.html
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.html
@@ -14,10 +14,13 @@
 
           <mat-form-field>
             <mat-label>{{ 'labels.inputs.Days From' | translate }}</mat-label>
-            <input matInput type="number" required formControlName="minimumAgeDays" />
+            <input matInput type="number" required formControlName="minimumAgeDays" min="1" />
             <mat-error *ngIf="delinquencyRangeForm.controls.minimumAgeDays.hasError('required')">
               {{ 'labels.inputs.Days From' | translate }} {{ 'labels.commons.is' | translate }}
               <strong>{{ 'labels.commons.required' | translate }}</strong>
+            </mat-error>
+            <mat-error *ngIf="delinquencyRangeForm.controls.minimumAgeDays.hasError('pattern')">
+              {{ 'labels.inputs.Days From' | translate }} must be a positive number.
             </mat-error>
           </mat-form-field>
 


### PR DESCRIPTION
**Changes Made :-**

-Fixed validation issue for "Days From" field in Delinquency Range creation form.

[WEB-450](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-450)

Before :- 
<img width="1359" height="724" alt="image-20251201-093825" src="https://github.com/user-attachments/assets/3a842909-6e45-4ce5-bfdb-eed50e672e23" />


After :- 
<img width="1359" height="724" alt="image" src="https://github.com/user-attachments/assets/ca9cc229-127a-4865-9f5c-158baa4a57cf" />


[WEB-450]: https://mifosforge.jira.com/browse/WEB-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the minimum age input: now enforces a positive value, shows a clear "must be a positive number" error for invalid entries, while keeping the existing required check and messages intact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->