### PR TITLE
WEB-441-fix: display CodeLookup values instead of IDs in datatable view

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
@@ -235,6 +235,11 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
             if (typeof value === 'number') {
               value = this.numberFormat.transform(value);
             }
+          } else if (columnDisplayType === 'CODELOOKUP') {
+            if (columnHeader.columnValues && value !== null && value !== undefined) {
+              const codeValue = columnHeader.columnValues.find((cv: any) => cv.id === value);
+              value = codeValue ? codeValue.value : value;
+            }
           }
           return true;
         }

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
@@ -25,8 +25,7 @@
       @for (columnHeader of dataObject.columnHeaders; track columnHeader; let i = $index) {
         <div class="flex-fill" [ngClass]="setAttributeClass(columnHeader.columnName)">
           <div class="mat-body-strong left flex-40">
-            {{ columnHeader.columnDisplayName }}
-            {{ getInputName(columnHeader.columnName) }}
+            {{ datatables.toDisplayLabel(columnHeader.columnName) }}
           </div>
           <div class="right flex-60">
             @switch (getColumnType(columnHeader.columnDisplayType, columnHeader.columnType)) {
@@ -48,6 +47,11 @@
               @case ('DECIMAL') {
                 <span>
                   {{ dataObject.data[0].row[i] | formatNumber }}
+                </span>
+              }
+              @case ('CODELOOKUP') {
+                <span>
+                  {{ datatables.getCodeLookupValue(columnHeader, dataObject.data[0].row[i]) }}
                 </span>
               }
               @case ('TEXT') {

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.scss
@@ -20,8 +20,6 @@
 
 .system-defined {
   margin-top: 3px;
-  color: $status-approved !important;
-  font-weight: 100;
 }
 
 .long-text {

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
@@ -43,7 +43,7 @@ export class DatatableSingleRowComponent implements OnInit {
   private dateUtils = inject(Dates);
   private dialog = inject(MatDialog);
   private settingsService = inject(SettingsService);
-  private datatables = inject(Datatables);
+  public datatables = inject(Datatables);
   private systemService = inject(SystemService);
 
   @Input() dataObject: any;
@@ -123,7 +123,8 @@ export class DatatableSingleRowComponent implements OnInit {
     const data = {
       title: 'Edit ' + this.datatableName + ' for ' + this.entityType,
       formfields: formfields,
-      layout: { addButtonText: 'Save' }
+      layout: { addButtonText: 'Submit' },
+      pristine: false
     };
     const editDialogRef = this.dialog.open(FormDialogComponent, { data, width: '50rem' });
     editDialogRef.afterClosed().subscribe((response: any) => {
@@ -180,6 +181,9 @@ export class DatatableSingleRowComponent implements OnInit {
         return columnDisplayType;
       }
       case 'DECIMAL': {
+        return columnDisplayType;
+      }
+      case 'CODELOOKUP': {
         return columnDisplayType;
       }
       case 'TEXT': {

--- a/src/app/system/manage-data-tables/view-data-table/view-data-table.component.html
+++ b/src/app/system/manage-data-tables/view-data-table/view-data-table.component.html
@@ -31,7 +31,12 @@
       <th mat-header-cell *matHeaderCellDef mat-sort-header class="center">
         {{ 'labels.inputs.Field Name' | translate }}
       </th>
-      <td mat-cell *matCellDef="let dataTableColumn">{{ dataTableColumn.columnName }}</td>
+      <td mat-cell *matCellDef="let dataTableColumn">
+        {{ getFieldDisplayName(dataTableColumn.columnName) }}
+        @if (datatables.getCodeName(dataTableColumn.columnName)) {
+          <span class="code-name">({{ datatables.getCodeName(dataTableColumn.columnName) }})</span>
+        }
+      </td>
     </ng-container>
 
     <ng-container matColumnDef="columnDisplayType">

--- a/src/app/system/manage-data-tables/view-data-table/view-data-table.component.scss
+++ b/src/app/system/manage-data-tables/view-data-table/view-data-table.component.scss
@@ -1,3 +1,9 @@
 table {
   width: 100%;
 }
+
+.code-name {
+  opacity: 0.6;
+  font-size: 0.9em;
+  margin-left: 4px;
+}

--- a/src/app/system/manage-data-tables/view-data-table/view-data-table.component.ts
+++ b/src/app/system/manage-data-tables/view-data-table/view-data-table.component.ts
@@ -19,7 +19,8 @@ import {
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 /** Custom Services */
-import { SystemService } from '../../system.service';
+import { SystemService } from 'app/system/system.service';
+import { Datatables } from 'app/core/utils/datatables';
 
 /** Custom Components */
 import { TranslateService } from '@ngx-translate/core';
@@ -60,6 +61,7 @@ export class ViewDataTableComponent implements OnInit {
   private router = inject(Router);
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  public datatables = inject(Datatables);
 
   /** Data Table Data */
   dataTableData: any;
@@ -103,6 +105,13 @@ export class ViewDataTableComponent implements OnInit {
    */
   ngOnInit() {
     this.setColumnsTable();
+  }
+
+  /**
+   * Get display name for field (e.g., "Actividad" from "ADDRESS_TYPE_cd_ACTIVIDAD")
+   */
+  getFieldDisplayName(columnName: string): string {
+    return this.datatables.toDisplayLabel(columnName);
   }
 
   /**


### PR DESCRIPTION
## Description

This pr improve the user experience by showing meaningful values instead of IDs and cleaner field labels.

#{Issue Number}
WEB-441

## Screenshots, if any
before:
<img width="1438" height="374" alt="image" src="https://github.com/user-attachments/assets/de189577-afe4-4a4a-ae8c-764d976d1669" />
after:
<img width="1627" height="389" alt="image" src="https://github.com/user-attachments/assets/f848a275-36b1-453a-b01a-ff2f5dcac666" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form and table field names now show human-readable labels (handles various naming patterns).
  * Code-lookup columns display their lookup values instead of raw IDs across single- and multi-row views.

* **Style**
  * Adjusted system-defined field styling and added a subtle code-name style for secondary field text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->