### PR TITLE
WEB-550 Fix OAUTH (Zitadel)

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -72,11 +72,15 @@ export const environment = {
   minPasswordLength: loadedEnv['minPasswordLength'] || 12,
 
   OIDC: {
-    oidcServerEnabled: window['env']['oidcServerEnabled'] === true || window['env']['oidcServerEnabled'] === 'true',
-    oidcBaseUrl: window['env']['oidcBaseUrl'] || '',
-    oidcClientId: window['env']['oidcClientId'] || '',
-    oidcApiUrl: window['env']['oidcApiUrl'] || '',
-    oidcFrontUrl: window['env']['oidcFrontUrl'] || ''
+    // Support legacy FINERACT_PLUGIN_OIDC_* variable names for backward compatibility
+    oidcServerEnabled:
+      loadedEnv['oidcServerEnabled'] === true ||
+      loadedEnv['oidcServerEnabled'] === 'true' ||
+      loadedEnv['FINERACT_PLUGIN_OIDC_ENABLED'] === 'true',
+    oidcBaseUrl: loadedEnv['oidcBaseUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_BASE_URL'] || '',
+    oidcClientId: loadedEnv['oidcClientId'] || loadedEnv['FINERACT_PLUGIN_OIDC_CLIENT_ID'] || '',
+    oidcApiUrl: loadedEnv['oidcApiUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_API_URL'] || '',
+    oidcFrontUrl: loadedEnv['oidcFrontUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_FRONTEND_URL'] || ''
   }
 };
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -76,11 +76,15 @@ export const environment = {
   minPasswordLength: loadedEnv.minPasswordLength || 12,
 
   OIDC: {
-    oidcServerEnabled: window['env']['oidcServerEnabled'] === true || window['env']['oidcServerEnabled'] === 'true',
-    oidcBaseUrl: window['env']['oidcBaseUrl'] || '',
-    oidcClientId: window['env']['oidcClientId'] || '',
-    oidcApiUrl: window['env']['oidcApiUrl'] || '',
-    oidcFrontUrl: window['env']['oidcFrontUrl'] || ''
+    // Support legacy FINERACT_PLUGIN_OIDC_* variable names for backward compatibility
+    oidcServerEnabled:
+      loadedEnv.oidcServerEnabled === true ||
+      loadedEnv.oidcServerEnabled === 'true' ||
+      loadedEnv.FINERACT_PLUGIN_OIDC_ENABLED === 'true',
+    oidcBaseUrl: loadedEnv.oidcBaseUrl || loadedEnv.FINERACT_PLUGIN_OIDC_BASE_URL || '',
+    oidcClientId: loadedEnv.oidcClientId || loadedEnv.FINERACT_PLUGIN_OIDC_CLIENT_ID || '',
+    oidcApiUrl: loadedEnv.oidcApiUrl || loadedEnv.FINERACT_PLUGIN_OIDC_API_URL || '',
+    oidcFrontUrl: loadedEnv.oidcFrontUrl || loadedEnv.FINERACT_PLUGIN_OIDC_FRONTEND_URL || ''
   }
 };
 


### PR DESCRIPTION
## Changes Made :-

- Added backward compatibility mapping for legacy FINERACT_PLUGIN_OIDC_* environment variables
- Maps old Zitadel OIDC configuration to new environment.OIDC.* format
- Ensures existing Zitadel deployments work without configuration changes
- Uses loadedEnv for null-safety and consistency with codebase standards
[
WEB :- 550](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-551)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * OIDC configuration resolution updated to read runtime environment values with backward-compatible fallbacks for legacy OIDC environment variable names.
  * OIDC enablement and endpoint/client settings now accept both modern and legacy environment formats for more robust startup behavior.
  * Server URL is now composed dynamically from base API, provider, and version settings for consistent deployment configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->