### PR TITLE
WEB-476-fix(clients): preserve aspect ratio when capturing client image

### DIFF
--- a/src/app/clients/clients-view/custom-dialogs/capture-image-dialog/capture-image-dialog.component.html
+++ b/src/app/clients/clients-view/custom-dialogs/capture-image-dialog/capture-image-dialog.component.html
@@ -1,7 +1,7 @@
 <div class="layout-column gap-2px">
   <h1 mat-dialog-title align="center">{{ 'labels.heading.Capture Client Image' | translate }}</h1>
 
-  <video #video width="540" height="480" autoplay></video>
+  <video #video class="capture-video" autoplay></video>
 
   <!-- Using a class will break renderer changes -->
   <canvas #canvas [ngStyle]="{ display: 'none' }"></canvas>

--- a/src/app/clients/clients-view/custom-dialogs/capture-image-dialog/capture-image-dialog.component.scss
+++ b/src/app/clients/clients-view/custom-dialogs/capture-image-dialog/capture-image-dialog.component.scss
@@ -4,8 +4,7 @@
   width: 100%;
   max-width: 640px;
   height: auto;
-  aspect-ratio: 4 / 3;
-  object-fit: cover;
+  object-fit: contain;
   border-radius: 4px;
   background-color: colors.$black;
 }

--- a/src/app/clients/clients-view/custom-dialogs/capture-image-dialog/capture-image-dialog.component.scss
+++ b/src/app/clients/clients-view/custom-dialogs/capture-image-dialog/capture-image-dialog.component.scss
@@ -1,0 +1,11 @@
+@use '../../../../../assets/styles/colours' as colors;
+
+.capture-video {
+  width: 100%;
+  max-width: 640px;
+  height: auto;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 4px;
+  background-color: colors.$black;
+}

--- a/src/app/clients/clients-view/custom-dialogs/capture-image-dialog/capture-image-dialog.component.ts
+++ b/src/app/clients/clients-view/custom-dialogs/capture-image-dialog/capture-image-dialog.component.ts
@@ -60,8 +60,13 @@ export class CaptureImageDialogComponent implements AfterViewInit, OnDestroy {
    */
   startCamera() {
     if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+      const videoConstraints: MediaTrackConstraints = {
+        width: { ideal: 640 },
+        height: { ideal: 480 },
+        facingMode: 'user'
+      };
       navigator.mediaDevices
-        .getUserMedia({ video: true })
+        .getUserMedia({ video: videoConstraints })
         .then((stream: MediaStream) => {
           this.renderer.setProperty(this.video.nativeElement, 'srcObject', stream);
           this.video.nativeElement.play();
@@ -101,13 +106,26 @@ export class CaptureImageDialogComponent implements AfterViewInit, OnDestroy {
 
   /**
    * Captures the image by drawing video state on canvas, then converts canvas state to data URL.
+   * Uses actual video dimensions to prevent aspect ratio distortion.
    * See https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL for details.
    */
   capture() {
     this.isCaptured = true;
     this.video.nativeElement.pause();
-    this.canvas.nativeElement.getContext('2d').drawImage(this.video.nativeElement, 0, 0, 150, 150);
-    this.clientImageDataURL = this.canvas.nativeElement.toDataURL();
+
+    // Get actual video stream dimensions to preserve aspect ratio
+    const videoWidth = this.video.nativeElement.videoWidth;
+    const videoHeight = this.video.nativeElement.videoHeight;
+
+    // Set canvas dimensions to match video stream
+    this.canvas.nativeElement.width = videoWidth;
+    this.canvas.nativeElement.height = videoHeight;
+
+    // Draw the video frame at full resolution without distortion
+    this.canvas.nativeElement.getContext('2d').drawImage(this.video.nativeElement, 0, 0, videoWidth, videoHeight);
+
+    // Convert to data URL with JPEG format for smaller file size
+    this.clientImageDataURL = this.canvas.nativeElement.toDataURL('image/jpeg', 0.9);
   }
 
   /**


### PR DESCRIPTION
## Description
This PR improves image distortion handling and enhances overall visual quality.

#{Issue Number}
WEB-476
## Screenshots, if any
before:
<img width="1666" height="340" alt="Screenshot 2025-12-04 140506" src="https://github.com/user-attachments/assets/36455782-2f02-49c3-a981-f934d7201e44" />
after:
<img width="1651" height="877" alt="Screenshot 2025-12-04 140955" src="https://github.com/user-attachments/assets/47230ca5-8865-43d5-8b56-e15cbe302d1f" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image capture now preserves full video resolution for noticeably higher-quality photos.
  * Improved error handling when camera access is denied, with clearer failure handling and more reliable behavior.

* **Style**
  * Refined video display styling (CSS class) for better sizing, aspect ratio handling and visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->