### PR TITLE
WEB-459 Shares to be issued field allows zero and negative values in share product creation form

### DIFF
--- a/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.html
+++ b/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.html
@@ -23,10 +23,14 @@
         matTooltip="{{ 'tooltips.Total number of shares that an orgranization' | translate }}"
         formControlName="sharesIssued"
         required
+        min="1"
       />
-      <mat-error>
+      <mat-error *ngIf="shareProductTermsForm.get('sharesIssued').hasError('required')">
         {{ 'labels.inputs.Shares to be Issued' | translate }} {{ 'labels.commons.is' | translate }}
         <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
+      <mat-error *ngIf="shareProductTermsForm.get('sharesIssued').hasError('min')">
+        {{ 'labels.inputs.Shares to be Issued' | translate }} must be at least <strong>1</strong>
       </mat-error>
     </mat-form-field>
 

--- a/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.ts
@@ -60,7 +60,9 @@ export class ShareProductTermsStepComponent implements OnInit {
       ],
       sharesIssued: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(1)]
       ],
       unitPrice: [
         '',


### PR DESCRIPTION
**Changes Made :-**

-Added validation to ensure the "Shares to be Issued" field only accepts positive values in the Create Share Product form.

[WEB-459](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-459)

[WEB-459]: https://mifosforge.jira.com/browse/WEB-459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Before :- 
<img width="1365" height="722" alt="image-20251203-021634" src="https://github.com/user-attachments/assets/05032a82-06ba-480e-9f01-e4c3121428d0" />

<img width="1365" height="720" alt="image-20251203-021700" src="https://github.com/user-attachments/assets/f1c872cf-a15f-4c46-b970-59784b5a7d7b" />


After :- 
<img width="1365" height="715" alt="image" src="https://github.com/user-attachments/assets/9adf9904-a176-4ffc-9476-f5413b646466" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shares issued field now enforces a minimum value requirement
  * Added conditional error messages to display specific validation feedback for required and minimum value constraints

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->