### PR TITLE
WEB-569 Negative values allowed for repayment event days in loan product creation form

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -760,6 +760,7 @@
           <mat-label>{{ 'labels.inputs.Due days for repayment event' | translate }}</mat-label>
           <input
             type="number"
+            min="0"
             matInput
             matTooltip="{{ 'tooltips.Maximum outstanding loan account balance' | translate }}"
             formControlName="dueDaysForRepaymentEvent"
@@ -769,6 +770,7 @@
           <mat-label>{{ 'labels.inputs.OverDue days for repayment event' | translate }}</mat-label>
           <input
             type="number"
+            min="0"
             matInput
             matTooltip="{{ 'tooltips.Maximum outstanding loan account balance' | translate }}"
             formControlName="overDueDaysForRepaymentEvent"

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -352,8 +352,14 @@ export class LoanProductSettingsStepComponent implements OnInit {
       enableDownPayment: [false],
       enableInstallmentLevelDelinquency: [false],
       useDueForRepaymentsConfigurations: [false],
-      dueDaysForRepaymentEvent: [''],
-      overDueDaysForRepaymentEvent: [''],
+      dueDaysForRepaymentEvent: [
+        '',
+        [Validators.min(0)]
+      ],
+      overDueDaysForRepaymentEvent: [
+        '',
+        [Validators.min(0)]
+      ],
       loanScheduleType: [
         LoanProducts.LOAN_SCHEDULE_TYPE_CUMULATIVE,
         Validators.required
@@ -401,7 +407,6 @@ export class LoanProductSettingsStepComponent implements OnInit {
           this.loanProductSettingsForm.removeControl('maximumGap');
         }
       });
-
     this.loanProductSettingsForm
       .get('isInterestRecalculationEnabled')
       .valueChanges.subscribe((isInterestRecalculationEnabled: any) => {


### PR DESCRIPTION
**Changes Made :-**

-Added min="0" attribute to the input fields for "Due days for repayment event" and "OverDue days for repayment event" to prevent users from entering negative values.
-Added Angular form validation (Validators.min(0)) for these fields to ensure negative values are not accepted at the form level.

[WEB-569](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-569)

Before  :- 
<img width="1365" height="720" alt="image" src="https://github.com/user-attachments/assets/b06a38ff-0ae5-4799-8c00-daef16b6e9df" />

After :- 
<img width="1365" height="720" alt="image" src="https://github.com/user-attachments/assets/711e506d-9eeb-43f0-aee8-0876bedd9d54" />


[WEB-569]: https://mifosforge.jira.com/browse/WEB-569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented negative values for "Due days for repayment" and "OverDue days for repayment" in loan product settings by enforcing non-negative input and validation, ensuring consistent and valid repayment timing entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->