### PR TITLE
WEB-616 For savings accounts the product name account number and external id must be in different rows in the blue box

### DIFF
--- a/src/app/savings/savings-account-view/savings-account-view.component.html
+++ b/src/app/savings/savings-account-view/savings-account-view.component.html
@@ -38,22 +38,31 @@
                   [matTooltip]="savingsAccountData.subStatus.value"
                 ></i>
               }
-              <span class="m-r-5">{{ 'labels.inputs.Savings Product' | translate }} :</span>
-              <span class="m-r-5"
-                ><mifosx-long-text textValue="{{ savingsAccountData.savingsProductName }}"></mifosx-long-text
-              ></span>
-              <mifosx-account-number
-                accountNo="{{ savingsAccountData.accountNo }}"
-                display="left"
-              ></mifosx-account-number>
-              <!-- External ID display -->
-              @if (savingsAccountData.externalId) {
-                <span class="external-id-row">
-                  <span class="m-r-5">{{ 'labels.inputs.External Id' | translate }} :</span>
-                  <span>{{ savingsAccountData.externalId }}</span>
-                </span>
-              }
             </h3>
+            <!-- Product Name Row -->
+            <span class="product-row">
+              <span class="m-r-5">{{ 'labels.inputs.Savings Product' | translate }} :</span>
+              <span class="m-r-5">
+                <mifosx-long-text textValue="{{ savingsAccountData.savingsProductName }}"></mifosx-long-text>
+              </span>
+            </span>
+            <!-- Account Number Row -->
+            <span class="account-number-row">
+              <span class="m-r-5">{{ 'labels.inputs.Account Number' | translate }} :</span>
+              <span class="m-r-5">
+                <mifosx-account-number
+                  accountNo="{{ savingsAccountData.accountNo }}"
+                  display="left"
+                ></mifosx-account-number>
+              </span>
+            </span>
+            <!-- External ID Row -->
+            @if (savingsAccountData.externalId) {
+              <span class="external-id-row">
+                <span class="m-r-5">{{ 'labels.inputs.External Id' | translate }} :</span>
+                <span>{{ savingsAccountData.externalId }}</span>
+              </span>
+            }
             <span class="account-overview">
               {{ 'labels.text.' + entityType | translate }} {{ 'labels.inputs.name' | translate }}:
               {{ savingsAccountData.clientName || savingsAccountData.groupName }}

--- a/src/app/savings/savings-account-view/savings-account-view.component.scss
+++ b/src/app/savings/savings-account-view/savings-account-view.component.scss
@@ -9,3 +9,9 @@
 mat-card-title {
   display: flex;
 }
+
+.product-row,
+.account-number-row,
+.external-id-row {
+  display: block;
+}


### PR DESCRIPTION
**Changes Made :-** 

-Refactored the savings account view to display Product Name, Account Number, and External Id each on separate rows in the blue account overview box for improved readability.

[WEB-616](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-616)

Before :-
<img width="1024" height="433" alt="image" src="https://github.com/user-attachments/assets/73c4a5ad-788d-4420-87ac-ba54d2b61f1c" />

After :-
<img width="1364" height="626" alt="image" src="https://github.com/user-attachments/assets/69a524d0-bcb4-42bb-a4fb-d99fa93559f4" />

<img width="1365" height="603" alt="image" src="https://github.com/user-attachments/assets/4f76529f-9aeb-40db-932a-84e8d19828a8" />

<img width="1360" height="621" alt="image" src="https://github.com/user-attachments/assets/13fa9b86-e0cf-409e-957e-e7d94967a308" />

<img width="1335" height="600" alt="image" src="https://github.com/user-attachments/assets/76748122-fa5d-4d10-8207-3ea5369607c5" />


[WEB-616]: https://mifosforge.jira.com/browse/WEB-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Restructured the savings account view layout: Savings Product, Account Number, and External ID are now presented as separate block rows instead of inline elements.
  * Preserved content, translations and conditional display of External ID; long-text and account-number components remain unchanged but are now shown in discrete, modular blocks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->