### PR TITLE
WEB-658 :- fix the language dropdown list align

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.scss
+++ b/src/app/core/shell/toolbar/toolbar.component.scss
@@ -99,3 +99,7 @@
     margin-bottom: 0;
   }
 }
+
+.white-text-language {
+  margin-top: 27px;
+}


### PR DESCRIPTION
## Description

fix the language dropdown list align


## Screenshots, if any
after

<img width="1874" height="334" alt="image" src="https://github.com/user-attachments/assets/4016dc57-3d14-46d5-9d2b-12ac4043b0ad" />

before

<img width="1858" height="292" alt="image" src="https://github.com/user-attachments/assets/e639effb-88f2-4f79-a1c5-ea21770398d6" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing for the language selector component in the toolbar for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->