### PR TITLE
WEB-571:fix(loans) dark theme for repayment schedule headers

### DIFF
--- a/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.scss
+++ b/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.scss
@@ -57,9 +57,13 @@ table {
 }
 
 .mat-header-cell {
-  color: rgba($color: #000, $alpha: 54%);
+  color: rgb(0 0 0 / 54%);
   font-size: 12px;
   font-weight: 500;
+}
+
+:host-context(.dark-theme) .mat-header-cell {
+  color: rgb(255 255 255 / 70%);
 }
 
 div.container {


### PR DESCRIPTION
This Pr Fixes dark theme support for repayment schedule table headers in the loans section.

[WEB:571](https://mifosforge.jira.com/browse/WEB-571)

Before:
<img width="1445" height="880" alt="Screenshot 2026-01-12 153339" src="https://github.com/user-attachments/assets/b6282f5b-6496-4553-bf38-fd87471a368a" />
After:
<img width="1445" height="843" alt="Screenshot 2026-01-12 153829" src="https://github.com/user-attachments/assets/8d451619-1ae8-4d83-b424-cfee29b0a962" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added dark theme support for the repayment schedule table headers with optimized colors for improved visibility and readability when dark mode is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->