### PR TITLE
WEB-337:fix(loans) standardize loan collateral dialog structure

### DIFF
--- a/src/app/loans/custom-dialog/loans-account-add-collateral-dialog/loans-account-add-collateral-dialog.component.html
+++ b/src/app/loans/custom-dialog/loans-account-add-collateral-dialog/loans-account-add-collateral-dialog.component.html
@@ -1,49 +1,53 @@
 <h1 mat-dialog-title>{{ 'labels.heading.Add Loan Collateral' | translate }}</h1>
 
-<div mat-dialog-content [formGroup]="addCollateralForm" class="layout-column">
-  <mat-form-field>
-    <mat-label>{{ 'labels.inputs.Collateral' | translate }}</mat-label>
-    <mat-select formControlName="collateral" required>
-      @for (collateralType of collateralTypeData; track collateralType) {
-        <mat-option [value]="collateralType">
-          {{ collateralType.name }}
-        </mat-option>
-      }
-    </mat-select>
-    <mat-error>
-      {{ 'labels.inputs.Collateral' | translate }} {{ 'labels.commons.is' | translate }}
-      <strong>{{ 'labels.commons.required' | translate }}</strong>
-    </mat-error>
-  </mat-form-field>
+<mat-dialog-content>
+  <form [formGroup]="addCollateralForm">
+    <div class="layout-column">
+      <mat-form-field>
+        <mat-label>{{ 'labels.inputs.Collateral' | translate }}</mat-label>
+        <mat-select formControlName="collateral" required>
+          @for (collateralType of collateralTypeData; track collateralType) {
+            <mat-option [value]="collateralType">
+              {{ collateralType.name }}
+            </mat-option>
+          }
+        </mat-select>
+        <mat-error>
+          {{ 'labels.inputs.Collateral' | translate }} {{ 'labels.commons.is' | translate }}
+          <strong>{{ 'labels.commons.required' | translate }}</strong>
+        </mat-error>
+      </mat-form-field>
 
-  <mat-form-field>
-    <mat-label>{{ 'labels.inputs.Quantity' | translate }}</mat-label>
-    <input type="number" [max]="maxQuantity" [min]="0" matInput formControlName="quantity" required />
-    @if (addCollateralForm.controls.quantity.hasError('required')) {
-      <mat-error>
-        {{ 'labels.inputs.Quantity' | translate }} {{ 'labels.commons.is' | translate }}
-        <strong>{{ 'labels.commons.required' | translate }}</strong>
-      </mat-error>
-    }
-    @if (addCollateralForm.controls.quantity.hasError('max')) {
-      <mat-error>
-        {{ 'labels.inputs.Quantity can not be more than' | translate }} <strong>{{ maxQuantity }}</strong>
-      </mat-error>
-    }
-  </mat-form-field>
+      <mat-form-field>
+        <mat-label>{{ 'labels.inputs.Quantity' | translate }}</mat-label>
+        <input type="number" [max]="maxQuantity" [min]="0" matInput formControlName="quantity" required />
+        @if (addCollateralForm.controls.quantity.hasError('required')) {
+          <mat-error>
+            {{ 'labels.inputs.Quantity' | translate }} {{ 'labels.commons.is' | translate }}
+            <strong>{{ 'labels.commons.required' | translate }}</strong>
+          </mat-error>
+        }
+        @if (addCollateralForm.controls.quantity.hasError('max')) {
+          <mat-error>
+            {{ 'labels.inputs.Quantity can not be more than' | translate }} <strong>{{ maxQuantity }}</strong>
+          </mat-error>
+        }
+      </mat-form-field>
 
-  <mat-form-field>
-    <mat-label>{{ 'labels.inputs.Total Value' | translate }}</mat-label>
-    <input type="text" matInput formControlName="totalValue" [disabled]="true" />
-  </mat-form-field>
+      <mat-form-field>
+        <mat-label>{{ 'labels.inputs.Total Value' | translate }}</mat-label>
+        <input type="text" matInput formControlName="totalValue" [disabled]="true" />
+      </mat-form-field>
 
-  <mat-form-field>
-    <mat-label>{{ 'labels.inputs.Total Collateral Value' | translate }}</mat-label>
-    <input type="text" matInput formControlName="totalCollateralValue" [disabled]="true" />
-  </mat-form-field>
-</div>
+      <mat-form-field>
+        <mat-label>{{ 'labels.inputs.Total Collateral Value' | translate }}</mat-label>
+        <input type="text" matInput formControlName="totalCollateralValue" [disabled]="true" />
+      </mat-form-field>
+    </div>
+  </form>
+</mat-dialog-content>
 
-<mat-dialog-actions class="layout-row layout-xs-column layout-align-center gap-2percent">
+<mat-dialog-actions align="center">
   <button mat-raised-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
   <button
     mat-raised-button


### PR DESCRIPTION
This PR fixes the structural inconsistency in the "Add Loan Collateral" dialog component to align it with the standard Material Design patterns used throughout the application.

[WEB-337](https://mifosforge.jira.com/browse/WEB-337)

Before:
<img width="792" height="693" alt="Screenshot 2026-01-02 041309" src="https://github.com/user-attachments/assets/c349e5db-a50a-4601-91b0-c46042323c7d" />
After:
<img width="643" height="637" alt="Screenshot 2026-01-02 041752" src="https://github.com/user-attachments/assets/7808b59e-239c-4d48-8b61-821ded87df16" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-337]: https://mifosforge.jira.com/browse/WEB-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the structure of the collateral account dialog form for improved code organization and maintainability. All existing functionality and validation logic remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->