### PR TITLE
WEB-654 fix: show only product-specific datatables in loan account view

### DIFF
--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -414,17 +414,19 @@
           {{ 'labels.inputs.External Asset Owner' | translate }}
         </a>
       }
-      @for (loanDatatable of loanDatatables; track loanDatatable) {
-        <a
-          mat-tab-link
-          *mifosxHasPermission="'READ_' + loanDatatable.registeredTableName"
-          [routerLink]="['./datatables', loanDatatable.registeredTableName]"
-          routerLinkActive
-          #datatable="routerLinkActive"
-          [active]="datatable.isActive"
-        >
-          {{ loanDatatable.registeredTableName }}
-        </a>
+      @if (datatablesReady) {
+        @for (loanDatatable of loanDatatables; track loanDatatable) {
+          <a
+            mat-tab-link
+            *mifosxHasPermission="'READ_' + loanDatatable.registeredTableName"
+            [routerLink]="['./datatables', loanDatatable.registeredTableName]"
+            routerLinkActive
+            #datatable="routerLinkActive"
+            [active]="datatable.isActive"
+          >
+            {{ loanDatatable.registeredTableName }}
+          </a>
+        }
       }
     </nav>
     <mat-tab-nav-panel #tabPanel>

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -788,4 +788,16 @@ export class LoansService {
   getLoanOriginators(loanId: any) {
     return this.http.get(`/loans/${loanId}/originators`);
   }
+
+  /**
+   * Get Entity Datatable Checks
+   * Used to filter datatables based on product configuration
+   * @param {number} offset Page offset
+   * @param {number} limit Number of entries
+   * @returns {Observable<any>} Entity Datatable Checks data
+   */
+  getEntityDataTableChecks(offset: number = 0, limit: number = -1): Observable<any> {
+    const httpParams = new HttpParams().set('offset', offset.toString()).set('limit', limit.toString());
+    return this.http.get('/entityDatatableChecks', { params: httpParams });
+  }
 }


### PR DESCRIPTION
This change updates the loan account view to ensure that only relevant datatable tabs are displayed for each loan product. Previously, all datatable tabs were shown for every loan product, regardless of their configuration, which could cause confusion for users. Now, the view checks for product-specific associations and only displays datatables that are linked to the current loan product, or to all products if no specific association exists. This improves the user experience by making the interface clearer and more accurate.



[WEB-654](https://mifosforge.jira.com/browse/WEB-654)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-654]: https://mifosforge.jira.com/browse/WEB-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loan datatables now dynamically display based on product-specific configurations; only datatables allowed for the current loan product are shown.
* **Bug Fixes**
  * Datatable tabs now wait for product-configuration checks before rendering, reducing flicker and ensuring a consistent tab list.
* **Fallback**
  * If configuration checks fail or are unavailable, all datatables remain visible to preserve access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->