### PR TITLE
WEB-508 fix: Hide language icon button on large screens, show only on small s…

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -90,8 +90,15 @@
     <mifosx-language-selector class="ml-1 language hide-lt-md" tabindex="0"></mifosx-language-selector>
   </div>
 
-  <button mat-icon-button [matMenuTriggerFor]="languageMenu" tabindex="0">
-    <mat-icon class="lg-icon">language</mat-icon>
+  <button
+    mat-icon-button
+    [matMenuTriggerFor]="languageMenu"
+    class="show-lt-md"
+    tabindex="0"
+    [attr.aria-label]="'labels.menus.Language Selector' | translate"
+    matTooltip="{{ 'labels.menus.Language Selector' | translate }}"
+  >
+    <mat-icon>language</mat-icon>
   </button>
 
   <div #notifications>

--- a/src/app/core/shell/toolbar/toolbar.component.scss
+++ b/src/app/core/shell/toolbar/toolbar.component.scss
@@ -58,15 +58,14 @@
   }
 }
 
-// Show icon on small screens
-.lg-icon {
+// Show language icon button only on small screens (when full selector is hidden)
+.show-lt-md {
   display: none;
 }
 
-@media (width <= 959px) {
-  .lg-icon {
-    display: block;
-    margin-left: 5px;
+@media (width <= 768px) {
+  .show-lt-md {
+    display: inline-flex;
   }
 }
 


### PR DESCRIPTION
…creens

## Description
This PR hide language icon button on large screens, show only on small screens

#{Issue Number}
WEB-508
## Screenshots, if any
before:
<img width="1822" height="513" alt="Screenshot 2025-12-18 005138" src="https://github.com/user-attachments/assets/2c610204-2218-4070-96ec-456da3e29c0b" />
<img width="440" height="806" alt="Screenshot 2025-12-18 005519" src="https://github.com/user-attachments/assets/9c2ba474-0fca-40ba-b7d6-d7e65351878f" />
after:
<img width="1846" height="970" alt="image" src="https://github.com/user-attachments/assets/70c30faf-dffc-4ac6-8299-f51c2ec51640" />
<img width="397" height="859" alt="image" src="https://github.com/user-attachments/assets/9562f441-dfce-42e5-9cb3-46699df715e5" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the toolbar language button for improved responsiveness on small screens (new display rules for narrow widths).
  * Refined icon display behavior to better match mobile/tablet layouts and ensure consistent sizing.

* **Accessibility**
  * Added an accessible label and tooltip for the language button to improve screen reader and UX support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->