### PR TITLE
WEB-466 Number of repayments field allows zero and negative values in loan product creation form

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -96,13 +96,13 @@
       <input type="number" matInput formControlName="minNumberOfRepayments" [min]="1" />
       <mat-error>
         {{ 'labels.commons.Minimum Value must be' | translate }}
-        <strong>{{ 'labels.commons.greater equal to than 0' | translate }}</strong>
+        <strong>1</strong>
       </mat-error>
     </mat-form-field>
 
     <mat-form-field class="flex-31">
       <mat-label>{{ 'labels.inputs.Default' | translate }}</mat-label>
-      <input type="number" matInput formControlName="numberOfRepayments" required />
+      <input type="number" matInput formControlName="numberOfRepayments" required [min]="1" />
       <mat-error>
         {{ 'labels.catalogs.Default' | translate }} {{ 'labels.inputs.Number of repayments' | translate }}
         {{ 'labels.commons.is' | translate }}
@@ -112,12 +112,12 @@
 
     <mat-form-field class="flex-31">
       <mat-label>{{ 'labels.inputs.Maximum' | translate }}</mat-label>
-      <input type="number" matInput formControlName="maxNumberOfRepayments" [min]="0" />
+      <input type="number" matInput formControlName="maxNumberOfRepayments" [min]="1" />
       <mat-error>
         {{ 'labels.commons.Maximum Value must be' | translate }}
-        <strong>{{ 'labels.commons.greater equal to than 0' | translate }}</strong>
+        <strong>1</strong>
         {{ 'labels.commons.and must be greater than' | translate }}
-        <strong>{{ 'labels.commons.Minimum Principal' | translate }}</strong>
+        <strong>{{ 'labels.inputs.Minimum' | translate }}</strong>
       </mat-error>
     </mat-form-field>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -194,12 +194,25 @@ export class LoanProductTermsStepComponent implements OnInit, OnChanges {
         Validators.required
       ],
       maxPrincipal: [''],
-      minNumberOfRepayments: [''],
+      minNumberOfRepayments: [
+        '',
+        [
+          Validators.pattern('^[1-9]\\d*$')
+        ]
+      ],
       numberOfRepayments: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.pattern('^[1-9]\\d*$')
+        ]
       ],
-      maxNumberOfRepayments: [''],
+      maxNumberOfRepayments: [
+        '',
+        [
+          Validators.pattern('^[1-9]\\d*$')
+        ]
+      ],
       isLinkedToFloatingInterestRates: [false],
       allowApprovedDisbursedAmountsOverApplied: [false],
       overAppliedCalculationType: [{ value: null, disabled: true }],


### PR DESCRIPTION
**Changes Made :-**

-Restricted the "Number of Repayments" fields in the Loan Product creation form to only allow positive integers (minimum value set to 1) for minimum, default, and maximum.

[WEB-466](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-466)

Before :-
<img width="1365" height="721" alt="image-20251203-033201" src="https://github.com/user-attachments/assets/d0e385cc-2725-4494-b113-42405b4d6b14" />

After :- 
<img width="1365" height="718" alt="image" src="https://github.com/user-attachments/assets/d8df5a55-65c2-4116-9309-f4a10c0f42b5" />


[WEB-466]: https://mifosforge.jira.com/browse/WEB-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a minimum of 1 for loan repayment count fields to prevent zero or empty entries.
  * Strengthened input validation for repayment-related fields and made error messages consistent with the new minimum.
  * Adjusted displayed validation text to clearly show "1" as the minimum where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->