### PR TITLE
WEB-519 Make configuration wizard description text visible in dark mode

### DIFF
--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -329,4 +329,19 @@ body.dark-theme {
       border-color: #424242;
     }
   }
+
+  // Configuration wizard dark theme styling
+  mifosx-configuration-wizard {
+    .config-wizard-content {
+      .description {
+        color: white !important;
+      }
+
+      .progress-section {
+        .progress-label {
+          color: white !important;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION

This PR fixes a visibility issue where the Configuration Wizard description text was not visible in dark mode

[WEB-519](https://mifosforge.jira.com/browse/WEB-519)

Before:
<img width="1019" height="586" alt="Screenshot 2025-12-23 020721" src="https://github.com/user-attachments/assets/cd9faf99-c44e-4941-9d00-6f197435bfc3" />
After:
<img width="1845" height="973" alt="Screenshot 2025-12-23 095753" src="https://github.com/user-attachments/assets/bba3087e-259c-4005-ae90-21b9087accb6" />




Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark theme styling for the configuration wizard to improve text contrast and readability of component descriptions and progress indicators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WEB-519]: https://mifosforge.jira.com/browse/WEB-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ