### PR TITLE
WEB-613 Allow to display IBAN account number in the external id section in the general tab of a saving account currently it is truncated

### DIFF
--- a/src/app/shared/external-identifier/external-identifier.component.html
+++ b/src/app/shared/external-identifier/external-identifier.component.html
@@ -15,7 +15,7 @@
       <span class="m-l-3" (click)="showValue()"><fa-icon icon="eye" size="sm" [title]="externalId"></fa-icon></span>
     }
     @if (!completed) {
-      <span class="m-l-5" (click)="showValue()">{{ externalId | externalIdentifier }}</span>
+      <span class="m-l-5" (click)="showValue()">{{ externalId }}</span>
     }
     @if (completed) {
       <span (click)="showValue()">{{ externalId }}</span>

--- a/src/app/shared/external-identifier/external-identifier.component.ts
+++ b/src/app/shared/external-identifier/external-identifier.component.ts
@@ -10,7 +10,6 @@ import { Component, Input, OnInit, inject } from '@angular/core';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { AlertService } from 'app/core/alert/alert.service';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { ExternalIdentifierPipe } from '../../pipes/external-identifier.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
 @Component({
@@ -19,8 +18,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   styleUrls: ['./external-identifier.component.scss'],
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
-    FaIconComponent,
-    ExternalIdentifierPipe
+    FaIconComponent
   ]
 })
 export class ExternalIdentifierComponent implements OnInit {


### PR DESCRIPTION
**Changes Made :-** 

-Display the full External ID (including IBANs) in the Savings Account General tab without truncation, and remove unused ExternalIdentifierPipe logic.

[WEB-613 ](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-613)

Before :- 
<img width="1024" height="450" alt="image" src="https://github.com/user-attachments/assets/02e61556-f47c-415c-88d5-1edb0b5055fc" />

After :- 
<img width="1365" height="543" alt="image" src="https://github.com/user-attachments/assets/05e2e5fb-2e67-48d7-b535-cf123dbe463d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified external identifier display by removing custom formatting from the component rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->