### PR TITLE
WEB-660:fix Incorrect rounding of report values

### DIFF
--- a/src/app/reports/run-report/run-report.component.ts
+++ b/src/app/reports/run-report/run-report.component.ts
@@ -189,7 +189,7 @@ export class RunReportComponent implements OnInit {
     if (this.exportToS3Allowed) {
       this.reportForm.addControl('exportOutputToS3', new UntypedFormControl(false));
     }
-    this.decimalChoice.patchValue('0');
+    this.decimalChoice.patchValue('2');
     this.setChildControls();
     this.addDateRangeValidator();
   }


### PR DESCRIPTION
Fixed incorrect rounding of decimal values in financial reports by changing the default decimal precision from 0 to 2 decimal places. This change ensures that monetary values display with appropriate precision instead of being rounded to the nearest integer.

[WEB-660](https://mifosforge.jira.com/browse/WEB-660)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-660]: https://mifosforge.jira.com/browse/WEB-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default decimal places setting in report output from 0 to 2 decimal places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->