### PR TITLE
WEB-648 refactor: replace magic numbers with LegalFormId enum

### DIFF
--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
@@ -181,7 +181,7 @@
       </div>
     }
 
-    @if (createClientForm.value.legalFormId === 1) {
+    @if (createClientForm.value.legalFormId === LegalFormId.PERSON) {
       <mat-form-field class="flex-48">
         <mat-label>{{ 'labels.inputs.Gender' | translate }}</mat-label>
         <mat-select formControlName="genderId">
@@ -205,7 +205,7 @@
       </mat-select>
     </mat-form-field>
 
-    @if (createClientForm.value.legalFormId === 1) {
+    @if (createClientForm.value.legalFormId === LegalFormId.PERSON) {
       <mat-checkbox class="flex-48 margin-v" labelPosition="before" formControlName="isStaff">
         {{ 'labels.inputs.Is staff' | translate }}?
       </mat-checkbox>

--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
@@ -19,6 +19,7 @@ import { Subject } from 'rxjs';
 import { filter, switchMap, takeUntil } from 'rxjs/operators';
 import { ClientsService } from 'app/clients/clients.service';
 import { Dates } from 'app/core/utils/dates';
+import { LegalFormId } from 'app/clients/models/legal-form.enum';
 
 /** Custom Services */
 import { SettingsService } from 'app/settings/settings.service';
@@ -56,6 +57,9 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
 
   @Output() legalFormChangeEvent = new EventEmitter<{ legalForm: number }>();
+
+  /** Expose enum to template */
+  readonly LegalFormId = LegalFormId;
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -161,7 +165,7 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
       .valueChanges.pipe(takeUntil(this.destroy$))
       .subscribe((legalFormId: number) => {
         this.legalFormChangeEvent.emit({ legalForm: legalFormId });
-        if (legalFormId === 1) {
+        if (legalFormId === LegalFormId.PERSON) {
           this.createClientForm.removeControl('fullname');
           this.createClientForm.removeControl('clientNonPersonDetails');
           this.createClientForm.addControl(
@@ -205,7 +209,7 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
           );
         }
       });
-    this.createClientForm.get('legalFormId').patchValue(1);
+    this.createClientForm.get('legalFormId').patchValue(LegalFormId.PERSON);
     this.createClientForm
       .get('active')
       .valueChanges.pipe(takeUntil(this.destroy$))
@@ -244,7 +248,7 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
   }
 
   getDateLabel(legalFormId: number, values: string[]): string {
-    return legalFormId === 1 ? values[0] : values[1];
+    return legalFormId === LegalFormId.PERSON ? values[0] : values[1];
   }
 
   /**

--- a/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.html
+++ b/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.html
@@ -13,10 +13,10 @@
 
   <div class="flex-fill">
     <span class="flex-40">{{ 'labels.inputs.name' | translate }}</span>
-    @if (client.legalFormId === 2) {
+    @if (client.legalFormId === LegalFormId.ENTITY) {
       <span class="flex-60">{{ client.fullname }}</span>
     }
-    @if (client.legalFormId === 1) {
+    @if (client.legalFormId === LegalFormId.PERSON) {
       <span class="flex-60"
         >{{ client.firstname }}
         {{ client.middlename ? client.middlename + ' ' + client.lastname : client.lastname }}</span
@@ -43,7 +43,9 @@
 
   @if (client.dateOfBirth) {
     <div class="flex-fill">
-      <span class="flex-40">{{ client.legalFormId === 1 ? 'Date of Birth' : 'Incorporation Date' }}</span>
+      <span class="flex-40">{{
+        client.legalFormId === LegalFormId.PERSON ? 'Date of Birth' : 'Incorporation Date'
+      }}</span>
       <span class="flex-60">{{ client.dateOfBirth | dateFormat }}</span>
     </div>
   }
@@ -115,7 +117,7 @@
     </div>
   }
 
-  @if (client.legalFormId === 1) {
+  @if (client.legalFormId === LegalFormId.PERSON) {
     @if (client.genderId) {
       <div class="flex-fill">
         <span class="flex-40">{{ 'labels.inputs.Gender' | translate }}</span>
@@ -128,7 +130,7 @@
     </div>
   }
 
-  @if (client.legalFormId === 2) {
+  @if (client.legalFormId === LegalFormId.ENTITY) {
     @if (client.clientNonPersonDetails.incorpValidityTillDate) {
       <div class="flex-fill">
         <span class="flex-40">{{ 'labels.inputs.Incorporation Validity Till Date' | translate }}</span>

--- a/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.ts
+++ b/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.ts
@@ -23,6 +23,7 @@ import { FindPipe } from '../../../pipes/find.pipe';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { YesnoPipe } from '../../../pipes/yesno.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { LegalFormId } from 'app/clients/models/legal-form.enum';
 
 /**
  * Client Preview Step Component
@@ -57,6 +58,9 @@ export class ClientPreviewStepComponent {
 
   /** Form submission event */
   @Output() submitEvent = new EventEmitter();
+
+  /** Expose enum to template */
+  readonly LegalFormId = LegalFormId;
 
   constructor() {}
 

--- a/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.ts
+++ b/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.ts
@@ -14,6 +14,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 /** Custom Imports */
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
+import { LegalFormId } from 'app/clients/models/legal-form.enum';
 
 /** Interfaces */
 interface ClientViewData {
@@ -71,16 +72,16 @@ export class PersonalDataTabComponent {
   }
 
   /**
-   * Check if client is a person (legalFormId = 1) or entity (legalFormId = 2)
+   * Check if client is a person (individual)
    */
   isPerson(): boolean {
-    return this.clientViewData?.legalForm?.id === 1;
+    return this.clientViewData?.legalForm?.id === LegalFormId.PERSON;
   }
 
   /**
-   * Check if client is a legal entity
+   * Check if client is a legal entity (organization)
    */
   isLegalEntity(): boolean {
-    return this.clientViewData?.legalForm?.id === 2;
+    return this.clientViewData?.legalForm?.id === LegalFormId.ENTITY;
   }
 }

--- a/src/app/clients/edit-client/edit-client.component.html
+++ b/src/app/clients/edit-client/edit-client.component.html
@@ -159,7 +159,7 @@
             <mat-datepicker #dateOfBirthDatePicker></mat-datepicker>
           </mat-form-field>
 
-          @if (legalFormId === 1) {
+          @if (legalFormId === LegalFormId.PERSON) {
             <mat-form-field class="flex-48">
               <mat-label>{{ 'labels.inputs.Gender' | translate }}</mat-label>
               <mat-select formControlName="genderId">
@@ -186,7 +186,7 @@
             </mat-select>
           </mat-form-field>
 
-          @if (legalFormId === 1) {
+          @if (legalFormId === LegalFormId.PERSON) {
             <mat-checkbox class="flex-48 margin-v" labelPosition="before" formControlName="isStaff">
               {{ 'labels.inputs.Is staff' | translate }}?
             </mat-checkbox>

--- a/src/app/clients/edit-client/edit-client.component.ts
+++ b/src/app/clients/edit-client/edit-client.component.ts
@@ -9,6 +9,7 @@
 /** Angular Imports */
 import { Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { LegalFormId } from 'app/clients/models/legal-form.enum';
 import {
   UntypedFormBuilder,
   UntypedFormGroup,
@@ -74,7 +75,10 @@ export class EditClientComponent implements OnInit {
   constitutionOptions: any;
   /** Gender Options */
   genderOptions: any;
-  legalFormId = 1;
+  legalFormId = LegalFormId.PERSON;
+
+  /** Expose enum to template */
+  readonly LegalFormId = LegalFormId;
 
   /**
    * Fetches client template data from `resolve`
@@ -96,7 +100,7 @@ export class EditClientComponent implements OnInit {
     this.createEditClientForm();
     this.setOptions();
     this.buildDependencies();
-    this.legalFormId = 1;
+    this.legalFormId = LegalFormId.PERSON;
     this.editClientForm.patchValue({
       officeId: this.clientDataAndTemplate.officeId,
       staffId: this.clientDataAndTemplate.staffId,
@@ -172,7 +176,7 @@ export class EditClientComponent implements OnInit {
    */
   buildDependencies() {
     this.editClientForm.get('legalFormId').valueChanges.subscribe((legalFormId: any) => {
-      if (legalFormId === 1) {
+      if (legalFormId === LegalFormId.PERSON) {
         this.editClientForm.removeControl('fullname');
         this.editClientForm.removeControl('clientNonPersonDetails');
         this.editClientForm.addControl(
@@ -217,7 +221,7 @@ export class EditClientComponent implements OnInit {
   }
 
   getDateLabel(legalFormId: number, values: string[]): string {
-    return legalFormId === 1 ? values[0] : values[1];
+    return legalFormId === LegalFormId.PERSON ? values[0] : values[1];
   }
 
   /**

--- a/src/app/clients/models/legal-form.enum.ts
+++ b/src/app/clients/models/legal-form.enum.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Legal Form IDs for client types.
+ * These represent the different legal forms a client can have.
+ */
+export enum LegalFormId {
+  /** Individual/Personal client */
+  PERSON = 1,
+  /** Non-person/Entity client (Organization, Corporation, etc.) */
+  ENTITY = 2
+}


### PR DESCRIPTION
This pr replaced hard-coded magic numbers (1 and 2) with a descriptive LegalFormId enum throughout the client management module to improve code readability and maintainability.

[WEB-648](https://mifosforge.jira.com/browse/WEB-648)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-648]: https://mifosforge.jira.com/browse/WEB-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated client form logic to use typed enumerations for legal form identification across multiple components, affecting client creation, preview, and editing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->