### PR TITLE
WEB-514 fix: make Print button styling consistent with Generate Report button

### DIFF
--- a/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.html
+++ b/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.html
@@ -37,7 +37,7 @@
 <div #output class="container m-t-20">
   <mat-card class="layout-column gap-3percent">
     <div class="layout-align-end">
-      <button mat-stroked-button color="primary" [disabled]="!template" (click)="print()">
+      <button mat-raised-button color="primary" [disabled]="!template" (click)="print()">
         <fa-icon icon="file" class="m-r-10"></fa-icon>
         {{ 'labels.buttons.Print' | translate }}
       </button>

--- a/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.scss
+++ b/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.scss
@@ -19,11 +19,6 @@
   height: 10rem;
 }
 
-.m-t-20 button {
-  background-color: #1976d2;
-  color: white;
-}
-
 ::ng-deep .container.m-t-20 mat-card p {
   display: block;
   margin-top: -1.9rem;


### PR DESCRIPTION
## Description

This pr make Print button styling consistent with Generate Report button

#{Issue Number}
WEB-514 

## Screenshots, if any
before:
<img width="901" height="484" alt="Screenshot 2025-12-20 231437" src="https://github.com/user-attachments/assets/d7b0af44-fd82-47f4-8d69-26d10b3e7d00" />
after:
<img width="1812" height="892" alt="image" src="https://github.com/user-attachments/assets/81d48653-289e-4745-a78b-74ac031cad91" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.
- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button styling in the client screen reports interface for improved visual appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->