### PR TITLE
WEB-359 Tab title labels.text.Fund Mapping not translated

### DIFF
--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3009,6 +3009,7 @@
     "For more details click": "Pro více podrobností klikněte",
     "Frequent Postings": "Časté příspěvky",
     "Fund": "Fond",
+    "Fund Mapping": "Mapování fondů",
     "Funds are associated with loans": "Finanční prostředky jsou spojeny s půjčkami",
     "fromEmail": "z e-mailu",
     "fromName": "ze jména",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3010,6 +3010,7 @@
     "For more details click": "Für weitere Details klicken Sie",
     "Frequent Postings": "Häufige Beiträge",
     "Fund": "Fonds",
+    "Fund Mapping": "Fondszuordnung",
     "Funds are associated with loans": "Mittel sind mit Krediten verbunden",
     "fromEmail": "aus der Email",
     "fromName": "von Namen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3020,6 +3020,7 @@
       "For more details click": "For more details click",
       "Frequent Postings": "Frequent Postings",
       "Fund": "Fund",
+      "Fund Mapping": "Fund Mapping",
       "Funds are associated with loans": "Funds are associated with loans",
       "fromEmail": "fromEmail",
       "fromName": "fromName",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3011,6 +3011,7 @@
       "For more details click": "Para más detalles haga clic",
       "Frequent Postings": "Publicaciones frecuentes",
       "Fund": "Fondo",
+      "Fund Mapping": "Mapeo de fondos",
       "Funds are associated with loans": "Los fondos están asociados con Créditos.",
       "fromEmail": "desde el e-mail",
       "fromName": "deNombre",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3013,6 +3013,7 @@
       "For more details click": "Para más detalles haga clic",
       "Frequent Postings": "Publicaciones frecuentes",
       "Fund": "Fondo",
+      "Fund Mapping": "Mapeo de fondos",
       "Funds are associated with loans": "Los fondos están asociados con Créditos.",
       "fromEmail": "desde el e-mail",
       "fromName": "deNombre",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3011,6 +3011,7 @@
       "For more details click": "Pour plus de détails cliquez",
       "Frequent Postings": "Publications fréquentes",
       "Fund": "Fonds",
+      "Fund Mapping": "Cartographie des fonds",
       "Funds are associated with loans": "Les fonds sont associés à des prêts",
       "fromEmail": "de l'email",
       "fromName": "deNom",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3011,6 +3011,7 @@
       "For more details click": "Per maggiori dettagli clicca",
       "Frequent Postings": "Pubblicazioni frequenti",
       "Fund": "Finanziare",
+      "Fund Mapping": "Mappatura dei fondi",
       "Funds are associated with loans": "I fondi sono associati ai prestiti",
       "fromEmail": "dall'email",
       "fromName": "dal nome",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3011,6 +3011,7 @@
       "For more details click": "자세한 내용을 보려면 클릭하세요.",
       "Frequent Postings": "자주 게시되는 게시물",
       "Fund": "축적",
+      "Fund Mapping": "자금 매핑",
       "Funds are associated with loans": "자금은 대출과 연결되어 있습니다",
       "fromEmail": "보낸사람이메일",
       "fromName": "이름에서",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3011,6 +3011,7 @@
       "For more details click": "Norėdami gauti daugiau informacijos, spustelėkite",
       "Frequent Postings": "Dažni skelbimai",
       "Fund": "Fondas",
+      "Fund Mapping": "Fondo planavimas",
       "Funds are associated with loans": "Lėšos yra susijusios su paskolomis",
       "fromEmail": "iš el. pašto",
       "fromName": "išVardas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3011,6 +3011,7 @@
       "For more details click": "Lai iegūtu sīkāku informāciju, noklikšķiniet",
       "Frequent Postings": "Bieža publicēšana",
       "Fund": "Fonds",
+      "Fund Mapping": "Fondu kartēšana",
       "Funds are associated with loans": "Līdzekļi ir saistīti ar aizdevumiem",
       "fromEmail": "no e-pasta",
       "fromName": "noVārds",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3010,6 +3010,7 @@
       "For more details click": "थप विवरणहरूको लागि क्लिक गर्नुहोस्",
       "Frequent Postings": "बारम्बार पोस्टिंगहरू",
       "Fund": "कोष",
+      "Fund Mapping": "कोष म्यापिङ",
       "Funds are associated with loans": "कोष ऋण संग सम्बन्धित छ",
       "fromEmail": "इमेलबाट",
       "fromName": "नामबाट",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3011,6 +3011,7 @@
       "For more details click": "Para mais detalhes clique",
       "Frequent Postings": "Postagens frequentes",
       "Fund": "Fundo",
+      "Fund Mapping": "Mapeamento de fundos",
       "Funds are associated with loans": "Os fundos estão associados a empréstimos",
       "fromEmail": "do email",
       "fromName": "de nome",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3008,6 +3008,7 @@
       "For more details click": "Kwa maelezo zaidi bofya",
       "Frequent Postings": "Machapisho ya Mara kwa Mara",
       "Fund": "Mfuko",
+      "Fund Mapping": "Ramani ya Fedha",
       "Funds are associated with loans": "Fedha zinahusishwa na mikopo",
       "fromEmail": "kutoka kwa Barua pepe",
       "fromName": "kutoka kwaJina",


### PR DESCRIPTION
Changes Made :- 

-Added missing labels.text.Fund Mapping translation key to all 13 language files to enable proper browser tab title translation when navigating to Admin → Organization → Fund Mapping page.

[WEB-359](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-359)

After :-  
![WhatsApp Image 2025-12-18 at 11 44 20 PM](https://github.com/user-attachments/assets/b340c9c9-c90b-4d19-9c26-19483c27f78b)

![WhatsApp Image 2025-12-18 at 11 45 02 PM](https://github.com/user-attachments/assets/a24f342d-3964-43ab-a734-ccb6c6443bc5)


[WEB-359]: https://mifosforge.jira.com/browse/WEB-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Fund Mapping" translations across languages: English, Spanish (Chile & Mexico), French, Italian, Korean, Lithuanian, Latvian, Nepali, Portuguese, Swahili, Czech, and German.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->