### PR TITLE
WEB-239: Fix Tax Components view page translation and layout

### DIFF
--- a/src/app/products/manage-tax-components/view-tax-component/view-tax-component.component.html
+++ b/src/app/products/manage-tax-components/view-tax-component/view-tax-component.component.html
@@ -39,7 +39,10 @@
 
         @if (taxComponentData.debitAccountType) {
           <div class="flex-50">
-            {{ taxComponentData.debitAccountType.value }}
+            {{
+              'labels.inputs.accounting.' + (taxComponentData.debitAccountType.value?.split('.')[1] || '').toUpperCase()
+                | translate
+            }}
           </div>
         }
 
@@ -51,8 +54,8 @@
 
         @if (taxComponentData.debitAccount) {
           <div class="flex-50">
-            ({{ 'labels.inputs.accounting.' + taxComponentData.debitAccount.glCode }})
-            {{ taxComponentData.debitAccount.name | translate }}
+            ({{ taxComponentData.debitAccount.glCode }})
+            {{ taxComponentData.debitAccount.name }}
           </div>
         }
 
@@ -64,7 +67,10 @@
 
         @if (taxComponentData.creditAccountType) {
           <div class="flex-50">
-            {{ taxComponentData.creditAccountType.value | translateKey: 'catalogs' }}
+            {{
+              'labels.inputs.accounting.' +
+                (taxComponentData.creditAccountType.value?.split('.')[1] || '').toUpperCase() | translate
+            }}
           </div>
         }
 


### PR DESCRIPTION
## Description

Fixed untranslated account type labels on Tax Components view page.

## Screenshots

**Before:** Untranslated labels
<img width="1912" height="940" alt="image" src="https://github.com/user-attachments/assets/f7d5503d-d63c-420a-8384-44f3e37205b0" />

**After:** Properly translated
<img width="803" height="528" alt="image" src="https://github.com/user-attachments/assets/4e295a38-5100-478e-9121-6ad00f19aa3b" />

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them
- [x] Read and understood the contribution guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved localization for account displays in the tax component view: account type labels now use dynamically constructed translation keys, while debit and credit account codes and names are shown in their original form (no longer passed through the translation system) for clearer, more consistent data presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->