### PR TITLE
WEB-524 Make Lock-in Period Optional for Savings Products

### DIFF
--- a/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
@@ -16,40 +16,62 @@
       </mat-error>
     </mat-form-field>
 
-    <span class="flex-48 hide-lt-md"></span>
+    <mat-divider class="flex-98"></mat-divider>
 
-    <mat-form-field class="flex-48">
-      <mat-label>{{ 'labels.inputs.Lock-in Period' | translate }}</mat-label>
-      <input
-        type="number"
-        matInput
-        matTooltip="{{ 'tooltips.Used to indicate the length of time' | translate }}"
-        formControlName="lockinPeriodFrequency"
-        min="1"
-        step="1"
-        required
-      />
-      <mat-error *ngIf="savingProductSettingsForm.get('lockinPeriodFrequency').hasError('required')">
-        {{ 'labels.inputs.Frequency' | translate }} {{ 'labels.commons.is' | translate }}
-        <strong>{{ 'labels.commons.required' | translate }}</strong>
-      </mat-error>
-      <mat-error *ngIf="savingProductSettingsForm.get('lockinPeriodFrequency').hasError('min')">
-        {{ 'tooltips.Frequency must be greater than zero' | translate }}
-      </mat-error>
-      <mat-error *ngIf="savingProductSettingsForm.get('lockinPeriodFrequency').hasError('pattern')">
-        {{ 'tooltips.Frequency must be a positive integer' | translate }}
-      </mat-error>
-    </mat-form-field>
+    <h3 class="mat-h3 flex-23">{{ 'labels.inputs.Lock-in Period' | translate }}</h3>
 
-    <mat-form-field class="flex-48">
-      <mat-select formControlName="lockinPeriodFrequencyType">
-        @for (lockinPeriodFrequencyType of lockinPeriodFrequencyTypeData; track lockinPeriodFrequencyType) {
-          <mat-option [value]="lockinPeriodFrequencyType.id">
-            {{ lockinPeriodFrequencyType.value | translateKey: 'catalogs' }}
-          </mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
+    <mat-checkbox
+      class="flex-73 margin-b"
+      labelPosition="before"
+      matTooltip="{{ 'tooltips.Used to indicate the length of time' | translate }}"
+      formControlName="enableLockinPeriod"
+    >
+      {{ 'labels.inputs.Enable Lock-in Period' | translate }}
+    </mat-checkbox>
+
+    @if (savingProductSettingsForm.value.enableLockinPeriod) {
+      <div class="flex-fill layout-row-wrap gap-2percent responsive-column">
+        <mat-form-field class="flex-48">
+          <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
+          <input
+            type="number"
+            matInput
+            matTooltip="{{ 'tooltips.The number at which lock in period occurs' | translate }}"
+            formControlName="lockinPeriodFrequency"
+            min="1"
+            step="1"
+            required
+          />
+          <mat-error *ngIf="savingProductSettingsForm.get('lockinPeriodFrequency')?.hasError('required')">
+            {{ 'labels.inputs.Frequency' | translate }} {{ 'labels.commons.is' | translate }}
+            <strong>{{ 'labels.commons.required' | translate }}</strong>
+          </mat-error>
+          <mat-error *ngIf="savingProductSettingsForm.get('lockinPeriodFrequency')?.hasError('min')">
+            {{ 'tooltips.Frequency must be greater than zero' | translate }}
+          </mat-error>
+          <mat-error *ngIf="savingProductSettingsForm.get('lockinPeriodFrequency')?.hasError('pattern')">
+            {{ 'tooltips.Frequency must be a positive integer' | translate }}
+          </mat-error>
+        </mat-form-field>
+
+        <mat-form-field class="flex-48">
+          <mat-label>{{ 'labels.inputs.Type' | translate }}</mat-label>
+          <mat-select formControlName="lockinPeriodFrequencyType" required>
+            @for (lockinPeriodFrequencyType of lockinPeriodFrequencyTypeData; track lockinPeriodFrequencyType) {
+              <mat-option [value]="lockinPeriodFrequencyType.id">
+                {{ lockinPeriodFrequencyType.value | translateKey: 'catalogs' }}
+              </mat-option>
+            }
+          </mat-select>
+          <mat-error *ngIf="savingProductSettingsForm.get('lockinPeriodFrequencyType')?.hasError('required')">
+            {{ 'labels.inputs.Type' | translate }} {{ 'labels.commons.is' | translate }}
+            <strong>{{ 'labels.commons.required' | translate }}</strong>
+          </mat-error>
+        </mat-form-field>
+      </div>
+    }
+
+    <mat-divider class="flex-98"></mat-divider>
 
     <mat-checkbox
       class="flex-48 margin-v"

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1597,6 +1597,7 @@
       "Enable Auto Repayment for Down Payment": "Povolit automatické splácení zálohy",
       "Enable Dormancy Tracking": "Povolit sledování dormance",
       "Enable Down Payment": "Povolit zálohu",
+      "Enable Lock-in Period": "Povolit zamykací období",
       "Enable Multiple Disbursals": "Povolit vícenásobné výplaty",
       "Enabled": "Povoleno",
       "End Date": "Datum ukončení",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1597,6 +1597,7 @@
       "Enable Auto Repayment for Down Payment": "Aktivieren Sie die automatische Rückzahlung für die Anzahlung",
       "Enable Dormancy Tracking": "Aktivieren Sie die Ruheverfolgung",
       "Enable Down Payment": "Anzahlung aktivieren",
+      "Enable Lock-in Period": "Sperrfrist aktivieren",
       "Enable Multiple Disbursals": "Aktivieren Sie Mehrfachauszahlungen",
       "Enabled": "Ermöglicht",
       "End Date": "Endtermin",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1601,6 +1601,7 @@
       "Enable Auto Repayment for Down Payment": "Enable Auto Repayment for Down Payment",
       "Enable Dormancy Tracking": "Enable Dormancy Tracking",
       "Enable Down Payment": "Enable Down Payment",
+      "Enable Lock-in Period": "Enable Lock-in Period",
       "Enable Multiple Disbursals": "Enable Multiple Disbursals",
       "Allow full term for each tranche": "Allow full term for each tranche",
       "Enabled": "Enabled",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1596,6 +1596,7 @@
       "Enable Auto Repayment for Down Payment": "Habilitar el pago automático para el pago inicial",
       "Enable Dormancy Tracking": "Habilitar seguimiento de inactividad",
       "Enable Down Payment": "Habilitar Pago inicial",
+      "Enable Lock-in Period": "Habilitar período de bloqueo",
       "Enable Multiple Disbursals": "Habilitar múltiples desembolsos",
       "Enabled": "Activado",
       "End Date": "Fecha final",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1596,6 +1596,7 @@
       "Enable Auto Repayment for Down Payment": "Habilitar el pago automático para el pago inicial",
       "Enable Dormancy Tracking": "Habilitar seguimiento de inactividad",
       "Enable Down Payment": "Habilitar Pago inicial",
+      "Enable Lock-in Period": "Habilitar período de bloqueo",
       "Enable Multiple Disbursals": "Habilitar múltiples desembolsos",
       "Enabled": "Activado",
       "End Date": "Fecha final",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1597,6 +1597,7 @@
       "Enable Auto Repayment for Down Payment": "Activer le remboursement automatique pour l'acompte",
       "Enable Dormancy Tracking": "Activer le suivi de la dormance",
       "Enable Down Payment": "Activer l'acompte",
+      "Enable Lock-in Period": "Activer la période de blocage",
       "Enable Multiple Disbursals": "Activer les décaissements multiples",
       "Enabled": "Activé",
       "End Date": "Date de fin",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1597,6 +1597,7 @@
       "Enable Auto Repayment for Down Payment": "Abilita il rimborso automatico per l'acconto",
       "Enable Dormancy Tracking": "Abilita il monitoraggio della dormienza",
       "Enable Down Payment": "Abilita l'acconto",
+      "Enable Lock-in Period": "Abilita periodo di blocco",
       "Enable Multiple Disbursals": "Abilita esborsi multipli",
       "Enabled": "Abilitato",
       "End Date": "Data di fine",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1598,6 +1598,7 @@
       "Enable Auto Repayment for Down Payment": "계약금 자동 상환 활성화",
       "Enable Dormancy Tracking": "휴면 추적 활성화",
       "Enable Down Payment": "계약금 활성화",
+      "Enable Lock-in Period": "잠금 기간 활성화",
       "Enable Multiple Disbursals": "다중 지불 활성화",
       "Enabled": "활성화됨",
       "End Date": "종료일",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1597,6 +1597,7 @@
       "Enable Auto Repayment for Down Payment": "Įgalinti automatinį pradinio įnašo grąžinimą",
       "Enable Dormancy Tracking": "Įgalinti ramybės būsenos stebėjimą",
       "Enable Down Payment": "Įgalinti pradinį įnašą",
+      "Enable Lock-in Period": "Įgalinti užrakinimo laikotarpį",
       "Enable Multiple Disbursals": "Įgalinti kelias išmokas",
       "Enabled": "Įjungtas",
       "End Date": "Pabaigos data",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1597,6 +1597,7 @@
       "Enable Auto Repayment for Down Payment": "Iespējot pirmās iemaksas automātisko atmaksu",
       "Enable Dormancy Tracking": "Iespējot miega režīma izsekošanu",
       "Enable Down Payment": "Iespējot pirmo iemaksu",
+      "Enable Lock-in Period": "Iespējot bloķēšanas periodu",
       "Enable Multiple Disbursals": "Iespējot vairākas izmaksas",
       "Enabled": "Iespējots",
       "End Date": "Beigu datums",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1597,6 +1597,7 @@
       "Enable Auto Repayment for Down Payment": "डाउन पेमेन्टको लागि स्वत: भुक्तानी सक्षम गर्नुहोस्",
       "Enable Dormancy Tracking": "निष्क्रियता ट्र्याकिङ सक्षम गर्नुहोस्",
       "Enable Down Payment": "डाउन पेमेन्ट सक्षम गर्नुहोस्",
+      "Enable Lock-in Period": "लक-इन अवधि सक्षम गर्नुहोस्",
       "Enable Multiple Disbursals": "बहुविध वितरण सक्षम गर्नुहोस्",
       "Enabled": "सक्षम गरियो",
       "End Date": "अन्त्य मिति",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1597,6 +1597,7 @@
       "Enable Auto Repayment for Down Payment": "Ativar reembolso automático para adiantamento",
       "Enable Dormancy Tracking": "Habilitar rastreamento de dormência",
       "Enable Down Payment": "Ativar adiantamento",
+      "Enable Lock-in Period": "Ativar período de bloqueio",
       "Enable Multiple Disbursals": "Habilitar múltiplos desembolsos",
       "Enabled": "Habilitado",
       "End Date": "Data final",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1595,6 +1595,7 @@
       "Enable Auto Repayment for Down Payment": "Washa Ulipaji Kiotomatiki kwa Malipo ya Chini",
       "Enable Dormancy Tracking": "Washa Ufuatiliaji wa Malalamiko",
       "Enable Down Payment": "Washa Malipo ya Chini",
+      "Enable Lock-in Period": "Washa Kipindi cha Kufunga",
       "Enable Multiple Disbursals": "Washa Utoaji Nyingi",
       "Enabled": "Imewashwa",
       "End Date": "Tarehe ya mwisho",


### PR DESCRIPTION
**Changes Made :-**

-Added "Enable Lock-in Period" checkbox control (defaults to false) to make the lock-in period feature optional for savings products
-Implemented conditional rendering and dynamic validation - frequency and type fields only appear when checkbox is enabled and become required with proper validators
-Updated form submission logic to exclude checkbox from API payload and ensure lock-in period values are only submitted when feature is enabled
-Added "Enable Lock-in Period" translation key across all 13 supported languages (en-US, es-CL, es-MX, de-DE, fr-FR, it-IT, cs-CS, ko-KO, lt-LT, lv-LV, pt-PT, sw-SW, ne-NE)

[WEB-524](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-524)

Before :-
<img width="865" height="861" alt="image" src="https://github.com/user-attachments/assets/a29f7a45-cbb6-4cd9-a034-4ed3cbc5b5d4" />

After :- 
<img width="1299" height="493" alt="image" src="https://github.com/user-attachments/assets/f7f8ece2-d799-459d-96e2-7d9193b9b001" />


[WEB-524]: https://mifosforge.jira.com/browse/WEB-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned lock-in period configuration: users can now enable or disable lock-in periods via a checkbox, with frequency and type inputs appearing only when enabled.

* **Localization**
  * Added translations for "Enable Lock-in Period" across 13 supported languages to enhance multilingual support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->