### PR TITLE
WEB-512 fix(login): correct logo image file extension

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -50,7 +50,7 @@
 
     <!-- Logo with Organization Name -->
     <div class="layout-row align-center-center flex-auto">
-      <img src="assets/images/mifos_lg-logo.png" alt="{{ 'APP_NAME' | translate }} Logo" class="img-container" />
+      <img src="assets/images/mifos_lg-logo.jpg" alt="{{ 'APP_NAME' | translate }} Logo" class="img-container" />
     </div>
 
     <!-- Form Section -->

--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -264,7 +264,7 @@ body.dark-theme {
 
   // Home page logo styling for dark mode
   mifosx-home {
-    [src*='mifos_lg-logo.png'] {
+    [src*='mifos_lg-logo.jpg'] {
       content: url('../assets/images/white-mifos.png');
     }
   }


### PR DESCRIPTION
## Description
This pr correct logo image file extension

#{Issue Number}
WEB-512

## Screenshots, if any
before:
<img width="567" height="952" alt="Screenshot 2025-12-19 204430" src="https://github.com/user-attachments/assets/a4496875-5ba9-49fa-bb07-c489bbe0d66c" />
after:
<img width="572" height="967" alt="Screenshot 2025-12-19 204744" src="https://github.com/user-attachments/assets/c9516d31-c7b0-4a9a-9334-819334d82da4" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the login interface logo to a different image format.
  * Aligned the dark-theme header to reference the updated logo asset.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->