### PR TITLE
WEB-481 :- a translation problem in mifos home page Tooltip text shows tooltips.Collection Sheet instead of Collection Sheet

### DIFF
--- a/src/app/core/shell/sidenav/sidenav.component.html
+++ b/src/app/core/shell/sidenav/sidenav.component.html
@@ -97,7 +97,7 @@
         <mat-list-item
           [routerLink]="['/collections/collection-sheet']"
           [matTooltipPosition]="tooltipPosition"
-          matTooltip="{{ 'tooltips.Collection Sheet' | translate }}"
+          matTooltip="{{ 'labels.menus.Collection Sheet' | translate }}"
           routerLinkActive="active-menu"
           [routerLinkActiveOptions]="{ exact: false }"
         >


### PR DESCRIPTION
## Description

a translation problem in mifos home page Tooltip text shows tooltips.Collection Sheet instead of Collection Sheet

<img width="711" height="770" alt="image" src="https://github.com/user-attachments/assets/78c7ad1b-1a2a-4b36-b41a-8757b83f08d3" />

<img width="603" height="712" alt="image" src="https://github.com/user-attachments/assets/74552969-6378-4834-82ff-d9d40562032c" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated localization references for menu item tooltips to align with current naming conventions in the translation system. No visible changes to user functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->