### PR TITLE
WEB-699 Fund Mapping: Loan Status and Product fields should be option…

### DIFF
--- a/src/app/organization/fund-mapping/fund-mapping.component.ts
+++ b/src/app/organization/fund-mapping/fund-mapping.component.ts
@@ -28,9 +28,7 @@ import {
   UntypedFormBuilder,
   UntypedFormControl,
   Validators,
-  ReactiveFormsModule,
-  AbstractControl,
-  ValidationErrors
+  ReactiveFormsModule
 } from '@angular/forms';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
@@ -123,38 +121,13 @@ export class FundMappingComponent implements OnInit {
   }
 
   /**
-   * Custom validator to ensure array fields are not empty.
-   * @param {AbstractControl} control - the form control to validate.
-   * @returns {ValidationErrors | null} - validation errors or null if valid.
-   */
-  private nonEmptyArrayValidator(control: AbstractControl): ValidationErrors | null {
-    const value = control.value;
-    if (!value || !Array.isArray(value) || value.length === 0) {
-      return { required: true };
-    }
-    if (value.every((item: any) => item === '' || item === null || item === undefined)) {
-      return { required: true };
-    }
-    return null;
-  }
-
-  /**
    * Creates the Fund Mapping Form
    */
   createFundMappingForm() {
     this.fundMappingForm = this.formBuilder.group({
-      loanStatus: [
-        [],
-        this.nonEmptyArrayValidator.bind(this)
-      ],
-      loanProducts: [
-        [],
-        this.nonEmptyArrayValidator.bind(this)
-      ],
-      offices: [
-        [],
-        this.nonEmptyArrayValidator.bind(this)
-      ],
+      loanStatus: [[]],
+      loanProducts: [[]],
+      offices: [[]],
       loanDateOption: [
         '',
         Validators.required


### PR DESCRIPTION
**Changes Made :-** 

-Removed required validators from `loanStatus` and `Products` form controls in Fund Mapping component .

[WEB-699](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-699)

Before :- 

<img width="640" height="338" alt="image" src="https://github.com/user-attachments/assets/57e2de21-79df-456a-bfe8-b7108ea7cac7" />


After :- 

<img width="1365" height="623" alt="image" src="https://github.com/user-attachments/assets/7ed86325-1f9e-427d-87a2-894c5bd6ee84" />


[WEB-699]: https://mifosforge.jira.com/browse/WEB-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed validation constraints from fund mapping form fields (loan status, loan products, and offices).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->