### PR TITLE
WEB-573: Improve UI of Password Preferences 

### DIFF
--- a/src/app/organization/password-preferences/password-preferences.component.html
+++ b/src/app/organization/password-preferences/password-preferences.component.html
@@ -1,6 +1,5 @@
 <!--
   Copyright since 2025 Mifos Initiative
-
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -10,14 +9,25 @@
   <mat-card>
     <form [formGroup]="passwordPreferencesForm" (ngSubmit)="submit()">
       <mat-card-content>
-        <mat-radio-group class="layout-column gap-10px radio-group-spacing" formControlName="validationPolicyId">
-          @for (passwordPreference of passwordPreferencesData; track passwordPreference) {
-            <mat-radio-button [value]="passwordPreference.id">
-              <span class="description-wrap">{{
-                passwordPreference.description | translateKey: 'passwordPreferences'
-              }}</span>
-            </mat-radio-button>
-          }
+        <mat-radio-group class="password-cards-container" formControlName="validationPolicyId">
+          <div
+            *ngFor="let passwordPreference of passwordPreferencesData; trackBy: trackByPasswordPreference"
+            class="password-card"
+            [class.selected]="passwordPreferencesForm.get('validationPolicyId')?.value === passwordPreference.id"
+          >
+            <div class="card-header">
+              <div class="card-heading">
+                {{ getPasswordLabel(passwordPreference) | translate }}
+              </div>
+              <mat-radio-button [value]="passwordPreference.id"></mat-radio-button>
+            </div>
+
+            <div class="card-description">
+              <span class="description-wrap">
+                {{ passwordPreference.description | translateKey: 'passwordPreferences' }}
+              </span>
+            </div>
+          </div>
         </mat-radio-group>
       </mat-card-content>
 

--- a/src/app/organization/password-preferences/password-preferences.component.scss
+++ b/src/app/organization/password-preferences/password-preferences.component.scss
@@ -10,14 +10,44 @@
   white-space: normal;
 }
 
-.radio-group-spacing {
+.password-cards-container {
   display: flex;
-  gap: 2rem;
-  flex-direction: row;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
 }
 
-@media (width <= 768px) {
-  .radio-group-spacing {
-    flex-direction: column;
+.password-card {
+  width: 100%;
+  border: 1px solid rgb(0 0 0 / 12%);
+  border-radius: 4px;
+  padding: 1.5rem;
+  box-sizing: border-box;
+
+  &.selected {
+    border-color: currentcolor;
+    border-width: 2px;
+  }
+
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  .card-heading {
+    font-weight: 500;
+    font-size: 1rem;
+  }
+
+  .card-description {
+    padding-left: 0;
+
+    .description-wrap {
+      white-space: normal;
+      display: block;
+      line-height: 1.5;
+    }
   }
 }

--- a/src/app/organization/password-preferences/password-preferences.component.ts
+++ b/src/app/organization/password-preferences/password-preferences.component.ts
@@ -82,6 +82,31 @@ export class PasswordPreferencesComponent implements OnInit {
   }
 
   /**
+   * TrackBy function for ngFor optimization.
+   * @param index Index of the item.
+   * @param item Password preference item.
+   * @returns Unique identifier for the item.
+   */
+  trackByPasswordPreference(index: number, item: any): any {
+    return item.id || index;
+  }
+
+  /**
+   * Gets the password preference label based on ID.
+   * @param preference Password preference object.
+   * @returns Translation key for the password preference label.
+   */
+  getPasswordLabel(preference: any): string {
+    // Map based on ID to ensure robustness
+    const labelMap: { [key: number]: string } = {
+      1: 'labels.inputs.Basic',
+      2: 'labels.inputs.Standard',
+      3: 'labels.inputs.Strong'
+    };
+    return labelMap[preference.id] || 'labels.inputs.Unknown';
+  }
+
+  /**
    * Submits the password preferences form and updates password preferences,
    * if successful redirects to organization view.
    */


### PR DESCRIPTION
This PR updates the Password Preferences UI to improve usability, visual clarity, and consistency with the overall Mifos web application. The existing layout relied on radio buttons with excessive free space and long inline descriptions, which made the interface harder to scan and less intuitive.

The updated design introduces a card-based selection for password strength options, improves spacing and alignment, and simplifies the presentation of rules, resulting in a cleaner and more user-friendly experience. All changes are limited to the frontend UI, with no impact on existing backend logic or password validation behavior.

BEFORE

<img width="2144" height="744" alt="image" src="https://github.com/user-attachments/assets/647fc158-d7cb-4dc2-96c8-9ea451dd70c4" />
 
AFTER
<img width="1310" height="684" alt="Screenshot 2026-01-14 at 11 57 24 PM" src="https://github.com/user-attachments/assets/d9d1cde4-69f7-44e0-ac43-77d622201ae9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned password preference selection from compact radio buttons to a modern, card-based layout with clearer descriptions and visible selected states.

* **New Features**
  * Cards display translated labels and descriptions for each option and improve selection clarity and rendering efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->