### PR TITLE
WEB-680 Fix provisioning criteria dialog allows negative values in age percentage fields

### DIFF
--- a/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.ts
@@ -187,6 +187,7 @@ export class CreateLoanProvisioningCriteriaComponent implements OnInit {
         value: definition ? definition.minAge : '',
         type: 'number',
         required: true,
+        min: 0,
         order: 1
       })
     );
@@ -197,6 +198,7 @@ export class CreateLoanProvisioningCriteriaComponent implements OnInit {
         value: definition ? definition.maxAge : '',
         type: 'number',
         required: true,
+        min: 0,
         order: 2
       })
     );
@@ -207,6 +209,7 @@ export class CreateLoanProvisioningCriteriaComponent implements OnInit {
         value: definition ? definition.provisioningPercentage : '',
         type: 'number',
         required: true,
+        min: 0,
         order: 3
       })
     );

--- a/src/app/organization/loan-provisioning-criteria/edit-loan-provisioning-criteria/edit-loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/edit-loan-provisioning-criteria/edit-loan-provisioning-criteria.component.ts
@@ -195,6 +195,7 @@ export class EditLoanProvisioningCriteriaComponent implements OnInit {
         value: definition ? definition.minAge : '',
         type: 'number',
         required: true,
+        min: 0,
         order: 1
       })
     );
@@ -205,6 +206,7 @@ export class EditLoanProvisioningCriteriaComponent implements OnInit {
         value: definition ? definition.maxAge : '',
         type: 'number',
         required: true,
+        min: 0,
         order: 2
       })
     );
@@ -215,6 +217,7 @@ export class EditLoanProvisioningCriteriaComponent implements OnInit {
         value: definition ? definition.provisioningPercentage : '',
         type: 'number',
         required: true,
+        min: 0,
         order: 3
       })
     );

--- a/src/app/shared/form-dialog/form-group.service.ts
+++ b/src/app/shared/form-dialog/form-group.service.ts
@@ -34,6 +34,12 @@ export class FormGroupService {
     if (formfield.required) {
       validators.push(Validators.required);
     }
+    if (formfield.min !== null && formfield.min !== undefined) {
+      validators.push(Validators.min(formfield.min));
+    }
+    if (formfield.max !== null && formfield.max !== undefined) {
+      validators.push(Validators.max(formfield.max));
+    }
     if (formfield.validators) {
       formfield.validators.forEach((validator: ValidatorFn) => validators.push(validator));
     }

--- a/src/app/shared/form-dialog/formfield/formfield.component.html
+++ b/src/app/shared/form-dialog/formfield/formfield.component.html
@@ -17,6 +17,8 @@
             matInput
             [formControlName]="formfield.controlName"
             [required]="formfield.required"
+            [attr.min]="formfield.min"
+            [attr.max]="formfield.max"
           />
         }
         @if (form.controls[formfield.controlName].hasError('max')) {


### PR DESCRIPTION
**Changes Made :-** 

-Adds min=0 validation to age/percentage fields by implementing Validators.min() in FormGroupService and HTML min attribute in formfield template.

[WEB-680](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-680)

Before :- 

<img width="283" height="190" alt="image" src="https://github.com/user-attachments/assets/689f75ab-1bc4-460d-a57b-4d2f3c963a8b" />


After :- 

<img width="273" height="194" alt="image" src="https://github.com/user-attachments/assets/187fce45-d461-43c0-8bc8-12d3dfcd0626" />


[WEB-680]: https://mifosforge.jira.com/browse/WEB-680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime min/max validation for numeric form inputs, enabling real-time range checks.
* **Improvements**
  * Numeric inputs now expose native min/max attributes for browser-level enforcement and UX.
* **Bug Fixes**
  * Loan provisioning forms now enforce non-negative values for age and provisioning percentage fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->