### PR TITLE
WEB-612 Display the External Id of a Savings account in the blue box

### DIFF
--- a/src/app/savings/savings-account-view/savings-account-view.component.html
+++ b/src/app/savings/savings-account-view/savings-account-view.component.html
@@ -46,6 +46,13 @@
                 accountNo="{{ savingsAccountData.accountNo }}"
                 display="left"
               ></mifosx-account-number>
+              <!-- External ID display -->
+              @if (savingsAccountData.externalId) {
+                <span class="external-id-row">
+                  <span class="m-r-5">{{ 'labels.inputs.External Id' | translate }} :</span>
+                  <span>{{ savingsAccountData.externalId }}</span>
+                </span>
+              }
             </h3>
             <span class="account-overview">
               {{ 'labels.text.' + entityType | translate }} {{ 'labels.inputs.name' | translate }}:


### PR DESCRIPTION
**Changes Made :-** 

-Display the full External ID value directly in the blue account header box of the Savings Account Details page, ensuring it is only shown when available and hidden when not set. 

[WEB-612](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-612)

Before :- 
<img width="1654" height="901" alt="image" src="https://github.com/user-attachments/assets/48713fbb-f5ad-49ea-a32f-57e75452b4ca" />

After :- 
<img width="1365" height="365" alt="image" src="https://github.com/user-attachments/assets/0d1a83f7-cb03-40f6-ba40-7e2edf3368f0" />

<img width="1365" height="308" alt="image" src="https://github.com/user-attachments/assets/c5abcbbb-98fe-44e2-ac76-d95420517501" />

<img width="1364" height="374" alt="image" src="https://github.com/user-attachments/assets/8aececab-5e68-489c-a075-857ce148c2b9" />

<img width="1365" height="328" alt="image" src="https://github.com/user-attachments/assets/b1185bda-bc67-4c1b-aefa-f52d509ddd33" />



[WEB-612]: https://mifosforge.jira.com/browse/WEB-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External IDs can now be shown in the savings account view when available. The external ID is displayed in the account header immediately after the account number for easier reference.
  * This display is conditional—if no external ID exists, the header remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->