### PR TITLE
WEB-620:fix datatable tab layout dark theme

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
@@ -7,23 +7,25 @@
 -->
 
 <div class="tab-container mat-typography">
-  <h3>{{ formatTabLabel(datatableName) }}</h3>
-  <div class="layout-row align-end m-b-20">
-    @if (!dataObject.data[0]) {
-      <button mat-raised-button color="primary" (click)="add()">
-        <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
-      </button>
-    }
-    @if (dataObject.data[0]) {
-      <button mat-raised-button color="primary" (click)="edit()">
-        <fa-icon icon="edit" class="m-r-10"></fa-icon>{{ 'labels.buttons.Edit' | translate }}
-      </button>
-    }
-    @if (dataObject.data[0]) {
-      <button class="delete-button" mat-raised-button color="warn" (click)="delete()">
-        <fa-icon icon="trash" class="m-r-10"></fa-icon>{{ 'labels.buttons.Delete' | translate }}
-      </button>
-    }
+  <div class="layout-row align-between align-items-center m-b-20">
+    <h3>{{ formatTabLabel(datatableName) }}</h3>
+    <div class="layout-row gap-10px">
+      @if (!dataObject.data[0]) {
+        <button mat-raised-button color="primary" (click)="add()">
+          <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
+        </button>
+      }
+      @if (dataObject.data[0]) {
+        <button mat-raised-button color="primary" (click)="edit()">
+          <fa-icon icon="edit" class="m-r-10"></fa-icon>{{ 'labels.buttons.Edit' | translate }}
+        </button>
+      }
+      @if (dataObject.data[0]) {
+        <button mat-raised-button color="warn" (click)="delete()">
+          <fa-icon icon="trash" class="m-r-10"></fa-icon>{{ 'labels.buttons.Delete' | translate }}
+        </button>
+      }
+    </div>
   </div>
 
   <mat-divider></mat-divider>

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.scss
@@ -13,8 +13,12 @@
   padding: 1%;
   margin: 1%;
 
-  .delete-button {
-    margin-left: 1%;
+  h3 {
+    margin: 0;
+  }
+
+  :host-context(.dark-theme) & h3 {
+    color: rgb(255 255 255 / 87%) !important;
   }
 }
 
@@ -42,9 +46,18 @@
 
   &:hover {
     background-color: rgb(0 0 0 / 4%);
-    border-left-color: var(--primary-color, #3f51b5);
+    border-left-color: $accent;
     transform: translateY(-2px);
     box-shadow: 0 2px 8px rgb(0 0 0 / 10%);
+  }
+}
+
+:host-context(.dark-theme) .data-item {
+  background-color: rgb(255 255 255 / 3%);
+
+  &:hover {
+    background-color: rgb(255 255 255 / 6%);
+    box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
   }
 }
 
@@ -55,6 +68,10 @@
   letter-spacing: 0.3px;
   font-weight: 500;
   line-height: 1.2;
+}
+
+:host-context(.dark-theme) .data-label {
+  color: rgb(255 255 255 / 70%) !important;
 }
 
 .data-value {
@@ -71,6 +88,10 @@
   div {
     width: 100%;
   }
+}
+
+:host-context(.dark-theme) .data-value {
+  color: rgb(255 255 255 / 87%) !important;
 }
 
 .default-value {
@@ -90,7 +111,7 @@
 .system-defined {
   margin-top: 3px;
   background-color: rgb(63 81 181 / 8%);
-  border-left-color: #3f51b5;
+  border-left-color: $accent;
 }
 
 .long-text {


### PR DESCRIPTION
Fixed UI inconsistencies and dark theme support in the datatable single-row component to improve user experience and maintain design consistency across the application.

[WEB-620](https://mifosforge.jira.com/browse/WEB-620)
Before:
<img width="1919" height="1078" alt="Screenshot 2026-01-23 140826" src="https://github.com/user-attachments/assets/7cce24ee-7d6c-4a2c-9e91-0129239455bd" />
After:
<img width="1882" height="1021" alt="image" src="https://github.com/user-attachments/assets/d5e07130-8ff4-415a-9253-5f849cf1f482" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-620]: https://mifosforge.jira.com/browse/WEB-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark theme support with adaptive styling.

* **Style**
  * Restructured header layout with improved spacing and alignment.
  * Enhanced visual consistency across light and dark modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->