### PR TITLE
WEB-566 Validation missing negative values accepted in currency in multiples of installment in multiples of and decimal places fields

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.html
@@ -31,14 +31,19 @@
       <mat-label>{{ 'labels.inputs.Decimal Places' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matTooltip="{{ 'tooltips.Number of decimal places to be used to track and report' | translate }}"
         matInput
         formControlName="digitsAfterDecimal"
         required
       />
-      <mat-error>
+      <mat-error *ngIf="loanProductCurrencyForm.get('digitsAfterDecimal')?.hasError('required')">
         {{ 'labels.inputs.Decimal Places' | translate }} {{ 'labels.commons.is' | translate }}
         <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
+      <mat-error *ngIf="loanProductCurrencyForm.get('digitsAfterDecimal')?.hasError('min')">
+        {{ 'labels.inputs.Decimal Places' | translate }} {{ 'labels.commons.Minimum Value must be' | translate }}
+        <strong>0</strong>
       </mat-error>
     </mat-form-field>
 
@@ -46,15 +51,33 @@
       <mat-label>{{ 'labels.inputs.Currency in multiples of' | translate }}</mat-label>
       <input
         type="number"
+        min="1"
         matInput
         matTooltip="{{ 'tooltips.Enter multiples of currency value' | translate }}"
         formControlName="inMultiplesOf"
+        required
       />
+      <mat-error *ngIf="loanProductCurrencyForm.get('inMultiplesOf')?.hasError('required')">
+        {{ 'labels.inputs.Currency in multiples of' | translate }} {{ 'labels.commons.is' | translate }}
+        <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
+      <mat-error *ngIf="loanProductCurrencyForm.get('inMultiplesOf')?.hasError('min')">
+        {{ 'labels.inputs.Currency in multiples of' | translate }}
+        {{ 'labels.commons.Minimum Value must be' | translate }} <strong>1</strong>
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Installment in multiples of' | translate }}</mat-label>
-      <input type="number" matInput formControlName="installmentAmountInMultiplesOf" />
+      <input type="number" min="1" matInput formControlName="installmentAmountInMultiplesOf" required />
+      <mat-error *ngIf="loanProductCurrencyForm.get('installmentAmountInMultiplesOf')?.hasError('required')">
+        {{ 'labels.inputs.Installment in multiples of' | translate }} {{ 'labels.commons.is' | translate }}
+        <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
+      <mat-error *ngIf="loanProductCurrencyForm.get('installmentAmountInMultiplesOf')?.hasError('min')">
+        {{ 'labels.inputs.Installment in multiples of' | translate }}
+        {{ 'labels.commons.Minimum Value must be' | translate }} <strong>1</strong>
+      </mat-error>
     </mat-form-field>
   </div>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
@@ -45,8 +45,8 @@ export class LoanProductCurrencyStepComponent implements OnInit {
       digitsAfterDecimal: this.loanProductsTemplate.currency.decimalPlaces
         ? this.loanProductsTemplate.currency.decimalPlaces
         : 2,
-      inMultiplesOf: this.loanProductsTemplate.currency.inMultiplesOf,
-      installmentAmountInMultiplesOf: this.loanProductsTemplate.installmentAmountInMultiplesOf
+      inMultiplesOf: this.loanProductsTemplate.currency.inMultiplesOf ?? 1,
+      installmentAmountInMultiplesOf: this.loanProductsTemplate.installmentAmountInMultiplesOf ?? 1
     });
   }
 
@@ -58,10 +58,25 @@ export class LoanProductCurrencyStepComponent implements OnInit {
       ],
       digitsAfterDecimal: [
         2,
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)
+        ]
       ],
-      inMultiplesOf: '',
-      installmentAmountInMultiplesOf: ''
+      inMultiplesOf: [
+        1,
+        [
+          Validators.required,
+          Validators.min(1)
+        ]
+      ],
+      installmentAmountInMultiplesOf: [
+        '',
+        [
+          Validators.required,
+          Validators.min(1)
+        ]
+      ]
     });
   }
 


### PR DESCRIPTION
**Changes Made :-**

-Added validation to prevent negative values for "Decimal Places", "Currency in multiples of", and "Installment in multiples of" fields in the loan product creation form.
-Set the minimum value for "Currency in multiples of" and "Installment in multiples of" to 1, and for "Decimal Places" to 0.

[WEB-566](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-566)

Before :-
<img width="1365" height="711" alt="image" src="https://github.com/user-attachments/assets/62c3bdd4-b3ac-42d9-a9e8-834907828041" />


After :- 
<img width="1365" height="720" alt="image" src="https://github.com/user-attachments/assets/1c7bd2f7-cf5a-4f9a-8c98-04b8548a4aa8" />


[WEB-566]: https://mifosforge.jira.com/browse/WEB-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for loan product currency fields: required checks and minimums to prevent invalid entries.
  * Improved error messages for decimal places, multiplier and installment fields to guide user correction.
  * Defaulting missing multiplier/installment values to sensible defaults to avoid empty or invalid submissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->