### PR TITLE
WEB-704 Restrict negative values for group rules minimum savings amount and share price fields

### DIFF
--- a/src/app/core/utils/datatables.ts
+++ b/src/app/core/utils/datatables.ts
@@ -44,18 +44,26 @@ export class Datatables {
   public getFormfields(columns: any, dateTransformColumns: string[], dataTableEntryObject: any) {
     return columns.map((column: any) => {
       const displayLabel = this.toDisplayLabel(column.columnName);
+      const colName = column.columnName ? column.columnName.toLowerCase().replace(/[_\s]+/g, '') : '';
+      const isMinSavingsAmount = colName.includes('minimumsavingsamountpermeeting');
+      const isPriceOneShare = colName.includes('priceofoneshare');
       switch (column.columnDisplayType) {
         case 'INTEGER':
         case 'STRING':
         case 'DECIMAL':
-        case 'TEXT':
-          return new InputBase({
+        case 'TEXT': {
+          const inputOptions: any = {
             controlName: column.columnName,
             label: displayLabel,
             value: '',
             type: column.columnDisplayType === 'INTEGER' || column.columnDisplayType === 'DECIMAL' ? 'number' : 'text',
             required: column.isColumnNullable ? false : true
-          });
+          };
+          if (isMinSavingsAmount || isPriceOneShare) {
+            inputOptions.min = 0;
+          }
+          return new InputBase(inputOptions);
+        }
         case 'BOOLEAN':
           return new CheckboxBase({
             controlName: column.columnName,


### PR DESCRIPTION
**Changes Made :-**

-Restricts "Minimum Savings Amount per Meeting" and "Price of one Share" fields in group rules form to only accept zero or positive values..

[WEB-704](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-704)

Before :- 

<img width="640" height="297" alt="image" src="https://github.com/user-attachments/assets/567d66a7-fc9c-45c9-b16f-3291e4c91d97" />

After :- 

<img width="1356" height="515" alt="image" src="https://github.com/user-attachments/assets/28ecc70c-266e-4df6-b171-bec22b8fa935" />



[WEB-704]: https://mifosforge.jira.com/browse/WEB-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation for numeric financial fields to enforce minimum value constraints, ensuring data consistency and preventing invalid entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->