### PR TITLE
WEB-709 Interest Rate Field Error Messages Not Translated

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -258,16 +258,14 @@
             }
           </mat-select>
           <mat-error>
-            {{ 'labels.inputs.Floating rate' | translate }} {{ 'labels.commons.is' | translate }}
-            <strong>{{ 'labels.commons.required' | translate }}</strong>
+            {{ 'labels.inputs.Floating rate' | translate }} {{ 'labels.commons.is required' | translate }}
           </mat-error>
         </mat-form-field>
         <mat-form-field class="flex-31">
           <mat-label>{{ 'labels.inputs.Differential Rate' | translate }}</mat-label>
           <input type="number" matInput formControlName="interestRateDifferential" required />
           <mat-error>
-            {{ 'labels.inputs.Differential rate' | translate }} {{ 'labels.commons.is' | translate }}
-            <strong>{{ 'labels.commons.required' | translate }}</strong>
+            {{ 'labels.inputs.Differential rate' | translate }} {{ 'labels.commons.is required' | translate }}
           </mat-error>
         </mat-form-field>
         <mat-checkbox class="flex-31" labelPosition="before" formControlName="isFloatingInterestRateCalculationAllowed">
@@ -277,8 +275,7 @@
           <mat-label>{{ 'labels.inputs.Minimum' | translate }}</mat-label>
           <input type="number" matInput formControlName="minDifferentialLendingRate" [min]="0" required />
           <mat-error>
-            {{ 'labels.inputs.Minimum interest rate' | translate }} {{ 'labels.commons.is' | translate }}
-            <strong>{{ 'labels.commons.required' | translate }}</strong>
+            {{ 'labels.inputs.Minimum interest rate' | translate }} {{ 'labels.commons.is required' | translate }}
           </mat-error>
         </mat-form-field>
         <mat-form-field class="flex-31">
@@ -286,16 +283,14 @@
           <input type="number" matInput formControlName="defaultDifferentialLendingRate" required />
           <mat-error>
             {{ 'labels.catalogs.Default' | translate }} {{ 'labels.inputs.Interest rate' | translate }}
-            {{ 'labels.commons.is' | translate }}
-            <strong>{{ 'labels.commons.required' | translate }}</strong>
+            {{ 'labels.commons.is required' | translate }}
           </mat-error>
         </mat-form-field>
         <mat-form-field class="flex-31">
           <mat-label>{{ 'labels.inputs.Maximum' | translate }}</mat-label>
           <input type="number" matInput formControlName="maxDifferentialLendingRate" required />
           <mat-error>
-            {{ 'labels.inputs.Maximum interest rate' | translate }} {{ 'labels.commons.is' | translate }}
-            <strong>{{ 'labels.commons.required' | translate }}</strong>
+            {{ 'labels.inputs.Maximum interest rate' | translate }} {{ 'labels.commons.is required' | translate }}
           </mat-error>
         </mat-form-field>
       </div>

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1297,6 +1297,11 @@
       "Pending Tasks": "Čekající úkoly"
     },
     "inputs": {
+      "Floating rate": "Plovoucí sazba",
+      "Differential rate": "Diferenční sazba",
+      "Minimum interest rate": "Minimální úroková sazba",
+      "Interest rate": "Úroková sazba",
+      "Maximum interest rate": "Maximální úroková sazba",
       "Terms": "Podmínky",
       "Settings": "Nastavení",
       "accounting": {

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1298,6 +1298,11 @@
       "Pending Tasks": "Ausstehende Aufgaben"
     },
     "inputs": {
+      "Floating rate": "Variabler Zinssatz",
+      "Differential rate": "Differenzzinssatz",
+      "Minimum interest rate": "Mindestzinssatz",
+      "Interest rate": "Zinssatz",
+      "Maximum interest rate": "Höchstzinssatz",
       "Terms": "Bedingungen",
       "Settings": "Einstellungen",
       "accounting": {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1302,6 +1302,11 @@
       "Global Impact": "Global Impact"
     },
     "inputs": {
+      "Floating rate": "Floating Rate",
+      "Differential rate": "Differential Rate",
+      "Minimum interest rate": "Minimum Interest Rate",
+      "Interest rate": "Interest Rate",
+      "Maximum interest rate": "Maximum Interest Rate",
       "Terms": "Terms",
       "Settings": "Settings",
       "accounting": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1298,6 +1298,11 @@
       "Pending Tasks": "Pending Tasks"
     },
     "inputs": {
+      "Floating rate": "Tasa flotante",
+      "Differential rate": "Tasa diferencial",
+      "Minimum interest rate": "Tasa de interés mínima",
+      "Interest rate": "Tasa de interés",
+      "Maximum interest rate": "Tasa de interés máxima",
       "Terms": "Términos",
       "Settings": "Configuración",
       "accounting": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1297,6 +1297,11 @@
       "Pending Tasks": "Tareas pendientes"
     },
     "inputs": {
+      "Floating rate": "Tasa flotante",
+      "Differential rate": "Tasa diferencial",
+      "Minimum interest rate": "Tasa de interés mínima",
+      "Interest rate": "Tasa de interés",
+      "Maximum interest rate": "Tasa de interés máxima",
       "Terms": "Términos",
       "Settings": "Configuración",
       "accounting": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1301,6 +1301,11 @@
       "Pending Tasks": "Tâches en attente"
     },
     "inputs": {
+      "Floating rate": "Taux flottant",
+      "Differential rate": "Taux différentiel",
+      "Minimum interest rate": "Taux d'intérêt minimum",
+      "Interest rate": "Taux d'intérêt",
+      "Maximum interest rate": "Taux d'intérêt maximum",
       "Terms": "Termes",
       "Settings": "Paramètres",
       "accounting": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1297,6 +1297,11 @@
       "Pending Tasks": "Pending Tasks"
     },
     "inputs": {
+      "Floating rate": "Tasso variabile",
+      "Differential rate": "Tasso differenziale",
+      "Minimum interest rate": "Tasso di interesse minimo",
+      "Interest rate": "Tasso di interesse",
+      "Maximum interest rate": "Tasso di interesse massimo",
       "Terms": "Termini",
       "Settings": "Impostazioni",
       "accounting": {

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1299,6 +1299,11 @@
       "Pending Tasks": "보류 중인 작업"
     },
     "inputs": {
+      "Floating rate": "변동 금리",
+      "Differential rate": "차등 금리",
+      "Minimum interest rate": "최소 이자율",
+      "Interest rate": "이자율",
+      "Maximum interest rate": "최대 이자율",
       "Terms": "약관",
       "Settings": "설정",
       "accounting": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1296,6 +1296,11 @@
       "Pending Tasks": "Laukiamos užduotys"
     },
     "inputs": {
+      "Floating rate": "Slankioji norma",
+      "Differential rate": "Diferencinis tarifas",
+      "Minimum interest rate": "Minimali palūkanų norma",
+      "Interest rate": "Palūkanų norma",
+      "Maximum interest rate": "Maksimali palūkanų norma",
       "Terms": "Sąlygos",
       "Settings": "Nustatymai",
       "accounting": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1298,6 +1298,11 @@
       "Pending Tasks": "Pending Tasks"
     },
     "inputs": {
+      "Floating rate": "Mainīgā likme",
+      "Differential rate": "Diferenciālā likme",
+      "Minimum interest rate": "Minimālā procentu likme",
+      "Interest rate": "Procentu likme",
+      "Maximum interest rate": "Maksimālā procentu likme",
       "Terms": "Noteikumi",
       "Settings": "Iestatījumi",
       "accounting": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1296,6 +1296,11 @@
       "Pending Tasks": "बाँकी कार्यहरू"
     },
     "inputs": {
+      "Floating rate": "चल दर",
+      "Differential rate": "अन्तर दर",
+      "Minimum interest rate": "न्यूनतम ब्याज दर",
+      "Interest rate": "ब्याज दर",
+      "Maximum interest rate": "अधिकतम ब्याज दर",
       "Terms": "सर्तहरू",
       "Settings": "सेटिङहरू",
       "accounting": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1297,6 +1297,11 @@
       "Pending Tasks": "Tarefas Pendentes"
     },
     "inputs": {
+      "Floating rate": "Taxa flutuante",
+      "Differential rate": "Taxa diferencial",
+      "Minimum interest rate": "Taxa de juro mínima",
+      "Interest rate": "Taxa de juro",
+      "Maximum interest rate": "Taxa de juro máxima",
       "Terms": "Termos",
       "Settings": "Configurações",
       "accounting": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1295,6 +1295,11 @@
       "Pending Tasks": "Kazi Zinazongoja"
     },
     "inputs": {
+      "Floating rate": "Kiwango cha Kuelea",
+      "Differential rate": "Kiwango cha Tofauti",
+      "Minimum interest rate": "Kiwango cha Riba cha Chini",
+      "Interest rate": "Kiwango cha Riba",
+      "Maximum interest rate": "Kiwango cha Riba cha Juu",
       "Terms": "Masharti",
       "Settings": "Mipangilio",
       "accounting": {


### PR DESCRIPTION
**Changed Made :-** 

-Added localized translations for interest rate field error messages in all supported language files.

[WEB-709](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-709)

Before :- 

<img width="640" height="151" alt="image" src="https://github.com/user-attachments/assets/a2fc8142-3c48-4efa-b893-12427e994937" />

After :- 

<img width="1030" height="168" alt="image" src="https://github.com/user-attachments/assets/c4d15368-9b39-4cfa-a612-eb09c6f1b6b3" />


<img width="985" height="174" alt="image" src="https://github.com/user-attachments/assets/9a3f686f-60a8-44c6-b936-c429b596990e" />


[WEB-709]: https://mifosforge.jira.com/browse/WEB-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded localization with added translations for floating/differential/minimum/maximum/interest rate labels across 13 locales (en, cs, de, es-CL, es-MX, fr, it, ko, lt, lv, ne, pt, sw).

* **Bug Fixes**
  * Standardized displayed validation messages for loan term fields to consistently read "... is required".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->