### PR TITLE
WEB-668 :- Dashboard chart legend labels not visible in dark theme mode

### DIFF
--- a/src/app/home/dashboard/amount-disbursed-pie/amount-disbursed-pie.component.ts
+++ b/src/app/home/dashboard/amount-disbursed-pie/amount-disbursed-pie.component.ts
@@ -7,12 +7,14 @@
  */
 
 /** Angular Imports */
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, DestroyRef } from '@angular/core';
 import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /** Custom Services */
 import { HomeService } from '../../home.service';
+import { ThemingService } from 'app/shared/theme-toggle/theming.service';
 
 /** Charting Imports */
 import { Chart, registerables } from 'chart.js';
@@ -41,6 +43,11 @@ Chart.register(...registerables);
 export class AmountDisbursedPieComponent implements OnInit {
   private homeService = inject(HomeService);
   private route = inject(ActivatedRoute);
+  private themingService = inject(ThemingService);
+  private destroyRef = inject(DestroyRef);
+
+  /** Current theme */
+  private currentTheme = 'light-theme';
 
   /** Static Form control for office Id */
   officeId = new UntypedFormControl();
@@ -71,6 +78,13 @@ export class AmountDisbursedPieComponent implements OnInit {
   ngOnInit() {
     this.getChartData();
     this.officeId.patchValue(1);
+    // Subscribe to theme changes to update chart legend colors
+    this.themingService.theme.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((theme) => {
+      this.currentTheme = theme;
+      if (this.chart) {
+        this.updateChartColors();
+      }
+    });
   }
 
   /**
@@ -98,6 +112,8 @@ export class AmountDisbursedPieComponent implements OnInit {
    * @param {any} data Chart Data.
    */
   setChart(data: any) {
+    const legendColor = this.getLegendColor();
+
     if (!this.chart) {
       this.chart = new Chart('disbursement-pie', {
         type: 'doughnut',
@@ -117,6 +133,13 @@ export class AmountDisbursedPieComponent implements OnInit {
           ]
         },
         options: {
+          plugins: {
+            legend: {
+              labels: {
+                color: legendColor
+              }
+            }
+          },
           layout: {
             padding: {
               top: 10,
@@ -127,6 +150,25 @@ export class AmountDisbursedPieComponent implements OnInit {
       });
     } else {
       this.chart.data.datasets[0].data = data;
+      this.chart.update();
+    }
+  }
+
+  /**
+   * Gets the legend color based on the current theme.
+   */
+  private getLegendColor(): string {
+    return this.currentTheme === 'dark-theme' ? 'white' : '#666';
+  }
+
+  /**
+   * Updates chart colors based on the current theme.
+   */
+  updateChartColors() {
+    const legendColor = this.getLegendColor();
+
+    if (this.chart?.options?.plugins?.legend?.labels) {
+      this.chart.options.plugins.legend.labels.color = legendColor;
       this.chart.update();
     }
   }


### PR DESCRIPTION
## Description

Chart legend labels in dashboard components were fixed color, invisible in dark mode. Solution: integrated ThemingService to dynamically set legend label colors white for dark theme, gray for light theme.

## Screenshots, if any
after
<img width="1668" height="882" alt="image" src="https://github.com/user-attachments/assets/2c4ef54c-1106-4c46-9c96-3a9398ac0dfa" />

before
<img width="1522" height="767" alt="image" src="https://github.com/user-attachments/assets/ad8e75ce-7d56-4a4b-a15b-0ef58757690e" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard charts (pie and bar) now adapt to theme changes: legend label colors update automatically for light/dark modes to improve contrast and consistency.
  * Chart color updates occur at runtime whenever the app theme changes, keeping visuals in sync without manual refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->