### PR TITLE
WEB-708 Required Field Validation Messages Not Displayed in Loan Product

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -28,6 +28,15 @@
     <mat-form-field class="flex-31">
       <mat-label>{{ 'labels.inputs.Default' | translate }}</mat-label>
       <input type="number" matInput formControlName="principal" required [min]="1" step="0.01" />
+      <mat-error
+        *ngIf="
+          loanProductTermsForm.get('principal')?.hasError('required') &&
+          (loanProductTermsForm.get('principal')?.touched || loanProductTermsForm.get('principal')?.dirty)
+        "
+      >
+        {{ 'labels.catalogs.Default' | translate }} {{ 'labels.inputs.Principal' | translate }}
+        {{ 'labels.commons.is required' | translate }}
+      </mat-error>
       <mat-error *ngIf="loanProductTermsForm.get('principal')?.hasError('min')">
         {{ 'labels.catalogs.Default' | translate }} {{ 'labels.inputs.Principal' | translate }}
         {{ 'labels.commons.is' | translate }}
@@ -59,6 +68,16 @@
               </mat-option>
             }
           </mat-select>
+          <mat-error
+            *ngIf="
+              loanProductTermsForm.get('overAppliedCalculationType')?.hasError('required') &&
+              (loanProductTermsForm.get('overAppliedCalculationType')?.touched ||
+                loanProductTermsForm.get('overAppliedCalculationType')?.dirty)
+            "
+          >
+            {{ 'labels.inputs.Over Amount Calculation Type' | translate }}
+            {{ 'labels.commons.is required' | translate }}
+          </mat-error>
         </mat-form-field>
       }
 
@@ -66,6 +85,15 @@
         <mat-form-field class="flex-fill flex-32">
           <mat-label>{{ 'labels.inputs.Over Amount' | translate }}</mat-label>
           <input type="number" matInput formControlName="overAppliedNumber" required />
+          <mat-error
+            *ngIf="
+              loanProductTermsForm.get('overAppliedNumber')?.hasError('required') &&
+              (loanProductTermsForm.get('overAppliedNumber')?.touched ||
+                loanProductTermsForm.get('overAppliedNumber')?.dirty)
+            "
+          >
+            {{ 'labels.inputs.Over Amount' | translate }} {{ 'labels.commons.is required' | translate }}
+          </mat-error>
         </mat-form-field>
       }
     </div>


### PR DESCRIPTION
**Chnages Made :-** 

-Added error messages for required fields on the Create Loan Product  .

[WEB-708](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-708)

Before :- 

<img width="640" height="255" alt="image" src="https://github.com/user-attachments/assets/b2401962-b4bc-495a-982c-f0f372194d4f" />

After :- 

<img width="1181" height="246" alt="image" src="https://github.com/user-attachments/assets/75835a3e-9e5d-43c1-9a27-5da99083ca46" />


[WEB-708]: https://mifosforge.jira.com/browse/WEB-708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved validation feedback in the loan product terms form with new error messages for required fields including principal, calculation type, and number inputs. Messages appear when fields are touched or modified to guide users through accurate form completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->