### PR TITLE
WEB-533 Tax Component creation not working as expected with GL accounts

### DIFF
--- a/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.html
+++ b/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.html
@@ -35,27 +35,6 @@
           </mat-form-field>
 
           <mat-form-field>
-            <mat-label>{{ 'labels.inputs.Debit Account Type' | translate }}</mat-label>
-            <mat-select formControlName="debitAccountType">
-              @for (debitAccountType of debitAccountTypeData; track debitAccountType) {
-                <mat-option [value]="debitAccountType.id">
-                  {{ debitAccountType.value | translateKey: 'inputs.accounting' }}
-                </mat-option>
-              }
-            </mat-select>
-          </mat-form-field>
-
-          @if (debitAccountData.length > 0) {
-            <mifosx-gl-account-selector
-              [inputFormControl]="taxComponentForm.controls.debitAccountId"
-              [glAccountList]="debitAccountData"
-              [required]="false"
-              [inputLabel]="'Debit Account'"
-            >
-            </mifosx-gl-account-selector>
-          }
-
-          <mat-form-field>
             <mat-label>{{ 'labels.inputs.Credit Account Type' | translate }}</mat-label>
             <mat-select formControlName="creditAccountType">
               @for (creditAccountType of creditAccountTypeData; track creditAccountType) {
@@ -68,9 +47,9 @@
 
           @if (creditAccountData.length > 0) {
             <mifosx-gl-account-selector
-              [inputFormControl]="taxComponentForm.controls.creditAccountId"
+              [inputFormControl]="getCreditAccountIdControl()"
               [glAccountList]="creditAccountData"
-              [required]="false"
+              [required]="true"
               [inputLabel]="'Credit Account'"
             >
             </mifosx-gl-account-selector>

--- a/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.ts
+++ b/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.ts
@@ -48,10 +48,6 @@ export class CreateTaxComponentComponent implements OnInit {
   creditAccountTypeData: any;
   /** Credit Account data. */
   creditAccountData: any[] = [];
-  /** Debit Account Type data. */
-  debitAccountTypeData: any;
-  /** Debit Account data. */
-  debitAccountData: any[] = [];
 
   /**
    * Retrieves the tax Component template data from `resolve`.
@@ -76,13 +72,21 @@ export class CreateTaxComponentComponent implements OnInit {
     this.maxDate = this.settingsService.maxAllowedDate;
     this.createTaxComponentForm();
     this.setConditionalControls();
+    const initialCreditAccountType = this.taxComponentForm.get('creditAccountType')?.value;
+    if (initialCreditAccountType) {
+      this.creditAccountData = this.getAccountsData(initialCreditAccountType);
+      if (this.creditAccountData.length > 0) {
+        this.taxComponentForm.get('creditAccountId').setValidators([Validators.required]);
+        this.taxComponentForm.get('creditAccountId').updateValueAndValidity();
+      }
+    }
   }
 
   /**
    * Creates the tax Component form
    */
   createTaxComponentForm() {
-    this.creditAccountTypeData = this.debitAccountTypeData = this.taxComponentTemplateData.glAccountTypeOptions;
+    this.creditAccountTypeData = this.taxComponentTemplateData.glAccountTypeOptions;
     this.taxComponentForm = this.formBuilder.group({
       name: [
         '',
@@ -97,7 +101,7 @@ export class CreateTaxComponentComponent implements OnInit {
         ]
       ],
       creditAccountType: [''],
-      debitAccountType: [''],
+      creditAccountId: [''],
       startDate: [
         '',
         Validators.required
@@ -109,13 +113,20 @@ export class CreateTaxComponentComponent implements OnInit {
    * Sets the conditional controls of the tax Component form
    */
   setConditionalControls() {
-    this.taxComponentForm.get('debitAccountType').valueChanges.subscribe((debitAccountTypeId) => {
-      this.debitAccountData = this.getAccountsData(debitAccountTypeId);
-      this.taxComponentForm.addControl('debitAccountId', new UntypedFormControl('', Validators.required));
-    });
+    const creditAccountIdControl = this.taxComponentForm.get('creditAccountId');
+
     this.taxComponentForm.get('creditAccountType').valueChanges.subscribe((creditAccountTypeId) => {
       this.creditAccountData = this.getAccountsData(creditAccountTypeId);
-      this.taxComponentForm.addControl('creditAccountId', new UntypedFormControl('', Validators.required));
+
+      if (creditAccountTypeId && this.creditAccountData.length > 0) {
+        creditAccountIdControl.setValidators([Validators.required]);
+        creditAccountIdControl.updateValueAndValidity();
+      } else {
+        creditAccountIdControl.clearValidators();
+        creditAccountIdControl.setValue('');
+        creditAccountIdControl.updateValueAndValidity();
+        this.creditAccountData = [];
+      }
     });
   }
 
@@ -135,7 +146,13 @@ export class CreateTaxComponentComponent implements OnInit {
         return this.taxComponentTemplateData.glAccountOptions.incomeAccountOptions || [];
       case 5:
         return this.taxComponentTemplateData.glAccountOptions.expenseAccountOptions || [];
+      default:
+        return [];
     }
+  }
+
+  getCreditAccountIdControl(): UntypedFormControl {
+    return this.taxComponentForm.get('creditAccountId') as UntypedFormControl;
   }
 
   /**
@@ -143,18 +160,32 @@ export class CreateTaxComponentComponent implements OnInit {
    * if successful redirects to Tax Components.
    */
   submit() {
-    const taxComponentFormData = this.taxComponentForm.value;
+    const formValues = this.taxComponentForm.getRawValue();
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;
-    const prevStartDate: Date = this.taxComponentForm.value.startDate;
-    if (taxComponentFormData.startDate instanceof Date) {
-      taxComponentFormData.startDate = this.dateUtils.formatDate(prevStartDate, dateFormat);
+
+    if (formValues.creditAccountType && !formValues.creditAccountId) {
+      this.taxComponentForm.get('creditAccountId').markAsTouched();
+      return;
     }
-    const data = {
-      ...taxComponentFormData,
+
+    let formattedStartDate: any = formValues.startDate;
+    if (formValues.startDate instanceof Date) {
+      formattedStartDate = this.dateUtils.formatDate(formValues.startDate, dateFormat);
+    }
+
+    const data: any = {
+      name: formValues.name,
+      percentage: formValues.percentage,
+      startDate: formattedStartDate,
       dateFormat,
       locale
     };
+    if (formValues.creditAccountType && formValues.creditAccountId) {
+      data.creditAccountType = formValues.creditAccountType;
+      data.creditAcountId = formValues.creditAccountId;
+    }
+
     this.productsService.createTaxComponent(data).subscribe((response: any) => {
       this.router.navigate(
         [


### PR DESCRIPTION
**Changes Made :-**

-Fixed the mandatory parameter error when creating tax components with credit account information by updating the parameter name from [creditAccountId] to [creditAcountId] to match the backend API's expected parameter name.
-Added validation to ensure the Credit Account field is required when a Credit Account Type is selected.
-Updated the submit method to only include credit account fields when both Credit Account Type and Credit Account are selected.
-Fixed conditional validators for the Credit Account field based on Credit Account Type selection.

[WEB-533](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-533)

[WEB-533]: https://mifosforge.jira.com/browse/WEB-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed debit account selection from tax component creation form.
  * Credit account field is now required.
  * Enhanced form validation and submission process for improved data accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->