### PR TITLE
WEB-462 Lock in period field allows zero and negative values in save product creation form

### DIFF
--- a/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
@@ -19,7 +19,20 @@
         matInput
         matTooltip="{{ 'tooltips.Used to indicate the length of time' | translate }}"
         formControlName="lockinPeriodFrequency"
+        min="1"
+        step="1"
+        required
       />
+      <mat-error *ngIf="savingProductSettingsForm.get('lockinPeriodFrequency').hasError('required')">
+        {{ 'labels.inputs.Frequency' | translate }} {{ 'labels.commons.is' | translate }}
+        <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
+      <mat-error *ngIf="savingProductSettingsForm.get('lockinPeriodFrequency').hasError('min')">
+        {{ 'tooltips.Frequency must be greater than zero' | translate }}
+      </mat-error>
+      <mat-error *ngIf="savingProductSettingsForm.get('lockinPeriodFrequency').hasError('pattern')">
+        {{ 'tooltips.Frequency must be a positive integer' | translate }}
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field class="flex-48">

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.ts
@@ -72,7 +72,14 @@ export class SavingProductSettingsStepComponent implements OnInit {
   createSavingProductSettingsForm() {
     this.savingProductSettingsForm = this.formBuilder.group({
       minRequiredOpeningBalance: [''],
-      lockinPeriodFrequency: [''],
+      lockinPeriodFrequency: [
+        '',
+        [
+          Validators.required,
+          Validators.min(1),
+          Validators.pattern('^[1-9]\\d*$')
+        ]
+      ],
       lockinPeriodFrequencyType: [''],
       withdrawalFeeForTransfers: [false],
       minBalanceForInterestCalculation: [''],


### PR DESCRIPTION
**Changes Made :-**

-Added validation to the "Lock-in Period" frequency field in the Create Saving Product form to ensure only positive integer values greater than zero are allowed.

[WEB-462](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-462)

[WEB-462]: https://mifosforge.jira.com/browse/WEB-462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for the locking period frequency field: it is now required, must be a positive integer (minimum 1), and shows clear, localized error messages for missing, too-small, or invalid-format input.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->