### PR TITLE
WEB-622 To have a button for printing a loan application

### DIFF
--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -182,6 +182,18 @@
       <ng-container matColumnDef="Actions">
         <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
         <td mat-cell class="center" *matCellDef="let element">
+          <!-- Print Icon -->
+          <button
+            class="account-action-button"
+            mat-raised-button
+            color="accent"
+            matTooltip="{{ 'tooltips.Print Loan Application' | translate }}"
+            matTooltipPosition="above"
+            aria-label="{{ 'tooltips.Print Loan Application' | translate }}"
+            (click)="openLoanApplicationReport($event, element.id)"
+          >
+            <i class="fa fa-print"></i>
+          </button>
           @if (element.status.active) {
             <button
               class="account-action-button"
@@ -303,6 +315,22 @@
       <ng-container matColumnDef="Closed Date">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
         <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+      </ng-container>
+      <ng-container matColumnDef="Actions">
+        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+        <td mat-cell class="center" *matCellDef="let element">
+          <!-- Print Icon -->
+          <button
+            class="account-action-button"
+            mat-raised-button
+            color="accent"
+            matTooltip="{{ 'tooltips.Print Loan Application' | translate }}"
+            matTooltipPosition="above"
+            (click)="openLoanApplicationReport($event, element.id)"
+          >
+            <i class="fa fa-print"></i>
+          </button>
+        </td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="closedLoansColumns"></tr>
       <tr

--- a/src/app/clients/clients-view/general-tab/general-tab.component.ts
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.ts
@@ -8,6 +8,7 @@
 
 /** Angular Imports */
 import { Component, OnInit, inject } from '@angular/core';
+import { environment } from '../../../../environments/environment';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services. */
@@ -66,6 +67,17 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   ]
 })
 export class GeneralTabComponent {
+  openLoanApplicationReport(event: MouseEvent, loanId: string) {
+    event.stopPropagation();
+    const baseApiUrl = environment.baseApiUrl?.replace(/\/$/, '') || '';
+    const apiProvider = environment.apiProvider?.replace(/\/$/, '') || '';
+    const apiVersion = environment.apiVersion?.replace(/\/$/, '') || '';
+    const tenantIdentifier = environment.fineractPlatformTenantId || 'default';
+    const locale = environment.defaultLanguage || 'en';
+    const dateFormat = 'dd MMMM yyyy';
+    const reportUrl = `${baseApiUrl}${apiProvider}${apiVersion}/runreports/LoanApplicationReport?tenantIdentifier=${tenantIdentifier}&locale=${locale}&dateFormat=${encodeURIComponent(dateFormat)}&R_loanId=${loanId}&output-type=PDF`;
+    window.open(reportUrl, '_blank', 'noopener,noreferrer');
+  }
   private route = inject(ActivatedRoute);
   private clientService = inject(ClientsService);
   private router = inject(Router);
@@ -88,7 +100,8 @@ export class GeneralTabComponent {
     'Loan Balance',
     'Amount Paid',
     'Type',
-    'Closed Date'
+    'Closed Date',
+    'Actions'
   ];
   /** Open Savings Accounts Columns */
   openSavingsColumns: string[] = [

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3555,6 +3555,7 @@
     "Activate": "aktivovat",
     "Add": "Přidat",
     "Add Filters": "Přidat filtry",
+    "Print Loan Application": "Tisknout žádost o úvěr",
     "Adjust Charge": "Upravte nabíjení",
     "After the minimum deposit term has passed": "Po uplynutí minimální doby vkladu mohou být stanoveny další doby trvání vkladu.",
     "Allocate Cash": "Přidělte hotovost",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3555,6 +3555,7 @@
     "Activate": "aktivieren Sie",
     "Add": "Hinzufügen",
     "Add Filters": "Filter hinzufügen",
+    "Print Loan Application": "Darlehensantrag drucken",
     "Adjust Charge": "Ladung anpassen",
     "After the minimum deposit term has passed": "Nach Ablauf der Mindesteinzahlungsdauer können zusätzliche Einzahlungsdauern festgelegt werden.",
     "Allocate Cash": "Bargeld zuweisen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3667,6 +3667,7 @@
     "Activate": "Activate",
     "Add": "Add",
     "Add Filters": "Add Filters",
+    "Print Loan Application": "Print Loan Application",
     "Adjust Charge": "Adjust Charge",
     "After the minimum deposit term has passed": "After the minimum deposit term has passed, additional deposit durations may be specified.",
     "Allocate Cash": "Allocate Cash",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3558,6 +3558,7 @@
     "Add future share value with date range": "Agregar valor compartido futuro con rango de fechas",
     "Activate": "Activar",
     "Add": "Agregar",
+    "Print Loan Application": "Imprimir solicitud de préstamo",
     "Add Filters": "Agregar filtros",
     "Adjust Charge": "Ajustar Comisión",
     "After the minimum deposit term has passed": "Una vez transcurrido el plazo mínimo de depósito, se pueden especificar duraciones de depósito adicionales.",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3562,6 +3562,7 @@
     "Activate": "Activar",
     "Add": "Agregar",
     "Add Filters": "Agregar filtros",
+    "Print Loan Application": "Imprimir solicitud de préstamo",
     "Adjust Charge": "Ajustar Comisión",
     "After the minimum deposit term has passed": "Una vez transcurrido el plazo mínimo de depósito, se pueden especificar duraciones de depósito adicionales.",
     "Allocate Cash": "Asignar efectivo",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3557,6 +3557,7 @@
     "Activate": "Activer",
     "Add": "Ajouter",
     "Add Filters": "Ajouter des filtres",
+    "Print Loan Application": "Imprimer la demande de prêt",
     "Adjust Charge": "Ajuster les frais",
     "After the minimum deposit term has passed": "Une fois la durée minimale de dépôt dépassée, des durées de dépôt supplémentaires peuvent être spécifiées.",
     "Allocate Cash": "Allouer de l'argent",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3557,6 +3557,7 @@
     "Activate": "Attivare",
     "Add": "Aggiungere",
     "Add Filters": "Aggiungi filtri",
+    "Print Loan Application": "Stampa domanda di prestito",
     "Adjust Charge": "Regola la carica",
     "After the minimum deposit term has passed": "Una volta trascorso il termine minimo di deposito, è possibile specificare durate di deposito aggiuntive.",
     "Allocate Cash": "Assegnare contanti",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3558,6 +3558,7 @@
     "Activate": "활성화",
     "Add": "추가하다",
     "Add Filters": "필터 추가",
+    "Print Loan Application": "대출 신청서 인쇄",
     "Adjust Charge": "요금 조정",
     "After the minimum deposit term has passed": "최소 입금 기간이 지난 후 추가 입금 기간을 지정할 수 있습니다.",
     "Allocate Cash": "현금 할당",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3558,6 +3558,7 @@
     "Activate": "Suaktyvinti",
     "Add": "Papildyti",
     "Add Filters": "Pridėti filtrus",
+    "Print Loan Application": "Spausdinti paskolos paraišką",
     "Adjust Charge": "Sureguliuokite įkrovimą",
     "After the minimum deposit term has passed": "Pasibaigus minimaliam indėlio terminui, gali būti nurodytos papildomos indėlio trukmės.",
     "Allocate Cash": "Paskirstykite grynuosius pinigus",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3558,6 +3558,7 @@
     "Activate": "Aktivizēt",
     "Add": "Pievienot",
     "Add Filters": "Pievienot filtrus",
+    "Print Loan Application": "Drukāt aizdevuma pieteikumu",
     "Adjust Charge": "Pielāgojiet uzlādi",
     "After the minimum deposit term has passed": "Pēc minimālā depozīta termiņa beigām var tikt noteikti papildu depozīta termiņi.",
     "Allocate Cash": "Piešķirt skaidru naudu",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3558,6 +3558,7 @@
     "Add": "थप्नुहोस्",
     "Add Filters": "फिल्टरहरू थप्नुहोस्",
     "Adjust Charge": "चार्ज समायोजन गर्नुहोस्",
+    "Print Loan Application": "ऋण आवेदन छाप्नुहोस्",
     "After the minimum deposit term has passed": "न्यूनतम जम्मा अवधि समाप्त भएपछि, थप जम्मा अवधि निर्दिष्ट गर्न सकिन्छ।",
     "Allocate Cash": "नगद आवंटित गर्नुहोस्",
     "Allowed": "अनुमति दिइयो",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3558,6 +3558,7 @@
     "Activate": "Ativar",
     "Add": "Adicionar",
     "Add Filters": "Adicionar filtros",
+    "Print Loan Application": "Imprimir Pedido de Empréstimo",
     "Adjust Charge": "Ajustar carga",
     "After the minimum deposit term has passed": "Depois que o prazo mínimo de depósito tiver passado, durações adicionais de depósito poderão ser especificadas.",
     "Allocate Cash": "Alocar dinheiro",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3558,6 +3558,7 @@
     "After the minimum deposit term has passed": "Baada ya muda wa chini wa amana kupita, muda wa ziada wa amana unaweza kubainishwa.",
     "Allocate Cash": "Tenga Pesa",
     "Allowed": "Ruhusiwa",
+    "Print Loan Application": "Chapisha Ombi la Mkopo",
     "Amount to be rounded off": "Kiasi kitakachopunguzwa (mfano: raundi 100 hadi 200, 300, 400, n.k)",
     "An boolean flag to attach": "Alama ya boolean ya kuambatisha ushuru kwa uchapishaji wa faida",
     "An boolean flag to attach  taxes to interest posting": "Alama ya boolean ya kuambatisha ushuru kwa uchapishaji wa faida",


### PR DESCRIPTION
**Changes Made :-**

-Added a print (printer) icon to the Actions column in the Loan Accounts section on the Client page.
-The print icon is always visible for all loan statuses (requested, pending, active, closed, etc.).
-Clicking the icon opens the Pentaho Loan Application Report in a new tab, passing the correct loanId dynamically as a parameter.

[WEB-622](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-622)

Before :- 
<img width="1024" height="575" alt="image" src="https://github.com/user-attachments/assets/b74de051-593a-4946-9ca9-4eab7e2828d5" />

After :- 
<img width="1060" height="272" alt="image" src="https://github.com/user-attachments/assets/b46ee321-f84f-496f-844c-df753cec7d4c" />


[WEB-622]: https://mifosforge.jira.com/browse/WEB-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Print action (accent-styled button with tooltip "Print Loan Application") to Actions columns in Loan Accounts (open loans), Closed Loans, and Closed Loan Accounts; opens the Loan Application report in a new browser tab for printing.
* **Localization**
  * Added "Print Loan Application" translations for multiple locales so the new Print action is localized.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->