### PR TITLE
WEB-411: UI improvements for journal entry form layout

### DIFF
--- a/src/app/accounting/create-journal-entry/create-journal-entry.component.html
+++ b/src/app/accounting/create-journal-entry/create-journal-entry.component.html
@@ -46,7 +46,7 @@
           </mat-form-field>
 
           @if (assetExternalizationEnabled) {
-            <mat-form-field class="flex-24">
+            <mat-form-field class="flex-23">
               <mat-label>{{ 'labels.inputs.External Asset Owner' | translate }}</mat-label>
               <input matInput formControlName="externalAssetOwner" />
             </mat-form-field>
@@ -63,7 +63,7 @@
                   [inputLabel]="'Affected GL Entry (Debit)'"
                 >
                 </mifosx-gl-account-selector>
-                <mat-form-field class="flex-43">
+                <mat-form-field class="flex-48">
                   <mat-label>{{ 'labels.inputs.Debit Amount' | translate }}</mat-label>
                   <input
                     type="number"
@@ -107,7 +107,7 @@
                   [inputLabel]="'Affected GL Entry (Credit)'"
                 >
                 </mifosx-gl-account-selector>
-                <mat-form-field class="flex-43">
+                <mat-form-field class="flex-48">
                   <mat-label>{{ 'labels.inputs.Credit Amount' | translate }}</mat-label>
                   <input
                     type="number"


### PR DESCRIPTION
This PR addresses UI alignment and spacing issues on the Create Journal Entry page that made the form appear visually unbalanced and difficult to scan.

The changes focus on improving layout structure, spacing consistency, and overall readability without altering any business logic or form behavior.

### **BEFORE**
<img width="1440" height="305" alt="3f281053-1675-436c-9698-b220808fa534" src="https://github.com/user-attachments/assets/2bfc7920-340e-4caa-ae1b-06b7666ad2fc" />


### **AFTER**
<img width="1394" height="326" alt="Screenshot 2026-02-03 at 11 18 39 PM" src="https://github.com/user-attachments/assets/72647dcd-782d-4499-be84-d3d6b96e5312" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted layout spacing for journal entry form fields to improve visual alignment when external asset functionality is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->