### PR TITLE
WEB-631 Set currency in multiples of field default to blank in loan product form

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
@@ -45,7 +45,7 @@ export class LoanProductCurrencyStepComponent implements OnInit {
       digitsAfterDecimal: this.loanProductsTemplate.currency.decimalPlaces
         ? this.loanProductsTemplate.currency.decimalPlaces
         : 2,
-      inMultiplesOf: this.loanProductsTemplate.currency.inMultiplesOf ?? 1,
+      inMultiplesOf: this.loanProductsTemplate.currency.inMultiplesOf || '',
       installmentAmountInMultiplesOf: this.loanProductsTemplate.installmentAmountInMultiplesOf ?? 1
     });
   }
@@ -64,7 +64,7 @@ export class LoanProductCurrencyStepComponent implements OnInit {
         ]
       ],
       inMultiplesOf: [
-        1,
+        '',
         [
           Validators.required,
           Validators.min(1)


### PR DESCRIPTION
**Changes Made :-**

-Set the default value of the "Currency in multiples of" field to blank in the Loan Product.

[WEB-631](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-631)

Before :-
<img width="1117" height="865" alt="image" src="https://github.com/user-attachments/assets/8ff58c45-fefe-46c3-8cae-584ad9adac6c" />

After :-
<img width="1070" height="267" alt="image" src="https://github.com/user-attachments/assets/46a73cd7-6b07-4d96-b468-9ef4ac0acd4b" />



[WEB-631]: https://mifosforge.jira.com/browse/WEB-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ