### PR TITLE
WEB-597 Render the client classification and its value if it is available in the client data box

### DIFF
--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -144,6 +144,14 @@
                       </td>
                       <td>{{ clientViewData.clientType.name }}</td>
                     </tr>
+                    @if (clientViewData.clientClassification) {
+                      <tr>
+                        <td>
+                          <b>{{ 'labels.inputs.Client Classification' | translate }}</b>
+                        </td>
+                        <td>{{ clientViewData.clientClassification.name }}</td>
+                      </tr>
+                    }
                   }
                   <tr>
                     <td>


### PR DESCRIPTION
**Changes Made :-** 

-Render the Client Classification and its value in the client data box on the client details page, ensuring it is visible when available.

[WEB-597](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-597)

Before :- 
<img width="1024" height="249" alt="image" src="https://github.com/user-attachments/assets/6b918ce4-f84c-4c74-ae06-ecdf9354244f" />

After :- 
<img width="1365" height="717" alt="image" src="https://github.com/user-attachments/assets/fa0dc4b7-b882-4105-8d99-d15ba8a5a354" />




[WEB-597]: https://mifosforge.jira.com/browse/WEB-597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clients can now view Client Classification information in the client details table when available. The field displays conditionally based on classification data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->