### PR TITLE
WEB-500 fix the sidenav background in darkmode

### DIFF
--- a/src/app/core/shell/sidenav/sidenav.component.scss
+++ b/src/app/core/shell/sidenav/sidenav.component.scss
@@ -180,7 +180,3 @@
     }
   }
 }
-
-.active-menu {
-  background-color: #e0e0e0;
-}


### PR DESCRIPTION
## Description
This PR improves the sidenav icon background in dark mode by removing the white background.

#{Issue Number}
WEB-500

## Screenshots, if any
before:
<img width="1919" height="1079" alt="Screenshot 2025-12-15 014406" src="https://github.com/user-attachments/assets/3813651c-bf3b-4888-8fe4-6cacee18b2fb" />
after:
<img width="1915" height="1016" alt="Screenshot 2025-12-15 014445" src="https://github.com/user-attachments/assets/ef1051e8-ff86-45e1-9e41-f1340cd418dc" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed background color styling from the active menu state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->