### PR TITLE
WEB-642: Loan originator view with optional fields

### DIFF
--- a/src/app/organization/loan-originators/edit-loan-originator/edit-loan-originator.component.ts
+++ b/src/app/organization/loan-originators/edit-loan-originator/edit-loan-originator.component.ts
@@ -35,7 +35,7 @@ export class EditLoanOriginatorComponent implements OnInit {
   private router = inject(Router);
 
   /** Loan Originator form. */
-  loanOriginatorForm: UntypedFormGroup;
+  loanOriginatorForm: UntypedFormGroup | null = null;
   /** Form data. */
   loanOriginatorsData: LoanOriginator;
   loanOriginatorsTemplateData: any;
@@ -88,10 +88,10 @@ export class EditLoanOriginatorComponent implements OnInit {
         Validators.required
       ],
       originatorTypeId: [
-        this.loanOriginatorsData.originatorType.id
+        this.loanOriginatorsData.originatorType?.id
       ],
       channelTypeId: [
-        this.loanOriginatorsData.channelType.id
+        this.loanOriginatorsData.channelType?.id
       ]
     });
   }

--- a/src/app/organization/loan-originators/view-loan-originator/view-loan-originator.component.html
+++ b/src/app/organization/loan-originators/view-loan-originator/view-loan-originator.component.html
@@ -46,7 +46,7 @@
         </div>
 
         <div class="flex-50">
-          {{ loanOriginatorData.originatorType.name }}
+          {{ loanOriginatorData.originatorType?.name }}
         </div>
 
         <div class="flex-50 mat-body-strong">
@@ -54,9 +54,15 @@
         </div>
 
         <div class="flex-50">
-          {{ loanOriginatorData.channelType.name }}
+          {{ loanOriginatorData.channelType?.name }}
         </div>
       </div>
     </mat-card-content>
+
+    <mat-card-actions class="layout-row align-center gap-5px responsive-column">
+      <button type="button" mat-raised-button [routerLink]="['../']">
+        {{ 'labels.buttons.Back' | translate }}
+      </button>
+    </mat-card-actions>
   </mat-card>
 </div>


### PR DESCRIPTION
## Description

There was an issue in the Loan Originator view due optional fields: Channel Type and Originator Type

[WEB-642](https://mifosforge.jira.com/browse/WEB-642)

## Screenshots, if any

https://github.com/user-attachments/assets/eb5afd7b-4601-4466-833b-62b2d2e01868


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-642]: https://mifosforge.jira.com/browse/WEB-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Back button to the loan originator view page for easier navigation.

* **Bug Fixes**
  * Improved stability in the loan originator editing interface by implementing safer handling of potentially missing data values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->