### PR TITLE
 WEB-666 Recurring deposit product form negative values allowed in settings fields

### DIFF
--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-settings-step/recurring-deposit-product-settings-step.component.html
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-settings-step/recurring-deposit-product-settings-step.component.html
@@ -26,6 +26,7 @@
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matInput
         formControlName="lockinPeriodFrequency"
         matTooltip="{{ 'tooltips.The number at which lock in period occurs' | translate }}"
@@ -49,6 +50,7 @@
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matInput
         formControlName="minDepositTerm"
         matTooltip="{{ 'tooltips.The number at which minimum deposit occurs' | translate }}"
@@ -81,6 +83,7 @@
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matInput
         formControlName="inMultiplesOfDepositTerm"
         matTooltip="{{ 'tooltips.The number at which multiple deposits occurs' | translate }}"
@@ -104,6 +107,7 @@
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
       <input
         type="number"
+        min="0"
         matInput
         formControlName="maxDepositTerm"
         matTooltip="{{ 'tooltips.The number at which minimum deposit occurs' | translate }}"
@@ -131,7 +135,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Penal Interest' | translate }} (%)</mat-label>
-      <input type="number" matInput formControlName="preClosurePenalInterest" />
+      <input type="number" min="0" matInput formControlName="preClosurePenalInterest" />
     </mat-form-field>
 
     <mat-form-field class="flex-48">

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-settings-step/recurring-deposit-product-settings-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-settings-step/recurring-deposit-product-settings-step.component.ts
@@ -102,22 +102,37 @@ export class RecurringDepositProductSettingsStepComponent implements OnInit {
       isMandatoryDeposit: [false],
       adjustAdvanceTowardsFuturePayments: [false],
       allowWithdrawal: [false],
-      lockinPeriodFrequency: [''],
+      lockinPeriodFrequency: [
+        '',
+        Validators.min(0)
+      ],
       lockinPeriodFrequencyType: [''],
       minDepositTerm: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)
+        ]
       ],
       minDepositTermTypeId: [
         '',
         Validators.required
       ],
-      inMultiplesOfDepositTerm: [''],
+      inMultiplesOfDepositTerm: [
+        '',
+        Validators.min(0)
+      ],
       inMultiplesOfDepositTermTypeId: [''],
-      maxDepositTerm: [''],
+      maxDepositTerm: [
+        '',
+        Validators.min(0)
+      ],
       maxDepositTermTypeId: [''],
       preClosurePenalApplicable: [false],
-      preClosurePenalInterest: [''],
+      preClosurePenalInterest: [
+        '',
+        Validators.min(0)
+      ],
       preClosurePenalInterestOnTypeId: [''],
       withHoldTax: [false]
     });


### PR DESCRIPTION
**Changes Made :-** 

-Prevent negative values for settings fields in Recurring Deposit Product form .

[WEB-666](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-666)

Before :- 

<img width="1024" height="510" alt="image" src="https://github.com/user-attachments/assets/d026b5f7-efee-43a6-ae9f-e7e0f5b7783b" />

After :- 

<img width="911" height="512" alt="image" src="https://github.com/user-attachments/assets/30cd477e-98c5-4dfd-95e9-2df66cb5c4ff" />


[WEB-666]: https://mifosforge.jira.com/browse/WEB-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recurring deposit product settings now enforce non-negative values for locking period frequency, deposit terms, and penalty interest fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->