### PR TITLE
WEB-595 verticals 3 dots are not displayed in any language different to english in the savings transaction tab

### DIFF
--- a/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.html
+++ b/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.html
@@ -129,7 +129,7 @@
         <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
         <td mat-cell class="center" *matCellDef="let transaction">
           <button mat-icon-button [matMenuTriggerFor]="transactionMenu" aria-label="" class="action-button">
-            <mat-icon>{{ 'labels.text.more_vert' | translate }}</mat-icon>
+            <mat-icon>more_vert</mat-icon>
           </button>
           <mat-menu #transactionMenu="matMenu">
             <button mat-menu-item (click)="showTransactions(transaction)">


### PR DESCRIPTION
**Changes Made :-**

-Fixed the issue where the vertical 3-dots (more_vert) icon was not displayed in any language other than English in the Savings Transaction tab.
-Updated the template to use the hardcoded Material icon name (more_vert) instead of a translation key, ensuring the icon always renders correctly regardless of the selected language.

[WEB-595](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-595)

Before :-
<img width="442" height="408" alt="image" src="https://github.com/user-attachments/assets/a286057a-9289-4a52-96da-c7f84aabf807" />

After :-
<img width="1365" height="718" alt="image" src="https://github.com/user-attachments/assets/7cec06c9-0622-4084-b344-c10aabe029e1" />

<img width="1365" height="717" alt="image" src="https://github.com/user-attachments/assets/c3ae0028-da66-4756-899d-9eb08f3b08f7" />


[WEB-595]: https://mifosforge.jira.com/browse/WEB-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the icon rendering in the transactions list actions menu, ensuring the proper visual display of the menu icon while maintaining all button functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->