### PR TITLE
WEB-700 Configuration Form Allows Negative Number Values

### DIFF
--- a/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.html
+++ b/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.html
@@ -23,7 +23,7 @@
 
           <mat-form-field>
             <mat-label>{{ 'labels.inputs.Number Value' | translate }}</mat-label>
-            <input matInput type="number" formControlName="value" />
+            <input matInput type="number" formControlName="value" min="0" />
           </mat-form-field>
 
           <mat-form-field>

--- a/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.ts
+++ b/src/app/system/configurations/global-configurations-tab/edit-configuration/edit-configuration.component.ts
@@ -78,7 +78,10 @@ export class EditConfigurationComponent implements OnInit {
         Validators.required
       ],
       description: [{ value: this.configuration.description, disabled: true }],
-      value: [this.configuration.value],
+      value: [
+        this.configuration.value,
+        [Validators.min(0)]
+      ],
       stringValue: [this.configuration.stringValue],
       dateValue: [this.configuration.dateValue]
     });


### PR DESCRIPTION
**Changes Made :-** 

-Prevented negative values in the configuration "Number Value" field by enforcing a minimum value of zero.

[WEB-700](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-700)

Before :- 

<img width="640" height="300" alt="image" src="https://github.com/user-attachments/assets/d9daf3ff-7ea4-4eb1-a39f-7becf8bd5570" />

After :- 

<img width="1365" height="636" alt="image" src="https://github.com/user-attachments/assets/5749ff40-9cba-4c3e-8c54-1f9023785fbc" />


[WEB-700]: https://mifosforge.jira.com/browse/WEB-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for configuration value fields to prevent negative numeric inputs. The system now enforces non-negative values during form submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->