### PR TITLE
WEB-517:Fix resolve overlap between text and buttons in Edit Meeting form

### DIFF
--- a/src/app/groups/groups-view/group-actions/edit-group-meeting/edit-group-meeting.component.html
+++ b/src/app/groups/groups-view/group-actions/edit-group-meeting/edit-group-meeting.component.html
@@ -63,7 +63,7 @@
             </mat-form-field>
           }
 
-          <mat-form-field class="m-b-5" (click)="startDatePicker.open()">
+          <mat-form-field class="m-b-30" (click)="startDatePicker.open()">
             <mat-label>{{ 'labels.inputs.Above Changes are Effective from' | translate }}</mat-label>
             <input
               matInput

--- a/src/app/groups/groups-view/group-actions/edit-group-meeting/edit-group-meeting.component.scss
+++ b/src/app/groups/groups-view/group-actions/edit-group-meeting/edit-group-meeting.component.scss
@@ -1,3 +1,3 @@
 .container {
-  max-width: 37rem;
+  max-width: 32rem;
 }


### PR DESCRIPTION
## Description

This pr 
fixes a UI issue where the warning hint text overlapped the Submit and Cancel buttons in the Edit Meeting form, making both hard to read.

#{Issue Number}
WEB-517

before:
<img width="1912" height="1025" alt="Screenshot 2025-12-23 000047" src="https://github.com/user-attachments/assets/c5eddd7f-551f-493c-b57d-0420b813fe48" />
after:
<img width="1829" height="886" alt="Screenshot 2025-12-23 000703" src="https://github.com/user-attachments/assets/ce977fcf-9277-4e97-8d13-532c49cfbef8" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
