### PR TITLE
WEB-665 Reccuring deposit product form negative values allowed for deposit amount fields

### DIFF
--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-terms-step/recurring-deposit-product-terms-step.component.html
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-terms-step/recurring-deposit-product-terms-step.component.html
@@ -12,12 +12,12 @@
 
     <mat-form-field class="flex-31">
       <mat-label>{{ 'labels.inputs.Minimum' | translate }}</mat-label>
-      <input type="number" matInput formControlName="minDepositAmount" />
+      <input type="number" min="0" matInput formControlName="minDepositAmount" />
     </mat-form-field>
 
     <mat-form-field class="flex-31">
       <mat-label>{{ 'labels.inputs.Default' | translate }}</mat-label>
-      <input type="number" matInput formControlName="depositAmount" required />
+      <input type="number" min="0" matInput formControlName="depositAmount" required />
       <mat-error>
         {{ 'labels.inputs.Default' | translate }} {{ 'labels.inputs.Deposit Amount' | translate }}
         {{ 'labels.commons.is' | translate }} <strong>{{ 'labels.commons.required' | translate }}</strong>
@@ -26,7 +26,7 @@
 
     <mat-form-field class="flex-31">
       <mat-label>{{ 'labels.inputs.Maximum' | translate }}</mat-label>
-      <input type="number" matInput formControlName="maxDepositAmount" />
+      <input type="number" min="0" matInput formControlName="maxDepositAmount" />
     </mat-form-field>
 
     <mat-divider class="flex-98"></mat-divider>

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-terms-step/recurring-deposit-product-terms-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-terms-step/recurring-deposit-product-terms-step.component.ts
@@ -64,12 +64,21 @@ export class RecurringDepositProductTermsStepComponent implements OnInit {
 
   createrecurringDepositProductTermsForm() {
     this.recurringDepositProductTermsForm = this.formBuilder.group({
-      minDepositAmount: [''],
+      minDepositAmount: [
+        '',
+        Validators.min(0)
+      ],
       depositAmount: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)
+        ]
       ],
-      maxDepositAmount: [''],
+      maxDepositAmount: [
+        '',
+        Validators.min(0)
+      ],
       interestCompoundingPeriodType: [
         '',
         Validators.required


### PR DESCRIPTION
**Changes Made : -**

-Prevent negative values for deposit amount fields in Recurring Deposit Product form .

[WEB-665](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-665)

Before :- 
<img width="1024" height="411" alt="image" src="https://github.com/user-attachments/assets/f550bbfe-924b-4086-840e-663ed9941cbf" />

After : -
<img width="985" height="273" alt="image" src="https://github.com/user-attachments/assets/4375a961-c79b-4efc-b2c6-7ad2729edf82" />



[WEB-665]: https://mifosforge.jira.com/browse/WEB-665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation constraints to prevent negative values for deposit amounts (minimum, default, and maximum) in recurring deposit product configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->