### PR TITLE
WEB-510 Fix date localization and transaction type translation

### DIFF
--- a/src/app/pipes/date-format.pipe.ts
+++ b/src/app/pipes/date-format.pipe.ts
@@ -1,26 +1,78 @@
-import { Pipe, PipeTransform, inject } from '@angular/core';
+import { Pipe, PipeTransform, inject, OnDestroy } from '@angular/core';
 import { SettingsService } from 'app/settings/settings.service';
+import { TranslateService } from '@ngx-translate/core';
+import { Subscription } from 'rxjs';
 import moment from 'moment';
 
-@Pipe({ name: 'dateFormat' })
-export class DateFormatPipe implements PipeTransform {
+// Load moment.js locale data for all supported languages
+import 'moment/locale/ne'; // Nepali
+import 'moment/locale/es'; // Spanish
+import 'moment/locale/de'; // German
+import 'moment/locale/fr'; // French
+import 'moment/locale/it'; // Italian
+import 'moment/locale/ko'; // Korean
+import 'moment/locale/lt'; // Lithuanian
+import 'moment/locale/lv'; // Latvian
+import 'moment/locale/pt'; // Portuguese
+import 'moment/locale/sw'; // Swahili
+import 'moment/locale/cs'; // Czech
+
+@Pipe({ name: 'dateFormat', pure: false })
+export class DateFormatPipe implements PipeTransform, OnDestroy {
   private settingsService = inject(SettingsService);
+  private translateService = inject(TranslateService);
+  private onLangChange: Subscription;
+
+  constructor() {
+    // Subscribe to language changes so Angular re-evaluates the pipe when language switches
+    this.onLangChange = this.translateService.onLangChange.subscribe(() => {
+      // No body needed; impure pipe will be re-run during change detection
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.onLangChange) {
+      this.onLangChange.unsubscribe();
+    }
+  }
 
   transform(value: any, dateFormat?: string): any {
     const defaultDateFormat = this.settingsService.dateFormat.replace('dd', 'DD');
-    if (typeof value === 'undefined') {
+    if (typeof value === 'undefined' || value === null) {
       return '';
     }
+
+    // Map SettingsService language code to a moment.js locale identifier
+    const langCode = this.settingsService.language.code;
+    let momentLocale: string;
+
+    if (!langCode) {
+      momentLocale = 'en';
+    } else if (langCode.includes('-')) {
+      // Convert codes like 'ne-NE' or 'es-MX' to base language 'ne', 'es'
+      momentLocale = langCode.split('-')[0];
+    } else {
+      momentLocale = langCode;
+    }
+
+    moment.locale(momentLocale);
+
     let dateVal;
-    moment.locale(this.settingsService.language.code);
-    if (value instanceof Array) {
+    if (Array.isArray(value)) {
+      // Backend sometimes returns [yyyy, MM, dd]
       dateVal = moment(value.join('-'), 'YYYY-MM-DD');
     } else {
       dateVal = moment(value);
     }
-    if (dateFormat == null) {
+
+    if (!dateVal.isValid()) {
+      return '';
+    }
+
+    if (!dateFormat) {
       return dateVal.format(defaultDateFormat);
     }
+
     return dateVal.format(dateFormat);
   }
 }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -704,6 +704,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "Splatná pokuta, úrok, jistina, poplatek, Pokuta předem, úrok, jistina, poplatek",
       "Principal": "Ředitel školy",
       "Repayment": "Splácení",
+      "Repayment (at time of disbursement)": "Splácení (v době výplaty)",
       "Down payment": "Záloha",
       "Charge refund": "Vrácení poplatku",
       "Charge adjustment": "Úprava náboje",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -704,6 +704,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "Fällige Strafe, Zinsen, Kapital, Gebühr, Vorabstrafe, Zinsen, Kapital, Gebühr",
       "Principal": "Rektor",
       "Repayment": "Rückzahlung",
+      "Repayment (at time of disbursement)": "Rückzahlung (zum Zeitpunkt der Auszahlung)",
       "Down payment": "Anzahlung",
       "Charge refund": "Rückerstattung der Gebühr",
       "Charge adjustment": "Gebührenanpassung",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -724,6 +724,7 @@
       "Share Building Contribution": "Share Building Contribution",
       "Principal": "Principal",
       "Repayment": "Repayment",
+      "Repayment (at time of disbursement)": "Repayment (at time of disbursement)",
       "Down payment": "Down payment",
       "Charge refund": "Charge refund",
       "Charge adjustment": "Charge adjustment",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -703,6 +703,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "Penalización vencida, Intereses, Capital, Comisiones, Penalización por adelantado, Intereses, Capital, Comisiones",
       "Principal": "Capital",
       "Repayment": "Reembolso",
+      "Repayment (at time of disbursement)": "Reembolso (al momento del desembolso)",
       "Down payment": "Auto Pago",
       "Charge refund": "Reembolso de cargo",
       "Charge adjustment": "Ajuste de cargo",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -703,6 +703,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "Penalización vencida, Intereses, Capital, Comisiones, Penalización por adelantado, Intereses, Capital, Comisiones",
       "Principal": "Capital",
       "Repayment": "Reembolso",
+      "Repayment (at time of disbursement)": "Reembolso (al momento del desembolso)",
       "Down payment": "Auto Pago",
       "Charge refund": "Reembolso de cargo",
       "Charge adjustment": "Ajuste de cargo",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -704,6 +704,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "Pénalité due, intérêts, principal, frais, Pénalité d'avance, intérêts, principal, frais",
       "Principal": "Principal",
       "Repayment": "Remboursement",
+      "Repayment (at time of disbursement)": "Remboursement (au moment du décaissement)",
       "Down payment": "Acompte",
       "Charge refund": "Remboursement des frais",
       "Charge adjustment": "Ajustement des frais",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -704,6 +704,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "Penale dovuta, interessi, capitale, commissione, Penale anticipata, interessi, capitale, commissione",
       "Principal": "Principale",
       "Repayment": "Rimborso",
+      "Repayment (at time of disbursement)": "Rimborso (al momento del disborso)",
       "Down payment": "Acconto",
       "Charge refund": "Rimborso addebito",
       "Charge adjustment": "Adeguamento della tariffa",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -704,6 +704,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "위약금, 이자, 원금, 수수료, 선납 위약금, 이자, 원금, 수수료",
       "Principal": "주요한",
       "Repayment": "반환",
+      "Repayment (at time of disbursement)": "상환 (지급 시)",
       "Down payment": "계약금",
       "Charge refund": "청구금액 환불",
       "Charge adjustment": "요금 조정",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -704,6 +704,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "Delspinigiai, delspinigiai, pagrindinė suma, mokestis, Avansinė bauda, ​​palūkanos, pagrindinė suma, mokestis",
       "Principal": "direktorius",
       "Repayment": "Grąžinimas",
+      "Repayment (at time of disbursement)": "Grąžinimas (išmokėjimo metu)",
       "Down payment": "Pradinis įnašas",
       "Charge refund": "Mokesčio grąžinimas",
       "Charge adjustment": "Krovinio reguliavimas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -704,6 +704,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "Maksājamais līgumsods, procenti, pamatsumma, maksa, avansa līgumsods, procenti, pamatsumma, maksa",
       "Principal": "Direktors",
       "Repayment": "Atmaksa",
+      "Repayment (at time of disbursement)": "Atmaksa (izmaksas laikā)",
       "Down payment": "Pirmā iemaksa",
       "Charge refund": "Maksas atmaksa",
       "Charge adjustment": "Uzlādes regulēšana",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -704,6 +704,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "बक्यौता जरिवाना, व्याज, मुद्दल, शुल्क, अग्रिम जरिवाना, व्याज, मूल, शुल्क",
       "Principal": "प्रिन्सिपल",
       "Repayment": "भुक्तानी",
+      "Repayment (at time of disbursement)": "भुक्तानी (वितरणको समयमा)",
       "Down payment": "डाउन पेमेन्ट",
       "Charge refund": "शुल्क फिर्ता",
       "Charge adjustment": "चार्ज समायोजन",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -704,6 +704,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "Pena devida, juros, principal, taxa, multa antecipada, juros, principal, taxa",
       "Principal": "Diretor",
       "Repayment": "Reembolso",
+      "Repayment (at time of disbursement)": "Reembolso (no momento do desembolso)",
       "Down payment": "Pagamento inicial",
       "Charge refund": "Reembolso de cobrança",
       "Charge adjustment": "Ajuste de cobrança",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -704,6 +704,7 @@
       "Due penalty, interest, principal, fee, In advance penalty, interest, principal, fee": "Adhabu inayostahili, riba, mkuu, ada, Adhabu ya mapema, riba, mkuu, ada",
       "Principal": "Mkuu wa shule",
       "Repayment": "Ulipaji",
+      "Repayment (at time of disbursement)": "Ulipaji (wakati wa malipo)",
       "Down payment": "Malipo ya chini",
       "Charge refund": "Maliza marejesho",
       "Charge adjustment": "Marekebisho ya malipo",


### PR DESCRIPTION
## Description
This pr
fix date localization and transaction type translation. Dates now update immediately when language changes by importing moment.js locales, making dateFormat pipe reactive (pure: false), and subscribing to language changes. Added missing "Repayment (at time of disbursement)" translation to all 13 language files. Both dates and transaction types now display correctly in the selected language without requiring page refresh.

#{Issue Number}
WEB-510

## Screenshots, if any
before:
<img width="1756" height="884" alt="Screenshot 2025-12-20 165445" src="https://github.com/user-attachments/assets/568ec811-1c19-4026-a20b-458526ea93d9" />
after:
<img width="1653" height="900" alt="Screenshot 2025-12-20 173527" src="https://github.com/user-attachments/assets/48c3ba0d-40bd-4a03-9913-e98ec0c65cdc" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dates in the application now automatically update when the user changes their language preference
  * Added "Repayment (at time of disbursement)" label across all supported languages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->