### PR TITLE
WEB-589 Prevent negative values for balance required and minimum balance in savings product form

### DIFF
--- a/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.html
@@ -97,7 +97,14 @@
         matInput
         matTooltip="{{ 'tooltips.Sets the balance required for interest calculation' | translate }}"
         formControlName="minBalanceForInterestCalculation"
+        min="0"
+        step="0.01"
       />
+      <mat-error *ngIf="savingProductSettingsForm.get('minBalanceForInterestCalculation').hasError('min')">
+        {{ 'labels.inputs.Balance Required for Interest Calculation' | translate }}
+        {{ 'labels.commons.must be' | translate }}
+        {{ 'labels.commons.a positive number' | translate }}
+      </mat-error>
     </mat-form-field>
 
     <mat-checkbox
@@ -116,7 +123,13 @@
         matInput
         matTooltip="{{ 'tooltips.Sets the minimum balance allowed for a saving account' | translate }}"
         formControlName="minRequiredBalance"
+        min="0"
+        step="0.01"
       />
+      <mat-error *ngIf="savingProductSettingsForm.get('minRequiredBalance').hasError('min')">
+        {{ 'labels.inputs.Minimum Balance' | translate }} {{ 'labels.commons.must be' | translate }}
+        {{ 'labels.commons.a positive number' | translate }}
+      </mat-error>
     </mat-form-field>
 
     <mat-checkbox

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.ts
@@ -94,9 +94,15 @@ export class SavingProductSettingsStepComponent implements OnInit {
       ],
       enableLockinPeriod: [false],
       withdrawalFeeForTransfers: [false],
-      minBalanceForInterestCalculation: [''],
+      minBalanceForInterestCalculation: [
+        '',
+        [Validators.min(0)]
+      ],
       enforceMinRequiredBalance: [false],
-      minRequiredBalance: [''],
+      minRequiredBalance: [
+        '',
+        [Validators.min(0)]
+      ],
       allowOverdraft: [false],
       withHoldTax: [false],
       isDormancyTrackingActive: [false]


### PR DESCRIPTION
**Changes Made :-** 

-Prevented negative values from being entered in the "Balance Required for Interest Calculation" and "Minimum Balance" fields in the savings product form by adding validation .

[WEB-589](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-589)

Before :- 
<img width="1024" height="300" alt="image" src="https://github.com/user-attachments/assets/e9f6a673-59a2-48a6-adba-818296e6ed04" />

After :- 
<img width="1365" height="719" alt="image" src="https://github.com/user-attachments/assets/29dfc4ad-b208-4653-b20e-24d767503ba2" />


[WEB-589]: https://mifosforge.jira.com/browse/WEB-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ