### PR TITLE
WEB-592:fix add missing translation keys for password preferences

### DIFF
--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -866,6 +866,7 @@
       "must be after or equal to start date": "musí být po nebo rovno datu zahájení"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "Heslo musí obsahovat alespoň 1 znak a ne více než 50 znaků",
       "Password must be at least 1 character and not more than 50 characters long": "Heslo musí obsahovat alespoň 1 znak a ne více než 50 znaků",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Heslo musí obsahovat alespoň 6 znaků, ne více než 50 znaků, musí obsahovat alespoň jedno velké písmeno, jedno malé písmeno, jednu číslici a žádnou mezeru",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Heslo musí být dlouhé 12 až 50 znaků, obsahovat alespoň jedno velké písmeno, jedno malé písmeno, jednu číslici a jeden speciální znak, bez mezer nebo po sobě jdoucích opakujících se znaků"
@@ -1262,6 +1263,9 @@
         "INCOME": "PŘÍJEM",
         "EXPENSE": "NÁKLADY"
       },
+      "Basic": "Základní",
+      "Standard": "Standardní",
+      "Strong": "Silný",
       "ACCOUNTING": "ÚČETNICTVÍ",
       "Percentage is required": "Je vyžadováno procento",
       "ADDRESS": "ADRESA",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -866,6 +866,7 @@
       "must be after or equal to start date": "muss nach oder gleich dem Startdatum sein"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "Das Passwort muss mindestens 1 Zeichen und nicht mehr als 50 Zeichen lang sein",
       "Password must be at least 1 character and not more than 50 characters long": "Das Passwort muss mindestens 1 Zeichen und nicht mehr als 50 Zeichen lang sein",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Das Passwort muss mindestens 6 Zeichen lang sein, nicht mehr als 50 Zeichen, muss mindestens einen Großbuchstaben, einen Kleinbuchstaben, eine Ziffer und kein Leerzeichen enthalten",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Das Passwort muss 12 bis 50 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben, eine Ziffer und ein Sonderzeichen enthalten, ohne Leerzeichen oder aufeinanderfolgende wiederholte Zeichen"
@@ -1263,6 +1264,9 @@
         "INCOME": "EINKOMMEN",
         "EXPENSE": "KOSTEN"
       },
+      "Basic": "Grundlegend",
+      "Standard": "Standard",
+      "Strong": "Stark",
       "Percentage is required": "Prozentsatz ist erforderlich",
       "ACCOUNTING": "BUCHHALTUNG",
       "ADDRESS": "ADRESSE",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -870,6 +870,7 @@
       "must be after or equal to start date": "must be after or equal to start date"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "Password must be at least 1 character and not more than 50 characters long",
       "Password must be at least 1 character and not more than 50 characters long": "Password must be at least 1 character and not more than 50 characters long",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters"
@@ -1267,6 +1268,9 @@
         "INCOME": "INCOME",
         "EXPENSE": "EXPENSE"
       },
+      "Basic": "Basic",
+      "Standard": "Standard",
+      "Strong": "Strong",
       "Percentage is required": "Percentage is required",
       "ACCOUNTING": "ACCOUNTING",
       "ADDRESS": "ADDRESS",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -865,6 +865,7 @@
       "must be after or equal to start date": "debe ser posterior o igual a la fecha de inicio"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "La contraseña debe tener al menos 1 carácter y no más de 50 caracteres",
       "Password must be at least 1 character and not more than 50 characters long": "La contraseña debe tener al menos 1 carácter y no más de 50 caracteres",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "La contraseña debe tener al menos 6 caracteres, no más de 50 caracteres, debe incluir al menos una letra mayúscula, una letra minúscula, un dígito numérico y ningún espacio",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "La contraseña debe tener entre 12 y 50 caracteres, conteniendo al menos una letra mayúscula, una letra minúscula, un dígito numérico y un carácter especial, sin espacios ni caracteres repetidos consecutivos"
@@ -1263,6 +1264,9 @@
         "INCOME": "INGRESO",
         "EXPENSE": "EGRESO"
       },
+      "Basic": "Básico",
+      "Standard": "Estándar",
+      "Strong": "Fuerte",
       "ACCOUNTING": "CONTABILIDAD",
       "Percentage is required": "Se requiere porcentaje",
       "ADDRESS": "DOMICILIO",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -865,6 +865,7 @@
       "must be after or equal to start date": "debe ser posterior o igual a la fecha de inicio"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "La contraseña debe tener al menos 1 carácter y no más de 50 caracteres",
       "Password must be at least 1 character and not more than 50 characters long": "La contraseña debe tener al menos 1 carácter y no más de 50 caracteres",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "La contraseña debe tener al menos 6 caracteres, no más de 50 caracteres, debe incluir al menos una letra mayúscula, una letra minúscula, un dígito numérico y ningún espacio",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "La contraseña debe tener entre 12 y 50 caracteres, conteniendo al menos una letra mayúscula, una letra minúscula, un dígito numérico y un carácter especial, sin espacios ni caracteres repetidos consecutivos"
@@ -1262,6 +1263,9 @@
         "INCOME": "INGRESO",
         "EXPENSE": "EGRESO"
       },
+      "Basic": "Básico",
+      "Standard": "Estándar",
+      "Strong": "Fuerte",
       "ACCOUNTING": "CONTABILIDAD",
       "Percentage is required": "Se requiere porcentaje",
       "ADDRESS": "DOMICILIO",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -866,6 +866,7 @@
       "must be after or equal to start date": "doit être postérieure ou égale à la date de début"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "Le mot de passe doit contenir au moins 1 caractère et pas plus de 50 caractères",
       "Password must be at least 1 character and not more than 50 characters long": "Le mot de passe doit contenir au moins 1 caractère et pas plus de 50 caractères",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Le mot de passe doit contenir au moins 6 caractères, pas plus de 50 caractères, doit inclure au moins une lettre majuscule, une lettre minuscule, un chiffre et aucun espace",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Le mot de passe doit contenir entre 12 et 50 caractères, incluant au moins une lettre majuscule, une lettre minuscule, un chiffre et un caractère spécial, sans espaces ni caractères répétés consécutifs"
@@ -1263,6 +1264,9 @@
         "INCOME": "REVENU",
         "EXPENSE": "FRAIS"
       },
+      "Basic": "Basique",
+      "Standard": "Standard",
+      "Strong": "Fort",
       "Percentage is required": "Le pourcentage est requis",
       "ACCOUNTING": "COMPTABILITÉ",
       "ADDRESS": "ADRESSE",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -866,6 +866,7 @@
       "must be after or equal to start date": "deve essere successiva o uguale alla data di inizio"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "La password deve contenere almeno 1 carattere e non più di 50 caratteri",
       "Password must be at least 1 character and not more than 50 characters long": "La password deve contenere almeno 1 carattere e non più di 50 caratteri",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "La password deve contenere almeno 6 caratteri, non più di 50 caratteri, deve includere almeno una lettera maiuscola, una lettera minuscola, una cifra numerica e nessuno spazio",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "La password deve contenere tra 12 e 50 caratteri, contenente almeno una lettera maiuscola, una lettera minuscola, una cifra numerica e un carattere speciale, senza spazi o caratteri ripetuti consecutivi"
@@ -1263,6 +1264,9 @@
         "INCOME": "REDDITO",
         "EXPENSE": "SPESE"
       },
+      "Basic": "Base",
+      "Standard": "Standard",
+      "Strong": "Forte",
       "Percentage is required": "Percentuale richiesta",
       "ACCOUNTING": "CONTABILITÀ",
       "ADDRESS": "INDIRIZZO",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -866,6 +866,7 @@
       "must be after or equal to start date": "시작 날짜 이후이거나 같아야 합니다"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "비밀번호는 최소 1자 이상 50자 이하여야 합니다",
       "Password must be at least 1 character and not more than 50 characters long": "비밀번호는 최소 1자 이상 50자 이하여야 합니다",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "비밀번호는 최소 6자 이상 50자 이하여야 하며, 최소 하나의 대문자, 하나의 소문자, 하나의 숫자 및 공백이 없어야 합니다",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "비밀번호는 12자 이상 50자 이하여야 하며, 최소 하나의 대문자, 하나의 소문자, 하나의 숫자 및 하나의 특수 문자를 포함해야 하며, 공백이나 연속된 반복 문자는 없어야 합니다"
@@ -1264,6 +1265,9 @@
         "INCOME": "소득",
         "EXPENSE": "비용"
       },
+      "Basic": "기본",
+      "Standard": "표준",
+      "Strong": "강력",
       "Percentage is required": "백분율이 필요합니다",
       "ACCOUNTING": "회계",
       "ADDRESS": "주소",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -866,6 +866,7 @@
       "must be after or equal to start date": "turi būti po pradžios datos arba jai lygi"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "Slaptažodis turi būti ne mažiau kaip 1 simbolis ir ne daugiau kaip 50 simbolių",
       "Password must be at least 1 character and not more than 50 characters long": "Slaptažodis turi būti ne mažiau kaip 1 simbolis ir ne daugiau kaip 50 simbolių",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Slaptažodis turi būti ne mažiau kaip 6 simboliai, ne daugiau kaip 50 simbolių, turi būti bent viena didžioji raidė, viena mažoji raidė, vienas skaitmuo ir neturėti tarpų",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Slaptažodis turi būti nuo 12 iki 50 simbolių, turėti bent vieną didžiąją raidę, vieną mažąją raidę, vieną skaitmenį ir vieną specialųjį simbolį, be tarpų arba iš eilės einančių pasikartojančių simbolių"
@@ -1263,6 +1264,9 @@
         "INCOME": "PAJAMOS",
         "EXPENSE": "IŠLAIDOS"
       },
+      "Basic": "Pagrindinis",
+      "Standard": "Standartinis",
+      "Strong": "Stiprus",
       "Percentage is required": "Reikalingas procentas",
       "ACCOUNTING": "APSKAITA",
       "ADDRESS": "ADRESAS",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -866,6 +866,7 @@
       "must be after or equal to start date": "jābūt pēc sākuma datuma vai vienādam ar to"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "Parolei jābūt vismaz 1 rakstzīmei un ne vairāk kā 50 rakstzīmēm",
       "Password must be at least 1 character and not more than 50 characters long": "Parolei jābūt vismaz 1 rakstzīmei un ne vairāk kā 50 rakstzīmēm",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Parolei jābūt vismaz 6 rakstzīmēm, ne vairāk kā 50 rakstzīmēm, jāiekļauj vismaz viens lielais burts, viens mazais burts, viens cipars un nedrīkst būt atstarpes",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Parolei jābūt no 12 līdz 50 rakstzīmēm, jāiekļauj vismaz viens lielais burts, viens mazais burts, viens cipars un viens speciāls rakstzīme, bez atstarpēm vai secīgiem atkārtotiem rakstzīmēm"
@@ -1263,6 +1264,9 @@
         "INCOME": "IENĀKUMI",
         "EXPENSE": "IZDEVUMI"
       },
+      "Basic": "Pamata",
+      "Standard": "Standarta",
+      "Strong": "Spēcīgs",
       "Percentage is required": "Nepieciešams procents",
       "ACCOUNTING": "GRĀMATVEDĪBA",
       "ADDRESS": "ADRESE",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -864,6 +864,7 @@
       "must be after or equal to start date": "सुरु मिति पछि वा बराबर हुनुपर्छ"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "पासवर्ड कम्तिमा १ क्यारेक्टर र ५० क्यारेक्टरभन्दा बढी नहुने हुनुपर्छ",
       "Password must be at least 1 character and not more than 50 characters long": "पासवर्ड कम्तिमा १ क्यारेक्टर र ५० क्यारेक्टरभन्दा बढी नहुने हुनुपर्छ",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "पासवर्ड कम्तिमा ६ क्यारेक्टर, ५० क्यारेक्टरभन्दा बढी नहुने, कम्तिमा एक अपरकेस अक्षर, एक लोअरकेस अक्षर, एक संख्यात्मक अंक र कुनै खाली ठाउँ नहुने हुनुपर्छ",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "पासवर्ड १२ देखि ५० क्यारेक्टर लामो हुनुपर्छ, जसमा कम्तिमा एक अपरकेस अक्षर, एक लोअरकेस अक्षर, एक संख्यात्मक अंक, र एक विशेष क्यारेक्टर हुनुपर्छ, कुनै खाली ठाउँ वा लगातार दोहोरिएका क्यारेक्टरहरू नहुने"
@@ -1261,6 +1262,9 @@
         "INCOME": "आय",
         "EXPENSE": "खर्च"
       },
+      "Basic": "आधारभूत",
+      "Standard": "मानक",
+      "Strong": "बलियो",
       "Percentage is required": "प्रतिशत आवश्यक छ",
       "ACCOUNTING": "लेखा",
       "ADDRESS": "ठेगाना",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -866,6 +866,7 @@
       "must be after or equal to start date": "deve ser posterior ou igual à data de início"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "A senha deve ter pelo menos 1 caractere e não mais que 50 caracteres",
       "Password must be at least 1 character and not more than 50 characters long": "A senha deve ter pelo menos 1 caractere e não mais que 50 caracteres",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "A senha deve ter pelo menos 6 caracteres, não mais que 50 caracteres, deve incluir pelo menos uma letra maiúscula, uma letra minúscula, um dígito numérico e nenhum espaço",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "A senha deve ter entre 12 e 50 caracteres, contendo pelo menos uma letra maiúscula, uma letra minúscula, um dígito numérico e um caractere especial, sem espaços ou caracteres repetidos consecutivos"
@@ -1263,6 +1264,9 @@
         "INCOME": "RENDA",
         "EXPENSE": "DESPESA"
       },
+      "Basic": "Básico",
+      "Standard": "Padrão",
+      "Strong": "Forte",
       "Percentage is required": "Percentual é obrigatório",
       "ACCOUNTING": "CONTABILIDADE",
       "ADDRESS": "ENDEREÇO",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -866,6 +866,7 @@
       "must be after or equal to start date": "lazima iwe baada ya au sawa na tarehe ya kuanza"
     },
     "passwordPreferences": {
+      "Password most be at least 1 character and not more that 50 characters long": "Nenosiri lazima liwe na angalau herufi 1 na si zaidi ya herufi 50",
       "Password must be at least 1 character and not more than 50 characters long": "Nenosiri lazima liwe na angalau herufi 1 na si zaidi ya herufi 50",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Nenosiri lazima liwe na angalau herufi 6, si zaidi ya herufi 50, lazima liwe na angalau herufi moja kubwa, herufi moja ndogo, nambari moja na hakuna nafasi",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Nenosiri lazima liwe na herufi 12 hadi 50, likiwa na angalau herufi moja kubwa, herufi moja ndogo, nambari moja na herufi maalum moja, bila nafasi au herufi zinazorudiwa mfululizo"
@@ -1261,6 +1262,9 @@
         "INCOME": "MAPATO",
         "EXPENSE": "GHARAMA"
       },
+      "Basic": "Msingi",
+      "Standard": "Kiwango",
+      "Strong": "Imara",
       "ACCOUNTING": "UHASIBU",
       "Percentage is required": "Asilimia inahitajika",
       "ADDRESS": "ANWANI",


### PR DESCRIPTION
This PR fixes missing translation keys on the Password Preferences page where several text elements were displaying as raw translation keys instead of their localized values.

[WEB-592](https://mifosforge.jira.com/browse/WEB-592)

Before:
<img width="1917" height="976" alt="Screenshot 2026-01-17 212454" src="https://github.com/user-attachments/assets/5c9eaa30-e67b-4b0c-a005-93efe55cac0c" />
After:
<img width="1912" height="1058" alt="image" src="https://github.com/user-attachments/assets/ae39edef-015f-4534-ae0b-42bfe425727b" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-592]: https://mifosforge.jira.com/browse/WEB-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ