### PR TITLE
WEB-667 fix(env): prevent undefinedundefined in oauthServerUrl

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -11,6 +11,8 @@ import env from './.env';
 
 // The `window['env']` object is loaded in the `index.html` file
 const loadedEnv = window['env'] || {};
+const base = loadedEnv['fineractApiUrl'];
+const provider = loadedEnv['apiProvider'];
 
 export const environment = {
   production: true,
@@ -27,7 +29,7 @@ export const environment = {
   baseApiUrl:
     loadedEnv['fineractApiUrl'] ||
     (loadedEnv['fineractApiUrls']?.length > 0 ? loadedEnv['fineractApiUrls'].split(',')[0] : window.location.origin),
-  oauthServerUrl: loadedEnv['oauthServerUrl'] || loadedEnv['fineractApiUrl'] + loadedEnv['apiProvider'],
+  oauthServerUrl: loadedEnv['oauthServerUrl'] ?? (base && provider ? `${base}${provider}` : ''),
   allowServerSwitch: loadedEnv.allowServerSwitch || 'true',
   apiProvider: loadedEnv['apiProvider'] || '/fineract-provider/api',
   apiVersion: loadedEnv['apiVersion'] || '/v1',


### PR DESCRIPTION
This change prevents the application from generating an invalid oauthServerUrl (specifically "undefinedundefined") when the backend API URL and provider are not explicitly configured in the environment variables. By ensuring valid default values are used or the URL remains empty if configuration is missing, we avoid connection errors during authentication flows in unconfigured environments.

[WEB-667](https://mifosforge.jira.com/browse/WEB-667)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-667]: https://mifosforge.jira.com/browse/WEB-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth server URL configuration handling to be more reliable across different environment setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->