### PR TITLE
WEB-570 Prevent Negative Values for Repayment Frequency in Loan Produ…

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -535,7 +535,7 @@
 
     <mat-form-field class="flex-30">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="repaymentEvery" required />
+      <input type="number" min="1" matInput formControlName="repaymentEvery" required />
       <mat-error>
         {{ 'labels.inputs.Repaid every' | translate }} {{ 'labels.inputs.Frequency' | translate }}
         {{ 'labels.commons.is' | translate }}
@@ -584,7 +584,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Minimum days between disbursal and first repayment date' | translate }}</mat-label>
-      <input type="number" matInput formControlName="minimumDaysBetweenDisbursalAndFirstRepayment" />
+      <input type="number" min="0" matInput formControlName="minimumDaysBetweenDisbursalAndFirstRepayment" />
     </mat-form-field>
   </div>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -266,13 +266,19 @@ export class LoanProductTermsStepComponent implements OnInit, OnChanges {
       ],
       repaymentEvery: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(1)
+        ]
       ],
       repaymentFrequencyType: [
         '',
         Validators.required
       ],
-      minimumDaysBetweenDisbursalAndFirstRepayment: [''],
+      minimumDaysBetweenDisbursalAndFirstRepayment: [
+        '',
+        []
+      ],
       repaymentStartDateType: [1],
       fixedLength: [null],
       interestRecognitionOnDisbursementDate: [false]


### PR DESCRIPTION
**Changes Made :-**

-Set the minimum value for "Minimum days between disbursal and first repayment date" to 1 in both the UI and Angular form validation.
-Updated the input field to use [min="1"] to prevent users from entering zero or negative values.
-Added [Validators.min(1)] to the Angular form .

[WEB-570](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-570)

Before :- 
<img width="1365" height="717" alt="image" src="https://github.com/user-attachments/assets/436b82e9-032d-4997-97af-9d6cceae6143" />

After :- 
<img width="1365" height="720" alt="image" src="https://github.com/user-attachments/assets/f28a16b5-27ac-4be4-8f10-679f1294b176" />


[WEB-570]: https://mifosforge.jira.com/browse/WEB-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened input validation for loan product terms: repayment frequency now requires a positive value and minimum days between disbursal and first repayment cannot be negative, preventing invalid entries and improving client-side validation messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->