### PR TITLE
WEB-452 Validation error total number of shares allows zero or negative values

### DIFF
--- a/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.html
+++ b/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.html
@@ -8,10 +8,14 @@
         matTooltip="{{ 'tooltips.Total number of shares that a product is offering' | translate }}"
         formControlName="totalShares"
         required
+        min="1"
       />
-      <mat-error>
+      <mat-error *ngIf="shareProductTermsForm.get('totalShares').hasError('required')">
         {{ 'labels.inputs.Total Number of Shares' | translate }} {{ 'labels.commons.is' | translate }}
         <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
+      <mat-error *ngIf="shareProductTermsForm.get('totalShares').hasError('min')">
+        {{ 'labels.inputs.Total Number of Shares' | translate }} must be at least <strong>1</strong>
       </mat-error>
     </mat-form-field>
 

--- a/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.ts
@@ -56,7 +56,9 @@ export class ShareProductTermsStepComponent implements OnInit {
     this.shareProductTermsForm = this.formBuilder.group({
       totalShares: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(1)]
       ],
       sharesIssued: [
         '',


### PR DESCRIPTION
**Changes Made :-**

-Added validation to ensure the "Total Number of Shares" field only accepts positive integers in the Create Share Product form.

[WEB-452](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-452)

[WEB-452]: https://mifosforge.jira.com/browse/WEB-452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Before :- 
<img width="1365" height="719" alt="image-20251201-231803" src="https://github.com/user-attachments/assets/c747028d-ce88-428a-bbb7-7a574062eef3" />

<img width="1353" height="719" alt="image-20251201-231740" src="https://github.com/user-attachments/assets/17406156-0e35-4fe3-a190-75b0fc263b4e" />

After :- 
<img width="1365" height="719" alt="image" src="https://github.com/user-attachments/assets/b5fd8788-eac8-444e-8e21-d3bd4258defd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the total shares field: enforces a minimum value of 1 and displays clearer, distinct error messages for required vs minimum violations, preventing invalid quantities during product configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->