### PR TITLE
WEB-674: Write-Off reason on product level input field label issue

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component.ts
@@ -111,7 +111,7 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
             'WriteOffReasonToExpense'
           ].includes(this.formType)) {
           const addData: AccountingMappingDTO = {
-            value: this.getValueData(response.data.value.chargeOffReasonCodeValueId),
+            value: this.getValueData(response.data.value.reasonCodeValueId),
             glAccount: this.getGlAccountData(response.data.value.expenseAccountId)
           };
           this.addTableData(addData);
@@ -177,7 +177,7 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
             'WriteOffReasonToExpense'
           ].includes(this.formType)) {
           updateData = {
-            value: this.getValueData(response.data.value.chargeOffReasonCodeValueId),
+            value: this.getValueData(response.data.value.reasonCodeValueId),
             glAccount: this.getGlAccountData(response.data.value.expenseAccountId)
           };
         } else if ([
@@ -235,7 +235,7 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
       case 'ChargeOffReasonExpense':
         return {
           title: 'Map Charge-off reasons to Expense accounts',
-          formfields: this.getChargeOffReasonExpenseFormfields(values)
+          formfields: this.getReasonsExpenseFormfields(values)
         };
       case 'BuydownFeeClassificationToIncome':
         return {
@@ -250,7 +250,7 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
       case 'WriteOffReasonToExpense':
         return {
           title: 'Map Write-off reasons to Expense accounts',
-          formfields: this.getChargeOffReasonExpenseFormfields(values)
+          formfields: this.getReasonsExpenseFormfields(values)
         };
     }
   }
@@ -321,14 +321,14 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
     return formfields;
   }
 
-  getChargeOffReasonExpenseFormfields(values?: any) {
+  getReasonsExpenseFormfields(values?: any) {
     const reasonOptions = this.accountingMappingOptions.filter(
       (item: any) => !this.currentFormValues.includes(item.id)
     );
     const formfields: FormfieldBase[] = [
       new SelectBase({
-        controlName: 'chargeOffReasonCodeValueId',
-        label: 'Charge-off reason',
+        controlName: 'reasonCodeValueId',
+        label: this.formType === 'ChargeOffReasonExpense' ? 'Charge-off reason' : 'Write-off reason',
         value: values ? values.value.id : reasonOptions[0].id,
         options: { label: 'name', value: 'id', data: reasonOptions },
         required: true,


### PR DESCRIPTION
## Description

There was an issue with an input dropdown label related to Write-Off Reason in the Loan Product advanced 

[WEB-674](https://mifosforge.jira.com/browse/WEB-674)

## Related issues and discussion

## Screenshots, if any

- Before
<img width="395" height="101" alt="image" src="https://github.com/user-attachments/assets/6b69aa69-6db1-4364-8973-445dd869a497" />

- After
<img width="381" height="122" alt="Screenshot 2026-02-10 at 10 15 09 a m" src="https://github.com/user-attachments/assets/8c0c2412-578f-4310-a411-e345c67762e5" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-674]: https://mifosforge.jira.com/browse/WEB-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected value source handling in expense account mapping for charge-off and write-off reason configurations.

* **Improvements**
  * Unified form field structure for expense reason mappings with dynamic labels that appropriately reflect the mapping type (charge-off vs. write-off reasons).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->