### PR TITLE
WEB-675 fix tenant drop down

### DIFF
--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -564,6 +564,20 @@
 .tenant-section {
   margin-bottom: 1rem;
   flex-shrink: 0;
+  width: 100%;
+
+  ::ng-deep mifosx-tenant-selector {
+    display: block;
+    width: 100%;
+
+    #tenant-selector {
+      width: 100%;
+
+      .mat-mdc-form-field-icon-prefix {
+        padding: 0 0.75rem 0 0.5rem;
+      }
+    }
+  }
 }
 
 // ===== Resources Section =====


### PR DESCRIPTION
Fix the tenant selector styling on the Two-Factor Authentication (2FA) login page to achieve visual consistency with the main login page. The tenant dropdown now properly stretches to full width and maintains consistent spacing and alignment across both login states.

[WEB-675](https://mifosforge.jira.com/browse/WEB-675)

Before:
<img width="841" height="920" alt="image" src="https://github.com/user-attachments/assets/5cbc9bfb-67b5-48ea-9ce3-3c713fd37a41" />
After:
<img width="575" height="972" alt="Screenshot 2026-02-07 175035" src="https://github.com/user-attachments/assets/dd29ed6b-7f41-413e-bd1b-2571d0bea102" />



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-675]: https://mifosforge.jira.com/browse/WEB-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated login page styling to ensure the tenant selector renders at full width with appropriate padding and alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->