### PR TITLE
WEB-656: Allow Undo Fixed Deposit transaction

### DIFF
--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-view/transactions-tab/transactions-tab.component.html
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-view/transactions-tab/transactions-tab.component.html
@@ -106,7 +106,7 @@
 
       <ng-container matColumnDef="actions">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let transaction">
+        <td mat-cell class="center" *matCellDef="let transaction; let idx = index">
           <button mat-icon-button [matMenuTriggerFor]="transactionMenu" aria-label="" class="action-button">
             <mat-icon>more_vert</mat-icon>
           </button>
@@ -115,6 +115,12 @@
               <mat-icon><fa-icon icon="eye" size="sm"></fa-icon></mat-icon>
               <span>{{ 'labels.text.View Transaction' | translate }}</span>
             </button>
+            @if (!isFirstTransaction(idx)) {
+              <button mat-menu-item (click)="undoTransaction(transaction)">
+                <mat-icon><fa-icon icon="undo" size="sm"></fa-icon></mat-icon>
+                <span>{{ 'tooltips.Undo Transaction' | translate }}</span>
+              </button>
+            }
             <button
               mat-menu-item
               (click)="routeEdit($event)"


### PR DESCRIPTION
## Description

Allow Undo Fixed Deposit transaction, currently supported by Fineract but not in the UI

[WEB-656](https://mifosforge.jira.com/browse/WEB-656)

## Related issues and discussion

## Screenshots
<img width="1569" height="674" alt="Screenshot 2026-02-02 at 2 15 44 p m" src="https://github.com/user-attachments/assets/a710a75e-93ff-4090-956a-c6f8df835428" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-656]: https://mifosforge.jira.com/browse/WEB-656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to undo fixed-deposit transactions via a confirmation dialog; action is hidden for the initial transaction.
  * Undo flow respects locale/date settings and refreshes the account view after completion without losing navigation context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->