### PR TITLE
WEB-396:fix align heading and add button in address, family, and iden…

### DIFF
--- a/src/app/clients/clients-view/address-tab/address-tab.component.html
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.html
@@ -1,14 +1,17 @@
 <div class="tab-container mat-typography">
-  <h3>{{ 'labels.heading.Address' | translate }}</h3>
-
-  <div class="layout-row align-flex-end">
-    <button mat-raised-button color="primary" (click)="addAddress()">
-      <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
-    </button>
+  <div class="layout-row align-start">
+    <div class="m-b-10">
+      <h3>{{ 'labels.heading.Address' | translate }}</h3>
+    </div>
+    <div class="action-button m-b-10 gap-25px">
+      <button mat-raised-button color="primary" (click)="addAddress()">
+        <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
+      </button>
+    </div>
   </div>
 
   <mat-accordion>
-    @for (address of clientAddressData; track address; let i = $index) {
+    @for (address of clientAddressData; track address.addressId; let i = $index) {
       <mat-expansion-panel class="address">
         <mat-expansion-panel-header>
           <mat-panel-title>

--- a/src/app/clients/clients-view/address-tab/address-tab.component.scss
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.scss
@@ -2,6 +2,10 @@
   padding: 1%;
   margin: 1%;
 
+  .action-button {
+    margin-left: auto;
+  }
+
   .address {
     .address-actions {
       margin-top: 1%;

--- a/src/app/clients/clients-view/family-members-tab/family-members-tab.component.html
+++ b/src/app/clients/clients-view/family-members-tab/family-members-tab.component.html
@@ -1,15 +1,18 @@
 <div class="tab-container mat-typography">
   <router-outlet>
-    <h3>{{ 'labels.heading.Family Members' | translate }}</h3>
-
-    <div class="layout-row align-flex-end">
-      <button mat-raised-button color="primary" [routerLink]="['./add']">
-        <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
-      </button>
+    <div class="layout-row align-start">
+      <div class="m-b-10">
+        <h3>{{ 'labels.heading.Family Members' | translate }}</h3>
+      </div>
+      <div class="action-button m-b-10 gap-25px">
+        <button mat-raised-button color="primary" [routerLink]="['./add']">
+          <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
+        </button>
+      </div>
     </div>
 
     <mat-accordion>
-      @for (member of clientFamilyMembers; track member; let i = $index) {
+      @for (member of clientFamilyMembers; track member.id; let i = $index) {
         <mat-expansion-panel class="family-member">
           <mat-expansion-panel-header>
             <mat-panel-title>

--- a/src/app/clients/clients-view/family-members-tab/family-members-tab.component.scss
+++ b/src/app/clients/clients-view/family-members-tab/family-members-tab.component.scss
@@ -2,6 +2,10 @@
   padding: 1%;
   margin: 1%;
 
+  .action-button {
+    margin-left: auto;
+  }
+
   .family-member {
     .family-member-actions {
       margin-top: 1%;

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.html
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.html
@@ -1,16 +1,19 @@
 <div class="tab-container mat-typography">
-  <h3>{{ 'labels.heading.Identities' | translate }}</h3>
-
-  <div class="layout-row align-flex-end">
-    <button
-      mat-raised-button
-      color="primary"
-      (click)="addIdentifier()"
-      *mifosxHasPermission="'CREATE_CLIENTIDENTIFIER'"
-    >
-      <fa-icon icon="plus" class="m-r-10"></fa-icon>
-      {{ 'labels.buttons.Add' | translate }}
-    </button>
+  <div class="layout-row align-start">
+    <div class="m-b-10">
+      <h3>{{ 'labels.heading.Identities' | translate }}</h3>
+    </div>
+    <div class="action-button m-b-10 gap-25px">
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="addIdentifier()"
+        *mifosxHasPermission="'CREATE_CLIENTIDENTIFIER'"
+      >
+        <fa-icon icon="plus" class="m-r-10"></fa-icon>
+        {{ 'labels.buttons.Add' | translate }}
+      </button>
+    </div>
   </div>
 
   <table mat-table #identifiersTable [dataSource]="clientIdentities" [ngStyle]="{ 'margin-top': '3%' }">

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.scss
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.scss
@@ -4,6 +4,10 @@
   padding: 1rem;
   margin: 1rem 0;
 
+  .action-button {
+    margin-left: auto;
+  }
+
   h3 {
     margin: 0;
   }


### PR DESCRIPTION
…tities tabs

This pr align heading text and Add button on the same row in Address, Family Members,
and Identities tabs to match the Committee tab pattern

[WEB-396](https://mifosforge.jira.com/browse/WEB-396)

Before:
<img width="1838" height="972" alt="Screenshot 2025-12-30 235103" src="https://github.com/user-attachments/assets/8083eba4-fb90-417b-818f-57f39caf81cb" />
After:
<img width="1915" height="1079" alt="image" src="https://github.com/user-attachments/assets/d9e74ecd-51f6-49db-afed-42b33af00301" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-396]: https://mifosforge.jira.com/browse/WEB-396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reorganized header and action-button layout across client views to separate headings from Add buttons and improve visual consistency.
  * Action buttons are now consistently right-aligned for clearer visual hierarchy and spacing.

* **Bug Fixes**
  * Improved list rendering stability to reduce unexpected reordering during item updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->