### PR TITLE
WEB-547 feat(proxy): forward fineract provider requests to sandbox for local dev

### DIFF
--- a/docs/backend-proxy.md
+++ b/docs/backend-proxy.md
@@ -18,26 +18,72 @@ The interesting part is there:
 ```js
 const proxyConfig = [
   {
-    context: '/api',
-    pathRewrite: { '^/api': '' },
-    target: 'https://api.chucknorris.io',
-    changeOrigin: true
+    context: ['/fineract-provider'],
+    target: 'https://sandbox.mifos.community',
+    pathRewrite: { '^/fineract-provider': '' },
+    changeOrigin: true,
+    secure: true,
+    logLevel: 'debug',
+    onProxyReq: function (proxyReq, req, res) {
+      // Log the rewritten path so the console shows the actual forwarded URL
+      const rewrittenPath = (req.url || '').replace(/^\/fineract-provider/, '');
+      console.log('[Proxy] Proxying:', req.method, req.url, '->', this.target + rewrittenPath);
+    },
+    onError: function (err, req, res) {
+      // Log proxy errors and return HTTP 502 to the client
+      console.error('[Proxy] Error while proxying request:', req.method, req.url, '->', this.target, '-', err.message);
+      if (res && !res.headersSent) {
+        res.writeHead(502, { 'Content-Type': 'text/plain' });
+        res.end('Proxy error: ' + err.message);
+      }
+    }
   }
 ];
 ```
 
-This is where you can setup one or more proxy rules.
+This forwards requests sent to `/fineract-provider/...` on the dev server to the Fineract backend root (for example,
+`/fineract-provider/1.0/...` becomes `https://sandbox.mifos.community/1.0/...`). Use `pathRewrite` to strip the prefix
+because the sandbox exposes Fineract APIs at the root path.
+
+**Error Handling:**
+
+The `onError` handler captures proxy failures (network errors, backend unreachable, timeouts, etc.) and:
+
+- Logs detailed error information to the server console (method, URL, target, error message)
+- Returns HTTP 502 (Bad Gateway) to the client with a plain-text error message
+
+Example server console output when proxy fails:
+
+```text
+[Proxy] Error while proxying request: GET /fineract-provider/api/v1/clients -> https://sandbox.mifos.community - ECONNREFUSED
+```
+
+Example client response:
+
+```http
+HTTP/1.1 502 Bad Gateway
+Content-Type: text/plain
+
+Proxy error: connect ECONNREFUSED
+```
+
+You can add multiple rules or change the `target` to point to other environments (demo, localhost, etc.).
 
 For the complete set of options, see the `http-proxy-middleware`
 [documentation](https://github.com/chimurai/http-proxy-middleware#options).
 
 ### Corporate proxy support
 
-To allow external API calls redirection through a corporate proxy, you will also find a `setupForCorporateProxy()`
-function in the proxy configuration file. By default, this method configures a corporate proxy agent based on the
-`HTTP_PROXY` environment variable, see the [corporate proxy documentation](corporate-proxy.md) for more details.
+The repository configures a helper function in `proxy.conf.js` named `setupForProxy` which will attach an
+`HttpsProxyAgent` to proxy entries when the `HTTP_PROXY` (or `http_proxy`) environment variable is present. This lets
+the dev server forward requests through a corporate proxy when required.
 
-If you need to, you can further customize this function to fit the network of your working environment.
+**Behavior:**
 
-If your corporate proxy use a custom SSL certificate, your may need to add the `secure: false` option to your
-backend proxy configuration.
+- **When `HTTP_PROXY` is set:** Logs `"Using proxy server: <url>"` and configures the agent for corporate proxy forwarding
+- **When `HTTP_PROXY` is not set:** Logs `"No proxy server configured. API requests will not be proxied."` — note that this refers only to corporate proxy forwarding; the Angular dev server proxy (forwarding `/fineract-provider` to the sandbox) still works normally
+
+See `proxy.conf.js` for the exact implementation.
+
+If your corporate proxy uses a custom SSL certificate you may need to set `secure: false` on the specific proxy entry
+or configure your environment to trust the corporate CA.

--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -2,7 +2,7 @@
 
 const { HttpsProxyAgent } = require('https-proxy-agent');
 
-/*
+/* IMPORTANT:
  * API proxy configuration.
  * This allows you to proxy HTTP request like `http.get('/api/stuff')` to another server/port.
  * This is especially useful during app development to avoid CORS issues while running a local server.
@@ -10,12 +10,33 @@ const { HttpsProxyAgent } = require('https-proxy-agent');
  */
 const proxyConfig = [
   {
-    context: '/api',
-    pathRewrite: { '^/api': '' },
-    target: 'https://api.chucknorris.io',
+    context: ['/fineract-provider'],
+    target: 'https://sandbox.mifos.community',
+    pathRewrite: { '^/fineract-provider': '' },
     changeOrigin: true,
-    secure: false
+    secure: true,
+    logLevel: 'debug',
+    onProxyReq: function (proxyReq, req, res) {
+      const rewrittenPath = (req.url || '').replace(/^\/fineract-provider/, '');
+      console.log('[Proxy] Proxying:', req.method, req.url, '->', this.target + rewrittenPath);
+    },
+    onError: function (err, req, res) {
+      console.error(
+        '[Proxy] Error while proxying request:',
+        req && req.method,
+        req && req.url,
+        '->',
+        this.target,
+        '-',
+        err && err.message
+      );
+      if (res && !res.headersSent) {
+        res.writeHead(502, { 'Content-Type': 'text/plain' });
+        res.end('Proxy error: ' + (err && err.message ? err.message : 'Unknown error'));
+      }
+    }
   }
+  // For local development use `proxy.localhost.conf js` .
 ];
 
 /*

--- a/proxy.localhost.conf.js
+++ b/proxy.localhost.conf.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * Proxy configuration for running the app against a local Fineract instance.
+ * Usage:
+ *   ng serve --proxy-config proxy.localhost.conf.js
+ */
+
+module.exports = [
+  {
+    context: ['/fineract-provider'],
+    target: 'http://localhost:8443',
+    pathRewrite: { '^/fineract-provider': '' },
+    changeOrigin: true,
+    secure: false,
+    logLevel: 'debug',
+    onProxyReq: function (proxyReq, req, res) {
+      const rewrittenPath = (req.url || '').replace(/^\/fineract-provider/, '');
+      console.log('[Proxy] Proxying:', req.method, req.url, '->', this.target + rewrittenPath);
+    },
+    onError: function (err, req, res) {
+      console.error(
+        '[Proxy] Error while proxying request:',
+        req && req.method,
+        req && req.url,
+        '->',
+        this.target,
+        '-',
+        err && err.message
+      );
+      if (res && !res.headersSent) {
+        res.writeHead(502, { 'Content-Type': 'text/plain' });
+        res.end('Proxy error: ' + (err && err.message ? err.message : 'Unknown error'));
+      }
+    }
+  }
+];


### PR DESCRIPTION
## Summary

This PR adds a development proxy that forwards `/fineract-provider` requests to the Mifos sandbox and documents how it works. It enables local frontend development against the remote Fineract sandbox or a local Fineract instance, improves request logging, and makes error handling more robust. It also includes a ready-to-use localhost proxy sample and corporate-proxy support.

---

## What Changed

### Proxy (`proxy.conf.js`)
- Forward `/fineract-provider` → `https://sandbox.mifos.community`.
- Add `pathRewrite` so requests map to the sandbox root.
- Log rewritten (forwarded) target URLs for easier debugging.
- Improve `onError`:
  - Log detailed proxy errors on the server.
  - Return clear HTTP **502** responses to clients on failure.
- Add `setupForProxy` to support corporate HTTP(S) proxies via `HTTPS_PROXY` / `HTTP_PROXY` (uses `HttpsProxyAgent` when set).
- Keep a commented/example snippet for `http://localhost:8443` behavior.

### Localhost proxy (`proxy.localhost.conf.js`) — **new**
- New ready-to-use proxy file targeting `http://localhost:8443` for local Fineract development.
- Same logging, `pathRewrite`, and `onError` behavior as sandbox config.
- Recommended for:
   ng serve --proxy-config proxy.localhost.conf.js
   

---
---

## Documentation

### `README.md`
- Added a section explaining how to use the development proxy (sandbox + localhost).
- Documented sandbox-related environment variables and clarified sandbox system reset behavior.
- Added `curl` examples:
  - Successful proxy request
  - Simulated failure returning **502**
- Clarified when `setupForProxy` / `HttpsProxyAgent` is needed (corporate proxy only).

### `backend-proxy.md`
- Replaced outdated examples with sandbox-specific guidance.
- Documented `onError` behavior with example server logs and client **502** responses.
- Clarified `setupForProxy` and `HTTP_PROXY` behavior.

---

## Files Changed
- `proxy.conf.js` (updated)
- `proxy.localhost.conf.js` (added)
- `README.md` (updated)
- `backend-proxy.md` (updated)

---

## Testing / How to Verify

### Start frontend using the localhost proxy

**Successful proxied request**
- Expect proxied **200** response from sandbox/local backend.
- Server console shows the rewritten target URL.

**Simulated failure**
- Stop the backend or point proxy target to an invalid host.
- Repeat the request; expect **HTTP/1.1 502 Bad Gateway** and server log with the error.

**Corporate proxy**
- Set `HTTP_PROXY` / `HTTPS_PROXY` environment variable and verify outbound proxying uses the upstream proxy  
  (logs the *Using proxy server:* message).

---

## Notes
- Use `proxy.localhost.conf.js` for local dev on `localhost:8443`; `setupForProxy` is only required for corporate upstream proxies.
- This PR improves developer experience by providing a simple switch between sandbox and local backends while giving clearer logs and error responses.

---

## Jira
- **WEB-547**

