### PR TITLE
WEB-621:fix: implement global centering for Material Table columns

### DIFF
--- a/src/app/products/charges/charges.component.html
+++ b/src/app/products/charges/charges.component.html
@@ -48,22 +48,30 @@
       </ng-container>
 
       <ng-container matColumnDef="chargeTimeType">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Time' | translate }}</th>
-        <td mat-cell *matCellDef="let charge">{{ charge.chargeTimeType.value | translateKey: 'catalogs' }}</td>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="center">{{ 'labels.inputs.Time' | translate }}</th>
+        <td mat-cell *matCellDef="let charge" class="center">
+          {{ charge.chargeTimeType.value | translateKey: 'catalogs' }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="chargeCalculationType">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Calculation' | translate }}</th>
-        <td mat-cell *matCellDef="let charge">{{ charge.chargeCalculationType.value | translateKey: 'catalogs' }}</td>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="center">
+          {{ 'labels.inputs.Calculation' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let charge" class="center">
+          {{ charge.chargeCalculationType.value | translateKey: 'catalogs' }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="amount">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Amount' | translate }}</th>
-        <td mat-cell *matCellDef="let charge" class="r-amount">{{ charge.amount | formatNumber }}</td>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="center">
+          {{ 'labels.inputs.Amount' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let charge" class="center">{{ charge.amount | formatNumber }}</td>
       </ng-container>
 
       <ng-container matColumnDef="penalty">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="center">
           {{ 'labels.commons.Is' | translate }} {{ 'labels.inputs.Penalty' | translate }}?
         </th>
         <td mat-cell *matCellDef="let charge" class="center">
@@ -89,7 +97,7 @@
       </ng-container>
 
       <ng-container matColumnDef="active">
-        <th mat-header-cell *matHeaderCellDef mat-sort-header>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header class="center">
           {{ 'labels.commons.Is' | translate }} {{ 'labels.status.Active' | translate }}?
         </th>
         <td mat-cell *matCellDef="let charge" class="center">

--- a/src/main.scss
+++ b/src/main.scss
@@ -703,7 +703,6 @@ mifosx-notifications-page td {
   width: 100%;
 }
 
-/* Global overflow helpers to avoid repeated component overrides */
 .overflow-hidden {
   overflow: hidden;
 }
@@ -799,5 +798,17 @@ mat-card {
     background-color: #303135 !important;
     border-color: #444 !important;
     color: rgb(255 255 255 / 60%) !important;
+  }
+}
+
+.mat-mdc-table {
+  .mat-mdc-header-cell.center,
+  .mat-mdc-cell.center {
+    text-align: center !important;
+    justify-content: center !important;
+
+    .mat-sort-header-container {
+      justify-content: center !important;
+    }
   }
 }


### PR DESCRIPTION
This PR implements a global solution for centering columns in Material Tables, resolving a common layout issue where .center utility classes were ineffective due to the internal Flexbox

[WEB-621](https://mifosforge.jira.com/browse/WEB-621)

Before:
<img width="1451" height="907" alt="Screenshot 2026-01-23 191943" src="https://github.com/user-attachments/assets/431df04a-f09c-4521-aa44-8975f9014cc9" />
After:
<img width="1902" height="974" alt="image" src="https://github.com/user-attachments/assets/3e1c6dde-9c7a-49a3-a36d-6053e5341546" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-621]: https://mifosforge.jira.com/browse/WEB-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ