### PR TITLE
WEB-647 fix(login): vertically center hero content box

### DIFF
--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -187,7 +187,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
     padding: 4rem;
   }
 


### PR DESCRIPTION
Fixed the vertical positioning of the hero content box on the login page. The semi-transparent shaded box containing "Mifos® X WebApp" title, description, and feature icons was appearing near the top of the hero panel instead of being vertically centered.

[WEB-647](https://mifosforge.jira.com/browse/WEB-647)
## Screenshots, if any

## Checklist
![Uploading image.png…]()


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-647]: https://mifosforge.jira.com/browse/WEB-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ