### PR TITLE
WEB-670: Loan modification saves charge value instead of percent

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.html
@@ -142,7 +142,7 @@
   </table>
 </div>
 
-<div class="layout-row responsive-column align-center gap-2px margin-t">
+<div class="layout-row responsive-column align-center gap-2px margin-t stepper-buttons">
   <button mat-raised-button matStepperPrevious>
     <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
     {{ 'labels.buttons.Previous' | translate }}

--- a/src/app/loans/loans-account-stepper/loans-account-datatable-step/loans-account-datatable-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-datatable-step/loans-account-datatable-step.component.html
@@ -54,7 +54,7 @@
     }
   </div>
 
-  <div class="layout-row align-center gap-2percent margin-t responsive-column">
+  <div class="layout-row align-center gap-2percent margin-t responsive-column stepper-buttons">
     <button mat-raised-button matStepperPrevious disabled>
       <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
       {{ 'labels.buttons.Previous' | translate }}

--- a/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.html
@@ -138,7 +138,7 @@
     </div>
   }
 
-  <div class="layout-row align-center gap-2percent margin-t responsive-column">
+  <div class="layout-row align-center gap-2percent margin-t responsive-column stepper-buttons">
     <button mat-raised-button matStepperPrevious disabled>
       <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
       {{ 'labels.buttons.Previous' | translate }}

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
@@ -390,7 +390,7 @@
   }
 </div>
 
-<div class="layout-row responsive-column align-center gap-2px margin-t">
+<div class="layout-row responsive-column align-center gap-2px margin-t stepper-buttons">
   <button mat-raised-button matStepperPrevious>
     <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
     {{ 'labels.buttons.Previous' | translate }}

--- a/src/app/loans/loans-account-stepper/loans-account-schedule-step/loans-account-schedule-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-schedule-step/loans-account-schedule-step.component.html
@@ -19,7 +19,7 @@
   </mifosx-repayment-schedule-tab>
 </div>
 
-<div class="layout-row responsive-column align-center gap-2px margin-t">
+<div class="layout-row responsive-column align-center gap-2px margin-t stepper-buttons">
   <button mat-raised-button matStepperPrevious>
     <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
     {{ 'labels.buttons.Previous' | translate }}

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
@@ -726,7 +726,7 @@
     </table>
   </div>
 
-  <div class="layout-row align-center gap-2percent margin-t responsive-column">
+  <div class="layout-row align-center gap-2percent margin-t responsive-column stepper-buttons">
     <button mat-raised-button matStepperPrevious>
       <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
       {{ 'labels.buttons.Previous' | translate }}

--- a/src/app/loans/loans-account-stepper/loans-active-client-members/loans-active-client-members.component.html
+++ b/src/app/loans/loans-account-stepper/loans-active-client-members/loans-active-client-members.component.html
@@ -59,7 +59,7 @@
   </div>
 }
 
-<div class="layout-row responsive-column align-center gap-2px margin-t">
+<div class="layout-row responsive-column align-center gap-2px margin-t stepper-buttons">
   <button mat-raised-button matStepperPrevious>
     <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
     {{ 'labels.buttons.Previous' | translate }}

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.html
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.html
@@ -56,7 +56,12 @@
 
     <ng-container matColumnDef="calculationtype">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Calculation Type' | translate }}</th>
-      <td mat-cell *matCellDef="let charge">{{ charge.chargeCalculationType.value }}</td>
+      <td mat-cell *matCellDef="let charge">
+        {{ charge.chargeCalculationType.value }}
+        @if (isPercentageCharge(charge)) {
+          ({{ charge.percentage | formatNumber: 2 }}%)
+        }
+      </td>
     </ng-container>
 
     <ng-container matColumnDef="due">

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { Component, OnInit, ViewChild, inject } from '@angular/core';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -47,6 +47,8 @@ import { CurrencyPipe } from '@angular/common';
 import { MatTooltip } from '@angular/material/tooltip';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { LoanCharge } from 'app/loans/models/loan-charge.model';
+import { FormatNumberPipe } from '@pipes/format-number.pipe';
 
 @Component({
   selector: 'mifosx-charges-tab',
@@ -69,7 +71,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatRow,
     MatPaginator,
     CurrencyPipe,
-    DateFormatPipe
+    DateFormatPipe,
+    FormatNumberPipe
   ]
 })
 export class ChargesTabComponent implements OnInit {
@@ -78,14 +81,14 @@ export class ChargesTabComponent implements OnInit {
   private dateUtils = inject(Dates);
   private router = inject(Router);
   private translateService = inject(TranslateService);
-  dialog = inject(MatDialog);
+  private dialog = inject(MatDialog);
   private settingsService = inject(SettingsService);
   private systemService = inject(SystemService);
 
   /** Loan Details Data */
   loanDetails: any;
   /** Charges Data */
-  chargesData: any;
+  chargesData: LoanCharge[] = [];
   /** Status */
   status: any;
   /** Columns to be displayed in charges table. */
@@ -232,7 +235,7 @@ export class ChargesTabComponent implements OnInit {
       new InputBase({
         controlName: 'amount',
         label: 'Amount',
-        value: charge.amount || charge.amountOrPercentage,
+        value: this.isPercentageCharge(charge) ? charge.amountOrPercentage : charge.amount,
         type: 'number',
         required: true
       })
@@ -294,5 +297,9 @@ export class ChargesTabComponent implements OnInit {
     this.router
       .navigateByUrl(`/clients/${clientId}/loans-accounts`, { skipLocationChange: true })
       .then(() => this.router.navigate([url]));
+  }
+
+  isPercentageCharge(loanCharge: LoanCharge): boolean {
+    return loanCharge.chargeCalculationType.code.includes('.percent.');
   }
 }

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -32,7 +32,7 @@
                   matTooltip="{{ 'labels.status.' + loanDetailsData.status.value | translate }}"
                   [ngClass]="iconLoanStatusColor() | statusLookup"
                 ></i>
-                <span class="m-r-5">{{ 'labels.heading.Loan Product' | translate }} :</span>
+                <span class="m-l-5 m-r-5">{{ 'labels.heading.Loan Product' | translate }} :</span>
                 <span class="m-r-5"
                   ><mifosx-long-text textValue="{{ loanDetailsData.loanProductName }}"></mifosx-long-text
                 ></span>

--- a/src/app/loans/models/loan-charge.model.ts
+++ b/src/app/loans/models/loan-charge.model.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Charge, Currency } from 'app/shared/models/general.model';
+import { OptionData } from 'app/shared/models/option-data.model';
+
+export interface LoanCharge {
+  id: number;
+  chargeId: number;
+  name: string;
+  chargeTimeType: Charge;
+  submittedOnDate: number[];
+  dueDate: number[];
+  chargeCalculationType: OptionData;
+  percentage: number;
+  amountPercentageAppliedTo: number;
+  currency: Currency;
+  amount: number;
+  amountPaid: number;
+  amountWaived: number;
+  amountWrittenOff: number;
+  amountOutstanding: number;
+  amountOrPercentage: number;
+  penalty: boolean;
+  chargePaymentMode: OptionData;
+  chargeTime: OptionData;
+  paid: boolean;
+  waived: boolean;
+  chargePayable: boolean;
+  loanId: number;
+  externalId: string;
+  externalLoanId: string;
+}

--- a/src/assets/styles/_form.scss
+++ b/src/assets/styles/_form.scss
@@ -44,3 +44,7 @@ textarea.noresize {
   margin-top: 5px;
   margin-bottom: 5px;
 }
+
+.stepper-buttons {
+  height: 38px;
+}


### PR DESCRIPTION
## Description

Loan modification saves charge value instead of percent and It shows the $ amount value actually charged on the loan. It saves the charge value as a giant percentage and explodes the charge value

## Related issues and discussion

[WEB-670](https://mifosforge.jira.com/browse/WEB-670)

## Screenshots, if any

https://github.com/user-attachments/assets/982cd405-fdbd-44d7-8136-79db725ae820


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-670]: https://mifosforge.jira.com/browse/WEB-670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized stepper navigation styling across loan forms and added a dedicated styling hook for consistent layout.

* **New Features**
  * Added Next and conditional Cancel buttons to stepper controls for clearer navigation.
  * Charges list now displays percentage values for percentage-based charges.

* **Bug Fixes**
  * Charge date editing enforces a maximum future date.
  * Improved handling of charge amounts and localized edit dialog titles.

* **Style**
  * Minor spacing tweak on loan product label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->