### PR TITLE
WEB-627 Implement Report Service in the Loan Application Print Icon

### DIFF
--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -893,4 +893,14 @@
       [routerLink]="['../', 'client-collateral', row.collateralId]"
     ></tr>
   </table>
+
+  <!-- PDF Viewer Modal -->
+  <div *ngIf="showPdf" class="pdf-modal-overlay">
+    <div class="pdf-modal-content">
+      <button mat-icon-button class="pdf-modal-close" (click)="closePdf()" aria-label="Close PDF">
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <embed [src]="pdfUrl" type="application/pdf" width="100%" height="600px" />
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Chnages Made :- 

-Implement report service in the loan application print icon.

[WEB-627 ](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-627)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app PDF viewer modal for loan application reports so users can view documents without opening external windows.
  * Close button to dismiss the PDF viewer; viewer can be opened from the collateral table area.

* **Bug Fixes / Reliability**
  * Service-driven report loading with improved error handling and user alerts.
  * Proper cleanup of viewer resources on close and component destruction to prevent memory leaks and stale links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->