### PR TITLE
WEB-461 Minimum Active Period Field Allows Zero and Negative Values i…

### DIFF
--- a/src/app/products/share-products/share-product-stepper/share-product-settings-step/share-product-settings-step.component.html
+++ b/src/app/products/share-products/share-product-stepper/share-product-settings-step/share-product-settings-step.component.html
@@ -74,7 +74,13 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="minimumActivePeriodForDividends" />
+      <input type="number" matInput formControlName="minimumActivePeriodForDividends" min="1" step="1" required />
+      <mat-error *ngIf="shareProductSettingsForm.get('minimumActivePeriodForDividends').hasError('required')">
+        Frequency is <strong>required</strong>
+      </mat-error>
+      <mat-error *ngIf="shareProductSettingsForm.get('minimumActivePeriodForDividends').hasError('min')">
+        Frequency must be greater than zero
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field class="flex-48">

--- a/src/app/products/share-products/share-product-stepper/share-product-settings-step/share-product-settings-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-settings-step/share-product-settings-step.component.ts
@@ -79,7 +79,14 @@ export class ShareProductSettingsStepComponent implements OnInit {
             Validators.pattern(/^[0-9]+$/)
           ]
         ],
-        minimumActivePeriodForDividends: [''],
+        minimumActivePeriodForDividends: [
+          '',
+          [
+            Validators.required,
+            Validators.min(1),
+            Validators.pattern(/^[0-9]+$/)
+          ]
+        ],
         minimumactiveperiodFrequencyType: [''],
         lockinPeriodFrequency: [''],
         lockinPeriodFrequencyType: [''],


### PR DESCRIPTION
Changes Made :-

-Added validation to the "Minimum Active Period" field in the Create Share Product form to ensure only positive values greater than zero are allowed.

[WEB-461](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-461)

[WEB-461]: https://mifosforge.jira.com/browse/WEB-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Before :- 
<img width="1355" height="718" alt="image-20251203-030035" src="https://github.com/user-attachments/assets/274563a5-0f75-41f5-bd1b-f36a516e5029" />

After :- 
<img width="1365" height="721" alt="image" src="https://github.com/user-attachments/assets/8875c2ba-69f8-40e4-a78e-1a058a79c409" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for the minimum active period field: the input is now required, accepts only digits, and enforces a minimum value of 1, with clear error messages when the field is empty or below the allowed minimum.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->