### PR TITLE
WEB-663 Fixed Deposit Product Form: Negative Values Allowed for Depos…

### DIFF
--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-terms-step/fixed-deposit-product-terms-step.component.html
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-terms-step/fixed-deposit-product-terms-step.component.html
@@ -14,6 +14,7 @@
       <mat-label>{{ 'labels.inputs.Minimum' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matInput
         formControlName="minDepositAmount"
         matTooltip="{{ 'tooltips.The minimum deposit amount required to open a fixed deposit' | translate }}"
@@ -24,6 +25,7 @@
       <mat-label>{{ 'labels.inputs.Default' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matInput
         formControlName="depositAmount"
         matTooltip="{{ 'tooltips.The default deposit amount expected' | translate }}"
@@ -40,6 +42,7 @@
 
       <input
         type="number"
+        min="0"
         matInput
         formControlName="maxDepositAmount"
         matTooltip="{{ 'tooltips.The maximum deposit amount allowed when a fixed deposit' | translate }}"

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-terms-step/fixed-deposit-product-terms-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-terms-step/fixed-deposit-product-terms-step.component.ts
@@ -68,12 +68,21 @@ export class FixedDepositProductTermsStepComponent implements OnInit {
 
   createFixedDepositProductTermsForm() {
     this.fixedDepositProductTermsForm = this.formBuilder.group({
-      minDepositAmount: [''],
+      minDepositAmount: [
+        '',
+        Validators.min(0)
+      ],
       depositAmount: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)
+        ]
       ],
-      maxDepositAmount: [''],
+      maxDepositAmount: [
+        '',
+        Validators.min(0)
+      ],
       interestCompoundingPeriodType: [
         '',
         Validators.required


### PR DESCRIPTION
**Changes Made :-** 

-Prevent negative values for deposit amount fields in Fixed Deposit Product form.

[WEB-663](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-663)

Before :- 
<img width="1363" height="626" alt="image" src="https://github.com/user-attachments/assets/885bf29d-6941-4c87-a0df-c822ca2a367b" />

After :- 
<img width="1023" height="451" alt="image" src="https://github.com/user-attachments/assets/b0160593-0b28-4093-87e1-5daecd532d3f" />


[WEB-663]: https://mifosforge.jira.com/browse/WEB-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deposit amount fields now enforce non-negative value validation for minimum deposit amount, deposit amount, and maximum deposit amount inputs, preventing invalid negative entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->