### PR TITLE
WEB-546 fix(images): correct mifos logo reference from png to jpg

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -52,7 +52,7 @@ export const environment = {
 
   displayBackEndInfo: loadedEnv['displayBackEndInfo'] || 'true',
   displayTenantSelector: loadedEnv['displayTenantSelector'] || 'true',
-  tenantLogoUrl: loadedEnv['tenantLogoUrl'] || 'assets/images/mifos_lg-logo.png',
+  tenantLogoUrl: loadedEnv['tenantLogoUrl'] || 'assets/images/mifos_lg-logo.jpg',
   documentationBaseUrl: loadedEnv['documentationBaseUrl'] || 'https://mifosforge.jira.com/wiki',
   // Time in seconds, default 60 seconds
   waitTimeForNotifications: loadedEnv['waitTimeForNotifications'] || 60,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -56,7 +56,7 @@ export const environment = {
 
   displayBackEndInfo: loadedEnv.displayBackEndInfo || 'true',
   displayTenantSelector: loadedEnv.displayTenantSelector || 'true',
-  tenantLogoUrl: loadedEnv.tenantLogoUrl || 'assets/images/mifos_lg-logo.png',
+  tenantLogoUrl: loadedEnv.tenantLogoUrl || 'assets/images/mifos_lg-logo.jpg',
   documentationBaseUrl: loadedEnv.documentationBaseUrl || 'https://mifosforge.jira.com/wiki',
   // Time in seconds, default 60 seconds
   waitTimeForNotifications: loadedEnv.waitTimeForNotifications || 60,

--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -271,7 +271,7 @@ body.dark-theme {
 
   // Home page logo styling for dark mode
   mifosx-home {
-    [src*='mifos_lg-logo.png'],
+    [src*='mifos_lg-logo.jpg'],
     [src$='_home.png'] {
       content: url('../assets/images/white-mifos.png');
     }


### PR DESCRIPTION
### Summary
This PR corrects incorrect references to `mifos_lg-logo.png` and replaces them
with the correct asset `mifos_lg-logo.jpg`.

The PNG file does not exist in the assets directory. Although the UI continued
to work due to an OR fallback (`tenantLogoUrl || assets/images/mifos_lg-logo.jpg`),
the incorrect reference was misleading and fragile.

### Impact
- No visible UI change (fallback already handled rendering)
- Improves correctness, consistency, and future maintainability

### Changes
- Updated logo references from `.png` to `.jpg` in:
  - `environment.ts`
  - `environment.prod.ts`
  - `_dark_content.scss`

### Evidence
- Screenshot attached showing the existing asset
<img width="302" height="556" alt="Screenshot 2026-01-02 at 9 20 01 PM" src="https://github.com/user-attachments/assets/e05d867f-cc8d-4591-bf86-63f2c6adc6f6" />


### Jira
- WEB-546
