### PR TITLE
WEB-511 Update login page logo to use tenant-specific branding

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -13,6 +13,9 @@ FINERACT_PLATFORM_TENANT_IDENTIFIER=default
 # Tenant Identifiers list delimited by comma
 FINERACT_PLATFORM_TENANTS_IDENTIFIER=default
 
+# Tenant Logo URL - supports external URLs (e.g., https://example.com/logo.png) or local paths. Leave empty to use default tenant-specific logos
+TENANT_LOGO_URL=
+
 MIFOS_DEFAULT_LANGUAGE=en-US
 
 MIFOS_SUPPORTED_LANGUAGES=cs-CS,de-DE,en-US,es-MX,fr-FR,it-IT,ko-KO,lt-LT,lv-LV,ne-NE,pt-PT

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -50,7 +50,7 @@
 
     <!-- Logo with Organization Name -->
     <div class="layout-row align-center-center flex-auto">
-      <img src="assets/images/mifos_lg-logo.png" alt="{{ 'APP_NAME' | translate }} Logo" class="img-container" />
+      <img [src]="logoPath" (error)="onLogoError()" alt="{{ 'APP_NAME' | translate }} Logo" class="img-container" />
     </div>
 
     <!-- Form Section -->

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -65,11 +65,13 @@ export class LoginComponent implements OnInit, OnDestroy {
   twoFactorAuthenticationRequired = false;
   /** Subscription to alerts. */
   alert$: Subscription;
+  logoPath = 'assets/images/default_home.png';
 
   /**
    * Subscribes to alert event of alert service.
    */
   ngOnInit() {
+    this.updateLogo();
     this.alert$ = this.alertService.alertEvent.subscribe((alertEvent: Alert) => {
       const alertType = alertEvent.type;
       if (alertType === 'Password Expired') {
@@ -82,6 +84,8 @@ export class LoginComponent implements OnInit, OnDestroy {
         this.resetPassword = false;
         this.twoFactorAuthenticationRequired = false;
         this.router.navigate(['/'], { replaceUrl: true });
+      } else if (alertType === 'Tenant Changed') {
+        this.updateLogo();
       }
     });
   }
@@ -107,5 +111,22 @@ export class LoginComponent implements OnInit, OnDestroy {
 
   allowServerSwitch(): boolean {
     return environment.allowServerSwitch === 'false' ? false : true;
+  }
+
+  updateLogo(): void {
+    if (environment.tenantLogoUrl && environment.tenantLogoUrl.trim() !== '') {
+      this.logoPath = environment.tenantLogoUrl;
+      return;
+    }
+    const tenant = this.settingsService.tenantIdentifier;
+    if (tenant && tenant !== 'default') {
+      this.logoPath = `assets/images/${tenant}_home.png`;
+    } else {
+      this.logoPath = 'assets/images/default_home.png';
+    }
+  }
+
+  onLogoError(): void {
+    this.logoPath = 'assets/images/default_home.png';
   }
 }

--- a/src/app/shared/tenant-selector/tenant-selector.component.ts
+++ b/src/app/shared/tenant-selector/tenant-selector.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
 import { SettingsService } from 'app/settings/settings.service';
+import { AlertService } from 'app/core/alert/alert.service';
 import { MatFormField, MatPrefix, MatLabel } from '@angular/material/form-field';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -17,6 +18,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class TenantSelectorComponent implements OnInit {
   private settingsService = inject(SettingsService);
+  private alertService = inject(AlertService);
 
   /** Tenant selector form control. */
   tenantSelector = new UntypedFormControl();
@@ -40,6 +42,7 @@ export class TenantSelectorComponent implements OnInit {
 
   setTenantIdentifier(): void {
     this.settingsService.setTenantIdentifier(this.tenantSelector.value);
+    this.alertService.alert({ type: 'Tenant Changed', message: this.tenantSelector.value });
   }
 
   allowSelection(): boolean {

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -12,6 +12,8 @@
   window["env"]["fineractPlatformTenantId"]  = '';
   window["env"]["fineractPlatformTenantIds"]  = '';
 
+  window['env']['tenantLogoUrl'] = '';
+
   // Language Environment variables
   window["env"]["defaultLanguage"] = '';
   window["env"]["supportedLanguages"] = '';

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -12,6 +12,8 @@
   window['env']['fineractPlatformTenantId'] = '$FINERACT_PLATFORM_TENANT_IDENTIFIER';
   window['env']['fineractPlatformTenantIds'] = '$FINERACT_PLATFORM_TENANTS_IDENTIFIER';
 
+  window['env']['tenantLogoUrl'] = '$TENANT_LOGO_URL';
+
   // Language Environment variables
   window['env']['defaultLanguage'] = '$MIFOS_DEFAULT_LANGUAGE';
   window['env']['supportedLanguages'] = '$MIFOS_SUPPORTED_LANGUAGES';

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -47,6 +47,7 @@ export const environment = {
 
   displayBackEndInfo: loadedEnv['displayBackEndInfo'] || 'true',
   displayTenantSelector: loadedEnv['displayTenantSelector'] || 'true',
+  tenantLogoUrl: loadedEnv['tenantLogoUrl'] || 'assets/images/mifos_lg-logo.png',
   // Time in seconds, default 60 seconds
   waitTimeForNotifications: loadedEnv['waitTimeForNotifications'] || 60,
   // Time in seconds, default 30 seconds

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -51,6 +51,7 @@ export const environment = {
 
   displayBackEndInfo: loadedEnv.displayBackEndInfo || 'true',
   displayTenantSelector: loadedEnv.displayTenantSelector || 'true',
+  tenantLogoUrl: loadedEnv.tenantLogoUrl || 'assets/images/mifos_lg-logo.png',
   // Time in seconds, default 60 seconds
   waitTimeForNotifications: loadedEnv.waitTimeForNotifications || 60,
   // Time in seconds, default 30 seconds

--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -264,7 +264,8 @@ body.dark-theme {
 
   // Home page logo styling for dark mode
   mifosx-home {
-    [src*='mifos_lg-logo.png'] {
+    [src*='mifos_lg-logo.png'],
+    [src$='_home.png'] {
       content: url('../assets/images/white-mifos.png');
     }
   }


### PR DESCRIPTION
**Chnages Made :-** 

-Updated the login page to use default_home.png instead of the hardcoded mifos_lg-logo.png, ensuring alignment with tenant-specific branding requirements.
-Implemented automatic logo updates on the login page when the tenant is changed via the dropdown, following the {tenant}_home.png naming convention.
-Enhanced the tenant selector to emit a “Tenant Changed” alert whenever the selected tenant is switched.
-Updated dark mode CSS selectors to correctly support the new logo naming convention (default_home.png and {tenant}_home.png), ensuring consistent theming across all tenant configurations.

[WEB-511](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-511)

[WEB-511]: https://mifosforge.jira.com/browse/WEB-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login logo now updates dynamically for selected tenants with a configurable tenant logo URL and a default fallback.

* **Bug Fixes**
  * Broken or missing logo images automatically revert to the default.
  * Tenant change events trigger a logo refresh.

* **Style**
  * Dark theme updated to support additional logo filename variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->