### PR TITLE
WEB-650 docs:add MIFOS_PRODUCTION_MODE environment variable documenta…

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,12 +281,13 @@ Available languages:
 
 #### UI Display Settings
 
-| Variable                           | Description                            | Default Value |
-| ---------------------------------- | -------------------------------------- | ------------- |
-| MIFOS_DISPLAY_TENANT_SELECTOR      | Display tenant selector in Login view  | true          |
-| MIFOS_DISPLAY_BACKEND_INFO         | Display backend info in footer         | true          |
-| MIFOS_ALLOW_SERVER_SWITCH_SELECTOR | Display DNS server list                | true          |
-| MIFOS_COMPLIANCE_HIDE_CLIENT_DATA  | Hide client names in UI (mask with \*) | false         |
+| Variable                           | Description                                | Default Value |
+| ---------------------------------- | ------------------------------------------ | ------------- |
+| MIFOS_DISPLAY_TENANT_SELECTOR      | Display tenant selector in Login view      | true          |
+| MIFOS_DISPLAY_BACKEND_INFO         | Display backend info in footer             | true          |
+| MIFOS_PRODUCTION_MODE              | Show minimal production hero on login page | false         |
+| MIFOS_ALLOW_SERVER_SWITCH_SELECTOR | Display DNS server list                    | true          |
+| MIFOS_COMPLIANCE_HIDE_CLIENT_DATA  | Hide client names in UI (mask with \*)     | false         |
 
 #### OAUTH Settings
 

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -37,6 +37,9 @@
   // Display or not the BackEnd Info
   window['env']['displayBackEndInfo'] = '';
 
+  // Show minimal production hero on login page
+  window['env']['productionMode'] = '';
+
   // Display or not the Tenant Selector
   window['env']['displayTenantSelector'] = '';
 

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -42,6 +42,9 @@
   // Display or not the BackEnd Info
   window['env']['displayBackEndInfo'] = '$MIFOS_DISPLAY_BACKEND_INFO';
 
+  // Show minimal production hero on login page
+  window['env']['productionMode'] = '$MIFOS_PRODUCTION_MODE';
+
   // Display or not the Tenant Selector
   window['env']['displayTenantSelector'] = '$MIFOS_DISPLAY_TENANT_SELECTOR';
 


### PR DESCRIPTION
…tion

Added documentation and configuration support for the new MIFOS_PRODUCTION_MODE environment variable. This variable controls the login page hero layout, allowing organizations to switch between a community-oriented display (with resources and links) and a minimal production display (showing only branding).

[WEB-650](https://mifosforge.jira.com/browse/WEB-650)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-650]: https://mifosforge.jira.com/browse/WEB-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production mode configuration variable for environment-specific behavior.

* **Chores**
  * Changed default setting: client data hiding is now disabled by default.

* **Documentation**
  * Enhanced README with improved formatting and updated configuration descriptions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->