### PR TITLE
WEB-558:feat add loan product import via JSON upload

### DIFF
--- a/src/app/products/loan-products/import-loan-product-dialog/import-loan-product-dialog.component.html
+++ b/src/app/products/loan-products/import-loan-product-dialog/import-loan-product-dialog.component.html
@@ -1,0 +1,24 @@
+<h1 mat-dialog-title>Import Loan Product</h1>
+
+<mat-dialog-content>
+  <form [formGroup]="importLoanProductForm">
+    <p>Select a JSON file containing the loan product definition.</p>
+
+    <!-- File Upload Component -->
+    <mifosx-file-upload (change)="onFileSelect($event)" acceptFilter=".json"> </mifosx-file-upload>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-raised-button mat-dialog-close>
+    {{ 'labels.buttons.Cancel' | translate }}
+  </button>
+  <button
+    mat-raised-button
+    color="primary"
+    [disabled]="!importLoanProductForm.valid"
+    [mat-dialog-close]="importLoanProductForm.value"
+  >
+    Import
+  </button>
+</mat-dialog-actions>

--- a/src/app/products/loan-products/import-loan-product-dialog/import-loan-product-dialog.component.scss
+++ b/src/app/products/loan-products/import-loan-product-dialog/import-loan-product-dialog.component.scss
@@ -1,0 +1,18 @@
+mat-dialog-content {
+  padding: 20px 24px;
+  min-height: 150px;
+
+  p {
+    margin-bottom: 20px;
+    color: rgb(0 0 0 / 60%);
+  }
+}
+
+mat-dialog-actions {
+  padding: 8px 24px 16px;
+  margin: 0;
+
+  button {
+    margin-left: 8px;
+  }
+}

--- a/src/app/products/loan-products/import-loan-product-dialog/import-loan-product-dialog.component.ts
+++ b/src/app/products/loan-products/import-loan-product-dialog/import-loan-product-dialog.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit, inject } from '@angular/core';
+import {
+  MatDialogRef,
+  MAT_DIALOG_DATA,
+  MatDialogTitle,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent
+} from '@angular/material/dialog';
+import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { FileUploadComponent } from '../../../shared/file-upload/file-upload.component';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+@Component({
+  selector: 'mifosx-import-loan-product-dialog',
+  templateUrl: './import-loan-product-dialog.component.html',
+  styleUrls: ['./import-loan-product-dialog.component.scss'],
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    MatDialogTitle,
+    MatDialogContent,
+    FileUploadComponent,
+    MatDialogActions,
+    MatDialogClose
+  ]
+})
+export class ImportLoanProductDialogComponent implements OnInit {
+  dialogRef = inject<MatDialogRef<ImportLoanProductDialogComponent>>(MatDialogRef);
+  private formBuilder = inject(UntypedFormBuilder);
+  data = inject(MAT_DIALOG_DATA);
+
+  /** Import Loan Product form. */
+  importLoanProductForm: UntypedFormGroup;
+
+  ngOnInit() {
+    this.createImportLoanProductForm();
+  }
+
+  /**
+   * Creates the import loan product form.
+   */
+  createImportLoanProductForm() {
+    this.importLoanProductForm = this.formBuilder.group({
+      file: [
+        '',
+        Validators.required
+      ]
+    });
+  }
+
+  /**
+   * Sets file form control value.
+   * @param {any} $event file change event.
+   */
+  onFileSelect($event: any) {
+    if ($event.target.files.length > 0) {
+      const file = $event.target.files[0];
+      this.importLoanProductForm.get('file').setValue(file);
+    }
+  }
+}

--- a/src/app/products/loan-products/loan-products.component.html
+++ b/src/app/products/loan-products/loan-products.component.html
@@ -5,6 +5,12 @@
       {{ 'labels.buttons.Create Loan Product' | translate }}
     </button>
   </div>
+  <div class="in-block">
+    <button mat-raised-button color="primary" (click)="openImportDialog()" *mifosxHasPermission="'CREATE_LOANPRODUCT'">
+      <fa-icon icon="upload" class="m-r-10"></fa-icon>
+      Import
+    </button>
+  </div>
 </div>
 
 <div class="container">


### PR DESCRIPTION
This pr added an Import button next to the "Create Loan Product" button that enables users to import loan product configurations from JSON files. This feature streamlines the process of creating loan products by allowing users to:
Upload pre-configured loan product definitions instead of manually entering all fields
Migrate loan products from other systems or environments
Backup and restore loan product configurations
Duplicate existing products with modifications

[WEB-558](https://mifosforge.jira.com/browse/WEB-558)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-558]: https://mifosforge.jira.com/browse/WEB-558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import Loan Product dialog allowing users to upload .json files and submit imports
  * Import button added to the loan products view to open the import dialog
  * Imported JSON is processed to create loan products and refresh the product list on success

* **Bug Fixes / Reliability**
  * Improved import error handling and user feedback for parse/API failures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->