### PR TITLE
WEB-606 Add the columns Username and Is Self Service in the User Page

### DIFF
--- a/src/app/users/users.component.html
+++ b/src/app/users/users.component.html
@@ -30,6 +30,11 @@
         <td mat-cell *matCellDef="let user">{{ user.firstname }}</td>
       </ng-container>
 
+      <ng-container matColumnDef="username">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Login Name' | translate }}</th>
+        <td mat-cell *matCellDef="let user">{{ user.username }}</td>
+      </ng-container>
+
       <ng-container matColumnDef="lastname">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Last Name' | translate }}</th>
         <td mat-cell *matCellDef="let user">{{ user.lastname }}</td>
@@ -43,6 +48,17 @@
       <ng-container matColumnDef="officeName">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Office' | translate }}</th>
         <td mat-cell *matCellDef="let user">{{ user.officeName }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="isSelfServiceUser">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.buttons.Is Self Service' | translate }}</th>
+        <td mat-cell *matCellDef="let user">
+          <span
+            [ngClass]="user.isSelfServiceUser ? 'self-service-true' : 'self-service-false'"
+            class="self-service-indicator"
+          ></span>
+          {{ user.isSelfServiceUser ? ('labels.buttons.Yes' | translate) : ('labels.buttons.No' | translate) }}
+        </td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>

--- a/src/app/users/users.component.scss
+++ b/src/app/users/users.component.scss
@@ -12,4 +12,24 @@ table {
   .select-row:hover {
     cursor: pointer;
   }
+
+  .self-service-indicator {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    margin-right: 0.5rem;
+    vertical-align: middle;
+    box-sizing: border-box;
+  }
+
+  .self-service-true {
+    background-color: #43a047;
+    border: 1px solid #388e3c;
+  }
+
+  .self-service-false {
+    background-color: #e53935;
+    border: 1px solid #b71c1c;
+  }
 }

--- a/src/app/users/users.component.ts
+++ b/src/app/users/users.component.ts
@@ -69,10 +69,12 @@ export class UsersComponent implements OnInit, AfterViewInit {
   usersData: any;
   /** Columns to be displayed in users table. */
   displayedColumns: string[] = [
+    'username',
     'firstname',
     'lastname',
     'email',
-    'officeName'
+    'officeName',
+    'isSelfServiceUser'
   ];
   /** Data source for users table. */
   dataSource: MatTableDataSource<any>;

--- a/src/app/users/view-user/view-user.component.html
+++ b/src/app/users/view-user/view-user.component.html
@@ -61,11 +61,13 @@
         <div class="content-row">
           <div class="label">{{ 'labels.buttons.Is Self Service' | translate }}</div>
           <div class="value">
-            <span
-              [ngClass]="userData.selfService ? 'self-service-true' : 'self-service-false'"
-              class="self-service-indicator"
-            ></span>
-            {{ userData.selfService ? ('labels.buttons.Yes' | translate) : ('labels.buttons.No' | translate) }}
+            <span class="self-service-container">
+              <span
+                [ngClass]="userData.selfService ? 'self-service-true' : 'self-service-false'"
+                class="self-service-indicator"
+              ></span>
+              {{ userData.selfService ? ('labels.buttons.Yes' | translate) : ('labels.buttons.No' | translate) }}
+            </span>
           </div>
         </div>
       </div>

--- a/src/app/users/view-user/view-user.component.scss
+++ b/src/app/users/view-user/view-user.component.scss
@@ -106,6 +106,12 @@
     border: 1px solid #b71c1c;
   }
 
+  .self-service-container {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
   button {
     transition: all 0.2s ease;
 


### PR DESCRIPTION
**Changes Made :-** 

-Added "Username" and "Is Self Service" columns to the User List page, including a colored indicator and localized text for the self-service status.
-Added "Username" in User Info page .
-Ensured consistent styling and translation for the self-service indicator and label across both the User List and User Info pages.

[WEB-606](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-606)

Before :- 
<img width="1024" height="464" alt="image" src="https://github.com/user-attachments/assets/95d9c5e0-ec7b-4bda-8763-780ba67ae819" />

After :-
<img width="1352" height="707" alt="image" src="https://github.com/user-attachments/assets/e3998acd-3c7e-4a9a-b27d-90529db433e6" />

<img width="1365" height="620" alt="image" src="https://github.com/user-attachments/assets/be7acdc1-412d-4d67-a513-b4427c08dc8c" />

<img width="1359" height="638" alt="image" src="https://github.com/user-attachments/assets/d688a96a-8380-4615-b6ed-27ab1f90661b" />

<img width="1365" height="604" alt="image" src="https://github.com/user-attachments/assets/1bb5d018-97b4-4e05-ac1f-9ea93715e233" />



[WEB-606]: https://mifosforge.jira.com/browse/WEB-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sortable "Username" column to the users table.
  * Added a "Self-service user" column showing Yes/No status.
  * Improved layout/alignment of the self-service indicator in the user details view.

* **Style**
  * Added color-coded visual indicators for self-service status (green/red) for clearer at-a-glance recognition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->