### PR TITLE
WEB-611: Add charge option menu loan overpaid

### DIFF
--- a/src/app/loans/loans-view/loan-accounts-button-config.ts
+++ b/src/app/loans/loans-view/loan-accounts-button-config.ts
@@ -115,6 +115,11 @@ export class LoansAccountButtonConfiguration {
       case 'Overpaid':
         this.buttonsArray = [
           {
+            name: 'Add Loan Charge',
+            icon: 'plus',
+            taskPermissionName: 'CREATE_LOANCHARGE'
+          },
+          {
             name: 'Transfer Funds',
             icon: 'exchange',
             taskPermissionName: 'CREATE_ACCOUNTTRANSFER'


### PR DESCRIPTION
## Description

Add charge option is available via BE,  so while execute POS/loans/{loanId}/charges withy valid data - success result and added charge is shown

[WEB-611](https://mifosforge.jira.com/browse/WEB-611)

## Related issues and discussion

## Screenshots, if any

<img width="1660" height="692" alt="Screenshot 2026-01-20 at 11 04 11 p m" src="https://github.com/user-attachments/assets/823e8940-2fcc-4e28-831d-7878e978bc97" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-611]: https://mifosforge.jira.com/browse/WEB-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Add Loan Charge" button for overpaid loan accounts, enabling users to create loan charges directly from the loan view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->