### PR TITLE
WEB-567 Negative Values Allowed in Loan Product Setting Fields

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -260,12 +260,12 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Grace on principal payment' | translate }}</mat-label>
-      <input type="number" matInput formControlName="graceOnPrincipalPayment" />
+      <input type="number" min="0" matInput formControlName="graceOnPrincipalPayment" />
     </mat-form-field>
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Grace on interest payment' | translate }}</mat-label>
-      <input type="number" matInput formControlName="graceOnInterestPayment" />
+      <input type="number" min="0" matInput formControlName="graceOnInterestPayment" />
     </mat-form-field>
 
     <mat-divider class="flex-98"></mat-divider>
@@ -298,6 +298,7 @@
       <mat-label>{{ 'labels.inputs.Interest free period' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matInput
         matTooltip="{{ 'tooltips.If the Interest Free Period' | translate }}"
         formControlName="graceOnInterestCharged"
@@ -308,6 +309,7 @@
       <mat-label>{{ 'labels.inputs.Arrears tolerance' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matInput
         matTooltip="{{ 'tooltips.With Arrears tolerance' | translate }}"
         formControlName="inArrearsTolerance"

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -300,10 +300,22 @@ export class LoanProductSettingsStepComponent implements OnInit {
         '',
         Validators.required
       ],
-      graceOnPrincipalPayment: [''],
-      graceOnInterestPayment: [''],
-      graceOnInterestCharged: [''],
-      inArrearsTolerance: [''],
+      graceOnPrincipalPayment: [
+        '',
+        [Validators.min(0)]
+      ],
+      graceOnInterestPayment: [
+        '',
+        [Validators.min(0)]
+      ],
+      graceOnInterestCharged: [
+        '',
+        [Validators.min(0)]
+      ],
+      inArrearsTolerance: [
+        '',
+        [Validators.min(0)]
+      ],
       daysInYearType: [
         '',
         Validators.required


### PR DESCRIPTION
**Changes Made :-**

-Added validation to prevent negative values for "Grace on principal payment", "Grace on interest payment", "Interest free period", and "Arrears tolerance" fields in the loan product settings form.
-Set the minimum value for all these fields to 0, ensuring negative values cannot be entered in the UI or form.

[WEB-567](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-567) 

Before :- 
<img width="1365" height="671" alt="image" src="https://github.com/user-attachments/assets/3fdc3420-1c3f-431c-b5b5-d0c2cb5cafcc" />

After :- 
<img width="1365" height="718" alt="image" src="https://github.com/user-attachments/assets/fe318f6e-1cca-442f-b7ad-8988d7396790" />


[WEB-567]: https://mifosforge.jira.com/browse/WEB-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form validation for loan product settings to enforce non-negative values on numeric input fields, including grace periods, interest payments, and tolerance settings. Users can no longer enter negative values in these fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->