### PR TITLE
WEB-76: Smaller text issues when editing Fixed Deposit Products

### DIFF
--- a/src/app/products/deposit-product-incentive-form-dialog/deposit-product-incentive-form-dialog.component.html
+++ b/src/app/products/deposit-product-incentive-form-dialog/deposit-product-incentive-form-dialog.component.html
@@ -29,7 +29,7 @@
     <mat-select formControlName="conditionType" required>
       @for (conditionType of conditionTypeData; track conditionType) {
         <mat-option [value]="conditionType.id">
-          {{ conditionType.value }}
+          {{ conditionLabelService.getConditionLabel(conditionType.value) }}
         </mat-option>
       }
     </mat-select>

--- a/src/app/shared/common-logic/condition-label.service.ts
+++ b/src/app/shared/common-logic/condition-label.service.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Injectable, inject } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConditionLabelService {
+  private translateService = inject(TranslateService);
+
+  getConditionLabel(value: string): string {
+    switch (value?.toLowerCase()) {
+      case 'lessthan':
+        return this.translateService.instant('labels.conditions.LessThan');
+
+      case 'equal':
+        return this.translateService.instant('labels.conditions.Equal');
+
+      case 'greterthan':
+        return this.translateService.instant('labels.conditions.GreaterThan');
+
+      case 'notequal':
+      case 'not_equal':
+        return this.translateService.instant('labels.conditions.NotEqual');
+
+      default:
+        return value;
+    }
+  }
+}

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -875,6 +875,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Heslo musí obsahovat alespoň 6 znaků, ne více než 50 znaků, musí obsahovat alespoň jedno velké písmeno, jedno malé písmeno, jednu číslici a žádnou mezeru",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Heslo musí být dlouhé 12 až 50 znaků, obsahovat alespoň jedno velké písmeno, jedno malé písmeno, jednu číslici a jeden speciální znak, bez mezer nebo po sobě jdoucích opakujících se znaků"
     },
+    "conditions": {
+      "LessThan": "Menší než",
+      "Equal": "Rovná se",
+      "GreaterThan": "Větší než",
+      "NotEqual": "Nerovná se"
+    },
     "heading": {
       "Account Linked Financial": "Seznam účtů spojených s různými finančními aktivitami. Chcete-li vědět více, klikněte:",
       "Account Name": "Jméno účtu",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -875,6 +875,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Das Passwort muss mindestens 6 Zeichen lang sein, nicht mehr als 50 Zeichen, muss mindestens einen Großbuchstaben, einen Kleinbuchstaben, eine Ziffer und kein Leerzeichen enthalten",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Das Passwort muss 12 bis 50 Zeichen lang sein und mindestens einen Großbuchstaben, einen Kleinbuchstaben, eine Ziffer und ein Sonderzeichen enthalten, ohne Leerzeichen oder aufeinanderfolgende wiederholte Zeichen"
     },
+    "conditions": {
+      "LessThan": "Kleiner als",
+      "Equal": "Gleich",
+      "GreaterThan": "Größer als",
+      "NotEqual": "Ungleich"
+    },
     "heading": {
       "Account Linked Financial": "Liste der Konten, die mit verschiedenen Finanzaktivitäten verknüpft sind. Um mehr zu erfahren, klicken Sie:",
       "Account Name": "Kontoname",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -879,6 +879,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters"
     },
+    "conditions": {
+      "LessThan": "Less than",
+      "Equal": "Equal",
+      "GreaterThan": "Greater than",
+      "NotEqual": "Not equal"
+    },
     "heading": {
       "Account Linked Financial": "List of accounts linked to different financial activities. To know more click:",
       "Account Name": "Account Name",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -874,6 +874,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "La contraseña debe tener al menos 6 caracteres, no más de 50 caracteres, debe incluir al menos una letra mayúscula, una letra minúscula, un dígito numérico y ningún espacio",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "La contraseña debe tener entre 12 y 50 caracteres, conteniendo al menos una letra mayúscula, una letra minúscula, un dígito numérico y un carácter especial, sin espacios ni caracteres repetidos consecutivos"
     },
+    "conditions": {
+      "LessThan": "Menor que",
+      "Equal": "Igual",
+      "GreaterThan": "Mayor que",
+      "NotEqual": "No igual"
+    },
     "heading": {
       "Account Linked Financial": "Listado de cuentas vinculadas a diferentes actividades financieras. Para saber más haga clic en:",
       "Account Name": "Nombre de la cuenta",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -874,6 +874,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "La contraseña debe tener al menos 6 caracteres, no más de 50 caracteres, debe incluir al menos una letra mayúscula, una letra minúscula, un dígito numérico y ningún espacio",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "La contraseña debe tener entre 12 y 50 caracteres, conteniendo al menos una letra mayúscula, una letra minúscula, un dígito numérico y un carácter especial, sin espacios ni caracteres repetidos consecutivos"
     },
+    "conditions": {
+      "LessThan": "Menor que",
+      "Equal": "Igual",
+      "GreaterThan": "Mayor que",
+      "NotEqual": "No igual"
+    },
     "heading": {
       "Account Linked Financial": "Listado de cuentas vinculadas a diferentes actividades financieras. Para saber más haga clic en:",
       "Account Name": "Nombre de la cuenta",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -875,6 +875,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Le mot de passe doit contenir au moins 6 caractères, pas plus de 50 caractères, doit inclure au moins une lettre majuscule, une lettre minuscule, un chiffre et aucun espace",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Le mot de passe doit contenir entre 12 et 50 caractères, incluant au moins une lettre majuscule, une lettre minuscule, un chiffre et un caractère spécial, sans espaces ni caractères répétés consécutifs"
     },
+    "conditions": {
+      "LessThan": "Inférieur à",
+      "Equal": "Égal",
+      "GreaterThan": "Supérieur à",
+      "NotEqual": "Différent de"
+    },
     "heading": {
       "Account Linked Financial": "Liste des comptes liés aux différentes activités financières. Pour en savoir plus cliquez :",
       "Account Name": "Nom du compte",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -875,6 +875,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "La password deve contenere almeno 6 caratteri, non più di 50 caratteri, deve includere almeno una lettera maiuscola, una lettera minuscola, una cifra numerica e nessuno spazio",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "La password deve contenere tra 12 e 50 caratteri, contenente almeno una lettera maiuscola, una lettera minuscola, una cifra numerica e un carattere speciale, senza spazi o caratteri ripetuti consecutivi"
     },
+    "conditions": {
+      "LessThan": "Minore di",
+      "Equal": "Uguale",
+      "GreaterThan": "Maggiore di",
+      "NotEqual": "Diverso da"
+    },
     "heading": {
       "Account Linked Financial": "Elenco dei conti collegati a diverse attività finanziarie. Per saperne di più clicca:",
       "Account Name": "Nome utente",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -875,6 +875,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "비밀번호는 최소 6자 이상 50자 이하여야 하며, 최소 하나의 대문자, 하나의 소문자, 하나의 숫자 및 공백이 없어야 합니다",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "비밀번호는 12자 이상 50자 이하여야 하며, 최소 하나의 대문자, 하나의 소문자, 하나의 숫자 및 하나의 특수 문자를 포함해야 하며, 공백이나 연속된 반복 문자는 없어야 합니다"
     },
+    "conditions": {
+      "LessThan": "보다 작음",
+      "Equal": "같음",
+      "GreaterThan": "보다 큼",
+      "NotEqual": "같지 않음"
+    },
     "heading": {
       "Account Linked Financial": "다양한 금융 활동과 연결된 계정 목록입니다. 자세한 내용을 보려면 다음을 클릭하세요.",
       "Account Name": "계정 이름",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -875,6 +875,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Slaptažodis turi būti ne mažiau kaip 6 simboliai, ne daugiau kaip 50 simbolių, turi būti bent viena didžioji raidė, viena mažoji raidė, vienas skaitmuo ir neturėti tarpų",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Slaptažodis turi būti nuo 12 iki 50 simbolių, turėti bent vieną didžiąją raidę, vieną mažąją raidę, vieną skaitmenį ir vieną specialųjį simbolį, be tarpų arba iš eilės einančių pasikartojančių simbolių"
     },
+    "conditions": {
+      "LessThan": "Mažiau nei",
+      "Equal": "Lygu",
+      "GreaterThan": "Daugiau nei",
+      "NotEqual": "Nelygu"
+    },
     "heading": {
       "Account Linked Financial": "Sąskaitų, susietų su įvairia finansine veikla, sąrašas. Norėdami sužinoti daugiau, spustelėkite:",
       "Account Name": "Paskyros vardas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -875,6 +875,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Parolei jābūt vismaz 6 rakstzīmēm, ne vairāk kā 50 rakstzīmēm, jāiekļauj vismaz viens lielais burts, viens mazais burts, viens cipars un nedrīkst būt atstarpes",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Parolei jābūt no 12 līdz 50 rakstzīmēm, jāiekļauj vismaz viens lielais burts, viens mazais burts, viens cipars un viens speciāls rakstzīme, bez atstarpēm vai secīgiem atkārtotiem rakstzīmēm"
     },
+    "conditions": {
+      "LessThan": "Mazāks nekā",
+      "Equal": "Vienāds",
+      "GreaterThan": "Lielāks nekā",
+      "NotEqual": "Nevienāds"
+    },
     "heading": {
       "Account Linked Financial": "Ar dažādām finanšu darbībām saistīto kontu saraksts. Lai uzzinātu vairāk, noklikšķiniet:",
       "Account Name": "Konta vārds",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -873,6 +873,13 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "पासवर्ड कम्तिमा ६ क्यारेक्टर, ५० क्यारेक्टरभन्दा बढी नहुने, कम्तिमा एक अपरकेस अक्षर, एक लोअरकेस अक्षर, एक संख्यात्मक अंक र कुनै खाली ठाउँ नहुने हुनुपर्छ",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "पासवर्ड १२ देखि ५० क्यारेक्टर लामो हुनुपर्छ, जसमा कम्तिमा एक अपरकेस अक्षर, एक लोअरकेस अक्षर, एक संख्यात्मक अंक, र एक विशेष क्यारेक्टर हुनुपर्छ, कुनै खाली ठाउँ वा लगातार दोहोरिएका क्यारेक्टरहरू नहुने"
     },
+    "conditions": {
+      "LessThan": "भन्दा कम",
+      "Equal": "बराबर",
+      "GreaterThan": "भन्दा ठुलो",
+      "NotEqual": "बराबर छैन"
+    },
+
     "heading": {
       "Account Linked Financial": "विभिन्न वित्तीय गतिविधिहरु संग जोडिएको खाताहरु को सूची। थप जान्नको लागि क्लिक गर्नुहोस्:",
       "Account Name": "खाताको नाम",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -875,6 +875,12 @@
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "A senha deve ter pelo menos 6 caracteres, não mais que 50 caracteres, deve incluir pelo menos uma letra maiúscula, uma letra minúscula, um dígito numérico e nenhum espaço",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "A senha deve ter entre 12 e 50 caracteres, contendo pelo menos uma letra maiúscula, uma letra minúscula, um dígito numérico e um caractere especial, sem espaços ou caracteres repetidos consecutivos"
     },
+    "conditions": {
+      "LessThan": "Menor que",
+      "Equal": "Igual",
+      "GreaterThan": "Maior que",
+      "NotEqual": "Diferente de"
+    },
     "heading": {
       "Account Linked Financial": "Lista de contas vinculadas a diferentes atividades financeiras. Para saber mais clique:",
       "Account Name": "Nome da conta",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -719,8 +719,6 @@
       "LOAN_PROVISIONING": "Utoaji wa Mkopo",
       "Loan Interest Recalculation": "Uhesabuji wa Riba ya Mkopo",
       "Reamortization": "Remortization",
-      "equals": "sawa",
-      "greater than": "kubwa kuliko",
       "Equal installments": "Awamu sawa",
       "Equal principal payments": "Malipo ya msingi sawa",
       "Till Pre-Close Date": "Hadi Tarehe ya Kufungwa",
@@ -874,6 +872,12 @@
       "Password must be at least 1 character and not more than 50 characters long": "Nenosiri lazima liwe na angalau herufi 1 na si zaidi ya herufi 50",
       "Password must be at least 6 characters, no more than 50 characters long, must include at least one upper case letter, one lower case letter, one numeric digit and no space": "Nenosiri lazima liwe na angalau herufi 6, si zaidi ya herufi 50, lazima liwe na angalau herufi moja kubwa, herufi moja ndogo, nambari moja na hakuna nafasi",
       "Password must be 12 to 50 characters long, containing at least one uppercase letter, one lowercase letter, one numeric digit, and one special character, with no spaces or consecutive repeating characters": "Nenosiri lazima liwe na herufi 12 hadi 50, likiwa na angalau herufi moja kubwa, herufi moja ndogo, nambari moja na herufi maalum moja, bila nafasi au herufi zinazorudiwa mfululizo"
+    },
+    "conditions": {
+      "LessThan": "Chini ya",
+      "Equal": "Sawa",
+      "GreaterThan": "Zaidi ya",
+      "NotEqual": "Sio sawa"
     },
     "heading": {
       "Account Linked Financial": "Orodha ya akaunti zilizounganishwa na shughuli tofauti za kifedha. Kujua zaidi bofya:",


### PR DESCRIPTION
[WEB-76](https://mifosforge.jira.com/browse/WEB-76)
What was changed
Updated the incentive condition dropdown to display user-friendly
labels instead of raw backend enum values.

Why this change was needed
The backend returns values such as greterthan, which were previously
rendered directly in the UI. This caused confusing labels to appear
during Fixed Deposit configuration.

What was done
Mapped backend condition values to readable UI labels
Ensured no backend or API behavior was modified
Related issues
Fixes: WEB-359
<img width="1470" height="796" alt="Screenshot 2026-01-19 at 8 07 19 PM" src="https://github.com/user-attachments/assets/b4a12879-1b41-40f8-baef-a8d29d2b9b9a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized condition labeling added so comparison operators show user-friendly translations.

* **Improvements**
  * Deposit product incentive dialog/form lifecycle and cleanup made more robust for smoother form interactions.

* **Chores (Localization)**
  * Added "conditions" translations across many locales.
  * Consolidated Swahili translations into the new conditions group and removed legacy standalone keys.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WEB-76]: https://mifosforge.jira.com/browse/WEB-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ