### PR TITLE
WEB-679 Fix Translation key not resolving in provisioning criteria definition dialog

### DIFF
--- a/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.ts
@@ -155,7 +155,7 @@ export class CreateLoanProvisioningCriteriaComponent implements OnInit {
    */
   editDefinition(definition: any) {
     const data = {
-      title: this.translateService.instant('labels.heading.Edit Criteria Definition'),
+      title: this.translateService.instant('labels.buttons.Edit Criteria Definition'),
       formfields: this.getDefinitionFormFields(definition),
       layout: { addButtonText: 'Confirm' }
     };

--- a/src/app/organization/loan-provisioning-criteria/edit-loan-provisioning-criteria/edit-loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/edit-loan-provisioning-criteria/edit-loan-provisioning-criteria.component.ts
@@ -165,7 +165,7 @@ export class EditLoanProvisioningCriteriaComponent implements OnInit {
    */
   editDefinition(definition: any) {
     const data = {
-      title: this.translateService.instant('labels.heading.Edit Criteria Definition'),
+      title: this.translateService.instant('labels.buttons.Edit Criteria Definition'),
       formfields: this.getDefinitionFormFields(definition),
       layout: { addButtonText: 'Confirm' }
     };


### PR DESCRIPTION
**Changes Made :-** 

-Changed the translation key from :-  labels.heading.Edit Criteria Definition to labels.buttons.Edit Criteria Definition

[WEB-679](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-679)

Before :- 

<img width="1365" height="657" alt="image" src="https://github.com/user-attachments/assets/e765deed-22f0-44be-a414-77a353debce0" />


After :- 

<img width="1365" height="677" alt="image" src="https://github.com/user-attachments/assets/1ccb60f2-66f2-4368-ab42-442f292b7e3b" />



[WEB-679]: https://mifosforge.jira.com/browse/WEB-679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dialog title labels for loan provisioning criteria dialogs to use the correct text identifier, ensuring consistent labeling across create and edit operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->