### PR TITLE
WEB-698 Assignment date is pre-filled by default in bulk loan reassignment form

### DIFF
--- a/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.ts
+++ b/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.ts
@@ -92,7 +92,7 @@ export class BulkLoanReassignmnetComponent implements OnInit {
         Validators.required
       ],
       assignmentDate: [
-        this.settingsService.businessDate,
+        '',
         Validators.required
       ],
       toLoanOfficerId: [


### PR DESCRIPTION
**Changes Made :-** 

-Removed default business date pre-population from the Assignment Date field in Bulk Loan Reassignment form to ensure users explicitly select a date.

[WEB-698](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-698)

Before :- 

<img width="1365" height="537" alt="image" src="https://github.com/user-attachments/assets/9dd8db10-64e1-46af-b87e-23739bd21885" />

After :- 

<img width="1365" height="533" alt="image" src="https://github.com/user-attachments/assets/c6e5de87-9c0a-48c0-aac9-c3f74bc0030d" />


[WEB-698]: https://mifosforge.jira.com/browse/WEB-698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the assignment date field in the bulk loan reassignment form. The field no longer auto-populates with a default date value and now requires explicit user input to complete the form. Form validation rules and submission logic remain fully functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->