### PR TITLE
WEB-523 The amount is not being displayed correctly.

### DIFF
--- a/src/app/loans/loans-view/general-tab/general-tab.component.ts
+++ b/src/app/loans/loans-view/general-tab/general-tab.component.ts
@@ -63,13 +63,13 @@ export class GeneralTabComponent implements OnInit {
   ];
   loanSummaryTableData: {
     property: string;
-    original: string;
-    adjustment: string;
-    paid: string;
-    waived: string;
-    writtenOff: string;
-    outstanding: string;
-    overdue: string;
+    original: number;
+    adjustment: number;
+    paid: number;
+    waived: number;
+    writtenOff: number;
+    outstanding: number;
+    overdue: number;
   }[];
   loanDetailsTableData: {
     key: string;
@@ -129,7 +129,7 @@ export class GeneralTabComponent implements OnInit {
       {
         property: 'Interest',
         original: this.loanDetails.summary.interestCharged,
-        adjustment: '0',
+        adjustment: 0,
         paid: this.loanDetails.summary.interestPaid,
         waived: this.loanDetails.summary.interestWaived,
         writtenOff: this.loanDetails.summary.interestWrittenOff,
@@ -139,7 +139,7 @@ export class GeneralTabComponent implements OnInit {
       {
         property: 'Fees',
         original: this.loanDetails.summary.feeChargesCharged,
-        adjustment: '0',
+        adjustment: 0,
         paid: this.loanDetails.summary.feeChargesPaid,
         waived: this.loanDetails.summary.feeChargesWaived,
         writtenOff: this.loanDetails.summary.feeChargesWrittenOff,
@@ -149,7 +149,7 @@ export class GeneralTabComponent implements OnInit {
       {
         property: 'Penalties',
         original: this.loanDetails.summary.penaltyChargesCharged,
-        adjustment: '0',
+        adjustment: 0,
         paid: this.loanDetails.summary.penaltyChargesPaid,
         waived: this.loanDetails.summary.penaltyChargesWaived,
         writtenOff: this.loanDetails.summary.penaltyChargesWrittenOff,


### PR DESCRIPTION
Changes Made :-

-Fixed loan summary table to display amounts in proper currency format (pesos with symbol and decimal places) by updating the interface to use number types instead of string types for all currency-related fields (original, adjustment, paid, waived, writtenOff, outstanding, overdue) and correcting the adjustment values from string '0' to numeric 0 for Interest, Fees, and Penalties rows.

[WEB-523](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-523)


[WEB-523]: https://mifosforge.jira.com/browse/WEB-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated loan summary financial data fields to use numeric values instead of string representations for more consistent data handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->