### PR TITLE
 WEB-463 Minimum Opening Balance Field Allows Zero and Negative Values in Saving Product Creation Form

### DIFF
--- a/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
@@ -7,7 +7,13 @@
         matInput
         matTooltip="{{ 'tooltips.Sets the minimum deposit amount' | translate }}"
         formControlName="minRequiredOpeningBalance"
+        min="0"
+        step="0.01"
       />
+      <mat-error *ngIf="savingProductSettingsForm.get('minRequiredOpeningBalance').hasError('min')">
+        {{ 'labels.inputs.Minimum Opening Balance' | translate }} {{ 'labels.commons.must be' | translate }}
+        {{ 'labels.commons.a positive number' | translate }}
+      </mat-error>
     </mat-form-field>
 
     <span class="flex-48 hide-lt-md"></span>

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.ts
@@ -71,7 +71,10 @@ export class SavingProductSettingsStepComponent implements OnInit {
 
   createSavingProductSettingsForm() {
     this.savingProductSettingsForm = this.formBuilder.group({
-      minRequiredOpeningBalance: [''],
+      minRequiredOpeningBalance: [
+        '',
+        [Validators.min(0)]
+      ],
       lockinPeriodFrequency: [
         '',
         [


### PR DESCRIPTION
**Changes Made :-**

- Added `Validators.min(0)` validation in TypeScript
- Added `min="0"` and `step="0.01"` attributes in HTML
- Updated error message to use translation keys

[WEB-463](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-463)

[WEB-463]: https://mifosforge.jira.com/browse/WEB-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Before :- 
<img width="1364" height="680" alt="image-20251203-030853" src="https://github.com/user-attachments/assets/00f5a14a-b4a2-4777-88f2-427db0c8017f" />

After :- 
<img width="1365" height="721" alt="image" src="https://github.com/user-attachments/assets/348c128b-6bd6-433b-a96c-5ccf0ad716fb" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the minimum opening balance: input now enforces a non-negative value and shows a clear localized error when the value is below the minimum.
  * Input behavior refined for decimal amounts to allow cent precision and prevent invalid entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->