### PR TITLE
WEB-465 Principal field allows zero and negative values in loan product creation form

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -10,31 +10,29 @@
 
     <mat-form-field class="flex-31">
       <mat-label>{{ 'labels.inputs.Minimum' | translate }}</mat-label>
-      <input type="number" matInput formControlName="minPrincipal" [min]="0" />
-      <mat-error>
+      <input type="number" matInput formControlName="minPrincipal" [min]="1" step="0.01" />
+      <mat-error *ngIf="loanProductTermsForm.get('minPrincipal')?.hasError('min')">
         {{ 'labels.commons.Minimum Value must be' | translate }}
-        <strong>{{ 'labels.commons.greater equal to than 0' | translate }}</strong>
+        <strong>{{ loanProductTermsForm.get('minPrincipal')?.errors?.['min']?.min || 1 }}</strong>
       </mat-error>
     </mat-form-field>
 
     <mat-form-field class="flex-31">
       <mat-label>{{ 'labels.inputs.Default' | translate }}</mat-label>
-      <input type="number" matInput formControlName="principal" required />
-      <mat-error>
+      <input type="number" matInput formControlName="principal" required [min]="1" step="0.01" />
+      <mat-error *ngIf="loanProductTermsForm.get('principal')?.hasError('min')">
         {{ 'labels.catalogs.Default' | translate }} {{ 'labels.inputs.Principal' | translate }}
         {{ 'labels.commons.is' | translate }}
-        <strong>{{ 'labels.commons.required' | translate }}</strong>
+        <strong>{{ loanProductTermsForm.get('principal')?.errors?.['min']?.min || 1 }}</strong>
       </mat-error>
     </mat-form-field>
 
     <mat-form-field class="flex-31">
       <mat-label>{{ 'labels.inputs.Maximum' | translate }}</mat-label>
-      <input type="number" matInput formControlName="maxPrincipal" [min]="0" />
-      <mat-error>
+      <input type="number" matInput formControlName="maxPrincipal" [min]="1" step="0.01" />
+      <mat-error *ngIf="loanProductTermsForm.get('maxPrincipal')?.hasError('min')">
         {{ 'labels.commons.Minimum Value must be' | translate }}
-        <strong>{{ 'labels.commons.greater equal to than 0' | translate }}</strong>
-        {{ 'labels.commons.and must be greater than' | translate }}
-        <strong>{{ 'labels.commons.Minimum Principal' | translate }}</strong>
+        <strong>{{ loanProductTermsForm.get('maxPrincipal')?.errors?.['min']?.min || 1 }}</strong>
       </mat-error>
     </mat-form-field>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -188,12 +188,25 @@ export class LoanProductTermsStepComponent implements OnInit, OnChanges {
   createLoanProductTermsForm() {
     this.loanProductTermsForm = this.formBuilder.group({
       useBorrowerCycle: [false],
-      minPrincipal: [''],
+      minPrincipal: [
+        '',
+        [
+          Validators.min(1)
+        ]
+      ],
       principal: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(1)
+        ]
       ],
-      maxPrincipal: [''],
+      maxPrincipal: [
+        '',
+        [
+          Validators.min(1)
+        ]
+      ],
       minNumberOfRepayments: [
         '',
         [


### PR DESCRIPTION
**Changes Made:**

Added validation to ensure the "Principal" field (minimum, default, and maximum) only accepts positive values (minimum 1, decimals allowed) in the Create Loan Product form.

[WEB-465](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-465)

Before :- 
<img width="1024" height="539" alt="image" src="https://github.com/user-attachments/assets/fffa0fdf-b78d-42cb-8a69-941197f2c4a9" />

After :- 
<img width="1365" height="720" alt="image" src="https://github.com/user-attachments/assets/31efecc8-3f25-465f-8e53-565db3823e27" />


[WEB-465]: https://mifosforge.jira.com/browse/WEB-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a minimum principal value of 1 across relevant fields to prevent zero entries.
  * Enabled decimal precision for principal inputs with 0.01 increments for finer entry.
  * Improved validation messaging so the displayed minimum/default value is consistent and only shown when the minimum error applies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->