### PR TITLE
WEB-513 fix/collection-heading-translation-dark-mode

### DIFF
--- a/src/app/collections/individual-collection-sheet/individual-collection-sheet.component.html
+++ b/src/app/collections/individual-collection-sheet/individual-collection-sheet.component.html
@@ -120,7 +120,7 @@
           <mat-paginator [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons></mat-paginator>
         }
         @if (savingsDataSource) {
-          <h2 class="mat-h2">{{ 'labels.inputs.Due Savings Collections' | translate }}</h2>
+          <h2 class="mat-h2">{{ 'labels.heading.Due Savings Collections' | translate }}</h2>
           <table class="mat-elevation-z1" mat-table [dataSource]="savingsDataSource" matSort>
             <ng-container matColumnDef="depositAccount">
               <th mat-header-cell *matHeaderCellDef mat-sort-header>

--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -175,6 +175,13 @@ body.dark-theme {
     color: white !important;
   }
 
+  // Override Material typography heading colors for dark theme
+  h2.mat-h2,
+  h3.mat-h3,
+  h4.mat-h4 {
+    color: rgb(255 255 255 / 87%) !important;
+  }
+
   mifosx-popover,
   .mat-menu-content,
   .mat-dialog-container {


### PR DESCRIPTION
## Description
This PR resolves two UI issues on the Individual Collection Sheet.
Fixed an incorrect translation reference that caused the “Due Savings Collections” heading to display a raw translation key instead of localized text.
Improved heading visibility in dark mode by ensuring collection-related headings remain readable and consistent with the dark theme design.

#{Issue Number}
WEB-513

## Screenshots, if any
before:
<img width="1408" height="964" alt="Screenshot 2025-12-20 164845" src="https://github.com/user-attachments/assets/b99147c3-acda-4a8c-a92c-118e689c6798" />
<img width="1756" height="884" alt="Screenshot 2025-12-20 165445" src="https://github.com/user-attachments/assets/20d22be6-59ca-41a6-8e2b-adaef7632094" />
after:
<img width="1822" height="970" alt="image" src="https://github.com/user-attachments/assets/214da4e2-3c93-4f34-b95e-22c6236a95c5" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark theme appearance with enhanced heading visibility for heading elements
* **Chores**
  * Reorganized translation key structure for content labels

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->