### PR TITLE
WEB-688 refactor: remove password toggle hover effects for cleaner UI

### DIFF
--- a/src/app/login/login-form/login-form.component.scss
+++ b/src/app/login/login-form/login-form.component.scss
@@ -161,11 +161,6 @@
         border: none;
         color: var(--md-sys-color-on-surface-variant, #44474e);
         transition: all 0.2s ease;
-
-        &:hover {
-          color: var(--md-sys-color-primary, #1074b9);
-          background: #1074b914;
-        }
       }
     }
 
@@ -341,11 +336,6 @@
 
       .mat-mdc-form-field-icon-suffix button {
         color: var(--md-sys-color-on-surface-variant, #c4c6d0);
-
-        &:hover {
-          color: var(--md-sys-color-primary, #5ba2ec);
-          background: #5ba2ec1f;
-        }
       }
     }
   }


### PR DESCRIPTION
This pr updated the login form password toggle button styling to remove unnecessary hover effects, creating a cleaner and more minimal user interface. The changes eliminate color transitions and background highlights when users hover over the password visibility toggle (eye icon) while preserving all existing functionality.

[WEB-688](https://mifosforge.jira.com/browse/WEB-688)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-688]: https://mifosforge.jira.com/browse/WEB-688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed hover effects from the password visibility toggle button in the login form, including dark-theme styling adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->