### PR TITLE
WEB-632 Set installment in multiples of and decimal places fields to empty by default in loan product form

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
@@ -42,11 +42,24 @@ export class LoanProductCurrencyStepComponent implements OnInit {
     this.currencyData = this.loanProductsTemplate.currencyOptions;
     this.loanProductCurrencyForm.patchValue({
       currencyCode: this.loanProductsTemplate.currency.code || this.currencyData[0].code,
-      digitsAfterDecimal: this.loanProductsTemplate.currency.decimalPlaces
-        ? this.loanProductsTemplate.currency.decimalPlaces
-        : 2,
-      inMultiplesOf: this.loanProductsTemplate.currency.inMultiplesOf || '',
-      installmentAmountInMultiplesOf: this.loanProductsTemplate.installmentAmountInMultiplesOf ?? 1
+      digitsAfterDecimal:
+        this.loanProductsTemplate.currency.decimalPlaces === 0 ||
+        this.loanProductsTemplate.currency.decimalPlaces === undefined ||
+        this.loanProductsTemplate.currency.decimalPlaces === null
+          ? ''
+          : this.loanProductsTemplate.currency.decimalPlaces,
+      inMultiplesOf:
+        this.loanProductsTemplate.currency.inMultiplesOf === 0 ||
+        this.loanProductsTemplate.currency.inMultiplesOf === undefined ||
+        this.loanProductsTemplate.currency.inMultiplesOf === null
+          ? ''
+          : this.loanProductsTemplate.currency.inMultiplesOf,
+      installmentAmountInMultiplesOf:
+        this.loanProductsTemplate.installmentAmountInMultiplesOf === 0 ||
+        this.loanProductsTemplate.installmentAmountInMultiplesOf === undefined ||
+        this.loanProductsTemplate.installmentAmountInMultiplesOf === null
+          ? ''
+          : this.loanProductsTemplate.installmentAmountInMultiplesOf
     });
   }
 
@@ -57,7 +70,7 @@ export class LoanProductCurrencyStepComponent implements OnInit {
         Validators.required
       ],
       digitsAfterDecimal: [
-        2,
+        '',
         [
           Validators.required,
           Validators.min(0)


### PR DESCRIPTION
**Changes Made :-**

-Set the "Installment in multiples of" and "Decimal Places" fields in the Loan Product form to be empty by default.

[WEB-631](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-632)

Before :- 
<img width="519" height="197" alt="image" src="https://github.com/user-attachments/assets/738e1806-c453-4232-a824-4d98a4f0358e" />

After :-
<img width="488" height="161" alt="image" src="https://github.com/user-attachments/assets/98e7653a-a062-46c3-bf58-505171c71a65" />


[WEB-631]: https://mifosforge.jira.com/browse/WEB-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Form defaults in the currency configuration step now use empty placeholders for decimal precision and multiple-based fields (including installment amounts) instead of numeric defaults.
  * Initialization and update logic preserved currency selection behavior while aligning field defaults with validation and UX expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->