### PR TITLE
WEB-549:fix(clients) add equal padding to family member dialog form

### DIFF
--- a/src/app/clients/client-stepper/client-family-members-step/client-family-member-dialog/client-family-member-dialog.component.scss
+++ b/src/app/clients/client-stepper/client-family-members-step/client-family-member-dialog/client-family-member-dialog.component.scss
@@ -4,3 +4,11 @@
   margin-top: 4px;
   margin-bottom: 8px;
 }
+
+form {
+  padding: 0 1.5rem;
+
+  .layout-row-wrap {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
This pr add equal padding to family member dialog form.

[WEB-549](https://mifosforge.jira.com/browse/WEB-549)

Before:
<img width="1223" height="820" alt="Screenshot 2026-01-02 020747" src="https://github.com/user-attachments/assets/5266f83c-f0d2-44b0-aef0-c5d942ff3f40" />
After:
<img width="1096" height="845" alt="image" src="https://github.com/user-attachments/assets/db200204-aee1-4a8e-9f87-3d24bc372fe0" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-549]: https://mifosforge.jira.com/browse/WEB-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced form layout and spacing in the client family member dialog for improved visual consistency and layout behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->