### PR TITLE
WEB-308: fix hardcoded documentation links

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -16,6 +16,9 @@ FINERACT_PLATFORM_TENANTS_IDENTIFIER=default
 # Tenant Logo URL - supports external URLs (e.g., https://example.com/logo.png) or local paths. Leave empty to use default tenant-specific logos
 TENANT_LOGO_URL=
 
+# Documentation base URL for in-app help links
+MIFOS_DOCUMENTATION_BASE_URL=https://mifosforge.jira.com/wiki
+
 MIFOS_DEFAULT_LANGUAGE=en-US
 
 MIFOS_SUPPORTED_LANGUAGES=cs-CS,de-DE,en-US,es-MX,fr-FR,it-IT,ko-KO,lt-LT,lv-LV,ne-NE,pt-PT

--- a/src/app/accounting/chart-of-accounts/create-gl-account/create-gl-account.component.html
+++ b/src/app/accounting/chart-of-accounts/create-gl-account/create-gl-account.component.html
@@ -125,11 +125,9 @@
   <h2>{{ 'labels.heading.Create GL account' | translate }}</h2>
   <p class="mw400">
     {{ 'labels.text.Filling Details' | translate }}
-    <a
-      href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67141745/Chart+of+Accounts+-+General+Ledger+Setup"
-      target="_blank"
-      >{{ 'labels.inputs.Chart of Accounts' | translate }}</a
-    >
+    <a [href]="'chartOfAccountsSetup' | documentationLink" target="_blank" rel="noopener noreferrer">{{
+      'labels.inputs.Chart of Accounts' | translate
+    }}</a>
   </p>
   <div class="layout-row align-end gap-2px responsive-column">
     <button mat-raised-button color="warn" (click)="popover.close(); configurationWizardService.closeConfigWizard()">

--- a/src/app/accounting/closing-entries/closing-entries.component.html
+++ b/src/app/accounting/closing-entries/closing-entries.component.html
@@ -105,7 +105,7 @@
 <ng-template #templateClosuresTable let-popover="popover">
   <h4>
     {{ 'labels.heading.List of closures. To know more click' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67895316/Closing+Entries" target="_blank">{{
+    <a [href]="'closingEntries' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Closing Entries' | translate
     }}</a>
   </h4>

--- a/src/app/accounting/create-journal-entry/create-journal-entry.component.html
+++ b/src/app/accounting/create-journal-entry/create-journal-entry.component.html
@@ -221,7 +221,7 @@
   <h2>{{ 'labels.heading.Add Journal Entry Form' | translate }}</h2>
   <p class="mw300">
     {{ 'labels.text.Red asterisk field' | translate }}
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67895310/Add+Journal+Entries" target="_blank">{{
+    <a [href]="'addJournalEntries' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Add Journal Entries' | translate
     }}</a>
   </p>

--- a/src/app/accounting/financial-activity-mappings/financial-activity-mappings.component.html
+++ b/src/app/accounting/financial-activity-mappings/financial-activity-mappings.component.html
@@ -71,11 +71,9 @@
 <ng-template #templateActivitiesTable let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.heading.Account Linked Financial' | translate }}
-    <a
-      href="https://mifosforge.jira.com/wiki/spaces/docs/pages/106430472/Accounts+linked+to+Financial+Activities"
-      target="_blank"
-      >{{ 'labels.heading.Accounts linked to Financial Activities' | translate }}</a
-    >
+    <a [href]="'financialActivityMappings' | documentationLink" target="_blank" rel="noopener noreferrer">{{
+      'labels.heading.Accounts linked to Financial Activities' | translate
+    }}</a>
   </h4>
   <div class="layout-row align-end gap-2px responsive-column">
     <button mat-raised-button color="warn" (click)="popover.close(); configurationWizardService.closeConfigWizard()">

--- a/src/app/accounting/migrate-opening-balances/migrate-opening-balances.component.html
+++ b/src/app/accounting/migrate-opening-balances/migrate-opening-balances.component.html
@@ -153,11 +153,9 @@
   <h2>{{ 'labels.heading.Migrate opening balances (Office-wise)' | translate }}</h2>
   <p class="mw300">
     {{ 'labels.text.Migrate Opening Balances' | translate }}
-    <a
-      href="https://mifosforge.jira.com/wiki/spaces/docs/pages/90243328/Migrate+opening+balances+Office-wise"
-      target="_blank"
-      >{{ 'labels.inputs.Migrate opening balances (Office-wise)' | translate }}</a
-    >
+    <a [href]="'migrateOpeningBalances' | documentationLink" target="_blank" rel="noopener noreferrer">{{
+      'labels.inputs.Migrate opening balances (Office-wise)' | translate
+    }}</a>
   </p>
   <div class="layout-row align-end gap-2px responsive-column">
     <button mat-raised-button color="warn" (click)="popover.close(); configurationWizardService.closeConfigWizard()">

--- a/src/app/core/shell/sidenav/sidenav.component.ts
+++ b/src/app/core/shell/sidenav/sidenav.component.ts
@@ -10,6 +10,7 @@ import { KeyboardShortcutsDialogComponent } from 'app/shared/keyboard-shortcuts-
 import { AuthenticationService } from '../../authentication/authentication.service';
 import { PopoverService } from '../../../configuration-wizard/popover/popover.service';
 import { ConfigurationWizardService } from '../../../configuration-wizard/configuration-wizard.service';
+import { DocumentationLinksService } from 'app/shared/services/documentation-links.service';
 
 /** Custom Imports */
 import { frequentActivities } from './frequent-activities';
@@ -54,6 +55,7 @@ export class SidenavComponent implements OnInit, AfterViewInit {
   private settingsService = inject(SettingsService);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private documentationLinks = inject(DocumentationLinksService);
 
   /** True if sidenav is in collapsed state. */
   @Input() sidenavCollapsed: boolean;
@@ -117,7 +119,7 @@ export class SidenavComponent implements OnInit, AfterViewInit {
    * Opens Mifos JIRA Wiki page.
    */
   help() {
-    window.open('https://mifosforge.jira.com/wiki/spaces/docs/pages/52035622/User+Manual', '_blank');
+    this.documentationLinks.open('userManual');
   }
 
   /**

--- a/src/app/core/shell/toolbar/toolbar.component.ts
+++ b/src/app/core/shell/toolbar/toolbar.component.ts
@@ -41,6 +41,7 @@ import { MatIcon } from '@angular/material/icon';
 import { NotificationsTrayComponent as NotificationsTrayComponent_1 } from '../../../shared/notifications-tray/notifications-tray.component';
 import { ThemeToggleComponent } from '../../../shared/theme-toggle/theme-toggle.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { DocumentationLinksService } from 'app/shared/services/documentation-links.service';
 
 import { environment } from '../../../../environments/environment';
 
@@ -75,6 +76,7 @@ export class ToolbarComponent implements OnInit, AfterViewInit, AfterContentChec
   private configurationWizardService = inject(ConfigurationWizardService);
   private dialog = inject(MatDialog);
   private changeDetector = inject(ChangeDetectorRef);
+  private documentationLinks = inject(DocumentationLinksService);
 
   /* Reference of institution */
   @ViewChild('institution') institution: ElementRef<any>;
@@ -148,7 +150,7 @@ export class ToolbarComponent implements OnInit, AfterViewInit, AfterContentChec
    * Opens Mifos JIRA Wiki page.
    */
   help() {
-    window.open('https://mifosforge.jira.com/wiki/spaces/docs/pages/52035622/User+Manual', '_blank');
+    this.documentationLinks.open('userManual');
   }
   /**
    * Popover function

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -14,15 +14,15 @@
       <h1 class="mat-display-1 cover-title">{{ 'APP_NAME' | translate }}</h1>
       <p class="mat-headline cover-description">
         {{ 'APP_NAME' | translate }} {{ 'labels.text.is designed by the' | translate }}
-        <a href="https://mifos.org/" target="_blank" class="cover-link">{{
+        <a [href]="'mifosHome' | documentationLink" target="_blank" rel="noopener noreferrer" class="cover-link">{{
           'labels.text.Mifos Initiative' | translate
         }}</a
         >. {{ 'labels.text.A' | translate }}
-        <a href="https://mifos.org/resources/community/" target="_blank" class="cover-link">{{
+        <a [href]="'mifosCommunity' | documentationLink" target="_blank" rel="noopener noreferrer" class="cover-link">{{
           'labels.text.global community' | translate
         }}</a>
         {{ 'labels.text.elimination of poverty' | translate }}
-        <a href="https://mifos.org/take-action/volunteer/" target="_blank" class="cover-link"
+        <a [href]="'mifosVolunteer' | documentationLink" target="_blank" rel="noopener noreferrer" class="cover-link"
           >{{ 'labels.text.Get involved' | translate }}!</a
         >
       </p>
@@ -112,41 +112,37 @@
 
 <!-- Contact Information/Resources Menus -->
 <mat-menu #resourcesMenu="matMenu">
-  <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/52035622/User+Manual" target="_blank" mat-menu-item>{{
+  <a [href]="'userManual' | documentationLink" target="_blank" rel="noopener noreferrer" mat-menu-item>{{
     'labels.links.User Manual' | translate
   }}</a>
-  <a
-    href="https://cwiki.apache.org/confluence/display/FINERACT/Apache+Fineract+1.0+Functional+Specifications"
-    target="_blank"
-    mat-menu-item
-    >{{ 'labels.links.Functional Specifications' | translate }}</a
-  >
-  <a href="https://cwiki.apache.org/confluence/display/FINERACT/Contributor%27s+Zone" target="_blank" mat-menu-item>{{
+  <a [href]="'fineractFunctionalSpecs' | documentationLink" target="_blank" rel="noopener noreferrer" mat-menu-item>{{
+    'labels.links.Functional Specifications' | translate
+  }}</a>
+  <a [href]="'fineractContributorZone' | documentationLink" target="_blank" rel="noopener noreferrer" mat-menu-item>{{
     'labels.links.Developer Zone' | translate
   }}</a>
 </mat-menu>
 
 <mat-menu #communityMenu="matMenu">
-  <a href="https://groups.google.com/forum/#!forum/mifosusers" target="_blank" mat-menu-item>{{
+  <a [href]="'mifosUserGroup' | documentationLink" target="_blank" rel="noopener noreferrer" mat-menu-item>{{
     'labels.links.User Group' | translate
   }}</a>
-  <a href="https://groups.google.com/forum/#!forum/mifosdeveloper" target="_blank" mat-menu-item>{{
+  <a [href]="'mifosDeveloperGroup' | documentationLink" target="_blank" rel="noopener noreferrer" mat-menu-item>{{
     'labels.links.Developer Group' | translate
   }}</a>
-  <a href="https://mifos.org/resources/community/communications/#mifos-irc" target="_blank" mat-menu-item>{{
+  <a [href]="'mifosIrc' | documentationLink" target="_blank" rel="noopener noreferrer" mat-menu-item>{{
     'labels.links.IRC' | translate
   }}</a>
 </mat-menu>
 
 <mat-menu #contributeMenu="matMenu">
-  <a
-    href="https://mifosforge.jira.com/wiki/spaces/MDZ/pages/92012624/Key+Design+Principles"
-    target="_blank"
-    mat-menu-item
-    >{{ 'labels.links.Key Design Principles' | translate }}</a
-  >
-  <a href="https://sourceforge.net/projects/mifos/" target="_blank" mat-menu-item>{{
+  <a [href]="'keyDesignPrinciples' | documentationLink" target="_blank" rel="noopener noreferrer" mat-menu-item>{{
+    'labels.links.Key Design Principles' | translate
+  }}</a>
+  <a [href]="'sourceforgeMifos' | documentationLink" target="_blank" rel="noopener noreferrer" mat-menu-item>{{
     'labels.links.Working with Code' | translate
   }}</a>
-  <a href="https://mifos.org/donate/" target="_blank" mat-menu-item>{{ 'labels.links.Donate' | translate }}</a>
+  <a [href]="'mifosDonate' | documentationLink" target="_blank" rel="noopener noreferrer" mat-menu-item>{{
+    'labels.links.Donate' | translate
+  }}</a>
 </mat-menu>

--- a/src/app/organization/currencies/manage-currencies/manage-currencies.component.html
+++ b/src/app/organization/currencies/manage-currencies/manage-currencies.component.html
@@ -69,7 +69,7 @@
   <h4>{{ 'labels.heading.Add Currency Form' | translate }}</h4>
   <p class="mw400">
     {{ 'labels.text.Used to add currency' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67141734/Currency+Configuration" target="_blank">{{
+    <a [href]="'currencyConfiguration' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Currency Configuration' | translate
     }}</a>
   </p>

--- a/src/app/organization/employees/create-employee/create-employee.component.html
+++ b/src/app/organization/employees/create-employee/create-employee.component.html
@@ -116,7 +116,7 @@
   <p class="mw400">
     {{ 'labels.text.Start filling the details' | translate }} <br />
     {{ 'labels.text.For more details click' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67141732/Manage+Employees" target="_blank">{{
+    <a [href]="'manageEmployees' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Manage Employees' | translate
     }}</a>
   </p>

--- a/src/app/organization/manage-funds/manage-funds.component.html
+++ b/src/app/organization/manage-funds/manage-funds.component.html
@@ -41,7 +41,7 @@
   <h2>{{ 'labels.heading.Manage Funds' | translate }}</h2>
   <p class="mw300">
     {{ 'labels.text.Used Add Fund' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67141736/Manage+Funds" target="_blank">{{
+    <a [href]="'manageFunds' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Manage Funds' | translate
     }}</a>
   </p>

--- a/src/app/organization/offices/create-office/create-office.component.html
+++ b/src/app/organization/offices/create-office/create-office.component.html
@@ -74,7 +74,7 @@
   <h2>{{ 'labels.heading.Create Office' | translate }}</h2>
   <p class="mw400">
     {{ 'labels.text.Filling Details' | translate }}
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67141727/Manage+Offices" target="_blank">{{
+    <a [href]="'manageOffices' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Manage Offices' | translate
     }}</a>
   </p>

--- a/src/app/organization/working-days/working-days.component.html
+++ b/src/app/organization/working-days/working-days.component.html
@@ -52,7 +52,7 @@
   <h2>{{ 'labels.heading.Working Days' | translate }}</h2>
   <p class="mw400">
     {{ 'labels.text.Click (Define Working Days)' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/90243212/Working+Days" target="_blank">{{
+    <a [href]="'workingDays' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Working Days' | translate
     }}</a>
   </p>

--- a/src/app/pipes/documentation-link.pipe.ts
+++ b/src/app/pipes/documentation-link.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform, inject } from '@angular/core';
+import { DocumentationLinksService } from 'app/shared/services/documentation-links.service';
+import { DocumentationPage } from 'app/shared/constants/documentation-links';
+
+@Pipe({ name: 'documentationLink', standalone: true })
+export class DocumentationLinkPipe implements PipeTransform {
+  private documentationLinks = inject(DocumentationLinksService);
+
+  transform(page: DocumentationPage): string {
+    return this.documentationLinks.getUrl(page);
+  }
+}

--- a/src/app/products/charges/charges.component.html
+++ b/src/app/products/charges/charges.component.html
@@ -152,7 +152,7 @@
 <ng-template #templateChargesTable let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.heading.List of charges in the organization. For more details click' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/72908813/Charges" target="_blank">{{
+    <a [href]="'charges' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.heading.Charges' | translate
     }}</a>
   </h4>

--- a/src/app/products/fixed-deposit-products/fixed-deposit-products.component.html
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-products.component.html
@@ -86,7 +86,7 @@
 <ng-template #templateFixedProductsTable let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.text.List of fixed deposit products in the organization' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/102629544/Fixed+Deposit+Products" target="_blank">{{
+    <a [href]="'fixedDepositProducts' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Fixed Deposit Products' | translate
     }}</a>
   </h4>

--- a/src/app/products/loan-products/loan-products.component.html
+++ b/src/app/products/loan-products/loan-products.component.html
@@ -104,7 +104,7 @@
 <ng-template #templateLoanProductsTable let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.heading.List of loan products in the organization' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/102039585/Loan+Products" target="_blank">{{
+    <a [href]="'loanProducts' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.heading.Loan Products' | translate
     }}</a>
   </h4>

--- a/src/app/products/recurring-deposit-products/recurring-deposit-products.component.html
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-products.component.html
@@ -95,7 +95,7 @@
 <ng-template #templateRecurringProductsTable let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.heading.List of recurring deposit products in the organization' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/102629552/Recurring+Deposit" target="_blank">{{
+    <a [href]="'recurringDepositProducts' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.heading.Recurring Deposit Products' | translate
     }}</a>
   </h4>

--- a/src/app/products/saving-products/saving-products.component.html
+++ b/src/app/products/saving-products/saving-products.component.html
@@ -81,7 +81,7 @@
 <ng-template #templateSavingProductTable let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.heading.List of saving products in the organization' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/102629497/Savings+Products" target="_blank">{{
+    <a [href]="'savingsProducts' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.heading.Savings Products' | translate
     }}</a>
   </h4>

--- a/src/app/products/share-products/share-products.component.html
+++ b/src/app/products/share-products/share-products.component.html
@@ -86,7 +86,7 @@
 <ng-template #templateShareProductsTable let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.heading.List of share products in the organization' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/129531946/Share+products" target="_blank">{{
+    <a [href]="'shareProducts' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.text.Share Products' | translate
     }}</a>
   </h4>

--- a/src/app/shared/constants/documentation-links.ts
+++ b/src/app/shared/constants/documentation-links.ts
@@ -1,0 +1,80 @@
+export type DocumentationPage =
+  | 'userManual'
+  | 'closingEntries'
+  | 'addJournalEntries'
+  | 'chartOfAccountsSetup'
+  | 'financialActivityMappings'
+  | 'migrateOpeningBalances'
+  | 'users'
+  | 'keyDesignPrinciples'
+  | 'rolesAndPermissions'
+  | 'shareProducts'
+  | 'loanProducts'
+  | 'manageReports'
+  | 'manageDataTables'
+  | 'manageSchedulerJobs'
+  | 'globalConfiguration'
+  | 'savingsProducts'
+  | 'manageCodes'
+  | 'configureMakerCheckerTasks'
+  | 'fixedDepositProducts'
+  | 'recurringDepositProducts'
+  | 'charges'
+  | 'workingDays'
+  | 'manageEmployees'
+  | 'currencyConfiguration'
+  | 'manageOffices'
+  | 'manageFunds'
+  | 'mifosHome'
+  | 'mifosCommunity'
+  | 'mifosVolunteer'
+  | 'fineractFunctionalSpecs'
+  | 'fineractContributorZone'
+  | 'mifosUserGroup'
+  | 'mifosDeveloperGroup'
+  | 'mifosIrc'
+  | 'sourceforgeMifos'
+  | 'mifosDonate'
+  | 'cronmaker';
+
+export const DOCUMENTATION_PATHS: Record<DocumentationPage, string> = {
+  userManual: 'spaces/docs/pages/52035622/User+Manual',
+  closingEntries: 'spaces/docs/pages/67895316/Closing+Entries',
+  addJournalEntries: 'spaces/docs/pages/67895310/Add+Journal+Entries',
+  chartOfAccountsSetup: 'spaces/docs/pages/67141745/Chart+of+Accounts+-+General+Ledger+Setup',
+  financialActivityMappings: 'spaces/docs/pages/106430472/Accounts+linked+to+Financial+Activities',
+  migrateOpeningBalances: 'spaces/docs/pages/90243328/Migrate+opening+balances+Office-wise',
+  users: 'spaces/docs/pages/67141740/Users',
+  keyDesignPrinciples: 'spaces/MDZ/pages/92012624/Key+Design+Principles',
+  rolesAndPermissions: 'spaces/docs/pages/67895364/Manage+Roles+and+Permissions',
+  shareProducts: 'spaces/docs/pages/129531946/Share+products',
+  loanProducts: 'spaces/docs/pages/102039585/Loan+Products',
+  manageReports: 'spaces/docs/pages/67895354/Manage+Reports',
+  manageDataTables: 'spaces/docs/pages/52592760/Manage+Data+Tables',
+  manageSchedulerJobs: 'spaces/docs/pages/67895356/Manage+Scheduler+Jobs',
+  globalConfiguration: 'spaces/docs/pages/67895362/Global+Configuration',
+  savingsProducts: 'spaces/docs/pages/102629497/Savings+Products',
+  manageCodes: 'spaces/docs/pages/67895350/Manage+Codes',
+  configureMakerCheckerTasks: 'spaces/docs/pages/67895359/Configure+Maker-Checker+Tasks',
+  fixedDepositProducts: 'spaces/docs/pages/102629544/Fixed+Deposit+Products',
+  recurringDepositProducts: 'spaces/docs/pages/102629552/Recurring+Deposit',
+  charges: 'spaces/docs/pages/72908813/Charges',
+  workingDays: 'spaces/docs/pages/90243212/Working+Days',
+  manageEmployees: 'spaces/docs/pages/67141732/Manage+Employees',
+  currencyConfiguration: 'spaces/docs/pages/67141734/Currency+Configuration',
+  manageOffices: 'spaces/docs/pages/67141727/Manage+Offices',
+  manageFunds: 'spaces/docs/pages/67141736/Manage+Funds',
+  // External links (full URLs)
+  mifosHome: 'https://mifos.org/',
+  mifosCommunity: 'https://mifos.org/resources/community/',
+  mifosVolunteer: 'https://mifos.org/take-action/volunteer/',
+  fineractFunctionalSpecs:
+    'https://cwiki.apache.org/confluence/display/FINERACT/Apache+Fineract+1.0+Functional+Specifications',
+  fineractContributorZone: 'https://cwiki.apache.org/confluence/display/FINERACT/Contributor%27s+Zone',
+  mifosUserGroup: 'https://groups.google.com/forum/#!forum/mifosusers',
+  mifosDeveloperGroup: 'https://groups.google.com/forum/#!forum/mifosdeveloper',
+  mifosIrc: 'https://mifos.org/resources/community/communications/#mifos-irc',
+  sourceforgeMifos: 'https://sourceforge.net/projects/mifos/',
+  mifosDonate: 'https://mifos.org/donate/',
+  cronmaker: 'http://www.cronmaker.com/'
+};

--- a/src/app/shared/services/documentation-links.service.ts
+++ b/src/app/shared/services/documentation-links.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { DOCUMENTATION_PATHS, DocumentationPage } from '../constants/documentation-links';
+
+const DEFAULT_DOCUMENTATION_BASE_URL = 'https://mifosforge.jira.com/wiki';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DocumentationLinksService {
+  private readonly baseUrl = this.normalizeBaseUrl(environment.documentationBaseUrl || DEFAULT_DOCUMENTATION_BASE_URL);
+
+  /**
+   * Build a full documentation URL for the given page key.
+   */
+  getUrl(page: DocumentationPage): string {
+    const path = DOCUMENTATION_PATHS[page];
+    if (!path) {
+      console.warn(`Unknown documentation page key requested: ${page}`);
+      return this.baseUrl;
+    }
+    return this.buildUrl(path);
+  }
+
+  /**
+   * Open the documentation URL for the given page key.
+   */
+  open(page: DocumentationPage, target: string = '_blank'): void {
+    const url = this.getUrl(page);
+    const windowFeatures = target === '_blank' ? 'noopener' : undefined;
+    window.open(url, target, windowFeatures);
+  }
+
+  private normalizeBaseUrl(value: string): string {
+    return (value || DEFAULT_DOCUMENTATION_BASE_URL).replace(/\/+$/, '');
+  }
+
+  private buildUrl(path: string): string {
+    if (!path) {
+      return this.baseUrl;
+    }
+    if (/^https?:\/\//i.test(path)) {
+      return path;
+    }
+    const cleanPath = path.replace(/^\/+/, '');
+    return `${this.baseUrl}/${cleanPath}`;
+  }
+}

--- a/src/app/standalone-shared.module.ts
+++ b/src/app/standalone-shared.module.ts
@@ -14,6 +14,7 @@ import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular
 import { MatButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { DateFormatPipe } from '@pipes/date-format.pipe';
+import { DocumentationLinkPipe } from '@pipes/documentation-link.pipe';
 import { TranslatePipe as NgxTranslatePipe } from '@ngx-translate/core';
 import { TranslatePipe } from '@pipes/translate.pipe';
 import { HasPermissionDirective } from './directives/has-permission/has-permission.directive';
@@ -43,6 +44,7 @@ export const STANDALONE_SHARED_IMPORTS = [
   MatButton,
   MatCheckbox,
   DateFormatPipe,
+  DocumentationLinkPipe,
   HasPermissionDirective,
 
   // Pipes and Directives

--- a/src/app/system/codes/create-code/create-code.component.html
+++ b/src/app/system/codes/create-code/create-code.component.html
@@ -33,7 +33,7 @@
   <p class="mw400">
     {{ 'labels.text.To create code,create' | translate }}<br />
     {{ 'labels.text.For more details click' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67895350/Manage+Codes" target="_blank">{{
+    <a [href]="'manageCodes' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Manage Codes' | translate
     }}</a>
   </p>

--- a/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.html
+++ b/src/app/system/configurations/global-configurations-tab/global-configurations-tab.component.html
@@ -96,7 +96,7 @@
 <ng-template #templateConfigurationsTable let-data let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.heading.Global Configuration options' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67895362/Global+Configuration" target="_blank">{{
+    <a [href]="'globalConfiguration' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Global Configurations' | translate
     }}</a>
   </h4>

--- a/src/app/system/configure-maker-checker-tasks/configure-maker-checker-tasks.component.html
+++ b/src/app/system/configure-maker-checker-tasks/configure-maker-checker-tasks.component.html
@@ -88,11 +88,9 @@
 <ng-template #templateMcTable let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.heading.List of all maker checker tasks' | translate }}:
-    <a
-      href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67895359/Configure+Maker-Checker+Tasks"
-      target="_blank"
-      >{{ 'labels.inputs.Configure Maker-Checker Tasks' | translate }}</a
-    >
+    <a [href]="'configureMakerCheckerTasks' | documentationLink" target="_blank" rel="noopener noreferrer">{{
+      'labels.inputs.Configure Maker-Checker Tasks' | translate
+    }}</a>
   </h4>
   <div class="layout-row align-end gap-2px responsive-column">
     <button mat-raised-button color="warn" (click)="popover.close(); configurationWizardService.closeConfigWizard()">

--- a/src/app/system/manage-data-tables/create-data-table/create-data-table.component.html
+++ b/src/app/system/manage-data-tables/create-data-table/create-data-table.component.html
@@ -219,7 +219,7 @@
   <h2>{{ 'labels.buttons.Create Datatable' | translate }}</h2>
   <p class="mw400">
     {{ 'labels.text.Filling Details' | translate }}
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/52592760/Manage+Data+Tables" target="_blank">{{
+    <a [href]="'manageDataTables' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Manage Datatables' | translate
     }}</a>
   </p>

--- a/src/app/system/manage-jobs/scheduler-jobs/manage-scheduler-jobs.component.html
+++ b/src/app/system/manage-jobs/scheduler-jobs/manage-scheduler-jobs.component.html
@@ -218,7 +218,7 @@
 <ng-template #templateJobsTable let-data let-popover="popover">
   <h4>
     {{ 'labels.heading.List of all scheduled batch jobs' | translate }}
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67895356/Manage+Scheduler+Jobs" target="_blank">{{
+    <a [href]="'manageSchedulerJobs' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.heading.Schedular Jobs' | translate
     }}</a>
   </h4>

--- a/src/app/system/manage-jobs/scheduler-jobs/view-scheduler-job/view-scheduler-job.component.html
+++ b/src/app/system/manage-jobs/scheduler-jobs/view-scheduler-job/view-scheduler-job.component.html
@@ -39,7 +39,7 @@
         </div>
 
         <div class="flex-50">
-          <a href="http://www.cronmaker.com/">
+          <a [href]="'cronmaker' | documentationLink" target="_blank" rel="noopener noreferrer">
             {{ 'labels.text.Click Here To Generate Cron Expression' | translate }}
           </a>
         </div>

--- a/src/app/system/manage-reports/manage-reports.component.html
+++ b/src/app/system/manage-reports/manage-reports.component.html
@@ -139,7 +139,7 @@
 <ng-template #templateReportsTable let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.heading.List of all currently available reports' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67895354/Manage+Reports" target="_blank">{{
+    <a [href]="'manageReports' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.heading.Manage Reports' | translate
     }}</a>
   </h4>

--- a/src/app/system/roles-and-permissions/roles-and-permissions.component.html
+++ b/src/app/system/roles-and-permissions/roles-and-permissions.component.html
@@ -108,11 +108,9 @@
 <ng-template #templateTableRolesandPermissions let-popover="popover">
   <h4 class="mw300">
     {{ 'labels.heading.List of roles defined within the organization' | translate }}:
-    <a
-      href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67895364/Manage+Roles+and+Permissions"
-      target="_blank"
-      >{{ 'labels.inputs.Manage Roles and Permission' | translate }}</a
-    >
+    <a [href]="'rolesAndPermissions' | documentationLink" target="_blank" rel="noopener noreferrer">{{
+      'labels.inputs.Manage Roles and Permission' | translate
+    }}</a>
   </h4>
   <div class="layout-row align-end gap-2px responsive-column">
     <button mat-raised-button color="warn" (click)="popover.close(); configurationWizardService.closeConfigWizard()">

--- a/src/app/users/create-user/create-user.component.html
+++ b/src/app/users/create-user/create-user.component.html
@@ -201,7 +201,7 @@
   <h2>{{ 'labels.heading.Create User' | translate }}</h2>
   <p class="mw400">
     {{ 'labels.text.Filling Details' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67141740/Users" target="_blank">{{
+    <a [href]="'users' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Users' | translate
     }}</a>
   </p>

--- a/src/app/web-app.component.ts
+++ b/src/app/web-app.component.ts
@@ -22,6 +22,7 @@ import { ThemeStorageService } from './shared/theme-picker/theme-storage.service
 import { AlertService } from './core/alert/alert.service';
 import { AuthenticationService } from './core/authentication/authentication.service';
 import { SettingsService } from './settings/settings.service';
+import { DocumentationLinksService } from 'app/shared/services/documentation-links.service';
 import { IdleTimeoutService } from './home/timeout-dialog/idle-timeout.service';
 import { SessionTimeoutDialogComponent } from './home/timeout-dialog/session-timeout-dialog.component';
 
@@ -121,7 +122,8 @@ export class WebAppComponent implements OnInit, OnDestroy {
     private themingService: ThemingService,
     private dateUtils: Dates,
     private idle: IdleTimeoutService,
-    private dialog: MatDialog
+    private dialog: MatDialog,
+    private documentationLinks: DocumentationLinksService
   ) {}
 
   @HostBinding('class') public cssClass: string;
@@ -264,7 +266,7 @@ export class WebAppComponent implements OnInit, OnDestroy {
   }
 
   help() {
-    window.open('https://mifosforge.jira.com/wiki/spaces/docs/pages/52035622/User+Manual', '_blank');
+    this.documentationLinks.open('userManual');
   }
 
   // Monitor all keyboard events and excute keyboard shortcuts

--- a/src/app/zitadel/users/create-user/create-user.component.html
+++ b/src/app/zitadel/users/create-user/create-user.component.html
@@ -211,7 +211,7 @@
   <h2>{{ 'labels.heading.Create User' | translate }}</h2>
   <p class="mw400">
     {{ 'labels.text.Filling Details' | translate }}:
-    <a href="https://mifosforge.jira.com/wiki/spaces/docs/pages/67141740/Users" target="_blank">{{
+    <a [href]="'users' | documentationLink" target="_blank" rel="noopener noreferrer">{{
       'labels.inputs.Users' | translate
     }}</a>
   </p>

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -32,6 +32,9 @@
   // Display or not the Tenant Selector
   window['env']['displayTenantSelector'] = '$MIFOS_DISPLAY_TENANT_SELECTOR';
 
+  // Documentation base URL for in-app help links
+  window['env']['documentationBaseUrl'] = '$MIFOS_DOCUMENTATION_BASE_URL';
+
   // Time in seconds for Notifications, default 60 seconds
   window['env']['waitTimeForNotifications'] = '$MIFOS_WAIT_TIME_FOR_NOTIFICATIONS';
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -53,6 +53,7 @@ export const environment = {
   displayBackEndInfo: loadedEnv['displayBackEndInfo'] || 'true',
   displayTenantSelector: loadedEnv['displayTenantSelector'] || 'true',
   tenantLogoUrl: loadedEnv['tenantLogoUrl'] || 'assets/images/mifos_lg-logo.png',
+  documentationBaseUrl: loadedEnv['documentationBaseUrl'] || 'https://mifosforge.jira.com/wiki',
   // Time in seconds, default 60 seconds
   waitTimeForNotifications: loadedEnv['waitTimeForNotifications'] || 60,
   // Time in seconds, default 30 seconds

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -57,6 +57,7 @@ export const environment = {
   displayBackEndInfo: loadedEnv.displayBackEndInfo || 'true',
   displayTenantSelector: loadedEnv.displayTenantSelector || 'true',
   tenantLogoUrl: loadedEnv.tenantLogoUrl || 'assets/images/mifos_lg-logo.png',
+  documentationBaseUrl: loadedEnv.documentationBaseUrl || 'https://mifosforge.jira.com/wiki',
   // Time in seconds, default 60 seconds
   waitTimeForNotifications: loadedEnv.waitTimeForNotifications || 60,
   // Time in seconds, default 30 seconds


### PR DESCRIPTION
This PR centralizes all documentation URLs behind a DocumentationLinksService and a documentationLink pipe, backed by a shared map of documentation paths. This removes hard-coded wiki URLs from templates and help actions and makes documentation links configurable per environment.

[WEB-308](https://mifosforge.jira.com/browse/WEB-308)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-308]: https://mifosforge.jira.com/browse/WEB-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a configurable documentation base URL (environment setting) for documentation links.
  * Adds a template-friendly documentation link pipe to resolve doc pages.

* **Refactor**
  * Replaces hard-coded external help/documentation URLs throughout the UI with dynamic documentation links.
  * Centralizes opening of documentation via a shared link service used by header/help actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->