### PR TITLE
WEB-526 fix:Bulk Import page headings appear dark instead of white in dark mode

### DIFF
--- a/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.scss
+++ b/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.scss
@@ -1,3 +1,5 @@
+@use '../../../../assets/styles/colours' as *;
+
 .container {
   padding: 24px;
   max-width: 100%;
@@ -128,4 +130,26 @@
 
 mat-paginator {
   margin-top: 16px;
+}
+
+:host-context(.dark-theme) {
+  .container {
+    .gap-2percent {
+      mat-card {
+        h3 {
+          color: $white;
+        }
+
+        h4 {
+          color: $white;
+        }
+      }
+    }
+
+    mat-card:last-child {
+      .documents {
+        color: $white;
+      }
+    }
+  }
 }


### PR DESCRIPTION

This pr  adds dark theme styles to set heading colors to white when dark mode is active, improving readability

[WEB-526](https://mifosforge.jira.com/browse/WEB-526)

Before:
<img width="1918" height="1076" alt="Screenshot 2025-12-27 023248" src="https://github.com/user-attachments/assets/07e7a2bd-a753-4a7c-bca1-4c7bf70e42de" />
After:
<img width="1909" height="1079" alt="Screenshot 2025-12-27 023555" src="https://github.com/user-attachments/assets/d259c27d-9e81-4208-9a4e-73ca6400872a" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-526]: https://mifosforge.jira.com/browse/WEB-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark theme support with improved text color contrast for headings and document sections in the bulk import view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->