### PR TITLE
WEB-454 Nominal annual interest field allows zero and negative values in saving product creation form

### DIFF
--- a/src/app/products/saving-products/saving-product-stepper/saving-product-terms-step/saving-product-terms-step.component.html
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-terms-step/saving-product-terms-step.component.html
@@ -8,10 +8,15 @@
         matTooltip="{{ 'tooltips.The default interest rate set' | translate }}"
         formControlName="nominalAnnualInterestRate"
         required
+        min="0"
+        step="0.01"
       />
-      <mat-error>
+      <mat-error *ngIf="savingProductTermsForm.get('nominalAnnualInterestRate').hasError('required')">
         {{ 'labels.inputs.Nominal Annual Interest' | translate }} {{ 'labels.commons.is' | translate }}
         <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
+      <mat-error *ngIf="savingProductTermsForm.get('nominalAnnualInterestRate').hasError('min')">
+        {{ 'labels.inputs.Nominal Annual Interest' | translate }} must be zero or greater
       </mat-error>
     </mat-form-field>
 

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-terms-step/saving-product-terms-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-terms-step/saving-product-terms-step.component.ts
@@ -50,7 +50,9 @@ export class SavingProductTermsStepComponent implements OnInit {
     this.savingProductTermsForm = this.formBuilder.group({
       nominalAnnualInterestRate: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)]
       ],
       interestCompoundingPeriodType: [
         '',


### PR DESCRIPTION
**Changes Made :-**

-Added validation to ensure the "Nominal Annual Interest" field only accepts positive values in the Create Saving Product form.

[WEB-454](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-454) 

Before :- 
<img width="1360" height="681" alt="image-20251203-031014" src="https://github.com/user-attachments/assets/b0783ff0-c209-435d-b1a7-d086972d918b" />

After :- 
<img width="1365" height="675" alt="image" src="https://github.com/user-attachments/assets/9e23839a-f160-4259-8a7d-a6802ca25fe3" />


<img width="1363" height="679" alt="image" src="https://github.com/user-attachments/assets/ae55b9bb-1e7b-431e-b6ee-9144f13244a4" />

<img width="1365" height="631" alt="image" src="https://github.com/user-attachments/assets/8254303b-26d7-45e2-991d-ef377eb36130" />



[WEB-454]: https://mifosforge.jira.com/browse/WEB-454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a minimum value of 0 for the annual interest rate field.
  * Added clearer, conditional error messages for required and minimum-value validation.
  * Improved input behavior to accept decimal interest values (step of 0.01).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->