### PR TITLE
Revert "WEB-469 Missing Value/Placeholder Next to Lock-in Period Dropdown"

### DIFF
--- a/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
@@ -36,7 +36,6 @@
     </mat-form-field>
 
     <mat-form-field class="flex-48">
-      <mat-label>{{ 'labels.inputs.Type' | translate }}</mat-label>
       <mat-select formControlName="lockinPeriodFrequencyType">
         @for (lockinPeriodFrequencyType of lockinPeriodFrequencyTypeData; track lockinPeriodFrequencyType) {
           <mat-option [value]="lockinPeriodFrequencyType.id">


### PR DESCRIPTION
Reverts openMF/web-app#2887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the label from the Lock-in Period Type field in the product settings form.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->