### PR TITLE
WEB-626 fix data table array mutation

### DIFF
--- a/src/app/system/manage-data-tables/data-table.resolver.ts
+++ b/src/app/system/manage-data-tables/data-table.resolver.ts
@@ -25,7 +25,8 @@ export class DataTableResolver {
 
   /**
    * Returns the Data Table data.
-   * TODO: Delete the extra column to avoid multiple usages of `this.columnsData.shift()`.
+   * Note: System columns (id, created_at, updated_at) are filtered by components
+   * using the Datatables.filterSystemColumns() utility method.
    * @returns {Observable<any>}
    */
   resolve(route: ActivatedRouteSnapshot): Observable<any> {

--- a/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.ts
+++ b/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.ts
@@ -29,6 +29,7 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 /** Custom Services */
 import { SystemService } from '../../system.service';
+import { Datatables } from 'app/core/utils/datatables';
 
 /** Data Imports */
 import { appTableData, entitySubTypeData } from '../app-table-data';
@@ -77,6 +78,7 @@ export class EditDataTableComponent implements OnInit {
   private router = inject(Router);
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  public datatables = inject(Datatables);
 
   /** Data Table Form. */
   dataTableForm: UntypedFormGroup;
@@ -225,13 +227,11 @@ export class EditDataTableComponent implements OnInit {
 
   /**
    * Initializes data table changes and column data.
+   * Filters out system columns (id, created_at, updated_at) using centralized utility.
    */
   initData() {
-    // Remove the 'id' column if it exists (primary key for multi-row datatables)
-    // but keep the relationship column visible (it's already marked as system)
-    if (this.columnData.length > 0 && this.columnData[0].columnName === 'id') {
-      this.columnData.shift();
-    }
+    // Use filterSystemColumns to remove all system fields consistently
+    this.columnData = this.datatables.filterSystemColumns(this.columnData);
 
     this.dataTableChangesData.apptableName = this.dataTableData.applicationTableName;
     this.dataTableChangesData.entitySubType = this.dataTableData.entitySubType;

--- a/src/app/system/manage-data-tables/view-data-table/view-data-table.component.ts
+++ b/src/app/system/manage-data-tables/view-data-table/view-data-table.component.ts
@@ -124,11 +124,12 @@ export class ViewDataTableComponent implements OnInit {
 
   /**
    * Initializes the data source, paginator and sorter for columns table.
+   * Filters out system columns (id, created_at, updated_at) using centralized utility.
    */
   setColumnsTable() {
-    this.columnsData.shift();
-    // TODO: Figure out a better approach in order to pass only updated parameters instead of all of them.
-    this.dataSource = new MatTableDataSource(this.columnsData);
+    // Use filterSystemColumns to remove system fields without mutating original data
+    const filteredColumns = this.datatables.filterSystemColumns(this.columnsData);
+    this.dataSource = new MatTableDataSource(filteredColumns);
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
   }


### PR DESCRIPTION
This PR fixes a critical array mutation bug in the data tables module that caused columns to disappear each time users refreshed the page or navigated back to data table views

[WEB-626](https://mifosforge.jira.com/browse/WEB-626)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-626]: https://mifosforge.jira.com/browse/WEB-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved consistency in filtering system columns (id, created_at, updated_at) across data table management components using a centralized utility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->