### PR TITLE
WEB-692 Datatables parameter is optional and must be skipped from being sent to the backend while creating a client

### DIFF
--- a/src/app/clients/create-client/create-client.component.ts
+++ b/src/app/clients/create-client/create-client.component.ts
@@ -161,7 +161,9 @@ export class CreateClientComponent {
       this.clientDatatables.forEach((clientDatatable: ClientDatatableStepComponent) => {
         datatables.push(clientDatatable.payload);
       });
-      clientData['datatables'] = datatables;
+      if (datatables.length > 0) {
+        clientData['datatables'] = datatables;
+      }
     }
 
     this.clientsService.createClient(clientData).subscribe((response: any) => {


### PR DESCRIPTION
**Changes Made :-**

-Fix datatables parameter issue . Now datatables  is optional and must be skipped from being sent to the backend while creating a client.

[WEB-692](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-692)


[WEB-692]: https://mifosforge.jira.com/browse/WEB-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized client creation requests to avoid sending empty data arrays, improving request efficiency and reducing unnecessary payload overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->