### PR TITLE
WEB-377:fix improve deposit form heading styling and appearance

### DIFF
--- a/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.html
+++ b/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.html
@@ -1,14 +1,14 @@
 <div class="container mat-elevation-z8">
   <mat-card>
     @if (transactionType.withdrawal) {
-      <h2 mat-title class="m-l-10">
+      <mat-card-title class="form-heading">
         {{ 'labels.heading.Withdraw Money From Saving Account' | translate }}
-      </h2>
+      </mat-card-title>
     }
     @if (transactionType.deposit) {
-      <h2 mat-title class="m-l-10">
+      <mat-card-title class="form-heading">
         {{ 'labels.heading.Deposit Money To Saving Account' | translate }}
-      </h2>
+      </mat-card-title>
     }
 
     <form [formGroup]="savingAccountTransactionForm" (ngSubmit)="submit()">

--- a/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.scss
+++ b/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.scss
@@ -13,3 +13,9 @@
 .right-label {
   padding-right: 25px !important;
 }
+
+.form-heading {
+  font-size: 1.25rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
The heading "Deposit Money To Saving Account" on the savings account deposit form has been improved to provide a better user experience and maintain consistency across the application

[WEB-377](https://mifosforge.jira.com/browse/WEB-377)

Before:
<img width="1919" height="1079" alt="Screenshot 2025-12-31 153626" src="https://github.com/user-attachments/assets/c16d75cc-c1a0-4b5d-8939-1799a9639f12" />
After:
<img width="1909" height="1079" alt="image" src="https://github.com/user-attachments/assets/7de7aca8-6a0a-4fa0-9f70-8eff979ed393" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-377]: https://mifosforge.jira.com/browse/WEB-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated heading elements for withdrawal and deposit sections with refreshed styling, including adjusted font size, weight, and spacing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->