### PR TITLE
WEB-655 feat(clients): filter datatables by client subtype (Person/En…

### DIFF
--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -24,6 +24,7 @@ import { CaptureImageDialogComponent } from './custom-dialogs/capture-image-dial
 
 /** Custom Services */
 import { ClientsService } from '../clients.service';
+import { LegalFormId } from '../models/legal-form.enum';
 import {
   MatCard,
   MatCardHeader,
@@ -144,9 +145,24 @@ export class ClientsViewComponent implements OnInit {
   constructor() {
     this.route.data.subscribe((data: { clientViewData: any; clientTemplateData: any; clientDatatables: any }) => {
       this.clientViewData = data.clientViewData;
-      this.clientDatatables = data.clientDatatables;
+      this.clientDatatables = this.filterDatatablesByClientSubtype(
+        data.clientDatatables,
+        data.clientViewData?.legalForm?.id
+      );
       this.clientTemplateData = data.clientTemplateData;
     });
+  }
+
+  /**
+   * Filters datatables based on the client's legal form (Person or Entity).
+   * Datatables without an entitySubType are kept visible for all client types.
+   */
+  private filterDatatablesByClientSubtype(datatables: any[], legalFormId: number): any[] {
+    if (!datatables || !legalFormId) {
+      return datatables || [];
+    }
+    const subtype = legalFormId === LegalFormId.PERSON ? 'person' : 'entity';
+    return datatables.filter((dt: any) => !dt.entitySubType || dt.entitySubType.toLowerCase() === subtype);
   }
 
   ngOnInit() {


### PR DESCRIPTION
…tity)

When viewing a client, all registered datatables were displayed as tabs regardless of the client's subtype. This meant a Person client would see Entity-only datatables (e.g., ENTITY_DATA) and vice versa, which is confusing and incorrect.
This change filters the datatable tabs in the Client View based on the client's 
Person clients (legalForm.id = 1) only see datatables with entitySubType: 'person'
Entity clients (legalForm.id = 2) only see datatables with entitySubType: 'entity'
Datatables without an entitySubType remain visible for all client types

[WEB-655](https://mifosforge.jira.com/browse/WEB-655)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-65]: https://mifosforge.jira.com/browse/WEB-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WEB-655]: https://mifosforge.jira.com/browse/WEB-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Client view now filters and displays datatables based on client type (person or entity), ensuring users see only relevant information specific to their client classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->