### PR TITLE
WEB-377: Reformat staff names in error messages to 'First Last' format

### DIFF
--- a/src/app/core/error-handler/error-handler.service.ts
+++ b/src/app/core/error-handler/error-handler.service.ts
@@ -57,6 +57,30 @@ export class ErrorHandlerService {
   }
 
   /**
+   * Reformats name from "Last, First" to "First Last" in error messages.
+   * @param message The error message that may contain a name in "Last, First" format
+   * @returns The error message with the name reformatted to "First Last"
+   */
+  private reformatNameInErrorMessage(message: string): string {
+    if (!message) {
+      return message;
+    }
+
+    // Match pattern: 'Last, First' (name in single quotes with comma)
+    const namePattern = /'([^']+),\s*([^']+)'/;
+    const match = message.match(namePattern);
+
+    if (match) {
+      const lastName = match[1].trim();
+      const firstName = match[2].trim();
+      // Replace "Last, First" with "First Last"
+      return message.replace(namePattern, `'${firstName} ${lastName}'`);
+    }
+
+    return message;
+  }
+
+  /**
    * Get user-friendly error message based on HTTP status
    * @param error The HTTP error response
    * @param context Optional context for more specific messages
@@ -73,8 +97,16 @@ export class ErrorHandlerService {
     }
 
     // Server-side error - Extract Fineract-specific error messages
-    const fineractError = error.error?.errors?.[0]?.defaultUserMessage;
-    const defaultMessage = error.error?.defaultUserMessage;
+    let fineractError = error.error?.errors?.[0]?.defaultUserMessage;
+    let defaultMessage = error.error?.defaultUserMessage;
+
+    // Reformat name from "Last, First" to "First Last" in error messages
+    if (fineractError) {
+      fineractError = this.reformatNameInErrorMessage(fineractError);
+    }
+    if (defaultMessage) {
+      defaultMessage = this.reformatNameInErrorMessage(defaultMessage);
+    }
 
     switch (error.status) {
       case 400:

--- a/src/app/core/http/error-handler.interceptor.ts
+++ b/src/app/core/http/error-handler.interceptor.ts
@@ -33,6 +33,30 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
   }
 
   /**
+   * Reformats name from "Last, First" to "First Last" in error messages.
+   * @param message The error message that may contain a name in "Last, First" format
+   * @returns The error message with the name reformatted to "First Last"
+   */
+  private reformatNameInErrorMessage(message: string): string {
+    if (!message) {
+      return message;
+    }
+
+    // Match pattern: 'Last, First' (name in single quotes with comma)
+    const namePattern = /'([^']+),\s*([^']+)'/;
+    const match = message.match(namePattern);
+
+    if (match) {
+      const lastName = match[1].trim();
+      const firstName = match[2].trim();
+      // Replace "Last, First" with "First Last"
+      return message.replace(namePattern, `'${firstName} ${lastName}'`);
+    }
+
+    return message;
+  }
+
+  /**
    * Error handler.
    */
   private handleError(response: HttpErrorResponse, request: HttpRequest<any>): Observable<HttpEvent<any>> {
@@ -43,6 +67,9 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
         errorMessage = response.error.errors[0].defaultUserMessage || response.error.errors[0].developerMessage;
       }
     }
+
+    // Reformat name from "Last, First" to "First Last" in error messages
+    errorMessage = this.reformatNameInErrorMessage(errorMessage);
 
     const isClientImage404 = status === 404 && request.url.includes('/clients/') && request.url.includes('/images');
 


### PR DESCRIPTION
This pr change automatically reformats names in error messages from "Last, First" to "First Last" to match the rest of the application. The fix applies across both error handlers (ErrorHandlerInterceptor and ErrorHandlerService) using pattern matching to detect and reformat names within single quotes

Before (incorrect format):
A staff with the given display name 'Kumar, Shubham' already exists
After (correct format):
A staff with the given display name 'Shubham Kumar' already exist

[WEB-377](https://mifosforge.jira.com/browse/WEB-377)
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-377]: https://mifosforge.jira.com/browse/WEB-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now consistently display names in "First Last" format instead of "Last, First" for improved clarity and readability throughout the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->