### PR TITLE
WEB-525 No report is displayed for Savings transactions

### DIFF
--- a/src/app/savings/savings-account-view/transactions/view-reciept/view-reciept.component.html
+++ b/src/app/savings/savings-account-view/transactions/view-reciept/view-reciept.component.html
@@ -5,5 +5,21 @@
     </button>
   </div>
 
-  <iframe [src]="pentahoUrl" frameborder="0" width="100%" height="600px;"></iframe>
+  <div *ngIf="pentahoUrl; else noData" class="pdf-container">
+    <iframe [src]="pentahoUrl" class="pdf-iframe"></iframe>
+  </div>
+
+  <ng-template #noData>
+    <div class="error-message">
+      <h3>Unable to Load Receipt</h3>
+      <p>The transaction receipt could not be loaded. This may be due to:</p>
+      <ul>
+        <li>Missing or incomplete report configuration</li>
+        <li>Report generation service unavailable</li>
+        <li>Invalid transaction data</li>
+      </ul>
+      <p><strong>Please contact your system administrator for assistance.</strong></p>
+      <p class="console-hint">Technical details may be available in the browser console (F12).</p>
+    </div>
+  </ng-template>
 </mat-card>

--- a/src/app/savings/savings-account-view/transactions/view-reciept/view-reciept.component.scss
+++ b/src/app/savings/savings-account-view/transactions/view-reciept/view-reciept.component.scss
@@ -1,8 +1,50 @@
 .container {
   max-width: 50rem;
+  margin: 0 auto;
 
   .back-button {
-    max-height: 2%;
-    margin-bottom: 2%;
+    margin-bottom: 1rem;
+  }
+
+  .pdf-container {
+    width: 100%;
+    height: calc(100vh - 250px);
+    min-height: 600px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #525659;
+
+    .pdf-iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+  }
+
+  .error-message {
+    padding: 2rem;
+    text-align: center;
+    background-color: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    margin: 1rem 0;
+
+    h3 {
+      color: #856404;
+      margin-bottom: 1rem;
+    }
+
+    ul {
+      text-align: left;
+      display: inline-block;
+      margin: 1rem 0;
+    }
+
+    .console-hint {
+      font-size: 0.875rem;
+      color: #6c757d;
+      margin-top: 1rem;
+    }
   }
 }


### PR DESCRIPTION
Changes Made :-

- Fixed savings transaction receipt display with improved styling and proper PDF rendering.
- Matched receipt container width (50rem) with loan receipts for consistent user experience.
- Added error handling and user-friendly error messages for failed receipt loads.
- Implemented console logging for debugging PDF generation issues.

[WEB-525](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-525)

[WEB-525]: https://mifosforge.jira.com/browse/WEB-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Show a helpful error message and guidance when a receipt cannot be loaded instead of displaying a broken embed.

* **Improvements**
  * Responsive layout and styling refinements for the receipt view for better display across screen sizes.
  * Added runtime checks and lifecycle cleanup to prevent broken or stale receipt loads, improving stability and resource handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->