### PR TITLE
WEB-469 Missing Value/Placeholder Next to Lock-in Period Dropdown

### DIFF
--- a/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
@@ -23,6 +23,7 @@
     </mat-form-field>
 
     <mat-form-field class="flex-48">
+      <mat-label>{{ 'labels.inputs.Type' | translate }}</mat-label>
       <mat-select formControlName="lockinPeriodFrequencyType">
         @for (lockinPeriodFrequencyType of lockinPeriodFrequencyTypeData; track lockinPeriodFrequencyType) {
           <mat-option [value]="lockinPeriodFrequencyType.id">


### PR DESCRIPTION
**Changes Made :-**

-Added a "Type" placeholder  in the Create Saving Product form .

[WEB-469](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-469)

Before :- 
<img width="1365" height="720" alt="image-20251203-035110" src="https://github.com/user-attachments/assets/c1ccb44e-808d-4d1a-98bb-e7e781533345" />

After :- 
<img width="1365" height="679" alt="image" src="https://github.com/user-attachments/assets/4e725358-1f73-42fe-85cd-ee77d2e9b778" />


[WEB-469]: https://mifosforge.jira.com/browse/WEB-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a clarifying label for the Type field in the saving product configuration screen to improve user interface clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->