### PR TITLE
WEB-464 Lock in Period Field Allows Zero and Negative Values in Share Product Creation Form

### DIFF
--- a/src/app/products/share-products/share-product-stepper/share-product-settings-step/share-product-settings-step.component.html
+++ b/src/app/products/share-products/share-product-stepper/share-product-settings-step/share-product-settings-step.component.html
@@ -98,7 +98,13 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="lockinPeriodFrequency" />
+      <input type="number" matInput formControlName="lockinPeriodFrequency" min="1" step="1" required />
+      <mat-error *ngIf="shareProductSettingsForm.get('lockinPeriodFrequency').hasError('required')">
+        Frequency is <strong>required</strong>
+      </mat-error>
+      <mat-error *ngIf="shareProductSettingsForm.get('lockinPeriodFrequency').hasError('min')">
+        Frequency must be greater than zero
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field class="flex-48">


### PR DESCRIPTION
Changes Made :-

Added validation to the "Lock-in Period" frequency field in the Create Share Product form to ensure only positive integer values greater than zero are allowed.

[WEB-464](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-464)

[WEB-464]: https://mifosforge.jira.com/browse/WEB-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cif

Before :- 
<img width="1365" height="681" alt="image-20251203-031147 (1)" src="https://github.com/user-attachments/assets/bf01e2cd-6692-49ca-82a6-340038515dc9" />

After :- 
<img width="1365" height="718" alt="image" src="https://github.com/user-attachments/assets/45883429-5795-4375-8a58-17fa6772dab7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced validation for the lock-in period frequency field in product settings. The field now requires input and enforces a minimum value of 1, with clear error messages displayed to guide users when validation requirements aren't met.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->