### PR TITLE
WEB-516:Fix update notes section styling for dark theme

### DIFF
--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -282,4 +282,50 @@ body.dark-theme {
   .select-row:hover {
     background-color: rgb(255 255 255 / 8%) !important;
   }
+
+  // Notes section dark theme styling
+  mifosx-entity-notes-tab {
+    .tab-container {
+      h3 {
+        color: white;
+      }
+    }
+
+    .note-card {
+      background-color: #303135;
+      border-color: #424242;
+      color: white;
+
+      &:hover {
+        box-shadow: 0 4px 8px rgb(0 0 0 / 30%);
+        border-color: #555;
+      }
+    }
+
+    .note-content {
+      color: white;
+    }
+
+    .note-footer {
+      border-top-color: #424242;
+    }
+
+    .note-meta {
+      color: rgb(255 255 255 / 70%);
+    }
+
+    .created-by {
+      color: #0098ff;
+    }
+
+    .created-date {
+      color: rgb(255 255 255 / 60%);
+    }
+
+    .empty-state {
+      background-color: #303135;
+      color: rgb(255 255 255 / 70%);
+      border-color: #424242;
+    }
+  }
 }


### PR DESCRIPTION
## Description
This pr Fixes the issue where notes section displayed white cards that didn't match the dark theme.

WEB-516

before:
<img width="1714" height="884" alt="Screenshot 2025-12-22 231156" src="https://github.com/user-attachments/assets/88f400f4-1aea-4bb9-af37-dfd6fea7f025" />
after:
<img width="1919" height="1031" alt="Screenshot 2025-12-22 232851" src="https://github.com/user-attachments/assets/b0bc17cb-b9be-4d3e-b488-3e842b1cddd6" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark-theme styling for the notes section with updated colors, backgrounds, borders, and hover effects for improved visual consistency in dark mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->