### PR TITLE
WEB-618 Negative values allowed for decimal places and currency multiples in share product form

### DIFF
--- a/src/app/products/share-products/share-product-stepper/share-product-currency-step/share-product-currency-step.component.html
+++ b/src/app/products/share-products/share-product-stepper/share-product-currency-step/share-product-currency-step.component.html
@@ -31,6 +31,7 @@
       <mat-label>{{ 'labels.inputs.Decimal Places' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matTooltip="{{ 'tooltips.Track and report on share accounts' | translate }}"
         matInput
         formControlName="digitsAfterDecimal"
@@ -46,6 +47,7 @@
       <mat-label>{{ 'labels.inputs.Currency in multiples of' | translate }}</mat-label>
       <input
         type="number"
+        min="1"
         matInput
         matTooltip="{{ 'tooltips.Amount to be rounded off' | translate }}"
         formControlName="inMultiplesOf"

--- a/src/app/products/share-products/share-product-stepper/share-product-currency-step/share-product-currency-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-currency-step/share-product-currency-step.component.ts
@@ -63,11 +63,17 @@ export class ShareProductCurrencyStepComponent implements OnInit {
       ],
       digitsAfterDecimal: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)
+        ]
       ],
       inMultiplesOf: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(1)
+        ]
       ]
     });
   }


### PR DESCRIPTION
**Changed Made : -**


-Restricted negative values for "Decimal Places" and "Currency in multiples of" in the share product currency step form.
-Set the minimum value for "Decimal Places" to 0 and "Currency in multiples of" to 1 in the HTML input fields using the [min] attribute.

[WEB-618
](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-618)

Before :- 
<img width="1363" height="547" alt="image" src="https://github.com/user-attachments/assets/2b6a842c-290a-40df-801e-4ca34d6de7b5" />

After : -
<img width="1365" height="523" alt="image" src="https://github.com/user-attachments/assets/45b5c44f-29e5-48b7-a0c7-2ddc4d57e933" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved currency configuration input validation to enforce non-negative decimal places and minimum value of 1 for currency multiples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->