### PR TITLE
WEB-534 Missing validation decimal places and currency multiples accept negative values in recurring deposit product form

### DIFF
--- a/src/app/products/saving-products/saving-product-stepper/saving-product-currency-step/saving-product-currency-step.component.html
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-currency-step/saving-product-currency-step.component.html
@@ -23,6 +23,7 @@
       <mat-label>{{ 'labels.inputs.Decimal Places' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matInput
         matTooltip="{{ 'tooltips.Track and report saving account' | translate }}"
         formControlName="digitsAfterDecimal"
@@ -38,9 +39,11 @@
       <mat-label>{{ 'labels.inputs.Currency in multiples of' | translate }}</mat-label>
       <input
         type="number"
+        min="1"
         matInput
         matTooltip="{{ 'tooltips.Amount to be rounded off' | translate }}"
         formControlName="inMultiplesOf"
+        required
       />
       <mat-error>
         {{ 'labels.inputs.Currency in multiples of' | translate }} {{ 'labels.commons.is' | translate }}

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-currency-step/saving-product-currency-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-currency-step/saving-product-currency-step.component.ts
@@ -50,9 +50,18 @@ export class SavingProductCurrencyStepComponent implements OnInit {
       ],
       digitsAfterDecimal: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)
+        ]
       ],
-      inMultiplesOf: ['']
+      inMultiplesOf: [
+        '',
+        [
+          Validators.required,
+          Validators.min(1)
+        ]
+      ]
     });
   }
 


### PR DESCRIPTION
**Changes Made :-**

-Set the minimum value for "Currency in multiples of" to 1 and "Decimal Places" to 0 in both the UI and Angular form validation.
-Updated the input fields to use [min="1"] for "Currency in multiples of" and [min="0"] for "Decimal Places" to prevent users from entering invalid values.
-Added [[Validators.min(1)]] for "Currency in multiples of" and [[Validators.min(0)]] for "Decimal Places" in the Angular form group.

[WEB-534](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-534)

[WEB-534]: https://mifosforge.jira.com/browse/WEB-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for currency step inputs in the saving products flow.
  * digitsAfterDecimal field now enforces a minimum value of 0.
  * inMultiplesOf field is now required and enforces a minimum value of 1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->