### PR TITLE
Labels labels.inputs.Terms and labels.inputs.Settings Not Translated on Create Savings Product Page

### DIFF
--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1284,6 +1284,8 @@
       "Status": "Stav"
     },
     "inputs": {
+      "Terms": "Podmínky",
+      "Settings": "Nastavení",
       "accounting": {
         "ASSET": "AKTIVUM",
         "LIABILITY": "ODPOVĚDNOST",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1285,6 +1285,8 @@
       "Status": "Status"
     },
     "inputs": {
+      "Terms": "Bedingungen",
+      "Settings": "Einstellungen",
       "accounting": {
         "ASSET": "VERMÖGENSWERT",
         "LIABILITY": "HAFTUNG",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1289,6 +1289,8 @@
       "Global Impact": "Global Impact"
     },
     "inputs": {
+      "Terms": "Terms",
+      "Settings": "Settings",
       "accounting": {
         "ASSET": "ASSET",
         "LIABILITY": "LIABILITY",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1285,6 +1285,8 @@
       "Status": "Estado"
     },
     "inputs": {
+      "Terms": "Términos",
+      "Settings": "Configuración",
       "accounting": {
         "ASSET": "ACTIVO",
         "LIABILITY": "PASIVO",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1284,6 +1284,8 @@
       "Status": "Estado"
     },
     "inputs": {
+      "Terms": "Términos",
+      "Settings": "Configuración",
       "accounting": {
         "ASSET": "ACTIVO",
         "LIABILITY": "PASIVO",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1285,6 +1285,8 @@
       "Status": "Statut"
     },
     "inputs": {
+      "Terms": "Termes",
+      "Settings": "Paramètres",
       "accounting": {
         "ASSET": "ACTIF",
         "LIABILITY": "RESPONSABILITÉ",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1284,6 +1284,8 @@
       "Status": "Stato"
     },
     "inputs": {
+      "Terms": "Termini",
+      "Settings": "Impostazioni",
       "accounting": {
         "ASSET": "RISORSA",
         "LIABILITY": "RESPONSABILITÀ",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1286,6 +1286,8 @@
       "Status": "상태"
     },
     "inputs": {
+      "Terms": "약관",
+      "Settings": "설정",
       "accounting": {
         "ASSET": "유산",
         "LIABILITY": "책임",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1283,6 +1283,8 @@
       "Status": "Statusas"
     },
     "inputs": {
+      "Terms": "Sąlygos",
+      "Settings": "Nustatymai",
       "accounting": {
         "ASSET": "TURTAS",
         "LIABILITY": "ATSAKOMYBĖ",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1285,6 +1285,8 @@
       "Status": "Statuss"
     },
     "inputs": {
+      "Terms": "Noteikumi",
+      "Settings": "Iestatījumi",
       "accounting": {
         "ASSET": "AKTĪVS",
         "LIABILITY": "ATBILDĪBA",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1283,6 +1283,8 @@
       "Status": "स्थिति"
     },
     "inputs": {
+      "Terms": "सर्तहरू",
+      "Settings": "सेटिङहरू",
       "accounting": {
         "ASSET": "सम्पत्ति",
         "LIABILITY": "दायित्व",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1284,6 +1284,8 @@
       "Status": "Status"
     },
     "inputs": {
+      "Terms": "Termos",
+      "Settings": "Configurações",
       "accounting": {
         "ASSET": "ATIVO",
         "LIABILITY": "RESPONSABILIDADE",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1281,6 +1281,8 @@
       "Status": "Hali"
     },
     "inputs": {
+      "Terms": "Masharti",
+      "Settings": "Mipangilio",
       "accounting": {
         "ASSET": "ASSET",
         "LIABILITY": "DHIMA",


### PR DESCRIPTION
Changes Made :- 

- Fix untranslated "Terms" and "Settings" labels on the Create Savings Product page by updating translation keys.

[WEB-662](http://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-662)

Before :-

<img width="1355" height="622" alt="image" src="https://github.com/user-attachments/assets/429365ba-fd79-4443-8e99-1bf712a9b5c0" />

After :-

<img width="1076" height="404" alt="image" src="https://github.com/user-attachments/assets/f5f31f0c-8cf6-462f-af26-03af5df23ba3" />

<img width="835" height="313" alt="image" src="https://github.com/user-attachments/assets/4395586a-a7c8-4ae3-b314-df709d3cf739" />


[WEB-662]: https://mifosforge.jira.com/browse/WEB-662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added localized translations for "Terms" and "Settings" labels across Czech, German, English, Spanish (Chile and Mexico), French, Italian, Korean, Lithuanian, Latvian, Nepali, Portuguese, and Swahili locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->