### PR TITLE
Fix: Unable to create Savings Account with Charges (Date Format Mismatch)

### DIFF
--- a/src/app/savings/create-savings-account/create-savings-account.component.ts
+++ b/src/app/savings/create-savings-account/create-savings-account.component.ts
@@ -133,8 +133,10 @@ export class CreateSavingsAccountComponent {
       charges: this.savingsAccount.charges.map((charge: any) => ({
         chargeId: charge.id,
         amount: charge.amount,
-        dueDate: charge.dueDate,
-        feeOnMonthDay: charge.feeOnMonthDay,
+        dueDate: charge.dueDate ? this.dateUtils.formatDate(charge.dueDate, dateFormat) : charge.dueDate,
+        feeOnMonthDay: charge.feeOnMonthDay
+          ? this.dateUtils.formatDate(charge.feeOnMonthDay, monthDayFormat)
+          : charge.feeOnMonthDay,
         feeInterval: charge.feeInterval
       })),
       submittedOnDate: this.dateUtils.formatDate(this.savingsAccount.submittedOnDate, dateFormat),


### PR DESCRIPTION
Fixed a bug where dueDate and feeOnMonthDay were sent as raw Date objects, causing API failure. Used dateUtils.formatDate to convert them to strings matching the global date format. Relates to PR #2713 (Fixes the blocker identified there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date-related charge fields for savings account creation are now formatted as strings before submission, ensuring due dates and month-day fee values are processed consistently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->