### PR TITLE
WEB-367 Creating duplicate accounting rules causes javascript errors that the user shouldnt see 1-1

### DIFF
--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3,6 +3,9 @@
   "Logged in as": "Přihlášen jako",
   "Remember me": "Zapamatuj si mě",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Omlouváme se, ale účetní pravidlo s tímto názvem již existuje."
+    },
     "error.resource.notImplemented.type": "Nenaimplementovaná chyba",
     "error.resource.notImplemented.message": "Funkce není implementována!",
     "linkedSavingsAccountOwnership": "Propojený spořicí účet nepatří vybranému klientovi.",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3,6 +3,9 @@
   "Logged in as": "Angemeldet als",
   "Remember me": "Erinnere dich an mich",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Entschuldigung, aber eine Buchungsregel mit diesem Namen existiert bereits."
+    },
     "error.resource.notImplemented.type": "Nicht implementierter Fehler",
     "error.resource.notImplemented.message": "Nicht implementierte Funktion!",
     "linkedSavingsAccountOwnership": "Verknüpftes Sparkonto gehört nicht zum ausgewählten Kunden.",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -5,6 +5,9 @@
   "error.resource.notImplemented.type": "Not Implemented Error",
   "error.resource.notImplemented.message": "Not implemented functionality!",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Sorry, but an Accounting Rule with this Name exists already."
+    },
     "linkedSavingsAccountOwnership": "Linked savings account does not belong to the selected client.",
     "clientNotInGSIM": "Client with ID {{id}} is not present in GSIM.",
     "Capitalized Income amount adjusted already adjusted": "Capitalized Income amount already adjusted",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3,6 +3,9 @@
   "Logged in as": "Conectado como",
   "Remember me": "Recordar me",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Lo sentimos, pero ya existe una regla contable con este nombre."
+    },
     "error.resource.notImplemented.type": "Error no implementado",
     "error.resource.notImplemented.message": "¡Funcionalidad no implementada!",
     "linkedSavingsAccountOwnership": "La cuenta de ahorro vinculada no pertenece al cliente seleccionado.",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3,6 +3,9 @@
   "Logged in as": "Conectado como",
   "Remember me": "Recordar me",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Lo sentimos, pero ya existe una regla contable con este nombre."
+    },
     "error.resource.notImplemented.type": "Error no implementado",
     "error.resource.notImplemented.message": "¡Funcionalidad no implementada!",
     "linkedSavingsAccountOwnership": "La cuenta de ahorro vinculada no pertenece al cliente seleccionado.",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3,6 +3,9 @@
   "Logged in as": "connecté en tant que",
   "Remember me": "Souviens-toi de moi",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Désolé, mais une règle comptable portant ce nom existe déjà."
+    },
     "error.resource.notImplemented.type": "Erreur non implémentée",
     "error.resource.notImplemented.message": "Fonctionnalité non implémentée !",
     "linkedSavingsAccountOwnership": "Le compte d'épargne lié n'appartient pas au client sélectionné.",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3,6 +3,9 @@
   "Logged in as": "Collegato come",
   "Remember me": "Ricordati di me",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Spiacenti, ma esiste già una regola contabile con questo nome."
+    },
     "error.resource.notImplemented.type": "Errore non implementato",
     "error.resource.notImplemented.message": "Funzionalità non implementata!",
     "linkedSavingsAccountOwnership": "Il conto di risparmio collegato non appartiene al cliente selezionato.",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3,6 +3,9 @@
   "Logged in as": "다음 계정으로 로그인됨",
   "Remember me": "날 기억해",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "죄송합니다. 이미 동일한 이름의 회계 규칙이 존재합니다."
+    },
     "error.resource.notImplemented.type": "구현되지 않은 오류",
     "error.resource.notImplemented.message": "구현되지 않은 기능입니다!",
     "linkedSavingsAccountOwnership": "연결된 저축 계좌가 선택한 클라이언트에 속하지 않습니다.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3,6 +3,9 @@
   "Logged in as": "prisijungęs kaip",
   "Remember me": "Prisimink mane",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Atsiprašome, bet apskaitos taisyklė su šiuo pavadinimu jau egzistuoja."
+    },
     "error.resource.notImplemented.type": "Neįdiegta klaida",
     "error.resource.notImplemented.message": "Funkcionalumas neįdiegtas!",
     "linkedSavingsAccountOwnership": "Susieta taupomoji sąskaita nepriklauso pasirinktam klientui.",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3,6 +3,9 @@
   "Logged in as": "ielogojies Kā",
   "Remember me": "Atceries mani",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Atvainojiet, bet grāmatvedības noteikums ar šo nosaukumu jau pastāv."
+    },
     "error.resource.notImplemented.type": "Neieviesta kļūda",
     "error.resource.notImplemented.message": "Funkcionalitāte nav ieviesta!",
     "linkedSavingsAccountOwnership": "Saistītais krājkonts nepieder izvēlētajam klientam.",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3,6 +3,9 @@
   "Logged in as": "को रूपमा लग इन गरियो",
   "Remember me": "मलाई सम्झनुहोस्",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "माफ गर्नुहोस्, यो नामको लेखा नियम पहिले नै अवस्थित छ।"
+    },
     "error.resource.notImplemented.type": "लागू नभएको त्रुटि",
     "error.resource.notImplemented.message": "कार्यक्षमता लागू गरिएको छैन!",
     "linkedSavingsAccountOwnership": "लिंक गरिएको बचत खाता चयनित ग्राहकको होइन।",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3,6 +3,9 @@
   "Logged in as": "logado como",
   "Remember me": "Lembre de mim",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Desculpe, mas já existe uma regra contabilística com este nome."
+    },
     "error.resource.notImplemented.type": "Erro não implementado",
     "error.resource.notImplemented.message": "Funcionalidade não implementada!",
     "linkedSavingsAccountOwnership": "A conta poupança vinculada não pertence ao cliente selecionado.",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3,6 +3,9 @@
   "Logged in as": "Imeingia kama",
   "Remember me": "Nikumbuke",
   "errors": {
+    "accountingRule": {
+      "duplicateName": "Samahani, lakini Kanuni ya Uhasibu yenye jina hili tayari ipo."
+    },
     "error.resource.notImplemented.type": "Hitilafu ya Kukamilika Haijatimizwa",
     "error.resource.notImplemented.message": "Utendakazi haujatekelezwa!",
     "linkedSavingsAccountOwnership": "Akaunti ya akiba iliyounganishwa haimilikiwi na mteja aliyechaguliwa.",

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,11 +1,3 @@
-// Version 1
-
-/*
- * Entry point of global application style.
- * Component-specific style should not go here and be included directly as part of the components.
- */
-
-// Import Default Theme for MifosX
 @use 'theme/mifosx-theme';
 @use 'theme/pictonblue-yellowgreen' as *;
 @use 'theme/indigo-pink' as *;
@@ -17,13 +9,20 @@
 @use 'lightgallery/scss/lg-thumbnail' as *;
 @use 'lightgallery/scss/lg-zoom' as *;
 @use 'lightgallery/scss/lg-fullscreen' as *;
+@use 'app/core/error-handler/error-handler.component';
 
 // Global Imports
 
 /* You can add global styles to this file, and also import other style files */
 
-// Error Handler Service Styles
-@use 'app/core/error-handler/error-handler.component';
+.custom-snackbar-top-right {
+  top: 48px !important;
+  right: 24px !important;
+  left: auto !important;
+  transform: none !important;
+  position: fixed !important;
+  z-index: 9999;
+}
 
 .scrollbar-styling {
   scrollbar-width: thin;


### PR DESCRIPTION
**Changes Made :-**

-Added user-friendly error handling for duplicate Accounting Rule names in the Create Accounting Rule form.
-Error message now appears at the top-right in the selected language, using i18n translation files.
-Updated all translation files to include the new error message key.

[WEB-367](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-367)

After Implementation - 
![WhatsApp Image 2025-12-14 at 7 03 18 PM](https://github.com/user-attachments/assets/fdb77184-8cc5-4b2f-b559-684bad0e03d9)

![WhatsApp Image 2025-12-14 at 7 03 18 PM](https://github.com/user-attachments/assets/af20756c-b4c0-45a7-92e0-64eab9239515)

![WhatsApp Image 2025-12-14 at 7 01 04 PM](https://github.com/user-attachments/assets/b139d8d8-cc94-434d-8fab-d6ddc9984b63)


[WEB-367]: https://mifosforge.jira.com/browse/WEB-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added localized error messages across 12+ languages for duplicate accounting rule names
  * Enhanced error notification system with improved visibility and positioning

* **Improvements**
  * Better error feedback during accounting rule creation with context-aware messages
  * Clearer user guidance when attempting to create rules with duplicate names

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->