### PR TITLE
WEB-685 Fix default values for due overdue days repayment event fields in loan product creation

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -169,20 +169,28 @@ export class LoanProductSettingsStepComponent implements OnInit {
     this.processingStrategyService.initialize(this.isAdvancedTransactionProcessingStrategy);
     this.validateAdvancedPaymentStrategyControls();
 
-    if (
-      this.loanProductsTemplate.dueDaysForRepaymentEvent != null &&
-      this.loanProductsTemplate.overDueDaysForRepaymentEvent != null
-    ) {
-      this.loanProductSettingsForm.patchValue({
-        useDueForRepaymentsConfigurations: false,
-        dueDaysForRepaymentEvent: this.loanProductsTemplate.dueDaysForRepaymentEvent,
-        overDueDaysForRepaymentEvent: this.loanProductsTemplate.overDueDaysForRepaymentEvent
-      });
+    if (this.toEdit) {
+      if (
+        this.loanProductsTemplate.dueDaysForRepaymentEvent != null &&
+        this.loanProductsTemplate.overDueDaysForRepaymentEvent != null
+      ) {
+        this.loanProductSettingsForm.patchValue({
+          useDueForRepaymentsConfigurations: false,
+          dueDaysForRepaymentEvent: this.loanProductsTemplate.dueDaysForRepaymentEvent,
+          overDueDaysForRepaymentEvent: this.loanProductsTemplate.overDueDaysForRepaymentEvent
+        });
+      } else {
+        this.loanProductSettingsForm.patchValue({
+          useDueForRepaymentsConfigurations: true,
+          dueDaysForRepaymentEvent: '',
+          overDueDaysForRepaymentEvent: ''
+        });
+      }
     } else {
       this.loanProductSettingsForm.patchValue({
-        useDueForRepaymentsConfigurations: true,
-        dueDaysForRepaymentEvent: null,
-        overDueDaysForRepaymentEvent: null
+        useDueForRepaymentsConfigurations: false,
+        dueDaysForRepaymentEvent: '',
+        overDueDaysForRepaymentEvent: ''
       });
     }
 


### PR DESCRIPTION
**Changes Made :-** 

-Changed default values for [dueDaysForRepaymentEvent and [overDueDaysForRepaymentEvent] fields from inheriting global configuration value to empty string, allowing users to enter their own values when creating new loan products while preserving existing values when editing.

[WEB-685 ](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-685)

Before :- 

<img width="1364" height="518" alt="image" src="https://github.com/user-attachments/assets/2666f1c0-21ad-4f75-934e-4776b16984c4" />

After :- 

<img width="1365" height="404" alt="image" src="https://github.com/user-attachments/assets/cc56d50a-86c7-4ca9-9705-d9c314135db5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repayment configuration handling so editing preserves repayment event fields only when both day values are present; otherwise configuration is enabled and fields are cleared.
  * When creating/new entries, repayment configuration is disabled and repayment day fields are reset to empty values.
  * Replaced nulls with empty values for non-edit flows to improve consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->