### PR TITLE
chore(start) : removed deprecated --aot flag from start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ng": "ng",
     "build": "node version.js && npm run env -s && ng build --configuration production --output-hashing=none",
     "build:prod": "node version.js && node --max-old-space-size=16384 ./node_modules/@angular/cli/bin/ng build --configuration production --output-hashing=none --base-href=/web-app/",
-    "start": "npm run env -s && ng serve --aot --proxy-config proxy.conf.js",
+    "start": "npm run env -s && ng serve --proxy-config proxy.conf.js",
     "serve:dev": "npm run env -s && ng serve --source-map",
     "serve:sw": "npm run build -s && npx http-server ./dist -p 4200",
     "lint": "eslint . && stylelint \"src/**/*.scss\" && prettier . --check && htmlhint \"src\" --config .htmlhintrc",


### PR DESCRIPTION
This PR removes the deprecated `--aot` flag from the npm start script.

Angular enables AOT by default in Angular 20+, and the `--aot` flag is no longer
supported by newer CLI versions, which was causing startup errors

### Changes;
- Removed obsolete `--aot` flag from `npm start` script

### Testing:
- Verified application starts successfully without errors..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development build configuration, adjusting compilation settings while maintaining existing proxy configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->