### PR TITLE
WEB-686 fix: reduce excessive spacing between buttons and content in …

### DIFF
--- a/src/app/profile/profile.component.scss
+++ b/src/app/profile/profile.component.scss
@@ -8,7 +8,7 @@
 
 .container {
   max-width: 37rem;
-  padding: 1rem;
+  padding: 0.25rem 1rem 1rem;
 
   mat-card {
     margin-bottom: 1rem;


### PR DESCRIPTION
…profile component

Reduced excessive vertical spacing between the action buttons (Permissions and Change Password) and the user information content boxes in the Profile component. The previous layout created an awkward visual gap that negatively impacted the user experience and made the interface feel disconnected.

[WEB-686](https://mifosforge.jira.com/browse/WEB-686)

Before:
<img width="1038" height="914" alt="Screenshot 2026-02-10 030425" src="https://github.com/user-attachments/assets/320210e7-38db-46f2-9cf3-1d46928852f7" />
After:
<img width="1094" height="913" alt="image" src="https://github.com/user-attachments/assets/53e4dfe5-734b-4971-bfee-e52633313b4d" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-686]: https://mifosforge.jira.com/browse/WEB-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted padding in the profile layout for refined spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->