### PR TITLE
WEB-568 Negative values allowed for arrears ageing overdue days for npa and principal threshold fields in loan product settings

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -382,7 +382,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.On arrears ageing' | translate }}</mat-label>
-      <input type="number" matInput formControlName="graceOnArrearsAgeing" />
+      <input type="number" min="0" matInput formControlName="graceOnArrearsAgeing" />
     </mat-form-field>
 
     <h4 class="flex-48">
@@ -398,7 +398,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Overdue days for NPA' | translate }}</mat-label>
-      <input type="number" matInput formControlName="overdueDaysForNPA" />
+      <input type="number" min="0" matInput formControlName="overdueDaysForNPA" />
     </mat-form-field>
 
     <mat-checkbox
@@ -411,7 +411,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Principal Threshold (%) for Last Instalment' | translate }}</mat-label>
-      <input type="number" matInput formControlName="principalThresholdForLastInstallment" />
+      <input type="number" min="0" matInput formControlName="principalThresholdForLastInstallment" />
     </mat-form-field>
 
     <mat-checkbox

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -313,10 +313,19 @@ export class LoanProductSettingsStepComponent implements OnInit {
         Validators.required
       ],
       canDefineInstallmentAmount: [false],
-      graceOnArrearsAgeing: [''],
-      overdueDaysForNPA: [''],
+      graceOnArrearsAgeing: [
+        '',
+        [Validators.min(0)]
+      ],
+      overdueDaysForNPA: [
+        '',
+        [Validators.min(0)]
+      ],
       accountMovesOutOfNPAOnlyOnArrearsCompletion: [false],
-      principalThresholdForLastInstallment: [''],
+      principalThresholdForLastInstallment: [
+        '',
+        [Validators.min(0)]
+      ],
       allowVariableInstallments: [false],
       disallowExpectedDisbursements: [false],
       canUseForTopup: [false],


### PR DESCRIPTION
**Changes Made :-**

-Added min="0" attribute to the input fields for "On arrears ageing", "Overdue days for NPA", and "Principal Threshold (%) for Last Installment" to prevent users from entering negative values.
-Added Angular form validation (Validators.min(0)) for the above fields to ensure negative values are not accepted at the form level.

[WEB-568](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-568)

Before :-
<img width="1024" height="312" alt="image" src="https://github.com/user-attachments/assets/ec314017-6731-45e4-8f7d-146930717ac6" />

After :- 
<img width="1365" height="533" alt="image" src="https://github.com/user-attachments/assets/287669da-4b0d-4e97-b86c-6b02b5d5b831" />


[WEB-568]: https://mifosforge.jira.com/browse/WEB-568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented negative value inputs for grace on arrears ageing, overdue days for NPA, and principal threshold for last installment in the loan product settings form through enhanced validation checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->