### PR TITLE
WEB-559: Do not call blindly "Is loan catch up running" API

### DIFF
--- a/src/app/system/manage-jobs/cob-workflow/cob-workflow.component.ts
+++ b/src/app/system/manage-jobs/cob-workflow/cob-workflow.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, inject } from '@angular/core';
+import { Component, Input, OnDestroy, inject } from '@angular/core';
 import { SystemService } from 'app/system/system.service';
 import { environment } from '../../../../environments/environment';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -15,7 +15,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     LoanLockedComponent
   ]
 })
-export class CobWorkflowComponent implements OnInit, OnDestroy {
+export class CobWorkflowComponent implements OnDestroy {
   private systemService = inject(SystemService);
 
   /** Wait time between API status calls 30 seg */
@@ -24,10 +24,6 @@ export class CobWorkflowComponent implements OnInit, OnDestroy {
   @Input() isCatchUpRunning = true;
   /** Timer to refetch COB Catch-Up status every 5 seconds */
   timer: any;
-
-  ngOnInit(): void {
-    this.getCOBCatchUpStatus();
-  }
 
   ngOnDestroy() {
     clearTimeout(this.timer);


### PR DESCRIPTION
## Description

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Automatic COB Catch-Up status fetch no longer runs on page load; status polling and manual check remain available. This reduces initial background activity and ensures status updates occur only when triggered or during active polling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->