### PR TITLE
WEB-594 Translate breadcrumbs account transfers using the i-18-n translation-key

### DIFF
--- a/src/app/account-transfers/account-transfers-routing.module.ts
+++ b/src/app/account-transfers/account-transfers-routing.module.ts
@@ -66,7 +66,11 @@ const routes: Routes = [
       },
       {
         path: 'account-transfers',
-        data: { title: 'View Account Transfer', breadcrumb: 'Account Transfers', routeParamBreadcrumb: false },
+        data: {
+          title: 'View Account Transfer',
+          breadcrumb: 'labels.breadcrumbs.Account Transfers',
+          routeParamBreadcrumb: false
+        },
         children: [
           {
             path: ':transferid',

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Domov"
+      "Home": "Domov",
+      "Account Transfers": "Převody mezi účty"
     },
     "buttons": {
       "Accept Transfer": "Přijmout převod",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Heim"
+      "Home": "Heim",
+      "Account Transfers": "Kontoüberweisungen"
     },
     "buttons": {
       "Accept Transfer": "Akzeptieren Sie die Übertragung",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -307,7 +307,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Home"
+      "Home": "Home",
+      "Account Transfers": "Account Transfers"
     },
     "buttons": {
       "Accept Transfer": "Accept Transfer",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Inicio"
+      "Home": "Inicio",
+      "Account Transfers": "Transferencias entre cuentas"
     },
     "buttons": {
       "Accept Transfer": "Aceptar transferencia",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Inicio"
+      "Home": "Inicio",
+      "Account Transfers": "Transferencias entre cuentas"
     },
     "buttons": {
       "Accept Transfer": "Aceptar transferencia",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Maison"
+      "Home": "Maison",
+      "Account Transfers": "Virements de compte"
     },
     "buttons": {
       "Accept Transfer": "Accepter le transfert",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Casa"
+      "Home": "Casa",
+      "Account Transfers": "Trasferimenti tra conti"
     },
     "buttons": {
       "Accept Transfer": "Accetta trasferimento",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "집"
+      "Home": "집",
+      "Account Transfers": "계좌 이체"
     },
     "buttons": {
       "Accept Transfer": "전송 수락",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Namai"
+      "Home": "Namai",
+      "Account Transfers": "Sąskaitų pervedimai"
     },
     "buttons": {
       "Accept Transfer": "Priimti perkėlimą",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Mājas"
+      "Home": "Mājas",
+      "Account Transfers": "Kontu pārskaitījumi"
     },
     "buttons": {
       "Accept Transfer": "Pieņemt pārsūtīšanu",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "घर"
+      "Home": "घर",
+      "Account Transfers": "खाता स्थानान्तरण"
     },
     "buttons": {
       "Accept Transfer": "स्थानान्तरण स्वीकार गर्नुहोस्",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Lar"
+      "Home": "Lar",
+      "Account Transfers": "Transferências entre contas"
     },
     "buttons": {
       "Accept Transfer": "Aceitar transferência",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -306,7 +306,8 @@
       }
     },
     "breadcrumbs": {
-      "Home": "Nyumbani"
+      "Home": "Nyumbani",
+      "Account Transfers": "Uhamisho za akaunti"
     },
     "buttons": {
       "Accept Transfer": "Kubali Uhamisho",


### PR DESCRIPTION
**Changes Made :-**

-Internationalized the "Account Transfers" breadcrumb by replacing the hardcoded label with an i18n translation key in the routing module.
-Added the "Account Transfers" key to all locale translation files under the breadcrumbs section, using proper translations or English fallback where needed.

[WEB-594](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-594)

[WEB-594]: https://mifosforge.jira.com/browse/WEB-594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated account transfers breadcrumb to display localized labels across all supported languages, enhancing navigation clarity for international users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->