### PR TITLE
WEB-598 Client Performance History doesn't render any value

### DIFF
--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -14,16 +14,17 @@
         <tr>
           <td>
             <p>
-              {{ 'labels.inputs.No. Of Loan Cycles' | translate }} :{{ clientSummary?.loanCycle }} <br />
-              {{ 'labels.inputs.No. of Active Loans' | translate }} :{{ clientSummary?.activeLoans }} <br />
-              {{ 'labels.inputs.Last Loan Amount' | translate }} :{{ clientSummary?.lastLoanAmount | formatNumber }}
+              {{ 'labels.inputs.No. Of Loan Cycles' | translate }} :{{ performanceHistory.loanCycle }} <br />
+              {{ 'labels.inputs.No. of Active Loans' | translate }} :{{ performanceHistory.activeLoans }} <br />
+              {{ 'labels.inputs.Last Loan Amount' | translate }} :{{ performanceHistory.lastLoanAmount | formatNumber }}
               <br />
             </p>
           </td>
           <td>
             <p>
-              {{ 'labels.inputs.No. of Active Savings' | translate }} :{{ clientSummary?.activeSavings }} <br />
-              {{ 'labels.inputs.Total Savings' | translate }} :{{ clientSummary?.totalSavings | formatNumber }} <br />
+              {{ 'labels.inputs.No. of Active Savings' | translate }} :{{ performanceHistory.activeSavings }} <br />
+              {{ 'labels.inputs.Total Savings' | translate }} :{{ performanceHistory.totalSavings | formatNumber }}
+              <br />
             </p>
           </td>
         </tr>


### PR DESCRIPTION
**Changed Made :-** 

-Render the Client Performance History and its value in the client data box on the client details page, ensuring it is visible when available.

[WEB-598](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-598)

Before :- 
<img width="821" height="575" alt="image" src="https://github.com/user-attachments/assets/9931fa22-f3c5-4cfb-bca9-76831a886b84" />

After :-
<img width="1365" height="720" alt="image" src="https://github.com/user-attachments/assets/65025353-a5c5-4e3b-926a-e0d45af76985" />

<img width="1365" height="720" alt="image" src="https://github.com/user-attachments/assets/864661a8-3f5f-42d0-8f45-b0bd6b3844a7" />






[WEB-598]: https://mifosforge.jira.com/browse/WEB-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated performance history calculation to derive metrics directly from account data instead of using pre-fetched summaries. Performance metrics (loan cycle, active loans, last loan amount, and savings data) are now computed automatically from available account information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->