### PR TITLE
WEB-356:fix(clients) improve upload signature dialog sizing and layout

### DIFF
--- a/src/app/clients/clients-view/custom-dialogs/upload-signature-dialog/upload-signature-dialog.component.html
+++ b/src/app/clients/clients-view/custom-dialogs/upload-signature-dialog/upload-signature-dialog.component.html
@@ -1,9 +1,9 @@
 <h1 mat-dialog-title>{{ 'labels.heading.Upload Client Signature' | translate }}</h1>
 
 <div>
-  <mifosx-file-upload flex="60%" (change)="onFileSelect($event)" acceptFilter=".png,.jpeg,.jpg"></mifosx-file-upload>
+  <mifosx-file-upload (change)="onFileSelect($event)" acceptFilter=".png,.jpeg,.jpg"></mifosx-file-upload>
 
-  <mat-dialog-actions align="end">
+  <mat-dialog-actions align="center">
     <button mat-raised-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
     <button mat-raised-button color="primary" [disabled]="!signature" [mat-dialog-close]="signature">
       {{ 'labels.buttons.Confirm' | translate }}

--- a/src/app/clients/clients-view/custom-dialogs/upload-signature-dialog/upload-signature-dialog.component.scss
+++ b/src/app/clients/clients-view/custom-dialogs/upload-signature-dialog/upload-signature-dialog.component.scss
@@ -1,0 +1,67 @@
+:host {
+  display: block;
+}
+
+[mat-dialog-title] {
+  margin: 0 0 0.75rem;
+  padding: 0;
+  text-align: center;
+}
+
+div {
+  padding: 0 1.25rem 1rem;
+  min-width: 25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+mifosx-file-upload {
+  width: 100%;
+  display: block;
+
+  ::ng-deep {
+    .mat-mdc-form-field {
+      margin-bottom: 0;
+
+      .mat-mdc-text-field-wrapper {
+        padding-bottom: 0;
+      }
+
+      .mat-mdc-form-field-subscript-wrapper {
+        margin-top: 0;
+      }
+    }
+
+    mat-form-field {
+      width: 100%;
+
+      .mat-mdc-form-field-infix {
+        padding: 0.5rem 0;
+        min-height: 2.5rem;
+      }
+    }
+  }
+}
+
+mat-dialog-actions {
+  margin: 0;
+  padding: 0.5rem 0 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+
+  button {
+    min-width: 5.625rem;
+    padding: 0 1rem;
+  }
+}
+
+@media (width <= 48rem) {
+  div {
+    min-width: 18.75rem;
+    padding: 0 1rem 0.75rem;
+    gap: 0.75rem;
+  }
+}


### PR DESCRIPTION
This pr improve upload signature dialog sizing and layout

[WEB-356](https://mifosforge.jira.com/browse/WEB-356)

Before:
<img width="462" height="331" alt="Screenshot 2026-01-02 044510" src="https://github.com/user-attachments/assets/0fa4f51e-c0e7-40e4-8792-fbb98ebf10b4" />
After:
<img width="639" height="365" alt="image" src="https://github.com/user-attachments/assets/245ca858-cf02-452e-9325-eb950368cf0f" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-356]: https://mifosforge.jira.com/browse/WEB-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned dialog action buttons to center for improved visual consistency and alignment.
  * Comprehensive styling enhancements to the upload signature dialog, including optimized spacing and layout.
  * Improved form field component styling and padding.
  * Enhanced responsive design with adaptive spacing and minimum widths for smaller viewports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->