### PR TITLE
WEB-623 refactor: remove hard-coded back-routing for component reload

### DIFF
--- a/src/app/core/services/data-reload.service.ts
+++ b/src/app/core/services/data-reload.service.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Injectable } from '@angular/core';
+import { ReplaySubject, Observable } from 'rxjs';
+
+/**
+ * Service to handle component data reloading without navigation hacks.
+ * Provides a clean way to trigger data refreshes across the application.
+ * Uses ReplaySubject to handle late subscribers and race conditions.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class DataReloadService {
+  private reloadSubjects = new Map<string, ReplaySubject<void>>();
+
+  /**
+   * Gets or creates a reload observable for a specific component/context.
+   * @param context Unique identifier for the reload context (e.g., 'savings-account', 'loan-view')
+   * @returns Observable that emits when a reload is triggered
+   */
+  getReloadObservable(context: string): Observable<void> {
+    if (!this.reloadSubjects.has(context)) {
+      this.reloadSubjects.set(context, new ReplaySubject<void>(1));
+    }
+    return this.reloadSubjects.get(context)!.asObservable();
+  }
+
+  /**
+   * Triggers a reload for the specified context.
+   * All components subscribed to this context will be notified.
+   * Late subscribers will immediately receive the last reload notification.
+   * @param context Unique identifier for the reload context
+   */
+  triggerReload(context: string): void {
+    if (!this.reloadSubjects.has(context)) {
+      this.reloadSubjects.set(context, new ReplaySubject<void>(1));
+    }
+    this.reloadSubjects.get(context)!.next();
+  }
+
+  /**
+   * Cleanup method to remove subjects when they're no longer needed.
+   * @param context Unique identifier for the reload context
+   */
+  cleanup(context: string): void {
+    if (this.reloadSubjects.has(context)) {
+      this.reloadSubjects.get(context)!.complete();
+      this.reloadSubjects.delete(context);
+    }
+  }
+}


### PR DESCRIPTION
This PR cleans up the way components reload their data. Earlier, reloading was done by navigating to another route and then coming back using hard-coded paths. This made the code harder to maintain and caused unnecessary routing just to refresh data.

With this change, components reload their data through a shared reload service instead of using route navigation. This keeps routing and data refresh separate, makes the code easier to understand, and provides a consistent approach that can be reused across components.

[WEB-623](https://mifosforge.jira.com/browse/WEB-623)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-623]: https://mifosforge.jira.com/browse/WEB-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ