### PR TITLE
WEB-451 Validation Message Missing for Description Field in Create Sh…

### DIFF
--- a/src/app/products/share-products/share-product-stepper/share-product-details-step/share-product-details-step.component.html
+++ b/src/app/products/share-products/share-product-stepper/share-product-details-step/share-product-details-step.component.html
@@ -37,6 +37,10 @@
         matTooltip="{{ 'tooltips.Provides additional information' | translate }}"
         required
       ></textarea>
+      <mat-error *ngIf="shareProductDetailsForm.get('description')?.hasError('required')">
+        {{ 'labels.inputs.Description' | translate }} {{ 'labels.commons.is' | translate }}
+        <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
     </mat-form-field>
   </div>
 


### PR DESCRIPTION
**Changes Made :-**

Added required field validation and error message for the "Description" field in the Details step of the Share Product creation form.

[WEB-451](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-451)

[WEB-451]: https://mifosforge.jira.com/browse/WEB-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation messaging for the description field—now displays error prompts when required information is missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->