### PR TITLE
WEB-503 fix: align centers general view with dark theme styles

### DIFF
--- a/src/app/organization/offices/view-office/general-tab/general-tab.component.ts
+++ b/src/app/organization/offices/view-office/general-tab/general-tab.component.ts
@@ -1,7 +1,6 @@
 /** Angular Imports */
 import { Component, inject } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ExternalIdentifierComponent } from '../../../../shared/external-identifier/external-identifier.component';
 import { DateFormatPipe } from '../../../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -15,7 +14,6 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   styleUrls: ['./general-tab.component.scss'],
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
-    FaIconComponent,
     ExternalIdentifierComponent,
     DateFormatPipe
   ]

--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -56,6 +56,7 @@
   }
 
   mifosx-clients-view,
+  mifosx-centers-view,
   mifosx-fixed-deposit-account-view,
   mifosx-loans-view,
   mifosx-shares-account-view,


### PR DESCRIPTION
## Description
Added the Centers account page to the dark theme so the Centers “General” page now uses the same dark cards and tabs as Clients and other account pages. This removes the white background.

Removed an unused FaIconComponent import from the Offices “General” tab to fix an Angular/esbuild warning (NG8113).
#{Issue Number}
WEB-503

## Screenshots, if any
before:
<img width="1822" height="653" alt="Screenshot 2025-12-16 004440" src="https://github.com/user-attachments/assets/f49741ea-c1cb-4958-9473-28a460a261dc" />
after:
<img width="1838" height="889" alt="image" src="https://github.com/user-attachments/assets/838fdc05-e914-4aec-b7a2-e9b0e30618fa" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Extended dark theme styling coverage to the centers view.

* **Refactor**
  * Removed unused icon library dependency from a component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->