### PR TITLE
WEB-684 Allow negative values in Fund Mapping

### DIFF
--- a/src/app/organization/fund-mapping/fund-mapping.component.html
+++ b/src/app/organization/fund-mapping/fund-mapping.component.html
@@ -132,6 +132,7 @@
                     type="number"
                     matInput
                     required
+                    min="0"
                     formControlName="minOutStandingAmountPercentage"
                     placeholder="{{ 'labels.inputs.Minimum Value' | translate }}"
                   />
@@ -150,6 +151,7 @@
                     type="number"
                     matInput
                     required
+                    min="0"
                     formControlName="outStandingAmountPercentage"
                     placeholder="{{ 'labels.inputs.Comparison Value' | translate }}"
                   />
@@ -168,6 +170,7 @@
                     type="number"
                     matInput
                     required
+                    min="0"
                     formControlName="maxOutStandingAmountPercentage"
                     placeholder="{{ 'labels.inputs.Maximum Value' | translate }}"
                   />
@@ -213,6 +216,7 @@
                     type="number"
                     matInput
                     required
+                    min="0"
                     formControlName="minOutstandingAmount"
                     placeholder="{{ 'labels.inputs.Minimum Value' | translate }}"
                   />
@@ -231,6 +235,7 @@
                     type="number"
                     matInput
                     required
+                    min="0"
                     formControlName="outstandingAmount"
                     placeholder="{{ 'labels.inputs.Comparison Value' | translate }}"
                   />
@@ -249,6 +254,7 @@
                     type="number"
                     matInput
                     required
+                    min="0"
                     formControlName="maxOutstandingAmount"
                     placeholder="{{ 'labels.inputs.Maximum Value' | translate }}"
                   />

--- a/src/app/organization/fund-mapping/fund-mapping.component.ts
+++ b/src/app/organization/fund-mapping/fund-mapping.component.ts
@@ -186,17 +186,26 @@ export class FundMappingComponent implements OnInit {
           if (_value === 'between') {
             this.fundMappingForm.addControl(
               'minOutStandingAmountPercentage',
-              new UntypedFormControl('', Validators.required)
+              new UntypedFormControl('', [
+                Validators.required,
+                Validators.min(0)
+              ])
             );
             this.fundMappingForm.addControl(
               'maxOutStandingAmountPercentage',
-              new UntypedFormControl('', Validators.required)
+              new UntypedFormControl('', [
+                Validators.required,
+                Validators.min(0)
+              ])
             );
             this.fundMappingForm.removeControl('outStandingAmountPercentage');
           } else {
             this.fundMappingForm.addControl(
               'outStandingAmountPercentage',
-              new UntypedFormControl('', Validators.required)
+              new UntypedFormControl('', [
+                Validators.required,
+                Validators.min(0)
+              ])
             );
             this.fundMappingForm.removeControl('minOutStandingAmountPercentage');
             this.fundMappingForm.removeControl('maxOutStandingAmountPercentage');
@@ -216,11 +225,29 @@ export class FundMappingComponent implements OnInit {
         this.fundMappingForm.addControl('outstandingAmountCondition', new UntypedFormControl('', Validators.required));
         this.fundMappingForm.get('outstandingAmountCondition').valueChanges.subscribe((_value: string) => {
           if (_value === 'between') {
-            this.fundMappingForm.addControl('minOutstandingAmount', new UntypedFormControl('', Validators.required));
-            this.fundMappingForm.addControl('maxOutstandingAmount', new UntypedFormControl('', Validators.required));
+            this.fundMappingForm.addControl(
+              'minOutstandingAmount',
+              new UntypedFormControl('', [
+                Validators.required,
+                Validators.min(0)
+              ])
+            );
+            this.fundMappingForm.addControl(
+              'maxOutstandingAmount',
+              new UntypedFormControl('', [
+                Validators.required,
+                Validators.min(0)
+              ])
+            );
             this.fundMappingForm.removeControl('outstandingAmount');
           } else {
-            this.fundMappingForm.addControl('outstandingAmount', new UntypedFormControl('', Validators.required));
+            this.fundMappingForm.addControl(
+              'outstandingAmount',
+              new UntypedFormControl('', [
+                Validators.required,
+                Validators.min(0)
+              ])
+            );
             this.fundMappingForm.removeControl('minOutstandingAmount');
             this.fundMappingForm.removeControl('maxOutstandingAmount');
           }


### PR DESCRIPTION
**Changes Made :-** 

-Add validation to prevent negative values in Fund Mapping form fields .

[WEB-684](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-684)

Before :- 

<img width="640" height="311" alt="image" src="https://github.com/user-attachments/assets/10831346-a906-4b9d-b283-a084e01a9af3" />


After :-

<img width="912" height="208" alt="image" src="https://github.com/user-attachments/assets/e1a8d9d5-12b9-49c4-99a5-6fb7446b8d18" />


[WEB-684]: https://mifosforge.jira.com/browse/WEB-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation to prevent negative values for outstanding amount and percentage fields, ensuring data integrity in numeric inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->