### PR TITLE
WEB-527 Date time format is not being rendered properly in the manage scheduler and cob jobs and data tablep ages

### DIFF
--- a/src/app/pipes/datetime-format.pipe.ts
+++ b/src/app/pipes/datetime-format.pipe.ts
@@ -26,7 +26,7 @@ export class DatetimeFormatPipe implements PipeTransform {
     } else {
       dateVal = moment(value as any);
     }
-    const fmt = datetimeFormat ?? 'yyyy-MM-ddTHH:mm:ssZ';
+    const fmt = datetimeFormat ?? 'YYYY-MM-DDTHH:mm:ssZ';
     return dateVal.format(fmt);
   }
 }


### PR DESCRIPTION
Changes Made:

-Fixed date/time rendering issue in "Manage Scheduler and COB Jobs" page (Previous Run and Next Run columns) and Data Tables (Created At and Updated At fields) where dates were displaying incorrectly with day-of-week abbreviations (e.g., "2025-12-SaT11:13:20-06:00" instead of "2025-12-28T11:13:20-06:00") by correcting the Moment.js format string in the [datetimeFormat] pipe from 'yyyy-MM-ddTHH:mm:ssZ' to 'YYYY-MM-DDTHH:mm:ssZ'.

[WEB-527](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-527)

Before :- 
<img width="1856" height="1018" alt="image" src="https://github.com/user-attachments/assets/03072f80-be41-4091-bb5a-48ab8cb4bc2e" />

<img width="1790" height="818" alt="image" src="https://github.com/user-attachments/assets/22110b9a-9f92-4a62-891b-b1ae12199276" />

After :- 
<img width="720" height="380" alt="image" src="https://github.com/user-attachments/assets/e3e603ff-49c3-4139-bc20-bafa536755ed" />

<img width="720" height="379" alt="image" src="https://github.com/user-attachments/assets/9de61338-9341-4229-9cb1-b6678ef9c66d" />


[WEB-527]: https://mifosforge.jira.com/browse/WEB-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

