### PR TITLE
WEB(483)-fix: replace displayName column with separate firstname and lastname …

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -567,7 +567,6 @@ export class LoansAccountTermsStepComponent implements OnInit, OnChanges {
         required: true,
         order: 2
       })
-
     ];
     const data = {
       title: 'Add Disbursement Details',

--- a/src/app/organization/employees/employees.component.html
+++ b/src/app/organization/employees/employees.component.html
@@ -28,9 +28,14 @@
 
   <div #tableEmployees class="mat-elevation-z8">
     <table mat-table [dataSource]="dataSource" matSort>
-      <ng-container matColumnDef="displayName">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.name' | translate }}</th>
-        <td mat-cell *matCellDef="let employee">{{ employee.displayName }}</td>
+      <ng-container matColumnDef="firstname">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.First Name' | translate }}</th>
+        <td mat-cell *matCellDef="let employee">{{ employee.firstname }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="lastname">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Last Name' | translate }}</th>
+        <td mat-cell *matCellDef="let employee">{{ employee.lastname }}</td>
       </ng-container>
 
       <ng-container matColumnDef="isLoanOfficer">

--- a/src/app/organization/employees/employees.component.ts
+++ b/src/app/organization/employees/employees.component.ts
@@ -63,7 +63,8 @@ export class EmployeesComponent implements OnInit, AfterViewInit {
   employeesData: any;
   /** Columns to be displayed in employees table. */
   displayedColumns: string[] = [
-    'displayName',
+    'firstname',
+    'lastname',
     'isLoanOfficer',
     'officeName',
     'isActive'


### PR DESCRIPTION
…columns

## Description
This pr replaces the single "Name" column with two separate columns:
First Name - displays the employee's first name
Last Name - displays the employee's last name

#{Issue Number}
WEB-483
## Screenshots, if any
before:
<img width="1680" height="736" alt="Screenshot 2025-12-09 235735" src="https://github.com/user-attachments/assets/ad6f9823-ef75-4ff0-ac9b-2ae8008f759a" />
after:
<img width="1655" height="682" alt="Screenshot 2025-12-10 000425" src="https://github.com/user-attachments/assets/6eeb692a-58b5-44e5-9328-beb7ed1188c1" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Employee table now shows First Name and Last Name as separate columns instead of a combined display name.

* **Style**
  * Minor form configuration formatting cleaned up (no user-facing behavior change).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->