### PR TITLE
WEB-216: UI allows to delete a group that is not "pending", but Fineract sends back error

### DIFF
--- a/src/app/groups/groups-view/groups-view.component.html
+++ b/src/app/groups/groups-view/groups-view.component.html
@@ -198,7 +198,13 @@
           <button mat-menu-item *mifosxHasPermission="'CLOSE_GROUP'" (click)="doAction('Close')">
             {{ 'labels.buttons.Close' | translate }}
           </button>
-          <button mat-menu-item *mifosxHasPermission="'DELETE_GROUP'" (click)="doAction('Delete')">
+          <button
+            mat-menu-item
+            *mifosxHasPermission="'DELETE_GROUP'"
+            [disabled]="!canDeleteGroup()"
+            matTooltip="Only pending groups can be deleted"
+            (click)="doAction('Delete')"
+          >
             {{ 'labels.buttons.Delete' | translate }}
           </button>
         </mat-menu>

--- a/src/app/groups/groups-view/groups-view.component.ts
+++ b/src/app/groups/groups-view/groups-view.component.ts
@@ -143,6 +143,9 @@ export class GroupsViewComponent implements OnInit, OnDestroy {
         this.unassignStaff();
         break;
       case 'Delete':
+        if (!this.canDeleteGroup()) {
+          return;
+        }
         this.deleteGroup();
         break;
     }
@@ -192,6 +195,13 @@ export class GroupsViewComponent implements OnInit, OnDestroy {
           .subscribe(() => this.reload());
       }
     });
+  }
+  /**
+   * Checks if the group can be deleted.
+   * Only groups in Pending state are allowed to be deleted.
+   */
+  canDeleteGroup(): boolean {
+    return this.groupViewData?.status?.value === 'Pending';
   }
 
   /**


### PR DESCRIPTION
[WEB-216](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?issueType=1&selectedIssue=WEB-216)
The delete group action was previously available in the UI for all group states, even though deletion is only allowed when a group is in the Pending state. This resulted in forbidden API calls and a confusing user experience.

This change disables the Delete action in the group actions menu when the group is not in a Pending state and adds a defensive guard in the component logic to prevent invalid delete attempts. This aligns the UI behavior with backend business rules and improves overall usability.

No additional dependencies are required for this change.

<img width="1470" height="875" alt="image" src="https://github.com/user-attachments/assets/01b0e3a3-ed0a-4d6c-90bc-66a4f3ff0d36" />





[WEB-216]: https://mifosforge.jira.com/browse/WEB-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Group deletion is now restricted to pending groups only; users attempting to delete other groups will see a disabled button with a clarifying tooltip.
  * Improved locale normalization in loan application reports for better accuracy across different regional settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->