### PR TITLE
WEB-416:fixd dark theme in documents section

### DIFF
--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.html
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.html
@@ -1,5 +1,5 @@
 <div class="tab-container mat-typography">
-  <div class="layout-row align-start-center header-row">
+  <div class="layout-row align-start-center">
     <h3 class="flex-90">{{ 'labels.heading.Documents' | translate }}</h3>
 
     <div class="flex-10" *mifosxHasPermission="'CREATE_DOCUMENT'">

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.scss
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.scss
@@ -5,11 +5,6 @@
   margin: 1rem 0;
 }
 
-.header-row {
-  display: flex;
-  align-items: center;
-}
-
 .document-grid {
   display: flex;
   flex-wrap: wrap;

--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -284,35 +284,89 @@ body.dark-theme {
     background-color: rgb(255 255 255 / 8%) !important;
   }
 
+  // Documents section dark theme styling
+  mifosx-entity-documents-tab {
+    .document-card {
+      background: #2d2d2d;
+      border-color: #444;
+      box-shadow: 0 1px 4px rgb(0 0 0 / 30%);
+
+      &:hover {
+        box-shadow: 0 4px 12px rgb(0 0 0 / 50%);
+      }
+    }
+
+    .thumb {
+      background: #1a1a1a;
+    }
+
+    .preview-overlay {
+      background: rgb(45 45 45 / 95%);
+      color: #0098ff;
+    }
+
+    .placeholder {
+      color: #b0b0b0;
+
+      fa-icon {
+        color: #888;
+      }
+    }
+
+    .card-body {
+      .title {
+        color: rgb(255 255 255 / 87%);
+      }
+
+      .meta {
+        color: #aaa;
+      }
+
+      .description {
+        color: rgb(255 255 255 / 70%);
+      }
+    }
+
+    .empty-state {
+      background: #2d2d2d;
+      border-color: #555;
+      color: rgb(255 255 255 / 70%);
+
+      .muted {
+        color: #888;
+      }
+    }
+  }
+
   // Notes section dark theme styling
   mifosx-entity-notes-tab {
     .tab-container {
       h3 {
-        color: white;
+        color: rgb(255 255 255 / 87%);
       }
     }
 
     .note-card {
-      background-color: #303135;
-      border-color: #424242;
-      color: white;
+      background-color: #2d2d2d;
+      border-color: #444;
+      box-shadow: 0 2px 4px rgb(0 0 0 / 30%);
 
       &:hover {
-        box-shadow: 0 4px 8px rgb(0 0 0 / 30%);
+        box-shadow: 0 4px 8px rgb(0 0 0 / 50%);
         border-color: #555;
       }
     }
 
     .note-content {
-      color: white;
+      color: rgb(255 255 255 / 87%);
     }
 
     .note-footer {
-      border-top-color: #424242;
+      border-top-color: #444;
     }
 
     .note-meta {
-      color: rgb(255 255 255 / 70%);
+      color: #aaa;
     }
 
     .created-by {
@@ -320,13 +374,13 @@ body.dark-theme {
     }
 
     .created-date {
-      color: rgb(255 255 255 / 60%);
+      color: #bbb;
     }
 
     .empty-state {
-      background-color: #303135;
+      background-color: #2d2d2d;
       color: rgb(255 255 255 / 70%);
-      border-color: #424242;
+      border-color: #555;
     }
   }
 


### PR DESCRIPTION
This pr centralize dark theme styles for documents  in the global `_dark_content.scss` file, following the existing pattern used for other components.

[WEB-416](https://mifosforge.jira.com/browse/WEB-416)

Before:
<img width="1919" height="976" alt="Screenshot 2025-12-30 224625" src="https://github.com/user-attachments/assets/d39e2fd6-52b3-442f-b0cd-9ad45866fdc2" />
After:
<img width="1914" height="1078" alt="image" src="https://github.com/user-attachments/assets/9be4104e-3310-4fda-b1e6-50c648943e1f" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-416]: https://mifosforge.jira.com/browse/WEB-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark theme styling for the documents section with improved card appearance, hover effects, and visual hierarchy.
  * Updated dark theme colors and contrast across the notes section for improved readability and consistency.
  * Refined layout styling for the documents tab header row.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->