### PR TITLE
WEB-458 Nominal unit price field allows zero and negative values in share product creation form

### DIFF
--- a/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.html
+++ b/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.html
@@ -38,10 +38,14 @@
         matTooltip="{{ 'tooltips.Unit/Nominal Price of each share' | translate }}"
         formControlName="unitPrice"
         required
+        min="1"
       />
-      <mat-error>
+      <mat-error *ngIf="shareProductTermsForm.get('unitPrice').hasError('required')">
         {{ 'labels.inputs.Nominal Price' | translate }} {{ 'labels.commons.is' | translate }}
         <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
+      <mat-error *ngIf="shareProductTermsForm.get('unitPrice').hasError('min')">
+        {{ 'labels.inputs.Nominal Price' | translate }} must be at least <strong>1</strong>
       </mat-error>
     </mat-form-field>
 

--- a/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.ts
@@ -64,7 +64,9 @@ export class ShareProductTermsStepComponent implements OnInit {
       ],
       unitPrice: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(1)]
       ],
       shareCapital: ['']
     });


### PR DESCRIPTION
**Changes Made :-**

-Added validation to ensure the "Nominal/Unit Price" field only accepts positive values in the Create Share Product form.

[WEB-458](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-458)

[WEB-458]: https://mifosforge.jira.com/browse/WEB-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced product pricing validation in the product terms step to enforce a minimum price of 1 and provide specific error messages when validation fails, ensuring users receive clearer feedback when submitting product information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->