### PR TITLE
WEB-561 Change the static html for i-18-n translated text the mifos in the footer html

### DIFF
--- a/src/app/shared/footer/footer.component.html
+++ b/src/app/shared/footer/footer.component.html
@@ -4,7 +4,7 @@
     @if (displayBackEndInfo) {
       <div class="footer-info">
         <span class="info-item">
-          <span class="info-label">Mifos® WebApp:</span>
+          <span class="info-label">{{ 'APP_NAME' | translate }}</span>
           <span class="info-value">{{ versions.mifos }}</span>
         </span>
         <span class="info-separator">•</span>
@@ -27,7 +27,7 @@
       <div class="layout-column m-t-10 m-b-10 content-wrapper footer-center">
         <table class="versions">
           <tr>
-            <td class="footer-content">Mifos® WebApp</td>
+            <td class="footer-content">{{ 'APP_NAME' | translate }}</td>
             <td class="right footer-content">
               {{ versions.mifos }} - <b>{{ hash }}</b>
             </td>

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1,5 +1,5 @@
 ﻿{
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "Přihlášen jako",
   "Remember me": "Zapamatuj si mě",
   "errors": {

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "Angemeldet als",
   "Remember me": "Erinnere dich an mich",
   "errors": {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "Logged in as",
   "Remember me": "Remember me",
   "error.resource.notImplemented.type": "Not Implemented Error",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "Conectado como",
   "Remember me": "Recordar me",
   "errors": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "Conectado como",
   "Remember me": "Recordar me",
   "errors": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "connecté en tant que",
   "Remember me": "Souviens-toi de moi",
   "errors": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "Collegato come",
   "Remember me": "Ricordati di me",
   "errors": {

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "다음 계정으로 로그인됨",
   "Remember me": "날 기억해",
   "errors": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "prisijungęs kaip",
   "Remember me": "Prisimink mane",
   "errors": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "ielogojies Kā",
   "Remember me": "Atceries mani",
   "errors": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "को रूपमा लग इन गरियो",
   "Remember me": "मलाई सम्झनुहोस्",
   "errors": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "logado como",
   "Remember me": "Lembre de mim",
   "errors": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1,5 +1,5 @@
 {
-  "APP_NAME": "Mifos® X",
+  "APP_NAME": "Mifos® X WebApp",
   "Logged in as": "Imeingia kama",
   "Remember me": "Nikumbuke",
   "errors": {


### PR DESCRIPTION
**Changes Made :-**

-Replaced static app name in the footer with the i18n translation key APP_NAME for proper localization.
-Updated all translation files to set APP_NAME as "Mifos® X WebApp" for consistency across languages.

[WEB-561 ](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-561)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application name throughout the UI and all supported language translations to consistently display "Mifos® X WebApp" instead of "Mifos® X" across 13 languages including English, Spanish, French, Portuguese, and others.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->