### PR TITLE
WEB-641: Fix sidebar navigation menu items alignment

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -813,3 +813,34 @@ mat-card {
     color: rgb(255 255 255 / 60%) !important;
   }
 }
+
+.app-sidenav {
+  .mat-mdc-nav-list .mat-mdc-list-item {
+    .mdc-list-item__primary-text {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    [matlisticon] {
+      flex-shrink: 0;
+      width: 24px;
+      min-width: 24px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+
+      fa-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .fa {
+        display: inline-block;
+        width: 1em;
+        text-align: center;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
Fixed sidebar menu items alignment using CSS-only approach. Added flexbox styling to `.mdc-list-item__primary-text` and fixed 24px width for `mat-icon` to ensure consistent icon-text alignment.

## Screenshots

| Before | After |
|--------|-------|
| <img width="273" height="596" alt="before" src="https://github.com/user-attachments/assets/ad6dbbc9-1613-414f-96df-9e642320891b" /> | <img width="273" height="596" alt="after" src="https://github.com/user-attachments/assets/a16c2700-4da7-4d8b-af70-da02cf6656a6" /> |
## Checklist
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved sidenav navigation list styling for consistent alignment, spacing and visual balance.
  * Fixed icon sizing and alignment in navigation items so icons no longer shrink, are consistently sized and centered, and scale uniformly with text.
  * Result: cleaner, more balanced navigation visuals and improved touch/visual consistency across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->