### PR TITLE
WEB-695: Add Github Action workflow for enforce PR title convention

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,26 @@
+name: Web App PR Compliance
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  verify-title:
+    name: Validate Jira Ticket ID
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verify Title Format
+        run: |
+          title="${{ github.event.pull_request.title }}"
+          regex="^WEB-[0-9]+: "
+
+          if [[ ! "$title" =~ $regex ]]; then
+            echo "::error::PR title '$title' is invalid."
+            echo "::error::It must start with a Jira Ticket ID (e.g., 'WEB-123: Description...')."
+            exit 1
+          fi
+          echo "Success: PR title matches the required format."


### PR DESCRIPTION
This adds a new GitHub Actions workflow to enforce PR title compliance. The workflow checks that all pull requests have a title starting with a Jira Ticket ID (e.g., "WEB-123: Description..."). If the format is incorrect, it fails the workflow and provides an error message.

