### PR TITLE
WEB-614 Fix dateValue formatting in configuration edit

### DIFF
--- a/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.ts
+++ b/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.ts
@@ -11,6 +11,7 @@ import { Component, OnInit, inject } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
 
 /** Custom Services */
 import { SystemService } from '../../../system.service';
@@ -35,6 +36,7 @@ export class EditConfigurationComponent implements OnInit {
   private settingsService = inject(SettingsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private dateUtils = inject(Dates);
 
   /** Minimum transaction date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -94,20 +96,33 @@ export class EditConfigurationComponent implements OnInit {
       this.configurationForm.value.stringValue != null ||
       this.configurationForm.value.dateValue != null
     ) {
-      const payload = {
+      const payload: any = {
         ...this.configurationForm.value
       };
+
       if (!this.configurationForm.value.stringValue) {
         delete payload.stringValue;
       }
+
       if (this.configurationForm.value.dateValue != null) {
-        payload.locale = this.settingsService.language.code;
-        payload.dateFormat = this.settingsService.dateFormat;
+        // Format the date according to the dateFormat setting
+        const dateFormat = this.settingsService.dateFormat || 'dd MMMM yyyy';
+
+        const formattedDate = this.dateUtils.formatDate(this.configurationForm.value.dateValue, dateFormat);
+
+        if (formattedDate) {
+          payload.dateValue = formattedDate;
+          payload.locale = this.settingsService.language.code;
+          payload.dateFormat = dateFormat;
+        } else {
+          // Avoid sending invalid/null date to backend
+          delete payload.dateValue;
+        }
       } else {
         delete payload.dateValue;
       }
 
-      this.systemService.updateConfiguration(this.configuration.id, payload).subscribe((response: any) => {
+      this.systemService.updateConfiguration(this.configuration.id, payload).subscribe(() => {
         this.router.navigate(['../../'], { relativeTo: this.route });
       });
     }


### PR DESCRIPTION
When adding a configuration for custom account number length, the system shows a warning about the date format being sent with an incorrect value. The date picker was sending dates in ISO format (2026-01-21T06:00:00.000Z) but the backend expected them formatted according to the dateFormat setting.

Changes:
- Added DatePipe to format dates according to the user's dateFormat setting
- Date values are now formatted as strings (e.g., '21 January 2026') before sending to backend
- Includes locale and dateFormat in the payload for proper backend processing

## Description
https://mifosforge.jira.com/browse/WEB-614

## Related issues and discussion
This issue was already present and assigned to me for resolution.

#WEB-614

## Screenshots
Before
<img width="744" height="690" alt="Screenshot 2026-02-02 183222" src="https://github.com/user-attachments/assets/125e28e9-1909-479d-8d29-7b92092a2d5c" />


After
<img width="1910" height="1021" alt="Screenshot 2026-02-02 182917" src="https://github.com/user-attachments/assets/d05503d5-4857-465e-9ba1-ed56a839bdef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date fields now respect your chosen language and date format (with a sensible default), ensuring consistent display and submission.
  * Invalid, empty, or unparsable date values are omitted from payloads so bad data is not sent.
  * After saving configuration changes, the app reliably returns you to the previous screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->