### PR TITLE
WEB-664 Fixed deposit product form negative values allowed in settings fields

### DIFF
--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-settings-step/fixed-deposit-product-settings-step.component.html
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-settings-step/fixed-deposit-product-settings-step.component.html
@@ -18,7 +18,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="lockinPeriodFrequency" />
+      <input type="number" min="0" matInput formControlName="lockinPeriodFrequency" />
     </mat-form-field>
 
     <mat-form-field class="flex-48">
@@ -39,7 +39,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="minDepositTerm" required />
+      <input type="number" min="0" matInput formControlName="minDepositTerm" required />
       <mat-error>
         {{ 'labels.inputs.Minimum Deposit Term Frequency' | translate }} {{ 'labels.commons.is' | translate }}
         <strong>{{ 'labels.commons.required' | translate }}</strong>
@@ -71,7 +71,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="inMultiplesOfDepositTerm" />
+      <input type="number" min="0" matInput formControlName="inMultiplesOfDepositTerm" />
     </mat-form-field>
 
     <mat-form-field class="flex-48">
@@ -92,7 +92,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="maxDepositTerm" />
+      <input type="number" min="0" matInput formControlName="maxDepositTerm" />
     </mat-form-field>
 
     <mat-form-field class="flex-48">
@@ -122,7 +122,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Penal Interest' | translate }} (%)</mat-label>
-      <input type="number" matInput formControlName="preClosurePenalInterest" />
+      <input type="number" min="0" matInput formControlName="preClosurePenalInterest" />
     </mat-form-field>
 
     <mat-form-field class="flex-48">

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-settings-step/fixed-deposit-product-settings-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-settings-step/fixed-deposit-product-settings-step.component.ts
@@ -97,22 +97,37 @@ export class FixedDepositProductSettingsStepComponent implements OnInit {
 
   createFixedDepositProductSettingsForm() {
     this.fixedDepositProductSettingsForm = this.formBuilder.group({
-      lockinPeriodFrequency: [''],
+      lockinPeriodFrequency: [
+        '',
+        Validators.min(0)
+      ],
       lockinPeriodFrequencyType: [''],
       minDepositTerm: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)
+        ]
       ],
       minDepositTermTypeId: [
         '',
         Validators.required
       ],
-      inMultiplesOfDepositTerm: [''],
+      inMultiplesOfDepositTerm: [
+        '',
+        Validators.min(0)
+      ],
       inMultiplesOfDepositTermTypeId: [''],
-      maxDepositTerm: [''],
+      maxDepositTerm: [
+        '',
+        Validators.min(0)
+      ],
       maxDepositTermTypeId: [''],
       preClosurePenalApplicable: [false],
-      preClosurePenalInterest: [''],
+      preClosurePenalInterest: [
+        '',
+        Validators.min(0)
+      ],
       preClosurePenalInterestOnTypeId: [''],
       withHoldTax: [false]
     });


### PR DESCRIPTION
**Changes Made :-** 

-Prevent negative values for settings fields in Fixed Deposit Product form.

[WEB-664](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-664)

Before :-

<img width="1024" height="530" alt="image" src="https://github.com/user-attachments/assets/3f268ed4-fa76-4831-88c0-966bbb72e599" />

After :-

<img width="752" height="427" alt="image" src="https://github.com/user-attachments/assets/45f53958-5ce1-4957-b359-e2a0142c9b4a" />


[WEB-664]: https://mifosforge.jira.com/browse/WEB-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for fixed deposit product settings to prevent negative values in deposit term, locking period, and penalty interest fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->