### PR TITLE
WEB-605 Change the vNEXT to MIFOS_INTERBANK_TRANSFERS variable and se…

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,10 @@ M**\*** T\*\*\*
 
 This applies to client name display, e.g. in Institution/Clients list.
 
+## Interbank Transfer Menu
+
+By default, the “Interbank Transfer” menu will be displayed in the hamburger menu of the Savings account.
+
 ## Releases
 
 ### 1.0.0 (Tag: 1.0.0-fineract1.11)

--- a/src/app/account-transfers/account-transfers.service.ts
+++ b/src/app/account-transfers/account-transfers.service.ts
@@ -132,7 +132,7 @@ export class AccountTransfersService {
     const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
     return this.http
       .post(
-        `${environment.vNextApiUrl}${environment.vNextApiVersion}${environment.vNextApiProvider}/participant`,
+        `${environment.mifosInterbankTransfersApiUrl}${environment.mifosInterbankTransfersApiVersion}${environment.mifosInterbankTransfersApiProvider}/participant`,
         JSON.stringify(payload),
         { headers }
       )
@@ -140,7 +140,7 @@ export class AccountTransfersService {
         switchMap((participant: any) => {
           const body = JSON.stringify({ ...payload, ownerFspId: participant.fspId });
           return this.http.post(
-            `${environment.vNextApiUrl}${environment.vNextApiVersion}${environment.vNextApiProvider}/partyinfo`,
+            `${environment.mifosInterbankTransfersApiUrl}${environment.mifosInterbankTransfersApiVersion}${environment.mifosInterbankTransfersApiProvider}/partyinfo`,
             body,
             { headers }
           );
@@ -151,7 +151,7 @@ export class AccountTransfersService {
   sendInterbankTransfer(body: any): Observable<any> {
     const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
     return this.http.post(
-      `${environment.vNextApiUrl}${environment.vNextApiVersion}${environment.vNextApiProvider}/executetransfer`,
+      `${environment.mifosInterbankTransfersApiUrl}${environment.mifosInterbankTransfersApiVersion}${environment.mifosInterbankTransfersApiProvider}/executetransfer`,
       body,
       { headers }
     );

--- a/src/app/savings/savings-account-view/savings-account-view.component.ts
+++ b/src/app/savings/savings-account-view/savings-account-view.component.ts
@@ -136,7 +136,7 @@ export class SavingsAccountViewComponent implements OnInit {
         taskPermissionName: 'CREATE_ACCOUNTTRANSFER'
       });
     }
-    if (this.savingsAccountData.externalId && environment.interbankTransfers) {
+    if (this.savingsAccountData.externalId && environment.mifosInterbankTransfersEnabled) {
       this.buttonConfig.addOption({
         name: 'Interbank Transfer',
         taskPermissionName: 'CREATE_ACCOUNTTRANSFER'

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -62,6 +62,12 @@
   // Hide client data (mask names)
   window['env']['complianceHideClientData'] = '';
 
+   // Interbank Transfers Environment variables
+  window['env']['mifosInterbankTransfersApiUrl'] = '';
+  window['env']['mifosInterbankTransfersApiProvider'] = '';
+  window['env']['mifosInterbankTransfersApiVersion'] = '';
+  window['env']['mifosInterbankTransfersEnabled'] = 'true';
+  
   // OIDC Plugin Environment variables
   window['env']['oidcServerEnabled'] = false;
   window['env']['oidcBaseUrl']       = '';

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -75,10 +75,10 @@
   // Hide client data (mask names)
   window['env']['complianceHideClientData'] = '$MIFOS_COMPLIANCE_HIDE_CLIENT_DATA';
 
-  window['env']['vNextApiUrl'] = '$VNEXT_API_URL';
-  window['env']['vNextApiProvider'] = '$VNEXT_API_PROVIDER';
-  window['env']['vNextApiVersion'] = '$VNEXT_API_VERSION';
-  window['env']['interbankTransfers'] = '$VNEXT_INTERBANK_TRANSFERS';
+  window['env']['mifosInterbankTransfersApiUrl'] = '$MIFOS_INTERBANK_TRANSFERS_API_URL';
+  window['env']['mifosInterbankTransfersApiProvider'] = '$MIFOS_INTERBANK_TRANSFERS_API_PROVIDER';
+  window['env']['mifosInterbankTransfersApiVersion'] = '$MIFOS_INTERBANK_TRANSFERS_API_VERSION';
+  window['env']['mifosInterbankTransfersEnabled'] = '$MIFOS_INTERBANK_TRANSFERS_ENABLED';
 
   // OIDC Plugin Environment variables
   window['env']['oidcServerEnabled'] = '$FINERACT_PLUGIN_OIDC_ENABLED';

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -73,10 +73,10 @@ export const environment = {
   },
   httpCacheEnabled: loadedEnv.httpCacheEnabled || false,
 
-  vNextApiUrl: window['env']['vNextApiUrl'] || 'https://apis.mifos.community',
-  vNextApiProvider: window['env']['vNextApiProvider'] || '/vnext1',
-  vNextApiVersion: window['env']['vNextApiVersion'] || '/v1.0',
-  interbankTransfers: window['env']['interbankTransfers'] || false,
+  mifosInterbankTransfersApiUrl: loadedEnv['mifosInterbankTransfersApiUrl'] || 'https://apis.mifos.community',
+  mifosInterbankTransfersApiProvider: loadedEnv['mifosInterbankTransfersApiProvider'] || '/vnext1',
+  mifosInterbankTransfersApiVersion: loadedEnv['mifosInterbankTransfersApiVersion'] || '/v1.0',
+  mifosInterbankTransfersEnabled: loadedEnv['mifosInterbankTransfersEnabled'] ?? true,
 
   minPasswordLength: loadedEnv['minPasswordLength'] || 12,
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -77,10 +77,10 @@ export const environment = {
   },
   httpCacheEnabled: loadedEnv.httpCacheEnabled || false,
 
-  vNextApiUrl: window.env?.vNextApiUrl || 'https://apis.flexcore.mx',
-  vNextApiProvider: window.env?.vNextApiProvider || '/vnext1',
-  vNextApiVersion: window.env?.vNextApiVersion || '/v1.0',
-  interbankTransfers: window.env?.interbankTransfers || false,
+  mifosInterbankTransfersApiUrl: window.env?.mifosInterbankTransfersApiUrl || 'https://apis.flexcore.mx',
+  mifosInterbankTransfersApiProvider: window.env?.mifosInterbankTransfersApiProvider || '/vnext1',
+  mifosInterbankTransfersApiVersion: window.env?.mifosInterbankTransfersApiVersion || '/v1.0',
+  mifosInterbankTransfersEnabled: window.env?.mifosInterbankTransfersEnabled ?? true,
 
   minPasswordLength: loadedEnv.minPasswordLength || 12,
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -20,10 +20,10 @@ interface Window {
     waitTimeForNotifications?: number;
     waitTimeForCOBCatchUp?: number;
     sessionIdleTimeout?: number;
-    vNextApiUrl?: string;
-    vNextApiProvider?: string;
-    vNextApiVersion?: string;
-    interbankTransfers?: boolean;
+    mifosInterbankTransfersApiUrl?: string;
+    mifosInterbankTransfersApiProvider?: string;
+    mifosInterbankTransfersApiVersion?: string;
+    mifosInterbankTransfersEnabled?: boolean;
     minPasswordLength?: number;
   };
 }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -34,10 +34,10 @@ interface Window {
     waitTimeForNotifications?: number;
     waitTimeForCOBCatchUp?: number;
     sessionIdleTimeout?: number;
-    vNextApiUrl?: string;
-    vNextApiProvider?: string;
-    vNextApiVersion?: string;
-    interbankTransfers?: boolean;
+    mifosInterbankTransfersApiUrl?: string;
+    mifosInterbankTransfersApiProvider?: string;
+    mifosInterbankTransfersApiVersion?: string;
+    mifosInterbankTransfersEnabled?: boolean;
     minPasswordLength?: number;
   };
 }


### PR DESCRIPTION
**Changed Made :-**

-The “Interbank Transfer” menu is now available by default in the hamburger menu of the Savings account.
-This feature allows users to easily initiate interbank transfers directly from their savings account dashboard.

[WEB-605](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-605)

[WEB-605]: https://mifosforge.jira.com/browse/WEB-605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Interbank Transfer Menu" docs noting the menu is shown by default for Savings accounts.

* **Chores**
  * Renamed and consolidated interbank transfer environment keys and deployment config.
  * Updated runtime/config for interbank transfer API endpoints and the feature enablement flag; interbank transfer button visibility now follows the new flag.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->