### PR TITLE
WEB-478-fix/i18n/savings-account-details-missing 

### DIFF
--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -2744,6 +2744,7 @@
       "All Fixed Deposits": "Všechny pevné vklady",
       "All Recurring Deposits": "Všechny opakované vklady",
       "All Savings": "Všechny úspory",
+      "Savings Account Details": "Podrobnosti spořicího účtu",
       "Allocate Cash": "Přidělte hotovost",
       "Allows you to create new fixed deposit product": "Tato možnost vám umožňuje vytvořit nový produkt s pevným vkladem.",
       "This option allows you to create new users in your organization": "Tato možnost vám umožňuje vytvářet nové uživatele ve vaší organizaci",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -2744,6 +2744,7 @@
       "All Fixed Deposits": "Alle Festgelder",
       "All Recurring Deposits": "Alle wiederkehrenden Einzahlungen",
       "All Savings": "Alle Einsparungen",
+      "Savings Account Details": "Sparkonto-Details",
       "Allocate Cash": "Bargeld zuweisen",
       "Allows you to create new fixed deposit product": "Mit dieser Option können Sie ein neues Festgeldprodukt erstellen.",
       "This option allows you to create new users in your organization": "Mit dieser Option können Sie neue Benutzer in Ihrer Organisation erstellen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2753,6 +2753,7 @@
       "All Fixed Deposits": "All Fixed Deposits",
       "All Recurring Deposits": "All Recurring Deposits",
       "All Savings": "All Savings",
+      "Savings Account Details": "Savings Account Details",
       "Allocate Cash": "Allocate Cash",
       "Allows you to create new fixed deposit product": "This option allows you to create a new fixed deposit product.",
       "This option allows you to create new users in your organization": "This option allows you to create new users in your organization",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -2744,6 +2744,7 @@
       "All Fixed Deposits": "Todos los depósitos fijos",
       "All Recurring Deposits": "Todos los depósitos recurrentes",
       "All Savings": "Todos los ahorros",
+      "Savings Account Details": "Detalles de la cuenta de ahorros",
       "Allocate Cash": "Asignar efectivo",
       "Allows you to create new fixed deposit product": "Esta opción le permite crear un nuevo producto de Depósito Fijo.",
       "This option allows you to create new users in your organization": "Esta opción le permite crear nuevos usuarios en su organización.",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -2746,6 +2746,7 @@
       "All Fixed Deposits": "Todos los depósitos fijos",
       "All Recurring Deposits": "Todos los depósitos recurrentes",
       "All Savings": "Todos los ahorros",
+      "Savings Account Details": "Detalles de la cuenta de ahorros",
       "Allocate Cash": "Asignar efectivo",
       "Allows you to create new fixed deposit product": "Esta opción le permite crear un nuevo producto de Depósito Fijo.",
       "This option allows you to create new users in your organization": "Esta opción le permite crear nuevos usuarios en su organización.",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -2744,6 +2744,7 @@
       "All Fixed Deposits": "Tous les dépôts fixes",
       "All Recurring Deposits": "Tous les dépôts récurrents",
       "All Savings": "Toutes les économies",
+      "Savings Account Details": "Détails du compte d'épargne",
       "Allocate Cash": "Allouer de l'argent",
       "Allows you to create new fixed deposit product": "Cette option vous permet de créer un nouveau produit de dépôt fixe.",
       "This option allows you to create new users in your organization": "Cette option vous permet de créer de nouveaux utilisateurs dans votre organisation",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -2744,6 +2744,7 @@
       "All Fixed Deposits": "Tutti i depositi fissi",
       "All Recurring Deposits": "Tutti i depositi ricorrenti",
       "All Savings": "Tutto il risparmio",
+      "Savings Account Details": "Dettagli del conto di risparmio",
       "Allocate Cash": "Assegnare contanti",
       "Allows you to create new fixed deposit product": "Questa opzione ti consente di creare un nuovo prodotto a deposito fisso.",
       "This option allows you to create new users in your organization": "Questa opzione ti consente di creare nuovi utenti nella tua organizzazione",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -2744,6 +2744,7 @@
       "All Fixed Deposits": "정기예금 전체",
       "All Recurring Deposits": "모든 정기 예금",
       "All Savings": "모든 저축",
+      "Savings Account Details": "저축 계좌 세부 정보",
       "Allocate Cash": "현금 할당",
       "Allows you to create new fixed deposit product": "이 옵션을 사용하면 새로운 정기 예금 상품을 생성할 수 있습니다.",
       "This option allows you to create new users in your organization": "이 옵션을 사용하면 조직에 새 사용자를 만들 수 있습니다.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -2744,6 +2744,7 @@
       "All Fixed Deposits": "Visi terminuoti indėliai",
       "All Recurring Deposits": "Visi periodiniai indėliai",
       "All Savings": "Visos santaupos",
+      "Savings Account Details": "Taupomosios sąskaitos informacija",
       "Allocate Cash": "Paskirstykite grynuosius pinigus",
       "Allows you to create new fixed deposit product": "Ši parinktis leidžia sukurti naują terminuoto indėlio produktą.",
       "This option allows you to create new users in your organization": "Ši parinktis leidžia sukurti naujų naudotojų jūsų organizacijoje",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -2744,6 +2744,7 @@
       "All Fixed Deposits": "Visi fiksētie noguldījumi",
       "All Recurring Deposits": "Visi atkārtotie noguldījumi",
       "All Savings": "Visi ietaupījumi",
+      "Savings Account Details": "Krājkonta informācija",
       "Allocate Cash": "Piešķirt skaidru naudu",
       "Allows you to create new fixed deposit product": "Šī opcija ļauj izveidot jaunu fiksētā depozīta produktu.",
       "This option allows you to create new users in your organization": "Šī opcija ļauj izveidot jaunus lietotājus jūsu organizācijā",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -2744,6 +2744,7 @@
       "All Fixed Deposits": "सबै फिक्स्ड डिपोजिटहरू",
       "All Recurring Deposits": "सबै आवर्ती निक्षेपहरू",
       "All Savings": "सबै बचत",
+      "Savings Account Details": "बचत खाता विवरण",
       "Allocate Cash": "नगद आवंटित गर्नुहोस्",
       "Allows you to create new fixed deposit product": "यो विकल्पले तपाईंलाई नयाँ फिक्स्ड डिपोजिट उत्पादन सिर्जना गर्न अनुमति दिन्छ।",
       "This option allows you to create new users in your organization": "यो विकल्पले तपाईंलाई आफ्नो संगठनमा नयाँ प्रयोगकर्ताहरू सिर्जना गर्न अनुमति दिन्छ",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -2744,6 +2744,7 @@
       "All Fixed Deposits": "Todos os depósitos fixos",
       "All Recurring Deposits": "Todos os depósitos recorrentes",
       "All Savings": "Todas as economias",
+      "Savings Account Details": "Detalhes da Conta Poupança",
       "Allocate Cash": "Alocar dinheiro",
       "Allows you to create new fixed deposit product": "Esta opção permite criar um novo produto de depósito fixo.",
       "This option allows you to create new users in your organization": "Esta opção permite criar novos usuários em sua organização",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -2743,6 +2743,7 @@
       "All Fixed Deposits": "Amana Zote Zisizohamishika",
       "All Recurring Deposits": "Amana Zote Zinazorudiwa",
       "All Savings": "Akiba Yote",
+      "Savings Account Details": "Maelezo ya Akaunti ya Akiba",
       "Allocate Cash": "Tenga Pesa",
       "Allows you to create new fixed deposit product": "Chaguo hili hukuruhusu kuunda bidhaa mpya ya amana isiyobadilika.",
       "This option allows you to create new users in your organization": "Chaguo hili hukuruhusu kuunda watumiaji wapya katika shirika lako",


### PR DESCRIPTION
## Description

This PR Added missing translation key "Savings Account Details" to the translation files so the page title displays properly instead of showing the raw translation key.

#{Issue Number}
WEB-478

## Screenshots, if any
before:
<img width="590" height="171" alt="Screenshot 2025-12-04 192827" src="https://github.com/user-attachments/assets/c887bd91-0be3-45b5-945d-3e4eb771be9d" />
after:
<img width="298" height="254" alt="image" src="https://github.com/user-attachments/assets/985cd77e-5465-458a-b24b-af0eef638129" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the "Savings Account Details" UI label translations in 13 languages: Czech, German, English, Spanish (CL & MX), French, Italian, Korean, Lithuanian, Latvian, Nepali, Portuguese, and Swahili.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->