### PR TITLE
Fix typo allowPartialPeriodInterestCalcualtion for allowPartialPeriodInterestCalculation

### DIFF
--- a/src/app/loans/edit-loans-account/edit-loans-account.component.ts
+++ b/src/app/loans/edit-loans-account/edit-loans-account.component.ts
@@ -205,7 +205,7 @@ export class EditLoansAccountComponent {
 
     // In Fineract, the POST and PUT endpoints for /v1/loans have a typo in the field
     // allowPartialPeriodInterestCalculation. Until that is fixed, we need to replace the field name in the payload.
-    loansAccountData.allowPartialPeriodInterestCalcualtion = loansAccountData.allowPartialPeriodInterestCalculation;
+    loansAccountData.allowPartialPeriodInterestCalculation = loansAccountData.allowPartialPeriodInterestCalculation;
     delete loansAccountData.allowPartialPeriodInterestCalculation;
 
     this.loansService.updateLoansAccount(this.loanId, loansAccountData).subscribe((response: any) => {

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -759,7 +759,7 @@ export class LoansService {
 
     // In Fineract, the POST and PUT endpoints for /v1/loans have a typo in the field
     // allowPartialPeriodInterestCalculation. Until that is fixed, we need to replace the field name in the payload.
-    loansAccountData.allowPartialPeriodInterestCalcualtion = loansAccountData.allowPartialPeriodInterestCalculation;
+    loansAccountData.allowPartialPeriodInterestCalculation = loansAccountData.allowPartialPeriodInterestCalculation;
     delete loansAccountData.allowPartialPeriodInterestCalculation;
     return loansAccountData;
   }

--- a/src/app/products/loan-products/loan-products.ts
+++ b/src/app/products/loan-products/loan-products.ts
@@ -83,7 +83,7 @@ export class LoanProducts {
 
     // In Fineract, the POST and PUT endpoints for /v1/loanproducts have a typo in the field
     // allowPartialPeriodInterestCalculation. Until that is fixed, we need to replace the field name in the payload.
-    loanProduct.allowPartialPeriodInterestCalcualtion = loanProduct.allowPartialPeriodInterestCalculation;
+    loanProduct.allowPartialPeriodInterestCalculation = loanProduct.allowPartialPeriodInterestCalculation;
     delete loanProduct.allowPartialPeriodInterestCalculation;
 
     // Set Default values If they were not set


### PR DESCRIPTION
Fix typo allowPartialPeriodInterestCalcualtion for allowPartialPeriodInterestCalculation

## Description
WEB-576:Fix typo allowPartialPeriodInterestCalcualtion for allowPartialPeriodInterestCalculation

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected the handling of partial period interest calculation settings across loan account operations. This ensures that loan account configuration preferences are properly saved and applied when users edit accounts or create new loan products.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->