### PR TITLE
WEB-446: Validation of re-Age amount during submission with null value

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.html
@@ -70,10 +70,7 @@
               <input matInput formControlName="note" />
             </mat-form-field>
             <div class="flex-fill">
-              <span
-                class="expandcollapsebutton m-l-10 m-t-5 m-b-5 flex-75"
-                (click)="addTransactionAmount = !addTransactionAmount"
-              >
+              <span class="expandcollapsebutton m-l-10 m-t-5 m-b-5 flex-75" (click)="displayTransactionAmount()">
                 <mat-slide-toggle>
                   <div>
                     <span class="m-l-10">{{ 'labels.inputs.Transaction Amount' | translate }}</span>
@@ -87,7 +84,7 @@
                 [isRequired]="false"
                 [inputFormControl]="reagingLoanForm.controls.transactionAmount"
                 [inputLabel]="'Transaction Amount'"
-                [minVal]="0.01"
+                [minVal]="loanTransactionData.amount"
                 [maxVal]="loanTransactionData.amount"
               >
               </mifosx-input-amount>

--- a/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.ts
@@ -88,7 +88,10 @@ export class LoanReagingComponent implements OnInit {
       ],
       transactionAmount: [
         ,
-        [Validators.max(this.loanTransactionData.amount)]
+        [
+          Validators.min(this.loanTransactionData.amount),
+          Validators.max(this.loanTransactionData.amount)
+        ]
       ],
       note: '',
       externalId: '',
@@ -142,6 +145,13 @@ export class LoanReagingComponent implements OnInit {
       error: (error) => {
         console.error('Error loading re-age preview:', error);
       }
+    });
+  }
+
+  displayTransactionAmount(): void {
+    this.addTransactionAmount = !this.addTransactionAmount;
+    this.reagingLoanForm.patchValue({
+      transactionAmount: null
     });
   }
 


### PR DESCRIPTION
## Description

There is a Scenario where the total outstanding amount could change during the time the re-age is previewed and applied

[WEB-446](https://mifosforge.jira.com/browse/WEB-446)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-446]: https://mifosforge.jira.com/browse/WEB-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced transaction amount validation in loan reaging to dynamically enforce realistic minimum and maximum limits based on loan amounts.
- Improved form submission handling to ensure transaction amount fields are properly processed during loan reaging operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->