### PR TITLE
WEB-443-fix/oidc-login-button-layout

### DIFF
--- a/src/app/login/login-form/login-form.component.html
+++ b/src/app/login/login-form/login-form.component.html
@@ -48,8 +48,8 @@
 </div>
 
 <div *ngIf="oidcServerEnabled" class="container container-margin">
-  <div *ngIf="!isLoggedIn">
-    <button mat-raised-button color="primary" class="login-button-z" (click)="loginOIDC()">
+  <div *ngIf="!isLoggedIn" class="layout-column align-center-center">
+    <button mat-raised-button color="primary" class="login-button-first flex-align-center" (click)="loginOIDC()">
       {{ 'labels.buttons.Login' | translate }}
       <mat-spinner [diameter]="20" *ngIf="loading"></mat-spinner>
     </button>

--- a/src/app/login/login-form/login-form.component.scss
+++ b/src/app/login/login-form/login-form.component.scss
@@ -34,6 +34,4 @@
 .container-margin {
   margin-top: 8rem;
   margin-bottom: 8rem;
-  border-radius: 50px;
-  border: solid 1px black;
 }


### PR DESCRIPTION
## Description
This pr improve OIDC login button layout so that when OIDC is enabled the login screen shows a single, centered blue “Login” button consistent with the existing username/password login button.
#{Issue Number}
WEB-443
## Screenshots, if any
before:
![WhatsApp Image 2025-11-28 at 17 02 35](https://github.com/user-attachments/assets/a5089e39-cbc7-449d-b91a-4db2d9e427f9)
after:
<img width="575" height="885" alt="Screenshot 2025-12-03 142812" src="https://github.com/user-attachments/assets/bcbb65cb-8c26-419f-820d-78466bfb6215" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated login button layout and styling to center and align the OIDC login action.
  * Replaced previous button styling with a new set of classes for improved appearance.
  * Removed container border and rounded corners for a cleaner form look.
  * Adjusted spacing and layout for more consistent visual presentation of the login form.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->