### PR TITLE
WEB-538 fix translation issue in notes module

### DIFF
--- a/src/app/shared/tabs/entity-notes-tab/entity-notes-tab.component.html
+++ b/src/app/shared/tabs/entity-notes-tab/entity-notes-tab.component.html
@@ -18,14 +18,7 @@
           cdkAutosizeMinRows="2"
         ></textarea>
       </mat-form-field>
-      <button
-        type="button"
-        mat-raised-button
-        class="flex-1"
-        color="primary"
-        [disabled]="!noteForm.valid"
-        (click)="addNote()"
-      >
+      <button type="submit" mat-raised-button class="flex-1" color="primary" [disabled]="!noteForm.valid">
         <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
       </button>
     </form>
@@ -41,7 +34,9 @@
             </div>
             <div class="note-footer">
               <div class="note-meta">
-                <div class="created-by">Created by {{ entityNote.createdByUsername }}</div>
+                <div class="created-by">
+                  {{ 'labels.inputs.Created By' | translate }} {{ entityNote.createdByUsername }}
+                </div>
                 <div class="created-date">
                   {{ entityNote.createdOn | dateFormat }}
                 </div>
@@ -52,18 +47,18 @@
                   mat-raised-button
                   color="primary"
                   (click)="editNote(entityNote.id, entityNote.note, i)"
-                  title="Edit note"
+                  [title]="'labels.heading.Edit Note' | translate"
                 >
-                  Edit
+                  {{ 'labels.buttons.Edit' | translate }}
                 </button>
                 <button
                   type="button"
                   mat-raised-button
                   color="warn"
                   (click)="deleteNote(entityNote.id, i)"
-                  title="Delete note"
+                  [title]="('labels.inputs.Note' | translate) + ': ' + ('labels.buttons.Delete' | translate)"
                 >
-                  Delete
+                  {{ 'labels.buttons.Delete' | translate }}
                 </button>
               </div>
             </div>

--- a/src/app/shared/tabs/entity-notes-tab/entity-notes-tab.component.ts
+++ b/src/app/shared/tabs/entity-notes-tab/entity-notes-tab.component.ts
@@ -11,6 +11,7 @@ import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'mifosx-entity-notes-tab',
@@ -30,6 +31,7 @@ export class EntityNotesTabComponent implements OnInit {
   private clientsService = inject(ClientsService);
   private groupsService = inject(GroupsService);
   private dialog = inject(MatDialog);
+  private translateService = inject(TranslateService);
 
   @ViewChild('formRef', { static: true }) formRef: any;
 
@@ -69,14 +71,14 @@ export class EntityNotesTabComponent implements OnInit {
             required: true,
             value: noteContent,
             controlType: 'input',
-            label: 'Note'
+            label: this.translateService.instant('labels.inputs.Note')
           }
         ],
         layout: {
           columns: 1,
           addButtonText: 'Confirm'
         },
-        title: 'Edit Note'
+        title: this.translateService.instant('labels.heading.Edit Note')
       }
     });
     editNoteDialogRef.afterClosed().subscribe((response: any) => {
@@ -87,8 +89,9 @@ export class EntityNotesTabComponent implements OnInit {
   }
 
   deleteNote(noteId: string, index: number) {
+    const noteLabel = this.translateService.instant('labels.inputs.Note');
     const deleteNoteDialogRef = this.dialog.open(DeleteDialogComponent, {
-      data: { deleteContext: `Note: ${this.entityNotes[index].note}` }
+      data: { deleteContext: `${noteLabel}: ${this.entityNotes[index].note}` }
     });
     deleteNoteDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {


### PR DESCRIPTION
This PR fixes translation issues in the Notes module where English text was displayed instead of the selected language. On the client's main screen, when adding a selected note, the note name and details (Institution → Client → Client → Note) were displayed in English and prevented note addition. Similarly, on the general screen of the Notes module in the credit module, when adding a selected note, the note name and details were displayed in English

[WEB-538](https://mifosforge.jira.com/browse/WEB-538)
[WEB-541](https://mifosforge.jira.com/browse/WEB-541)

<img width="1915" height="1079" alt="image" src="https://github.com/user-attachments/assets/e136c924-458d-4a45-b746-b7ec1720ed6c" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-538]: https://mifosforge.jira.com/browse/WEB-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEB-541]: https://mifosforge.jira.com/browse/WEB-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Localization**
  * Added translation support for all note-related UI strings, including edit and delete action labels, titles, and confirmation messages.

* **Improvements**
  * Enhanced form submission flow for note creation to better align button actions with form submission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->