### PR TITLE
WEB-574: Add reserved branch names and tags policy to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,25 @@ We follow a strict branching model to keep our history clean.
   - **Format:** `WEB-<ID>-<short-description>`
   - **Example:** `git checkout -b WEB-123-fix-login-button`
 
+### Reserved Branch Names and Tags
+
+The following branch names and tags (and derivatives and extensions e.g., `releasev1.0`) are reserved for use by Mifos Organisation. Any branches created by non-admins with these names will be deleted without notice:
+
+- `main`
+- `master`
+- `dev`
+- `development`
+- `sec`
+- `security`
+- `mifos`
+- `release`
+- `rel`
+- `rc`
+- `staging`
+- `prod`
+- `production`
+- `gsoc`
+
 ---
 
 ## Step 4: UI/UX Consistency


### PR DESCRIPTION
This pr Added documentation to CONTRIBUTING.md to clarify reserved branch names and tags that are restricted for use by Mifos Organisation only.
Reserved names include: main, master, dev, development, sec, security, mifos, release, rel, rc, staging, prod, production, gsoc (and their derivatives/extensions).
This helps prevent accidental branch naming conflicts and maintains repository organization.

[WEB-574](https://mifosforge.jira.com/browse/WEB-574)
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-574]: https://mifosforge.jira.com/browse/WEB-574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines to document reserved branch and tag names used by the organization. Branches created with reserved names by non-admin users will be deleted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->