### PR TITLE
WEB-637 :- Display "No Data Available" message instead of empty tables on Client General Tab

### DIFF
--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -54,67 +54,73 @@
     </div>
   </div>
 
-  <table mat-table [dataSource]="upcomingCharges">
-    <ng-container matColumnDef="Name">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.name' | translate }}</th>
-      <td mat-cell *matCellDef="let element">
-        <i class="fa fa-stop" [ngClass]="!(element.isWaived || element.isPaid) | statusLookup"></i> {{ element.name }}
-      </td>
-    </ng-container>
+  @if (upcomingCharges?.length === 0) {
+    <div class="no-data-message">
+      <p>{{ 'labels.messages.No Upcoming Charges Available' | translate }}</p>
+    </div>
+  } @else {
+    <table mat-table [dataSource]="upcomingCharges">
+      <ng-container matColumnDef="Name">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.name' | translate }}</th>
+        <td mat-cell *matCellDef="let element">
+          <i class="fa fa-stop" [ngClass]="!(element.isWaived || element.isPaid) | statusLookup"></i> {{ element.name }}
+        </td>
+      </ng-container>
 
-    <ng-container matColumnDef="Due as of">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Due as of' | translate }}</th>
-      <td mat-cell *matCellDef="let element">{{ element.dueDate | dateFormat }}</td>
-    </ng-container>
+      <ng-container matColumnDef="Due as of">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Due as of' | translate }}</th>
+        <td mat-cell *matCellDef="let element">{{ element.dueDate | dateFormat }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="Due">
-      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Due' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let element">{{ element.amount | formatNumber }}</td>
-    </ng-container>
+      <ng-container matColumnDef="Due">
+        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Due' | translate }}</th>
+        <td mat-cell class="r-amount" *matCellDef="let element">{{ element.amount | formatNumber }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="Paid">
-      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Paid' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let element">{{ element.amountPaid | formatNumber }}</td>
-    </ng-container>
+      <ng-container matColumnDef="Paid">
+        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Paid' | translate }}</th>
+        <td mat-cell class="r-amount" *matCellDef="let element">{{ element.amountPaid | formatNumber }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="Waived">
-      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Waived' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let element">{{ element.amountWaived | formatNumber }}</td>
-    </ng-container>
+      <ng-container matColumnDef="Waived">
+        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Waived' | translate }}</th>
+        <td mat-cell class="r-amount" *matCellDef="let element">{{ element.amountWaived | formatNumber }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="Outstanding">
-      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Outstanding' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let element">{{ element.amountOutstanding | formatNumber }}</td>
-    </ng-container>
+      <ng-container matColumnDef="Outstanding">
+        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Outstanding' | translate }}</th>
+        <td mat-cell class="r-amount" *matCellDef="let element">{{ element.amountOutstanding | formatNumber }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="Actions">
-      <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-      <td mat-cell class="center" *matCellDef="let element">
-        <button
-          class="account-action-button"
-          mat-raised-button
-          color="primary"
-          (click)="routeEdit($event)"
-          [routerLink]="['../', 'charges', element.id, 'pay']"
-          *mifosxHasPermission="'PAY_CLIENTCHARGE'"
-        >
-          <i class="fa fa-dollar"></i>
-        </button>
-        <button
-          class="account-action-button"
-          mat-raised-button
-          color="primary"
-          (click)="routeEdit($event); waiveCharge(element.id, element.clientId)"
-          *mifosxHasPermission="'WAIVE_CLIENTCHARGE'"
-        >
-          <i class="fa fa-flag"></i>
-        </button>
-      </td>
-    </ng-container>
+      <ng-container matColumnDef="Actions">
+        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+        <td mat-cell class="center" *matCellDef="let element">
+          <button
+            class="account-action-button"
+            mat-raised-button
+            color="primary"
+            (click)="routeEdit($event)"
+            [routerLink]="['../', 'charges', element.id, 'pay']"
+            *mifosxHasPermission="'PAY_CLIENTCHARGE'"
+          >
+            <i class="fa fa-dollar"></i>
+          </button>
+          <button
+            class="account-action-button"
+            mat-raised-button
+            color="primary"
+            (click)="routeEdit($event); waiveCharge(element.id, element.clientId)"
+            *mifosxHasPermission="'WAIVE_CLIENTCHARGE'"
+          >
+            <i class="fa fa-flag"></i>
+          </button>
+        </td>
+      </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="upcomingChargesColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: upcomingChargesColumns" [routerLink]="['../', 'charges', row.id]"></tr>
-  </table>
+      <tr mat-header-row *matHeaderRowDef="upcomingChargesColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: upcomingChargesColumns" [routerLink]="['../', 'charges', row.id]"></tr>
+    </table>
+  }
 
   <!-- loans accounts overview table -->
   <div class="heading-content">
@@ -133,213 +139,225 @@
   </div>
 
   @if (!showClosedLoanAccounts) {
-    <table mat-table [dataSource]="loanAccounts | accountsFilter: 'loan'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i
-            class="fa fa-stop"
-            [ngClass]="element.inArrears ? 'status-active-overdue' : (element.status.code | statusLookup)"
-          ></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Loan Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Loan Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Original Loan">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Original Loan' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          {{ element.originalLoan | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Loan Balance">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Loan Balance' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let element">
-          {{ element.loanBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Amount Paid">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Amount Paid' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let element">
-          {{ element.amountPaid | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Type">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Type' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          <i
-            class="fa fa-large"
-            [ngClass]="element.loanType.value === 'Individual' ? 'fa-user' : 'fa-group'"
-            matTooltip="{{ element.loanType.value }}"
-            matTooltipPosition="above"
-          ></i>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Actions">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          <!-- Print Icon -->
-          <button
-            class="account-action-button"
-            mat-raised-button
-            color="accent"
-            matTooltip="{{ 'tooltips.Print Loan Application' | translate }}"
-            matTooltipPosition="above"
-            aria-label="{{ 'tooltips.Print Loan Application' | translate }}"
-            (click)="openLoanApplicationReport($event, element.id)"
-          >
-            <i class="fa fa-print"></i>
-          </button>
-          @if (element.status.active) {
+    @if ((loanAccounts | accountsFilter: 'loan')?.length === 0) {
+      <div class="no-data-message">
+        <p>{{ 'labels.messages.No Active Loan Accounts Available' | translate }}</p>
+      </div>
+    } @else {
+      <table mat-table [dataSource]="loanAccounts | accountsFilter: 'loan'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i
+              class="fa fa-stop"
+              [ngClass]="element.inArrears ? 'status-active-overdue' : (element.status.code | statusLookup)"
+            ></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Loan Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Loan Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Original Loan">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Original Loan' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            {{ element.originalLoan | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Loan Balance">
+          <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Loan Balance' | translate }}</th>
+          <td mat-cell class="r-amount" *matCellDef="let element">
+            {{ element.loanBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Amount Paid">
+          <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Amount Paid' | translate }}</th>
+          <td mat-cell class="r-amount" *matCellDef="let element">
+            {{ element.amountPaid | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Type">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Type' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            <i
+              class="fa fa-large"
+              [ngClass]="element.loanType.value === 'Individual' ? 'fa-user' : 'fa-group'"
+              matTooltip="{{ element.loanType.value }}"
+              matTooltipPosition="above"
+            ></i>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Actions">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            <!-- Print Icon -->
             <button
               class="account-action-button"
               mat-raised-button
-              color="primary"
-              matTooltip="{{ 'tooltips.Make Repayment' | translate }}"
+              color="accent"
+              matTooltip="{{ 'tooltips.Print Loan Application' | translate }}"
               matTooltipPosition="above"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'loans-accounts', element.id, 'actions', 'Make Repayment']"
+              aria-label="{{ 'tooltips.Print Loan Application' | translate }}"
+              (click)="openLoanApplicationReport($event, element.id)"
             >
-              <i class="fa fa-dollar"></i>
+              <i class="fa fa-print"></i>
             </button>
-          }
-          @if (element.status.pendingApproval) {
-            <span>
+            @if (element.status.active) {
               <button
                 class="account-action-button"
                 mat-raised-button
                 color="primary"
-                matTooltip="{{ 'tooltips.Approve' | translate }}"
+                matTooltip="{{ 'tooltips.Make Repayment' | translate }}"
                 matTooltipPosition="above"
-                *mifosxHasPermission="'APPROVE_LOAN'"
                 (click)="routeEdit($event)"
-                [routerLink]="['../', 'loans-accounts', element.id, 'actions', 'Approve']"
+                [routerLink]="['../', 'loans-accounts', element.id, 'actions', 'Make Repayment']"
               >
-                <i class="fa fa-check"></i>
+                <i class="fa fa-dollar"></i>
               </button>
-            </span>
-          }
-          @if (!element.status.pendingApproval && !element.status.active && !element.status.overpaid) {
-            <span>
-              <button
-                class="account-action-button"
-                mat-raised-button
-                color="primary"
-                matTooltip="{{ 'tooltips.Disburse' | translate }}"
-                matTooltipPosition="above"
-                *mifosxHasPermission="'DISBURSE_LOAN'"
-                (click)="routeEdit($event)"
-                [routerLink]="['../', 'loans-accounts', element.id, 'actions', 'Disburse']"
-              >
-                <i class="fa fa-flag"></i>
-              </button>
-            </span>
-          }
-          @if (!element.status.pendingApproval && !element.status.active && element.status.overpaid) {
-            <span>
-              <button
-                class="account-action-button"
-                mat-raised-button
-                color="primary"
-                matTooltip="{{ 'tooltips.Transfer Funds' | translate }}"
-                matTooltipPosition="above"
-                *mifosxHasPermission="'DISBURSE_LOAN'"
-                (click)="routeEdit($event); routeTransferFund(element.id)"
-              >
-                <i class="fa fa-exchange"></i>
-              </button>
-            </span>
-          }
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="openLoansColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: openLoansColumns"
-        [routerLink]="['../', 'loans-accounts', row.id, 'general']"
-        class="select-row"
-      ></tr>
-    </table>
+            }
+            @if (element.status.pendingApproval) {
+              <span>
+                <button
+                  class="account-action-button"
+                  mat-raised-button
+                  color="primary"
+                  matTooltip="{{ 'tooltips.Approve' | translate }}"
+                  matTooltipPosition="above"
+                  *mifosxHasPermission="'APPROVE_LOAN'"
+                  (click)="routeEdit($event)"
+                  [routerLink]="['../', 'loans-accounts', element.id, 'actions', 'Approve']"
+                >
+                  <i class="fa fa-check"></i>
+                </button>
+              </span>
+            }
+            @if (!element.status.pendingApproval && !element.status.active && !element.status.overpaid) {
+              <span>
+                <button
+                  class="account-action-button"
+                  mat-raised-button
+                  color="primary"
+                  matTooltip="{{ 'tooltips.Disburse' | translate }}"
+                  matTooltipPosition="above"
+                  *mifosxHasPermission="'DISBURSE_LOAN'"
+                  (click)="routeEdit($event)"
+                  [routerLink]="['../', 'loans-accounts', element.id, 'actions', 'Disburse']"
+                >
+                  <i class="fa fa-flag"></i>
+                </button>
+              </span>
+            }
+            @if (!element.status.pendingApproval && !element.status.active && element.status.overpaid) {
+              <span>
+                <button
+                  class="account-action-button"
+                  mat-raised-button
+                  color="primary"
+                  matTooltip="{{ 'tooltips.Transfer Funds' | translate }}"
+                  matTooltipPosition="above"
+                  *mifosxHasPermission="'DISBURSE_LOAN'"
+                  (click)="routeEdit($event); routeTransferFund(element.id)"
+                >
+                  <i class="fa fa-exchange"></i>
+                </button>
+              </span>
+            }
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="openLoansColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: openLoansColumns"
+          [routerLink]="['../', 'loans-accounts', row.id, 'general']"
+          class="select-row"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Closed Loan Accounts -->
   @if (showClosedLoanAccounts) {
-    <table mat-table [dataSource]="loanAccounts | accountsFilter: 'loan' : 'closed'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i
-            class="fa fa-stop"
-            [ngClass]="element.inArrears ? 'status-active-overdue' : (element.status.code | statusLookup)"
-          ></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Loan Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Loan Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Original Loan">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Original Loan' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Loan Balance">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Loan Balance' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let element">
-          {{ element.loanBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Amount Paid">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Amount Paid' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let element">
-          {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Type">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Type' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          <i
-            class="fa fa-large"
-            [ngClass]="element.loanType.value === 'Individual' ? 'fa-user' : 'fa-group'"
-            matTooltip=" {{ element.loanType.value }}"
-            matTooltipPosition="above"
-          ></i>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Closed Date">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Actions">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          <!-- Print Icon -->
-          <button
-            class="account-action-button"
-            mat-raised-button
-            color="accent"
-            matTooltip="{{ 'tooltips.Print Loan Application' | translate }}"
-            matTooltipPosition="above"
-            (click)="openLoanApplicationReport($event, element.id)"
-          >
-            <i class="fa fa-print"></i>
-          </button>
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="closedLoansColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: closedLoansColumns"
-        [routerLink]="['../', 'loans-accounts', row.id, 'general']"
-        class="select-row"
-      ></tr>
-    </table>
+    @if ((loanAccounts | accountsFilter: 'loan' : 'closed')?.length === 0) {
+      <div class="no-data-message">
+        <p>{{ 'labels.messages.No Closed Loan Accounts Available' | translate }}</p>
+      </div>
+    } @else {
+      <table mat-table [dataSource]="loanAccounts | accountsFilter: 'loan' : 'closed'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i
+              class="fa fa-stop"
+              [ngClass]="element.inArrears ? 'status-active-overdue' : (element.status.code | statusLookup)"
+            ></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Loan Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Loan Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Original Loan">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Original Loan' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Loan Balance">
+          <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Loan Balance' | translate }}</th>
+          <td mat-cell class="r-amount" *matCellDef="let element">
+            {{ element.loanBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Amount Paid">
+          <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Amount Paid' | translate }}</th>
+          <td mat-cell class="r-amount" *matCellDef="let element">
+            {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Type">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Type' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            <i
+              class="fa fa-large"
+              [ngClass]="element.loanType.value === 'Individual' ? 'fa-user' : 'fa-group'"
+              matTooltip=" {{ element.loanType.value }}"
+              matTooltipPosition="above"
+            ></i>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Closed Date">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Actions">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            <!-- Print Icon -->
+            <button
+              class="account-action-button"
+              mat-raised-button
+              color="accent"
+              matTooltip="{{ 'tooltips.Print Loan Application' | translate }}"
+              matTooltipPosition="above"
+              (click)="openLoanApplicationReport($event, element.id)"
+            >
+              <i class="fa fa-print"></i>
+            </button>
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="closedLoansColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: closedLoansColumns"
+          [routerLink]="['../', 'loans-accounts', row.id, 'general']"
+          class="select-row"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Saving overview Table -->
@@ -359,124 +377,136 @@
   </div>
 
   @if (!showClosedSavingAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isSavings'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Savings Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Last Active">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Balance">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let element">
-          {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Actions">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          @if (element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Deposit']"
-            >
-              <i class="fa fa-arrow-up"></i>
-            </button>
-          }
-          @if (element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Withdrawal']"
-            >
-              <i class="fa fa-arrow-down"></i>
-            </button>
-          }
-          @if (element.status.submittedAndPendingApproval) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Approve']"
-            >
-              <i class="fa fa-check"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Undo Approval']"
-            >
-              <i class="fa fa-undo"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Activate']"
-            >
-              <i class="fa fa-check-circle"></i>
-            </button>
-          }
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: openSavingsColumns"
-        [routerLink]="['../', 'savings-accounts', row.id, 'general']"
-      ></tr>
-    </table>
+    @if ((savingAccounts | accountsFilter: 'saving' : 'open' : 'isSavings')?.length === 0) {
+      <div class="no-data-message">
+        <p>{{ 'labels.messages.No Active Saving Accounts Available' | translate }}</p>
+      </div>
+    } @else {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isSavings'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Savings Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Last Active">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Balance">
+          <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
+          <td mat-cell class="r-amount" *matCellDef="let element">
+            {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Actions">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            @if (element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Deposit']"
+              >
+                <i class="fa fa-arrow-up"></i>
+              </button>
+            }
+            @if (element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Withdrawal']"
+              >
+                <i class="fa fa-arrow-down"></i>
+              </button>
+            }
+            @if (element.status.submittedAndPendingApproval) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Approve']"
+              >
+                <i class="fa fa-check"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Undo Approval']"
+              >
+                <i class="fa fa-undo"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Activate']"
+              >
+                <i class="fa fa-check-circle"></i>
+              </button>
+            }
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: openSavingsColumns"
+          [routerLink]="['../', 'savings-accounts', row.id, 'general']"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Closed Saving Accounts -->
   @if (showClosedSavingAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isSavings'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Savings Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Closed Date">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: closedSavingsColumns"
-        [routerLink]="['../', 'savings-accounts', row.id, 'general']"
-      ></tr>
-    </table>
+    @if ((savingAccounts | accountsFilter: 'saving' : 'closed' : 'isSavings')?.length === 0) {
+      <div class="no-data-message">
+        <p>{{ 'labels.messages.No Closed Saving Accounts Available' | translate }}</p>
+      </div>
+    } @else {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isSavings'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Savings Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Closed Date">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: closedSavingsColumns"
+          [routerLink]="['../', 'savings-accounts', row.id, 'general']"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Fixed Deposit Table -->
@@ -496,101 +526,113 @@
   </div>
 
   @if (!showClosedFixedAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isFixed'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fixed Deposit Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Last Active">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Balance">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let element">
-          {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Actions">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          @if (element.status.submittedAndPendingApproval) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Approve']"
-            >
-              <i class="fa fa-check"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Undo Approval']"
-            >
-              <i class="fa fa-undo"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Activate']"
-            >
-              <i class="fa fa-check-circle"></i>
-            </button>
-          }
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: openSavingsColumns"
-        [routerLink]="['../', 'fixed-deposits-accounts', row.id, 'general']"
-      ></tr>
-    </table>
+    @if ((savingAccounts | accountsFilter: 'saving' : 'open' : 'isFixed')?.length === 0) {
+      <div class="no-data-message">
+        <p>{{ 'labels.messages.No Active Fixed Deposit Accounts Available' | translate }}</p>
+      </div>
+    } @else {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isFixed'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fixed Deposit Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Last Active">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Balance">
+          <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
+          <td mat-cell class="r-amount" *matCellDef="let element">
+            {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Actions">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            @if (element.status.submittedAndPendingApproval) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Approve']"
+              >
+                <i class="fa fa-check"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Undo Approval']"
+              >
+                <i class="fa fa-undo"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Activate']"
+              >
+                <i class="fa fa-check-circle"></i>
+              </button>
+            }
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: openSavingsColumns"
+          [routerLink]="['../', 'fixed-deposits-accounts', row.id, 'general']"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Closed Fixed Deposit Accounts -->
 
   @if (showClosedFixedAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isFixed'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fixed Deposit Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Closed Date">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: closedSavingsColumns"
-        [routerLink]="['../', 'fixed-deposits-accounts', row.id, 'general']"
-      ></tr>
-    </table>
+    @if ((savingAccounts | accountsFilter: 'saving' : 'closed' : 'isFixed')?.length === 0) {
+      <div class="no-data-message">
+        <p>{{ 'labels.messages.No Closed Fixed Deposit Accounts Available' | translate }}</p>
+      </div>
+    } @else {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isFixed'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fixed Deposit Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Closed Date">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: closedSavingsColumns"
+          [routerLink]="['../', 'fixed-deposits-accounts', row.id, 'general']"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Recurring Deposit Table -->
@@ -610,106 +652,118 @@
   </div>
 
   @if (!showClosedRecurringAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isRecurring'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Recurring Deposit Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Last Active">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Balance">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let element">
-          {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Actions">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          @if (element.status.submittedAndPendingApproval) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              *mifosxHasPermission="'APPROVE_SAVINGSACCOUNT'"
-              [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Approve']"
-              color="primary"
-            >
-              <i class="fa fa-check"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              *mifosxHasPermission="'APPROVALUNDO_SAVINGSACCOUNT'"
-              [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Undo Approval']"
-            >
-              <i class="fa fa-undo"></i>
-            </button>
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              *mifosxHasPermission="'ACTIVATE_SAVINGSACCOUNT'"
-              [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Activate']"
-            >
-              <i class="fa fa-check-circle"></i>
-            </button>
-          }
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: openSavingsColumns"
-        [routerLink]="['../', 'recurring-deposits-accounts', row.id, 'general']"
-        class="select-row"
-      ></tr>
-    </table>
+    @if ((savingAccounts | accountsFilter: 'saving' : 'open' : 'isRecurring')?.length === 0) {
+      <div class="no-data-message">
+        <p>{{ 'labels.messages.No Active Recurring Deposit Accounts Available' | translate }}</p>
+      </div>
+    } @else {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isRecurring'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Recurring Deposit Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Last Active">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Balance">
+          <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
+          <td mat-cell class="r-amount" *matCellDef="let element">
+            {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Actions">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            @if (element.status.submittedAndPendingApproval) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                *mifosxHasPermission="'APPROVE_SAVINGSACCOUNT'"
+                [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Approve']"
+                color="primary"
+              >
+                <i class="fa fa-check"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                *mifosxHasPermission="'APPROVALUNDO_SAVINGSACCOUNT'"
+                [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Undo Approval']"
+              >
+                <i class="fa fa-undo"></i>
+              </button>
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                *mifosxHasPermission="'ACTIVATE_SAVINGSACCOUNT'"
+                [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Activate']"
+              >
+                <i class="fa fa-check-circle"></i>
+              </button>
+            }
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: openSavingsColumns"
+          [routerLink]="['../', 'recurring-deposits-accounts', row.id, 'general']"
+          class="select-row"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Closed Recurring Deposit Accounts -->
   @if (showClosedRecurringAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isRecurring'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Recurring Deposit Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Closed Date">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: closedSavingsColumns"
-        [routerLink]="['../', 'recurring-deposits-accounts', row.id, 'general']"
-        class="select-row"
-      ></tr>
-    </table>
+    @if ((savingAccounts | accountsFilter: 'saving' : 'closed' : 'isRecurring')?.length === 0) {
+      <div class="no-data-message">
+        <p>{{ 'labels.messages.No Closed Recurring Deposit Accounts Available' | translate }}</p>
+      </div>
+    } @else {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isRecurring'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Recurring Deposit Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Closed Date">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: closedSavingsColumns"
+          [routerLink]="['../', 'recurring-deposits-accounts', row.id, 'general']"
+          class="select-row"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Shares overview Table -->
@@ -729,108 +783,120 @@
   </div>
 
   @if (!showClosedShareAccounts) {
-    <table mat-table [dataSource]="shareAccounts | accountsFilter: 'share'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Share Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Share Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Approved Shares">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Approved Shares' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.totalApprovedShares }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Pending For Approval Shares">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Pending For Approval Shares' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.totalPendingForApprovalShares }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Actions">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          @if (element.status.submittedAndPendingApproval) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Approve']"
-            >
-              <i class="fa fa-check"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Undo Approval']"
-            >
-              <i class="fa fa-undo"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Activate']"
-            >
-              <i class="fa fa-check-circle"></i>
-            </button>
-          }
-        </td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="openSharesColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: openSharesColumns"
-        [routerLink]="['../', 'shares-accounts', row.id, 'general']"
-      ></tr>
-    </table>
+    @if ((shareAccounts | accountsFilter: 'share')?.length === 0) {
+      <div class="no-data-message">
+        <p>{{ 'labels.messages.No Active Share Accounts Available' | translate }}</p>
+      </div>
+    } @else {
+      <table mat-table [dataSource]="shareAccounts | accountsFilter: 'share'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Share Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Share Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Approved Shares">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Approved Shares' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.totalApprovedShares }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Pending For Approval Shares">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Pending For Approval Shares' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.totalPendingForApprovalShares }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Actions">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            @if (element.status.submittedAndPendingApproval) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Approve']"
+              >
+                <i class="fa fa-check"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Undo Approval']"
+              >
+                <i class="fa fa-undo"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Activate']"
+              >
+                <i class="fa fa-check-circle"></i>
+              </button>
+            }
+          </td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="openSharesColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: openSharesColumns"
+          [routerLink]="['../', 'shares-accounts', row.id, 'general']"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Closed Share Accounts -->
   @if (showClosedShareAccounts) {
-    <table mat-table [dataSource]="shareAccounts | accountsFilter: 'share' : 'closed'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Share Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Share Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Approved Shares">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Approved Shares' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.totalApprovedShares }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Pending For Approval Shares">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Pending For Approval Shares' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.totalPendingForApprovalShares }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Closed Date">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="closedSharesColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: closedSharesColumns"
-        [routerLink]="['../', 'shares-accounts', row.id, 'general']"
-      ></tr>
-    </table>
+    @if ((shareAccounts | accountsFilter: 'share' : 'closed')?.length === 0) {
+      <div class="no-data-message">
+        <p>{{ 'labels.messages.No Closed Share Accounts Available' | translate }}</p>
+      </div>
+    } @else {
+      <table mat-table [dataSource]="shareAccounts | accountsFilter: 'share' : 'closed'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Share Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Share Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Approved Shares">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Approved Shares' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.totalApprovedShares }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Pending For Approval Shares">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Pending For Approval Shares' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.totalPendingForApprovalShares }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Closed Date">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+        </ng-container>
+        <tr mat-header-row *matHeaderRowDef="closedSharesColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: closedSharesColumns"
+          [routerLink]="['../', 'shares-accounts', row.id, 'general']"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Collateral Data Table -->
@@ -849,50 +915,56 @@
     </div>
   </div>
 
-  <table mat-table [dataSource]="collaterals">
-    <ng-container matColumnDef="ID">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.ID' | translate }}</th>
-      <td mat-cell *matCellDef="let element">{{ element.collateralId }}</td>
-    </ng-container>
+  @if (collaterals?.length === 0) {
+    <div class="no-data-message">
+      <p>{{ 'labels.messages.No Collateral Data Available' | translate }}</p>
+    </div>
+  } @else {
+    <table mat-table [dataSource]="collaterals">
+      <ng-container matColumnDef="ID">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.ID' | translate }}</th>
+        <td mat-cell *matCellDef="let element">{{ element.collateralId }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="Name">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.name' | translate }}</th>
-      <td mat-cell *matCellDef="let element">{{ element.name }}</td>
-    </ng-container>
+      <ng-container matColumnDef="Name">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.name' | translate }}</th>
+        <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="Quantity">
-      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Quantity' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let element">{{ element.quantity | formatNumber }}</td>
-    </ng-container>
+      <ng-container matColumnDef="Quantity">
+        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Quantity' | translate }}</th>
+        <td mat-cell class="r-amount" *matCellDef="let element">{{ element.quantity | formatNumber }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="Total Value">
-      <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Total Value' | translate }}</th>
-      <td mat-cell class="r-amount" *matCellDef="let element">
-        {{
-          element.basePrice * element.quantity | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2'
-        }}
-      </td>
-    </ng-container>
+      <ng-container matColumnDef="Total Value">
+        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Total Value' | translate }}</th>
+        <td mat-cell class="r-amount" *matCellDef="let element">
+          {{
+            element.basePrice * element.quantity | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2'
+          }}
+        </td>
+      </ng-container>
 
-    <ng-container matColumnDef="Total Collateral Value">
-      <th mat-header-cell class="r-amount" *matHeaderCellDef>
-        {{ 'labels.inputs.Total Collateral Value' | translate }}
-      </th>
-      <td mat-cell class="r-amount" *matCellDef="let element">
-        {{
-          (element.pctToBase * element.basePrice * element.quantity) / 100
-            | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2'
-        }}
-      </td>
-    </ng-container>
+      <ng-container matColumnDef="Total Collateral Value">
+        <th mat-header-cell class="r-amount" *matHeaderCellDef>
+          {{ 'labels.inputs.Total Collateral Value' | translate }}
+        </th>
+        <td mat-cell class="r-amount" *matCellDef="let element">
+          {{
+            (element.pctToBase * element.basePrice * element.quantity) / 100
+              | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2'
+          }}
+        </td>
+      </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="collateralsColumns"></tr>
-    <tr
-      mat-row
-      *matRowDef="let row; columns: collateralsColumns"
-      [routerLink]="['../', 'client-collateral', row.collateralId]"
-    ></tr>
-  </table>
+      <tr mat-header-row *matHeaderRowDef="collateralsColumns"></tr>
+      <tr
+        mat-row
+        *matRowDef="let row; columns: collateralsColumns"
+        [routerLink]="['../', 'client-collateral', row.collateralId]"
+      ></tr>
+    </table>
+  }
 
   <!-- PDF Viewer Modal -->
   <div *ngIf="showPdf" class="pdf-modal-overlay">

--- a/src/app/clients/clients-view/general-tab/general-tab.component.scss
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.scss
@@ -56,3 +56,18 @@
   align-items: center; /* Ensure buttons are vertically aligned */
   gap: 0.5rem; /* Add spacing between buttons if needed */
 }
+
+.no-data-message {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: #757575;
+  font-style: italic;
+  background-color: #f5f5f5;
+  border-radius: 4px;
+  margin: 1rem 0;
+
+  p {
+    margin: 0;
+    font-size: 1rem;
+  }
+}

--- a/src/app/clients/clients-view/general-tab/general-tab.component.ts
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.ts
@@ -217,13 +217,13 @@ export class GeneralTabComponent implements OnDestroy {
   /** Client Account Data */
   clientAccountData: any;
   /** Loan Accounts Data */
-  loanAccounts: any;
+  loanAccounts: any[] = [];
   /** Savings Accounts Data */
-  savingAccounts: any;
+  savingAccounts: any[] = [];
   /** Shares Accounts Data */
-  shareAccounts: any;
+  shareAccounts: any[] = [];
   /** Upcoming Charges Data */
-  upcomingCharges: any;
+  upcomingCharges: any[] = [];
   /** Performance History Data */
   performanceHistory: {
     loanCycle: number;
@@ -239,7 +239,7 @@ export class GeneralTabComponent implements OnDestroy {
     totalSavings: 0
   };
   /** Collaterals Data */
-  collaterals: any;
+  collaterals: any[] = [];
 
   /** Show Closed Loan Accounts */
   showClosedLoanAccounts = false;
@@ -264,11 +264,11 @@ export class GeneralTabComponent implements OnDestroy {
     this.route.data.subscribe(
       (data: { clientAccountsData: any; clientChargesData: any; clientSummary: any; clientCollateralData: any }) => {
         this.clientAccountData = data.clientAccountsData;
-        this.savingAccounts = data.clientAccountsData.savingsAccounts;
-        this.loanAccounts = data.clientAccountsData.loanAccounts;
-        this.shareAccounts = data.clientAccountsData.shareAccounts;
-        this.upcomingCharges = data.clientChargesData.pageItems;
-        this.collaterals = data.clientCollateralData;
+        this.savingAccounts = data.clientAccountsData.savingsAccounts || [];
+        this.loanAccounts = data.clientAccountsData.loanAccounts || [];
+        this.shareAccounts = data.clientAccountsData.shareAccounts || [];
+        this.upcomingCharges = data.clientChargesData.pageItems || [];
+        this.collaterals = data.clientCollateralData || [];
         this.clientid = this.route.parent.snapshot.params['clientId'];
 
         // Compute performance history from accounts data

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3527,7 +3527,19 @@
     "Login": "Přihlásit se"
   },
   "messages": {
-    "No Data Found": "Nebyla nalezena žádná data"
+    "No Data Found": "Nebyla nalezena žádná data",
+    "No Upcoming Charges Available": "Žádné nadcházející poplatky k dispozici",
+    "No Active Loan Accounts Available": "Žádné aktivní úvěrové účty k dispozici",
+    "No Closed Loan Accounts Available": "Žádné uzavřené úvěrové účty k dispozici",
+    "No Active Saving Accounts Available": "Žádné aktivní spořicí účty k dispozici",
+    "No Closed Saving Accounts Available": "Žádné uzavřené spořicí účty k dispozici",
+    "No Active Fixed Deposit Accounts Available": "Žádné aktivní vkladové účty k dispozici",
+    "No Closed Fixed Deposit Accounts Available": "Žádné uzavřené vkladové účty k dispozici",
+    "No Active Recurring Deposit Accounts Available": "Žádné aktivní opakující se vkladové účty k dispozici",
+    "No Closed Recurring Deposit Accounts Available": "Žádné uzavřené opakující se vkladové účty k dispozici",
+    "No Active Share Accounts Available": "Žádné aktivní účty podílů k dispozici",
+    "No Closed Share Accounts Available": "Žádné uzavřené účty podílů k dispozici",
+    "No Collateral Data Available": "Žádná data o kolaterálu k dispozici"
   },
   "languages": {
     "cs-CS": "Čeština",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3527,7 +3527,19 @@
     "Login": "Anmeldung"
   },
   "messages": {
-    "No Data Found": "Keine Daten gefunden"
+    "No Data Found": "Keine Daten gefunden",
+    "No Upcoming Charges Available": "Keine bevorstehenden Gebühren verfügbar",
+    "No Active Loan Accounts Available": "Keine aktiven Darlehenskonten verfügbar",
+    "No Closed Loan Accounts Available": "Keine geschlossenen Darlehenskonten verfügbar",
+    "No Active Saving Accounts Available": "Keine aktiven Sparkonten verfügbar",
+    "No Closed Saving Accounts Available": "Keine geschlossenen Sparkonten verfügbar",
+    "No Active Fixed Deposit Accounts Available": "Keine aktiven Festgeldkonten verfügbar",
+    "No Closed Fixed Deposit Accounts Available": "Keine geschlossenen Festgeldkonten verfügbar",
+    "No Active Recurring Deposit Accounts Available": "Keine aktiven wiederkehrenden Einlagenkonten verfügbar",
+    "No Closed Recurring Deposit Accounts Available": "Keine geschlossenen wiederkehrenden Einlagenkonten verfügbar",
+    "No Active Share Accounts Available": "Keine aktiven Aktienkonten verfügbar",
+    "No Closed Share Accounts Available": "Keine geschlossenen Aktienkonten verfügbar",
+    "No Collateral Data Available": "Keine Sicherheitendaten verfügbar"
   },
   "languages": {
     "cs-CS": "Čeština (Tschechisch)",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3638,7 +3638,19 @@
       "Login": "Login"
     },
     "messages": {
-      "No Data Found": "No Data Found"
+      "No Data Found": "No Data Found",
+      "No Upcoming Charges Available": "No Upcoming Charges Available",
+      "No Active Loan Accounts Available": "No Active Loan Accounts Available",
+      "No Closed Loan Accounts Available": "No Closed Loan Accounts Available",
+      "No Active Saving Accounts Available": "No Active Saving Accounts Available",
+      "No Closed Saving Accounts Available": "No Closed Saving Accounts Available",
+      "No Active Fixed Deposit Accounts Available": "No Active Fixed Deposit Accounts Available",
+      "No Closed Fixed Deposit Accounts Available": "No Closed Fixed Deposit Accounts Available",
+      "No Active Recurring Deposit Accounts Available": "No Active Recurring Deposit Accounts Available",
+      "No Closed Recurring Deposit Accounts Available": "No Closed Recurring Deposit Accounts Available",
+      "No Active Share Accounts Available": "No Active Share Accounts Available",
+      "No Closed Share Accounts Available": "No Closed Share Accounts Available",
+      "No Collateral Data Available": "No Collateral Data Available"
     }
   },
   "languages": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3530,7 +3530,19 @@
       "Login": "Acceso"
     },
     "messages": {
-      "No Data Found": "No se encontraron datos"
+      "No Data Found": "No se encontraron datos",
+      "No Upcoming Charges Available": "No hay cargos próximos disponibles",
+      "No Active Loan Accounts Available": "No hay cuentas de crédito activas disponibles",
+      "No Closed Loan Accounts Available": "No hay cuentas de crédito cerradas disponibles",
+      "No Active Saving Accounts Available": "No hay cuentas de ahorro activas disponibles",
+      "No Closed Saving Accounts Available": "No hay cuentas de ahorro cerradas disponibles",
+      "No Active Fixed Deposit Accounts Available": "No hay cuentas de depósito fijo activas disponibles",
+      "No Closed Fixed Deposit Accounts Available": "No hay cuentas de depósito fijo cerradas disponibles",
+      "No Active Recurring Deposit Accounts Available": "No hay cuentas de depósito recurrente activas disponibles",
+      "No Closed Recurring Deposit Accounts Available": "No hay cuentas de depósito recurrente cerradas disponibles",
+      "No Active Share Accounts Available": "No hay cuentas de acciones activas disponibles",
+      "No Closed Share Accounts Available": "No hay cuentas de acciones cerradas disponibles",
+      "No Collateral Data Available": "No hay datos de colateral disponibles"
     }
   },
   "languages": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3533,7 +3533,19 @@
       "Login": "Acceso"
     },
     "messages": {
-      "No Data Found": "No se encontraron datos"
+      "No Data Found": "No se encontraron datos",
+      "No Upcoming Charges Available": "No hay cargos próximos disponibles",
+      "No Active Loan Accounts Available": "No hay cuentas de crédito activas disponibles",
+      "No Closed Loan Accounts Available": "No hay cuentas de crédito cerradas disponibles",
+      "No Active Saving Accounts Available": "No hay cuentas de ahorro activas disponibles",
+      "No Closed Saving Accounts Available": "No hay cuentas de ahorro cerradas disponibles",
+      "No Active Fixed Deposit Accounts Available": "No hay cuentas de depósito fijo activas disponibles",
+      "No Closed Fixed Deposit Accounts Available": "No hay cuentas de depósito fijo cerradas disponibles",
+      "No Active Recurring Deposit Accounts Available": "No hay cuentas de depósito recurrente activas disponibles",
+      "No Closed Recurring Deposit Accounts Available": "No hay cuentas de depósito recurrente cerradas disponibles",
+      "No Active Share Accounts Available": "No hay cuentas de acciones activas disponibles",
+      "No Closed Share Accounts Available": "No hay cuentas de acciones cerradas disponibles",
+      "No Collateral Data Available": "No hay datos de colateral disponibles"
     }
   },
   "languages": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3528,7 +3528,19 @@
       "Login": "Se connecter"
     },
     "messages": {
-      "No Data Found": "Aucune donnée trouvée"
+      "No Data Found": "Aucune donnée trouvée",
+      "No Upcoming Charges Available": "Aucun frais à venir disponible",
+      "No Active Loan Accounts Available": "Aucun compte de prêt actif disponible",
+      "No Closed Loan Accounts Available": "Aucun compte de prêt fermé disponible",
+      "No Active Saving Accounts Available": "Aucun compte d'épargne actif disponible",
+      "No Closed Saving Accounts Available": "Aucun compte d'épargne fermé disponible",
+      "No Active Fixed Deposit Accounts Available": "Aucun compte de dépôt à terme actif disponible",
+      "No Closed Fixed Deposit Accounts Available": "Aucun compte de dépôt à terme fermé disponible",
+      "No Active Recurring Deposit Accounts Available": "Aucun compte de dépôt récurrent actif disponible",
+      "No Closed Recurring Deposit Accounts Available": "Aucun compte de dépôt récurrent fermé disponible",
+      "No Active Share Accounts Available": "Aucun compte d'actions actif disponible",
+      "No Closed Share Accounts Available": "Aucun compte d'actions fermé disponible",
+      "No Collateral Data Available": "Aucune donnée de garantie disponible"
     }
   },
   "languages": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3528,7 +3528,19 @@
       "Login": "Login"
     },
     "messages": {
-      "No Data Found": "Nessun dato trovato"
+      "No Data Found": "Nessun dato trovato",
+      "No Upcoming Charges Available": "Nessun addebito imminente disponibile",
+      "No Active Loan Accounts Available": "Nessun conto prestito attivo disponibile",
+      "No Closed Loan Accounts Available": "Nessun conto prestito chiuso disponibile",
+      "No Active Saving Accounts Available": "Nessun conto risparmio attivo disponibile",
+      "No Closed Saving Accounts Available": "Nessun conto risparmio chiuso disponibile",
+      "No Active Fixed Deposit Accounts Available": "Nessun conto deposito fisso attivo disponibile",
+      "No Closed Fixed Deposit Accounts Available": "Nessun conto deposito fisso chiuso disponibile",
+      "No Active Recurring Deposit Accounts Available": "Nessun conto deposito ricorrente attivo disponibile",
+      "No Closed Recurring Deposit Accounts Available": "Nessun conto deposito ricorrente chiuso disponibile",
+      "No Active Share Accounts Available": "Nessun conto azioni attivo disponibile",
+      "No Closed Share Accounts Available": "Nessun conto azioni chiuso disponibile",
+      "No Collateral Data Available": "Nessun dato collaterale disponibile"
     }
   },
   "languages": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3529,7 +3529,19 @@
       "Login": "Prisijungti"
     },
     "messages": {
-      "No Data Found": "Duomenų nerasta"
+      "No Data Found": "Duomenų nerasta",
+      "No Upcoming Charges Available": "Nėra artėjančių mokesčių",
+      "No Active Loan Accounts Available": "Nėra aktyvių paskolų sąskaitų",
+      "No Closed Loan Accounts Available": "Nėra uždarytų paskolų sąskaitų",
+      "No Active Saving Accounts Available": "Nėra aktyvių taupymo sąskaitų",
+      "No Closed Saving Accounts Available": "Nėra uždarytų taupymo sąskaitų",
+      "No Active Fixed Deposit Accounts Available": "Nėra aktyvių terminuotų indėlių sąskaitų",
+      "No Closed Fixed Deposit Accounts Available": "Nėra uždarytų terminuotų indėlių sąskaitų",
+      "No Active Recurring Deposit Accounts Available": "Nėra aktyvių pasikartojančių indėlių sąskaitų",
+      "No Closed Recurring Deposit Accounts Available": "Nėra uždarytų pasikartojančių indėlių sąskaitų",
+      "No Active Share Accounts Available": "Nėra aktyvių akcijų sąskaitų",
+      "No Closed Share Accounts Available": "Nėra uždarytų akcijų sąskaitų",
+      "No Collateral Data Available": "Nėra užstato duomenų"
     }
   },
   "languages": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3529,7 +3529,19 @@
       "Login": "Pieslēgties"
     },
     "messages": {
-      "No Data Found": "Dati nav atrasti"
+      "No Data Found": "Dati nav atrasti",
+      "No Upcoming Charges Available": "Nav gaidāmo maksājumu",
+      "No Active Loan Accounts Available": "Nav aktīvu aizdevumu kontu",
+      "No Closed Loan Accounts Available": "Nav slēgtu aizdevumu kontu",
+      "No Active Saving Accounts Available": "Nav aktīvu krājkontu",
+      "No Closed Saving Accounts Available": "Nav slēgtu krājkontu",
+      "No Active Fixed Deposit Accounts Available": "Nav aktīvu termiņnoguldījumu kontu",
+      "No Closed Fixed Deposit Accounts Available": "Nav slēgtu termiņnoguldījumu kontu",
+      "No Active Recurring Deposit Accounts Available": "Nav aktīvu periodisku noguldījumu kontu",
+      "No Closed Recurring Deposit Accounts Available": "Nav slēgtu periodisku noguldījumu kontu",
+      "No Active Share Accounts Available": "Nav aktīvu akciju kontu",
+      "No Closed Share Accounts Available": "Nav slēgtu akciju kontu",
+      "No Collateral Data Available": "Nav pieejami ķīlas dati"
     }
   },
   "languages": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3528,7 +3528,19 @@
       "Login": "लग - इन"
     },
     "messages": {
-      "No Data Found": "कुनै डाटा फेला परेन"
+      "No Data Found": "कुनै डाटा फेला परेन",
+      "No Upcoming Charges Available": "आउँदो शुल्कहरू उपलब्ध छैनन्",
+      "No Active Loan Accounts Available": "कुनै सक्रिय रिण खाताहरू उपलब्ध छैनन्",
+      "No Closed Loan Accounts Available": "कुनै बन्द रिण खाताहरू उपलब्ध छैनन्",
+      "No Active Saving Accounts Available": "कुनै सक्रिय बचत खाताहरू उपलब्ध छैनन्",
+      "No Closed Saving Accounts Available": "कुनै बन्द बचत खाताहरू उपलब्ध छैनन्",
+      "No Active Fixed Deposit Accounts Available": "कुनै सक्रिय निश्चित निक्षेप खाताहरू उपलब्ध छैनन्",
+      "No Closed Fixed Deposit Accounts Available": "कुनै बन्द निश्चित निक्षेप खाताहरू उपलब्ध छैनन्",
+      "No Active Recurring Deposit Accounts Available": "कुनै सक्रिय आवर्ती निक्षेप खाताहरू उपलब्ध छैनन्",
+      "No Closed Recurring Deposit Accounts Available": "कुनै बन्द आवर्ती निक्षेप खाताहरू उपलब्ध छैनन्",
+      "No Active Share Accounts Available": "कुनै सक्रिय शेयर खाताहरू उपलब्ध छैनन्",
+      "No Closed Share Accounts Available": "कुनै बन्द शेयर खाताहरू उपलब्ध छैनन्",
+      "No Collateral Data Available": "कुनै धरौटी डाटा उपलब्ध छैन"
     }
   },
   "languages": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3529,7 +3529,19 @@
       "Login": "Conecte-se"
     },
     "messages": {
-      "No Data Found": "Nenhum dado encontrado"
+      "No Data Found": "Nenhum dado encontrado",
+      "No Upcoming Charges Available": "Nenhum encargo futuro disponível",
+      "No Active Loan Accounts Available": "Nenhuma conta de empréstimo ativa disponível",
+      "No Closed Loan Accounts Available": "Nenhuma conta de empréstimo encerrada disponível",
+      "No Active Saving Accounts Available": "Nenhuma conta poupança ativa disponível",
+      "No Closed Saving Accounts Available": "Nenhuma conta poupança encerrada disponível",
+      "No Active Fixed Deposit Accounts Available": "Nenhuma conta de depósito fixo ativa disponível",
+      "No Closed Fixed Deposit Accounts Available": "Nenhuma conta de depósito fixo encerrada disponível",
+      "No Active Recurring Deposit Accounts Available": "Nenhuma conta de depósito recorrente ativa disponível",
+      "No Closed Recurring Deposit Accounts Available": "Nenhuma conta de depósito recorrente encerrada disponível",
+      "No Active Share Accounts Available": "Nenhuma conta de ações ativa disponível",
+      "No Closed Share Accounts Available": "Nenhuma conta de ações encerrada disponível",
+      "No Collateral Data Available": "Nenhum dado de garantia disponível"
     }
   },
   "languages": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3525,7 +3525,19 @@
       "Login": "Ingia"
     },
     "messages": {
-      "No Data Found": "Hakuna Data Imepatikana"
+      "No Data Found": "Hakuna Data Imepatikana",
+      "No Upcoming Charges Available": "Hakuna malipo yanayokuja yanapatikana",
+      "No Active Loan Accounts Available": "Hakuna akaunti za mkopo zinazofanya kazi zinapatikana",
+      "No Closed Loan Accounts Available": "Hakuna akaunti za mkopo zilizofungwa zinapatikana",
+      "No Active Saving Accounts Available": "Hakuna akaunti za akiba zinazofanya kazi zinapatikana",
+      "No Closed Saving Accounts Available": "Hakuna akaunti za akiba zilizofungwa zinapatikana",
+      "No Active Fixed Deposit Accounts Available": "Hakuna akaunti za amana za kudumu zinazofanya kazi zinapatikana",
+      "No Closed Fixed Deposit Accounts Available": "Hakuna akaunti za amana za kudumu zilizofungwa zinapatikana",
+      "No Active Recurring Deposit Accounts Available": "Hakuna akaunti za amana za kurudiwa zinazofanya kazi zinapatikana",
+      "No Closed Recurring Deposit Accounts Available": "Hakuna akaunti za amana za kurudiwa zilizofungwa zinapatikana",
+      "No Active Share Accounts Available": "Hakuna akaunti za hisa zinazofanya kazi zinapatikana",
+      "No Closed Share Accounts Available": "Hakuna akaunti za hisa zilizofungwa zinapatikana",
+      "No Collateral Data Available": "Hakuna data ya dhamana inayopatikana"
     }
   },
   "languages": {


### PR DESCRIPTION
## Description

Display "No Data Available" message instead of empty tables on Client General Tab

## Screenshots, if any

before

https://github.com/user-attachments/assets/e181ae3b-45b8-4146-9b55-bd8432abc4b6

after

https://github.com/user-attachments/assets/ba29dccf-bad7-42ea-a7f3-6adb79ff5400



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added empty-state messaging across Upcoming Charges, Loan, Saving, Fixed Deposit, Recurring Deposit, Share sections and Collateral — displays localized "No … Available" messages instead of empty tables.

* **Chores**
  * Added corresponding localized "No … Available" strings for multiple locales.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->