### PR TITLE
WEB-530 Add money symbol for the debit credit and balance columns in the savings account transaction page

### DIFF
--- a/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.html
+++ b/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.html
@@ -79,7 +79,11 @@
           [ngClass]="savingsTransactionColor(transaction)"
           (click)="showTransactions(transaction)"
         >
-          {{ isDebit(transaction.transactionType) ? (transaction.amount | formatNumber) : 'N/A' }}
+          {{
+            isDebit(transaction.transactionType)
+              ? (transaction.amount | currency: currency?.code || 'USD' : 'symbol-narrow' : '1.2-2')
+              : 'N/A'
+          }}
         </td>
       </ng-container>
 
@@ -92,7 +96,11 @@
           [ngClass]="savingsTransactionColor(transaction)"
           (click)="showTransactions(transaction)"
         >
-          {{ !isDebit(transaction.transactionType) ? (transaction.amount | formatNumber) : 'N/A' }}
+          {{
+            !isDebit(transaction.transactionType)
+              ? (transaction.amount | currency: currency?.code || 'USD' : 'symbol-narrow' : '1.2-2')
+              : 'N/A'
+          }}
         </td>
       </ng-container>
 
@@ -105,7 +113,7 @@
           [ngClass]="savingsTransactionColor(transaction)"
           (click)="showTransactions(transaction)"
         >
-          {{ transaction.runningBalance | formatNumber }}
+          {{ transaction.runningBalance | currency: currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
         </td>
       </ng-container>
 

--- a/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit, ViewChild, inject } from '@angular/core';
 import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
+import { CurrencyPipe, NgClass } from '@angular/common';
 import {
   MatTableDataSource,
   MatTable,
@@ -26,7 +27,7 @@ import { SavingsService } from 'app/savings/savings.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { UndoTransactionDialogComponent } from '../custom-dialogs/undo-transaction-dialog/undo-transaction-dialog.component';
 import { MatDialog } from '@angular/material/dialog';
-import { NgClass } from '@angular/common';
+import { Currency } from 'app/shared/models/general.model';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { ExternalIdentifierComponent } from '../../../shared/external-identifier/external-identifier.component';
@@ -34,7 +35,6 @@ import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { MatIcon } from '@angular/material/icon';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
-import { FormatNumberPipe } from '../../../pipes/format-number.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
 /**
@@ -69,7 +69,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatRow,
     MatPaginator,
     DateFormatPipe,
-    FormatNumberPipe
+    CurrencyPipe
   ]
 })
 export class TransactionsTabComponent implements OnInit {
@@ -82,6 +82,8 @@ export class TransactionsTabComponent implements OnInit {
 
   /** Savings Account Status */
   status: any;
+  /** Currency */
+  currency: Currency | null = null;
   /** Transactions Data */
   transactionsData: SavingsAccountTransaction[] = [];
   /** Form control to handle accural parameter */
@@ -116,6 +118,7 @@ export class TransactionsTabComponent implements OnInit {
     this.route.parent.parent.data.subscribe((data: { savingsAccountData: any }) => {
       this.transactionsData = data.savingsAccountData.transactions;
       this.status = data.savingsAccountData.status.value;
+      this.currency = data.savingsAccountData.currency || null;
     });
     this.accountId = this.route.parent.parent.snapshot.params['savingAccountId'];
   }


### PR DESCRIPTION
**Changes Made :-**

-Added currency symbols to Debit, Credit, and Balance columns in the savings account transaction page by importing [CurrencyPipe] and [Currency] model, and retrieving currency data from parent savings account data .
-Updated HTML template to replace formatNumber pipe with Angular's [currency] pipe using [currency.code] and symbol-narrow format for proper currency symbol rendering (e.g., $, €, ₹, BTN)

[WEB-530](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-530)

Before :- 
<img width="1612" height="724" alt="image" src="https://github.com/user-attachments/assets/61d4817a-6ac0-49f6-898d-6b039f2ff076" />

After :- 
<img width="1365" height="718" alt="image" src="https://github.com/user-attachments/assets/043a2728-8a4c-4013-8da3-2b6b1826c4c9" />



[WEB-530]: https://mifosforge.jira.com/browse/WEB-530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved currency formatting in the transactions view: debit, credit, and running balance now use the account's currency with narrow symbol and enhanced decimal precision (1.2-2), preserving "N/A" where applicable for clearer, consistent monetary display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->