### PR TITLE
WEB-593 Translate account types in the Transfer Details Page

### DIFF
--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.html
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.html
@@ -67,7 +67,9 @@
 
             <div class="info-row">
               <span class="info-label">{{ 'labels.inputs.Account Type' | translate }}:</span>
-              <span class="info-value">{{ viewAccountTransferData.fromAccountType?.value }}</span>
+              <span class="info-value" *ngIf="viewAccountTransferData.fromAccountType?.value">
+                {{ 'labels.catalogs.' + viewAccountTransferData.fromAccountType.value | translate }}
+              </span>
             </div>
 
             <div class="info-row">
@@ -98,7 +100,9 @@
 
             <div class="info-row">
               <span class="info-label">{{ 'labels.inputs.Account Type' | translate }}:</span>
-              <span class="info-value">{{ viewAccountTransferData.toAccountType?.value }}</span>
+              <span class="info-value" *ngIf="viewAccountTransferData.toAccountType?.value">
+                {{ 'labels.catalogs.' + viewAccountTransferData.toAccountType.value | translate }}
+              </span>
             </div>
 
             <div class="info-row">


### PR DESCRIPTION
**Changes Made :-** 

-Add i18n translation support for account types ("Savings Account" and "Loan Account") on the Transfer Details Page.

[WEB-593](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-593)

Before :- 
<img width="859" height="803" alt="image" src="https://github.com/user-attachments/assets/dee815e6-cb30-4db1-ba85-9ae21633a044" />

After :- 
<img width="965" height="476" alt="image" src="https://github.com/user-attachments/assets/518c9c8a-3106-43be-982c-ab107abefdd6" />

<img width="998" height="478" alt="image" src="https://github.com/user-attachments/assets/08882214-e7b7-4a16-9e26-94887ee14dd7" />


[WEB-593]: https://mifosforge.jira.com/browse/WEB-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account transfer details now display localized account type labels instead of raw codes in the "Transferred From" and "Transferred To" sections, improving clarity and readability for end users. Labels are shown only when values exist, avoiding empty placeholders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->