### PR TITLE
WEB-609 fix:correct license header position in index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,3 @@
-<!doctype html>
 <!--
   Copyright since 2025 Mifos Initiative
 
@@ -6,6 +5,8 @@
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
+
+<!doctype html>
 
 <html lang="en" class="h-full bg-gray-100">
   <head>


### PR DESCRIPTION
This pr fixed the position of the MPL-2.0 license header in src/index.html.The license header was not at the top of the file, causing the CI header validation script (check-file-headers.js) to fail.
The header has been moved to the very beginning of the file (before <!doctype html>) to comply with project licensing requirements and pass automated header checks.

[WEB-609](https://mifosforge.jira.com/browse/WEB-609)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-609]: https://mifosforge.jira.com/browse/WEB-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ