### PR TITLE
WEB-637 :- Display "No Data Available" message instead of empty tables on Client General Tab

### DIFF
--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -112,8 +112,17 @@
       </td>
     </ng-container>
 
+    <ng-container matColumnDef="no-data">
+      <td mat-footer-cell *matFooterCellDef [attr.colspan]="upcomingChargesColumns.length">
+        <div class="no-data-message">
+          <p>{{ 'labels.messages.No Upcoming Charges Available' | translate }}</p>
+        </div>
+      </td>
+    </ng-container>
+
     <tr mat-header-row *matHeaderRowDef="upcomingChargesColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: upcomingChargesColumns" [routerLink]="['../', 'charges', row.id]"></tr>
+    <tr mat-footer-row *matFooterRowDef="upcomingCharges?.length === 0 ? ['no-data'] : []"></tr>
   </table>
 
   <!-- loans accounts overview table -->
@@ -256,12 +265,25 @@
           }
         </td>
       </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="openLoansColumns.length">
+          <div class="no-data-message">
+            <p>{{ 'labels.messages.No Active Loan Accounts Available' | translate }}</p>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="openLoansColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: openLoansColumns"
         [routerLink]="['../', 'loans-accounts', row.id, 'general']"
         class="select-row"
+      ></tr>
+      <tr
+        mat-footer-row
+        *matFooterRowDef="(loanAccounts | accountsFilter: 'loan')?.length === 0 ? ['no-data'] : []"
       ></tr>
     </table>
   }
@@ -332,12 +354,25 @@
           </button>
         </td>
       </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedLoansColumns.length">
+          <div class="no-data-message">
+            <p>{{ 'labels.messages.No Closed Loan Accounts Available' | translate }}</p>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="closedLoansColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: closedLoansColumns"
         [routerLink]="['../', 'loans-accounts', row.id, 'general']"
         class="select-row"
+      ></tr>
+      <tr
+        mat-footer-row
+        *matFooterRowDef="(loanAccounts | accountsFilter: 'loan' : 'closed')?.length === 0 ? ['no-data'] : []"
       ></tr>
     </table>
   }
@@ -441,11 +476,26 @@
           }
         </td>
       </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
+          <div class="no-data-message">
+            <p>{{ 'labels.messages.No Active Saving Accounts Available' | translate }}</p>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: openSavingsColumns"
         [routerLink]="['../', 'savings-accounts', row.id, 'general']"
+      ></tr>
+      <tr
+        mat-footer-row
+        *matFooterRowDef="
+          (savingAccounts | accountsFilter: 'saving' : 'open' : 'isSavings')?.length === 0 ? ['no-data'] : []
+        "
       ></tr>
     </table>
   }
@@ -470,11 +520,26 @@
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
         <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
       </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
+          <div class="no-data-message">
+            <p>{{ 'labels.messages.No Closed Saving Accounts Available' | translate }}</p>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: closedSavingsColumns"
         [routerLink]="['../', 'savings-accounts', row.id, 'general']"
+      ></tr>
+      <tr
+        mat-footer-row
+        *matFooterRowDef="
+          (savingAccounts | accountsFilter: 'saving' : 'closed' : 'isSavings')?.length === 0 ? ['no-data'] : []
+        "
       ></tr>
     </table>
   }
@@ -554,11 +619,26 @@
           }
         </td>
       </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
+          <div class="no-data-message">
+            <p>{{ 'labels.messages.No Active Fixed Deposit Accounts Available' | translate }}</p>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: openSavingsColumns"
         [routerLink]="['../', 'fixed-deposits-accounts', row.id, 'general']"
+      ></tr>
+      <tr
+        mat-footer-row
+        *matFooterRowDef="
+          (savingAccounts | accountsFilter: 'saving' : 'open' : 'isFixed')?.length === 0 ? ['no-data'] : []
+        "
       ></tr>
     </table>
   }
@@ -584,11 +664,26 @@
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
         <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
       </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
+          <div class="no-data-message">
+            <p>{{ 'labels.messages.No Closed Fixed Deposit Accounts Available' | translate }}</p>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: closedSavingsColumns"
         [routerLink]="['../', 'fixed-deposits-accounts', row.id, 'general']"
+      ></tr>
+      <tr
+        mat-footer-row
+        *matFooterRowDef="
+          (savingAccounts | accountsFilter: 'saving' : 'closed' : 'isFixed')?.length === 0 ? ['no-data'] : []
+        "
       ></tr>
     </table>
   }
@@ -672,12 +767,27 @@
           }
         </td>
       </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
+          <div class="no-data-message">
+            <p>{{ 'labels.messages.No Active Recurring Deposit Accounts Available' | translate }}</p>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: openSavingsColumns"
         [routerLink]="['../', 'recurring-deposits-accounts', row.id, 'general']"
         class="select-row"
+      ></tr>
+      <tr
+        mat-footer-row
+        *matFooterRowDef="
+          (savingAccounts | accountsFilter: 'saving' : 'open' : 'isRecurring')?.length === 0 ? ['no-data'] : []
+        "
       ></tr>
     </table>
   }
@@ -702,12 +812,27 @@
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
         <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
       </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
+          <div class="no-data-message">
+            <p>{{ 'labels.messages.No Closed Recurring Deposit Accounts Available' | translate }}</p>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: closedSavingsColumns"
         [routerLink]="['../', 'recurring-deposits-accounts', row.id, 'general']"
         class="select-row"
+      ></tr>
+      <tr
+        mat-footer-row
+        *matFooterRowDef="
+          (savingAccounts | accountsFilter: 'saving' : 'closed' : 'isRecurring')?.length === 0 ? ['no-data'] : []
+        "
       ></tr>
     </table>
   }
@@ -789,11 +914,24 @@
           }
         </td>
       </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSharesColumns.length">
+          <div class="no-data-message">
+            <p>{{ 'labels.messages.No Active Share Accounts Available' | translate }}</p>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="openSharesColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: openSharesColumns"
         [routerLink]="['../', 'shares-accounts', row.id, 'general']"
+      ></tr>
+      <tr
+        mat-footer-row
+        *matFooterRowDef="(shareAccounts | accountsFilter: 'share')?.length === 0 ? ['no-data'] : []"
       ></tr>
     </table>
   }
@@ -824,11 +962,24 @@
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
         <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
       </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSharesColumns.length">
+          <div class="no-data-message">
+            <p>{{ 'labels.messages.No Closed Share Accounts Available' | translate }}</p>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="closedSharesColumns"></tr>
       <tr
         mat-row
         *matRowDef="let row; columns: closedSharesColumns"
         [routerLink]="['../', 'shares-accounts', row.id, 'general']"
+      ></tr>
+      <tr
+        mat-footer-row
+        *matFooterRowDef="(shareAccounts | accountsFilter: 'share' : 'closed')?.length === 0 ? ['no-data'] : []"
       ></tr>
     </table>
   }
@@ -886,12 +1037,21 @@
       </td>
     </ng-container>
 
+    <ng-container matColumnDef="no-data">
+      <td mat-footer-cell *matFooterCellDef [attr.colspan]="collateralsColumns.length">
+        <div class="no-data-message">
+          <p>{{ 'labels.messages.No Collateral Data Available' | translate }}</p>
+        </div>
+      </td>
+    </ng-container>
+
     <tr mat-header-row *matHeaderRowDef="collateralsColumns"></tr>
     <tr
       mat-row
       *matRowDef="let row; columns: collateralsColumns"
       [routerLink]="['../', 'client-collateral', row.collateralId]"
     ></tr>
+    <tr mat-footer-row *matFooterRowDef="collaterals?.length === 0 ? ['no-data'] : []"></tr>
   </table>
 
   <!-- PDF Viewer Modal -->

--- a/src/app/clients/clients-view/general-tab/general-tab.component.scss
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.scss
@@ -56,3 +56,15 @@
   align-items: center; /* Ensure buttons are vertically aligned */
   gap: 0.5rem; /* Add spacing between buttons if needed */
 }
+
+.no-data-message {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--mdc-theme-text-secondary-on-background, #666);
+  font-size: 14px;
+  cursor: auto;
+
+  p {
+    margin: 0;
+  }
+}

--- a/src/app/clients/clients-view/general-tab/general-tab.component.ts
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.ts
@@ -23,7 +23,11 @@ import {
   MatHeaderRowDef,
   MatHeaderRow,
   MatRowDef,
-  MatRow
+  MatRow,
+  MatFooterCellDef,
+  MatFooterCell,
+  MatFooterRowDef,
+  MatFooterRow
 } from '@angular/material/table';
 import { NgClass } from '@angular/common';
 import { AccountNumberComponent } from '../../../shared/account-number/account-number.component';
@@ -62,6 +66,10 @@ import { EMPTY } from 'rxjs';
     MatHeaderRow,
     MatRowDef,
     MatRow,
+    MatFooterCellDef,
+    MatFooterCell,
+    MatFooterRowDef,
+    MatFooterRow,
     AccountNumberComponent,
     LongTextComponent,
     MatTooltip,
@@ -217,13 +225,13 @@ export class GeneralTabComponent implements OnDestroy {
   /** Client Account Data */
   clientAccountData: any;
   /** Loan Accounts Data */
-  loanAccounts: any;
+  loanAccounts: any[] = [];
   /** Savings Accounts Data */
-  savingAccounts: any;
+  savingAccounts: any[] = [];
   /** Shares Accounts Data */
-  shareAccounts: any;
+  shareAccounts: any[] = [];
   /** Upcoming Charges Data */
-  upcomingCharges: any;
+  upcomingCharges: any[] = [];
   /** Performance History Data */
   performanceHistory: {
     loanCycle: number;
@@ -239,7 +247,7 @@ export class GeneralTabComponent implements OnDestroy {
     totalSavings: 0
   };
   /** Collaterals Data */
-  collaterals: any;
+  collaterals: any[] = [];
 
   /** Show Closed Loan Accounts */
   showClosedLoanAccounts = false;
@@ -264,15 +272,18 @@ export class GeneralTabComponent implements OnDestroy {
     this.route.data.subscribe(
       (data: { clientAccountsData: any; clientChargesData: any; clientSummary: any; clientCollateralData: any }) => {
         this.clientAccountData = data.clientAccountsData;
-        this.savingAccounts = data.clientAccountsData.savingsAccounts;
-        this.loanAccounts = data.clientAccountsData.loanAccounts;
-        this.shareAccounts = data.clientAccountsData.shareAccounts;
-        this.upcomingCharges = data.clientChargesData.pageItems;
-        this.collaterals = data.clientCollateralData;
+        this.savingAccounts = data.clientAccountsData?.savingsAccounts ?? [];
+        this.loanAccounts = data.clientAccountsData?.loanAccounts ?? [];
+        this.shareAccounts = data.clientAccountsData?.shareAccounts ?? [];
+
+        this.upcomingCharges = data.clientChargesData?.pageItems ?? [];
+
+        this.collaterals = data.clientCollateralData ?? [];
+
         this.clientid = this.route.parent.snapshot.params['clientId'];
 
         // Compute performance history from accounts data
-        this.computePerformanceHistory(data.clientAccountsData);
+        this.computePerformanceHistory(data.clientAccountsData ?? { loanAccounts: [], savingsAccounts: [] });
       }
     );
   }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3528,7 +3528,19 @@
     "Login": "Přihlásit se"
   },
   "messages": {
-    "No Data Found": "Nebyla nalezena žádná data"
+    "No Data Found": "Nebyla nalezena žádná data",
+    "No Upcoming Charges Available": "Žádné nadcházející poplatky k dispozici",
+    "No Active Loan Accounts Available": "Žádné aktivní úvěrové účty k dispozici",
+    "No Closed Loan Accounts Available": "Žádné uzavřené úvěrové účty k dispozici",
+    "No Active Saving Accounts Available": "Žádné aktivní spořicí účty k dispozici",
+    "No Closed Saving Accounts Available": "Žádné uzavřené spořicí účty k dispozici",
+    "No Active Fixed Deposit Accounts Available": "Žádné aktivní účty s pevným vkladem k dispozici",
+    "No Closed Fixed Deposit Accounts Available": "Žádné uzavřené účty s pevným vkladem k dispozici",
+    "No Active Recurring Deposit Accounts Available": "Žádné aktivní opakující se účty s vkladem k dispozici",
+    "No Closed Recurring Deposit Accounts Available": "Žádné uzavřené opakující se účty s vkladem k dispozici",
+    "No Active Share Accounts Available": "Žádné aktivní účty podílů k dispozici",
+    "No Closed Share Accounts Available": "Žádné uzavřené účty podílů k dispozici",
+    "No Collateral Data Available": "Žádná data o kolaterálu k dispozici"
   },
   "languages": {
     "cs-CS": "Čeština",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3528,7 +3528,19 @@
     "Login": "Anmeldung"
   },
   "messages": {
-    "No Data Found": "Keine Daten gefunden"
+    "No Data Found": "Keine Daten gefunden",
+    "No Upcoming Charges Available": "Keine bevorstehenden Gebühren verfügbar",
+    "No Active Loan Accounts Available": "Keine aktiven Darlehenskonten verfügbar",
+    "No Closed Loan Accounts Available": "Keine geschlossenen Darlehenskonten verfügbar",
+    "No Active Saving Accounts Available": "Keine aktiven Sparkonten verfügbar",
+    "No Closed Saving Accounts Available": "Keine geschlossenen Sparkonten verfügbar",
+    "No Active Fixed Deposit Accounts Available": "Keine aktiven Festgeldkonten verfügbar",
+    "No Closed Fixed Deposit Accounts Available": "Keine geschlossenen Festgeldkonten verfügbar",
+    "No Active Recurring Deposit Accounts Available": "Keine aktiven wiederkehrenden Einlagenkonten verfügbar",
+    "No Closed Recurring Deposit Accounts Available": "Keine geschlossenen wiederkehrenden Einlagenkonten verfügbar",
+    "No Active Share Accounts Available": "Keine aktiven Aktienkonten verfügbar",
+    "No Closed Share Accounts Available": "Keine geschlossenen Aktienkonten verfügbar",
+    "No Collateral Data Available": "Keine Sicherheiten verfügbar"
   },
   "languages": {
     "cs-CS": "Čeština (Tschechisch)",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3639,7 +3639,19 @@
       "Login": "Login"
     },
     "messages": {
-      "No Data Found": "No Data Found"
+      "No Data Found": "No Data Found",
+      "No Upcoming Charges Available": "No Upcoming Charges Available",
+      "No Active Loan Accounts Available": "No Active Loan Accounts Available",
+      "No Closed Loan Accounts Available": "No Closed Loan Accounts Available",
+      "No Active Saving Accounts Available": "No Active Saving Accounts Available",
+      "No Closed Saving Accounts Available": "No Closed Saving Accounts Available",
+      "No Active Fixed Deposit Accounts Available": "No Active Fixed Deposit Accounts Available",
+      "No Closed Fixed Deposit Accounts Available": "No Closed Fixed Deposit Accounts Available",
+      "No Active Recurring Deposit Accounts Available": "No Active Recurring Deposit Accounts Available",
+      "No Closed Recurring Deposit Accounts Available": "No Closed Recurring Deposit Accounts Available",
+      "No Active Share Accounts Available": "No Active Share Accounts Available",
+      "No Closed Share Accounts Available": "No Closed Share Accounts Available",
+      "No Collateral Data Available": "No Collateral Data Available"
     }
   },
   "languages": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3531,7 +3531,19 @@
       "Login": "Acceso"
     },
     "messages": {
-      "No Data Found": "No se encontraron datos"
+      "No Data Found": "No se encontraron datos",
+      "No Upcoming Charges Available": "No hay cargos próximos disponibles",
+      "No Active Loan Accounts Available": "No hay cuentas de crédito activas disponibles",
+      "No Closed Loan Accounts Available": "No hay cuentas de crédito cerradas disponibles",
+      "No Active Saving Accounts Available": "No hay cuentas de ahorro activas disponibles",
+      "No Closed Saving Accounts Available": "No hay cuentas de ahorro cerradas disponibles",
+      "No Active Fixed Deposit Accounts Available": "No hay cuentas de depósito fijo activas disponibles",
+      "No Closed Fixed Deposit Accounts Available": "No hay cuentas de depósito fijo cerradas disponibles",
+      "No Active Recurring Deposit Accounts Available": "No hay cuentas de depósito recurrente activas disponibles",
+      "No Closed Recurring Deposit Accounts Available": "No hay cuentas de depósito recurrente cerradas disponibles",
+      "No Active Share Accounts Available": "No hay cuentas de acciones activas disponibles",
+      "No Closed Share Accounts Available": "No hay cuentas de acciones cerradas disponibles",
+      "No Collateral Data Available": "No hay datos de garantía disponibles"
     }
   },
   "languages": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3534,7 +3534,19 @@
       "Login": "Acceso"
     },
     "messages": {
-      "No Data Found": "No se encontraron datos"
+      "No Data Found": "No se encontraron datos",
+      "No Upcoming Charges Available": "No hay cargos próximos disponibles",
+      "No Active Loan Accounts Available": "No hay cuentas de crédito activas disponibles",
+      "No Closed Loan Accounts Available": "No hay cuentas de crédito cerradas disponibles",
+      "No Active Saving Accounts Available": "No hay cuentas de ahorro activas disponibles",
+      "No Closed Saving Accounts Available": "No hay cuentas de ahorro cerradas disponibles",
+      "No Active Fixed Deposit Accounts Available": "No hay cuentas de depósito fijo activas disponibles",
+      "No Closed Fixed Deposit Accounts Available": "No hay cuentas de depósito fijo cerradas disponibles",
+      "No Active Recurring Deposit Accounts Available": "No hay cuentas de depósito recurrente activas disponibles",
+      "No Closed Recurring Deposit Accounts Available": "No hay cuentas de depósito recurrente cerradas disponibles",
+      "No Active Share Accounts Available": "No hay cuentas de acciones activas disponibles",
+      "No Closed Share Accounts Available": "No hay cuentas de acciones cerradas disponibles",
+      "No Collateral Data Available": "No hay datos de garantía disponibles"
     }
   },
   "languages": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3529,7 +3529,19 @@
       "Login": "Se connecter"
     },
     "messages": {
-      "No Data Found": "Aucune donnée trouvée"
+      "No Data Found": "Aucune donnée disponible",
+      "No Upcoming Charges Available": "Aucun frais à venir disponible",
+      "No Active Loan Accounts Available": "Aucun compte de prêt actif disponible",
+      "No Closed Loan Accounts Available": "Aucun compte de prêt fermé disponible",
+      "No Active Saving Accounts Available": "Aucun compte d'épargne actif disponible",
+      "No Closed Saving Accounts Available": "Aucun compte d'épargne fermé disponible",
+      "No Active Fixed Deposit Accounts Available": "Aucun compte de dépôt à terme actif disponible",
+      "No Closed Fixed Deposit Accounts Available": "Aucun compte de dépôt à terme fermé disponible",
+      "No Active Recurring Deposit Accounts Available": "Aucun compte de dépôt récurrent actif disponible",
+      "No Closed Recurring Deposit Accounts Available": "Aucun compte de dépôt récurrent fermé disponible",
+      "No Active Share Accounts Available": "Aucun compte d'actions actif disponible",
+      "No Closed Share Accounts Available": "Aucun compte d'actions fermé disponible",
+      "No Collateral Data Available": "Aucune donnée de garantie disponible"
     }
   },
   "languages": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3529,7 +3529,19 @@
       "Login": "Login"
     },
     "messages": {
-      "No Data Found": "Nessun dato trovato"
+      "No Data Found": "Nessun dato trovato",
+      "No Upcoming Charges Available": "Nessun addebito imminente disponibile",
+      "No Active Loan Accounts Available": "Nessun conto di prestito attivo disponibile",
+      "No Closed Loan Accounts Available": "Nessun conto di prestito chiuso disponibile",
+      "No Active Saving Accounts Available": "Nessun conto di risparmio attivo disponibile",
+      "No Closed Saving Accounts Available": "Nessun conto di risparmio chiuso disponibile",
+      "No Active Fixed Deposit Accounts Available": "Nessun conto di deposito fisso attivo disponibile",
+      "No Closed Fixed Deposit Accounts Available": "Nessun conto di deposito fisso chiuso disponibile",
+      "No Active Recurring Deposit Accounts Available": "Nessun conto di deposito ricorrente attivo disponibile",
+      "No Closed Recurring Deposit Accounts Available": "Nessun conto di deposito ricorrente chiuso disponibile",
+      "No Active Share Accounts Available": "Nessun conto di azioni attivo disponibile",
+      "No Closed Share Accounts Available": "Nessun conto di azioni chiuso disponibile",
+      "No Collateral Data Available": "Nessun dato collaterale disponibile"
     }
   },
   "languages": {

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3530,7 +3530,19 @@
       "Login": "로그인"
     },
     "messages": {
-      "No Data Found": "데이터를 찾을 수 없음"
+      "No Data Found": "데이터를 찾을 수 없음",
+      "No Upcoming Charges Available": "예정된 청구가 없습니다",
+      "No Active Loan Accounts Available": "활성 대출 계정이 없습니다",
+      "No Closed Loan Accounts Available": "해지된 대출 계정이 없습니다",
+      "No Active Saving Accounts Available": "활성 저축 계정이 없습니다",
+      "No Closed Saving Accounts Available": "해지된 저축 계정이 없습니다",
+      "No Active Fixed Deposit Accounts Available": "활성 정기 예금 계정이 없습니다",
+      "No Closed Fixed Deposit Accounts Available": "해지된 정기 예금 계정이 없습니다",
+      "No Active Recurring Deposit Accounts Available": "활성 적립식 예금 계정이 없습니다",
+      "No Closed Recurring Deposit Accounts Available": "해지된 적립식 예금 계정이 없습니다",
+      "No Active Share Accounts Available": "활성 주식 계정이 없습니다",
+      "No Closed Share Accounts Available": "해지된 주식 계정이 없습니다",
+      "No Collateral Data Available": "담보 데이터가 없습니다"
     }
   },
   "languages": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3530,7 +3530,19 @@
       "Login": "Prisijungti"
     },
     "messages": {
-      "No Data Found": "Duomenų nerasta"
+      "No Data Found": "Duomenų nerasta",
+      "No Upcoming Charges Available": "Nėra artėjančių mokesčių",
+      "No Active Loan Accounts Available": "Nėra aktyvių paskolų sąskaitų",
+      "No Closed Loan Accounts Available": "Nėra uždarytų paskolų sąskaitų",
+      "No Active Saving Accounts Available": "Nėra aktyvių taupomosios sąskaitos",
+      "No Closed Saving Accounts Available": "Nėra uždarytų taupomosios sąskaitos",
+      "No Active Fixed Deposit Accounts Available": "Nėra aktyvių terminuotų indėlių sąskaitų",
+      "No Closed Fixed Deposit Accounts Available": "Nėra uždarytų terminuotų indėlių sąskaitų",
+      "No Active Recurring Deposit Accounts Available": "Nėra aktyvių pasikartojančių indėlių sąskaitų",
+      "No Closed Recurring Deposit Accounts Available": "Nėra uždarytų pasikartojančių indėlių sąskaitų",
+      "No Active Share Accounts Available": "Nėra aktyvių akcijų sąskaitų",
+      "No Closed Share Accounts Available": "Nėra uždarytų akcijų sąskaitų",
+      "No Collateral Data Available": "Nėra užstato duomenų"
     }
   },
   "languages": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3530,7 +3530,19 @@
       "Login": "Pieslēgties"
     },
     "messages": {
-      "No Data Found": "Dati nav atrasti"
+      "No Data Found": "Dati nav atrasti",
+      "No Upcoming Charges Available": "Nav gaidāmo maksu",
+      "No Active Loan Accounts Available": "Nav aktīvu aizdevumu kontu",
+      "No Closed Loan Accounts Available": "Nav slēgtu aizdevumu kontu",
+      "No Active Saving Accounts Available": "Nav aktīvu krājkontu",
+      "No Closed Saving Accounts Available": "Nav slēgtu krājkontu",
+      "No Active Fixed Deposit Accounts Available": "Nav aktīvu termiņnoguldījumu kontu",
+      "No Closed Fixed Deposit Accounts Available": "Nav slēgtu termiņnoguldījumu kontu",
+      "No Active Recurring Deposit Accounts Available": "Nav aktīvu periodisku noguldījumu kontu",
+      "No Closed Recurring Deposit Accounts Available": "Nav slēgtu periodisku noguldījumu kontu",
+      "No Active Share Accounts Available": "Nav aktīvu akciju kontu",
+      "No Closed Share Accounts Available": "Nav slēgtu akciju kontu",
+      "No Collateral Data Available": "Nav pieejamu nodrošinājuma datu"
     }
   },
   "languages": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3528,7 +3528,19 @@
       "Login": "लग - इन"
     },
     "messages": {
-      "No Data Found": "कुनै डाटा फेला परेन"
+      "No Data Found": "कुनै डाटा फेला परेन",
+      "No Upcoming Charges Available": "आउँदो शुल्कहरू उपलब्ध छैनन्",
+      "No Active Loan Accounts Available": "कुनै सक्रिय ऋण खाताहरू उपलब्ध छैनन्",
+      "No Closed Loan Accounts Available": "कुनै बन्द ऋण खाताहरू उपलब्ध छैनन्",
+      "No Active Saving Accounts Available": "कुनै सक्रिय बचत खाताहरू उपलब्ध छैनन्",
+      "No Closed Saving Accounts Available": "कुनै बन्द बचत खाताहरू उपलब्ध छैनन्",
+      "No Active Fixed Deposit Accounts Available": "कुनै सक्रिय फिक्स्ड डिपोजिट खाताहरू उपलब्ध छैनन्",
+      "No Closed Fixed Deposit Accounts Available": "कुनै बन्द फिक्स्ड डिपोजिट खाताहरू उपलब्ध छैनन्",
+      "No Active Recurring Deposit Accounts Available": "कुनै सक्रिय आवर्ती जम्मा खाताहरू उपलब्ध छैनन्",
+      "No Closed Recurring Deposit Accounts Available": "कुनै बन्द आवर्ती जम्मा खाताहरू उपलब्ध छैनन्",
+      "No Active Share Accounts Available": "कुनै सक्रिय शेयर खाताहरू उपलब्ध छैनन्",
+      "No Closed Share Accounts Available": "कुनै बन्द शेयर खाताहरू उपलब्ध छैनन्",
+      "No Collateral Data Available": "कुनै संपार्श्विक डाटा उपलब्ध छैन"
     }
   },
   "languages": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3529,7 +3529,19 @@
       "Login": "Conecte-se"
     },
     "messages": {
-      "No Data Found": "Nenhum dado encontrado"
+      "No Data Found": "Nenhum dado encontrado",
+      "No Upcoming Charges Available": "Nenhuma cobrança futura disponível",
+      "No Active Loan Accounts Available": "Nenhuma conta de empréstimo ativa disponível",
+      "No Closed Loan Accounts Available": "Nenhuma conta de empréstimo encerrada disponível",
+      "No Active Saving Accounts Available": "Nenhuma conta de poupança ativa disponível",
+      "No Closed Saving Accounts Available": "Nenhuma conta de poupança encerrada disponível",
+      "No Active Fixed Deposit Accounts Available": "Nenhuma conta de depósito fixo ativa disponível",
+      "No Closed Fixed Deposit Accounts Available": "Nenhuma conta de depósito fixo encerrada disponível",
+      "No Active Recurring Deposit Accounts Available": "Nenhuma conta de depósito recorrente ativa disponível",
+      "No Closed Recurring Deposit Accounts Available": "Nenhuma conta de depósito recorrente encerrada disponível",
+      "No Active Share Accounts Available": "Nenhuma conta de ações ativa disponível",
+      "No Closed Share Accounts Available": "Nenhuma conta de ações encerrada disponível",
+      "No Collateral Data Available": "Nenhum dado de garantia disponível"
     }
   },
   "languages": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3526,7 +3526,19 @@
       "Login": "Ingia"
     },
     "messages": {
-      "No Data Found": "Hakuna Data Imepatikana"
+      "No Data Found": "Hakuna Data Imepatikana",
+      "No Upcoming Charges Available": "Hakuna malipo yanayokuja yanapatikana",
+      "No Active Loan Accounts Available": "Hakuna akaunti za mkopo zinazofanya kazi zinapatikana",
+      "No Closed Loan Accounts Available": "Hakuna akaunti za mkopo zilizofungwa zinapatikana",
+      "No Active Saving Accounts Available": "Hakuna akaunti za akiba zinazofanya kazi zinapatikana",
+      "No Closed Saving Accounts Available": "Hakuna akaunti za akiba zilizofungwa zinapatikana",
+      "No Active Fixed Deposit Accounts Available": "Hakuna akaunti za amana zisizohamishika zinazofanya kazi zinapatikana",
+      "No Closed Fixed Deposit Accounts Available": "Hakuna akaunti za amana zisizohamishika zilizofungwa zinapatikana",
+      "No Active Recurring Deposit Accounts Available": "Hakuna akaunti za amana za mara kwa mara zinazofanya kazi zinapatikana",
+      "No Closed Recurring Deposit Accounts Available": "Hakuna akaunti za amana za mara kwa mara zilizofungwa zinapatikana",
+      "No Active Share Accounts Available": "Hakuna akaunti za hisa zinazofanya kazi zinapatikana",
+      "No Closed Share Accounts Available": "Hakuna akaunti za hisa zilizofungwa zinapatikana",
+      "No Collateral Data Available": "Hakuna data ya dhamana inayopatikana"
     }
   },
   "languages": {


### PR DESCRIPTION
## Description

Display "No Data Available" message instead of empty tables on Client General Tab.


## Screenshots, if any
after


https://github.com/user-attachments/assets/c8e5089d-37dd-4c68-881a-21ea274f43bf

before

https://github.com/user-attachments/assets/489397cf-e001-4912-9f3d-f7a5f7f91cd0


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Empty-state footer rows added to multiple account and charge tables to surface localized "no data" messages when lists are empty.

* **Style**
  * Centered, padded styling for empty-state messages for consistent appearance.

* **Localization**
  * Multilingual catalog expanded with specific "no data" messages for upcoming charges, active/closed account types, and collateral across many locales.

* **Bug Fixes**
  * Collections defaulted to empty and bindings hardened to prevent rendering issues when data is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->