### PR TITLE
WEB-536:fix resolve chargeIds parameter error in penalty waiving

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/loan-reschedule/loan-reschedule.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/loan-reschedule/loan-reschedule.component.ts
@@ -126,11 +126,25 @@ export class LoanRescheduleComponent implements OnInit {
     };
     data.loanId = this.loanId;
 
-    // Add waived penalty charge IDs if penalties are being waived
+    // Waive penalties first if selected, then submit reschedule
     if (this.waivePenalties.value && this.selectedPenalties.length > 0) {
-      data.chargeIds = this.selectedPenalties;
+      this.penaltyManagementService.waivePenalties(this.loanId, this.selectedPenalties).subscribe({
+        next: () => {
+          this.submitReschedule(data);
+        },
+        error: (error: any) => {
+          console.error('Error waiving penalties:', error);
+          // Continue with reschedule even if waive fails
+          this.submitReschedule(data);
+        }
+      });
+    } else {
+      this.submitReschedule(data);
     }
+  }
 
+  /** Submit the reschedule after penalties are waived */
+  private submitReschedule(data: any) {
     this.loanService.submitRescheduleData(data).subscribe((response: any) => {
       // TODO: needs to be updated
       // mentioned in Community App:

--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
@@ -326,11 +326,25 @@ export class MakeRepaymentComponent implements OnInit {
     }
     delete data.skipInterestRefund;
 
-    // Add waived penalty charge IDs if penalties are being waived
+    // Waive penalties first if selected, then submit repayment
     if (this.waivePenalties && this.selectedPenalties.length > 0) {
-      data.chargeIds = this.selectedPenalties;
+      this.penaltyManagementService.waivePenalties(this.loanId, this.selectedPenalties).subscribe({
+        next: () => {
+          this.submitRepayment(data);
+        },
+        error: (error: any) => {
+          console.error('Error waiving penalties:', error);
+          // Continue with repayment even if waive fails
+          this.submitRepayment(data);
+        }
+      });
+    } else {
+      this.submitRepayment(data);
     }
+  }
 
+  /** Submit the repayment after penalties are waived */
+  private submitRepayment(data: any) {
     this.loanService.submitLoanActionButton(this.loanId, data, this.command).subscribe((response: any) => {
       this.router.navigate(['../../transactions'], { relativeTo: this.route });
     });


### PR DESCRIPTION
This pr adjusts penalty-waiving behavior so penalties are waived via the dedicated waive endpoint before submitting repayment or reschedule requests.

[WEB-536](https://mifosforge.jira.com/browse/WEB-536)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-536]: https://mifosforge.jira.com/browse/WEB-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Penalty waivers can now be applied during loan rescheduling
  * Penalty waivers can now be applied during repayment transactions
  * Support for waiving multiple penalties simultaneously

* **Bug Fixes**
  * Improved error handling: penalty waiver failures no longer block primary transaction completion

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->