### PR TITLE
WEB-630 Days till field allows negative values in create delinquency range form

### DIFF
--- a/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.html
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.html
@@ -24,7 +24,7 @@
 
           <mat-form-field>
             <mat-label>{{ 'labels.inputs.Days From' | translate }}</mat-label>
-            <input matInput type="number" required formControlName="minimumAgeDays" min="1" />
+            <input matInput type="number" required formControlName="minimumAgeDays" min="0" />
             @if (delinquencyRangeForm.controls.minimumAgeDays.hasError('required')) {
               <mat-error>
                 {{ 'labels.inputs.Days From' | translate }} {{ 'labels.commons.is' | translate }}
@@ -38,7 +38,7 @@
 
           <mat-form-field>
             <mat-label>{{ 'labels.inputs.Days Till' | translate }}</mat-label>
-            <input matInput type="number" formControlName="maximumAgeDays" />
+            <input matInput type="number" required formControlName="maximumAgeDays" min="1" />
           </mat-form-field>
         </div>
       </mat-card-content>

--- a/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.ts
@@ -48,14 +48,15 @@ export class CreateRangeComponent implements OnInit {
         0,
         [
           Validators.required,
-          Validators.pattern('^(0*[1-9][0-9]*?)$'),
+          Validators.pattern('^(0|[1-9][0-9]*)$'),
           Validators.max(1000)
         ]
       ],
       maximumAgeDays: [
         '',
         [
-          Validators.pattern('^(0*[1-9][0-9]*?)$'),
+          Validators.required,
+          Validators.pattern('^(0*[1-9][0-9]*)$'),
           Validators.max(10000)
         ]
       ]


### PR DESCRIPTION
**Changes Made :-**

-Set the minimum value for "Days Till" fields to 1 to prevent zero or negative input.

[WEB-630](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-630)

Before :-
<img width="1361" height="712" alt="image" src="https://github.com/user-attachments/assets/f76ca1cd-14bb-40cf-96c3-25deb2945163" />

After :-
<img width="1361" height="637" alt="image" src="https://github.com/user-attachments/assets/3ddd7472-a706-4054-b2c9-d425674b4b3b" />


[WEB-630]: https://mifosforge.jira.com/browse/WEB-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation for delinquency-range creation: maximum-age field is now required and enforces positive values, while minimum-age now allows zero. Validation rules and error feedback were tightened to prevent invalid entries and provide clearer UI guidance when configuring age ranges.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->