### PR TITLE
WEB-713: Hide tenant dropdown when Fineract Platform Tenants is not defined

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -93,7 +93,7 @@
         <!-- Form Section -->
         <div class="form-section">
           <!-- Tenant Selector -->
-          @if (displayTenantSelector()) {
+          @if (showTenantSelector) {
             <div class="tenant-section">
               <mifosx-tenant-selector></mifosx-tenant-selector>
             </div>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -73,6 +73,8 @@ import { VersionService } from '../system/version.service';
   ]
 })
 export class LoginComponent implements OnInit, OnDestroy {
+  /** Whether to show the tenant selector dropdown */
+  showTenantSelector = true;
   /** Show version info table if env allows */
   displayBackendInfo = environment.displayBackEndInfo !== 'false';
   /** Production mode - minimal hero with branding only */
@@ -115,6 +117,7 @@ export class LoginComponent implements OnInit, OnDestroy {
    * Subscribes to alert event of alert service and theme changes.
    */
   ngOnInit() {
+    this.showTenantSelector = this.calculateTenantSelectorVisibility();
     this.updateLogo();
     this.themeDarkEnabled = this.settingsService.themeDarkEnabled;
     // Subscribe to theme changes
@@ -193,12 +196,21 @@ export class LoginComponent implements OnInit, OnDestroy {
     window.location.reload();
   }
 
-  displayTenantSelector(): boolean {
-    // Hide tenant selector when OAuth2 is enabled (tenant is determined by OAuth server)
+  private calculateTenantSelectorVisibility(): boolean {
     if (environment.oauth.enabled) {
       return false;
     }
-    return environment.displayTenantSelector === 'false' ? false : true;
+    if (environment.displayTenantSelector === 'false') {
+      return false;
+    }
+    const tenantIds = environment.fineractPlatformTenantIds
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0);
+    if (tenantIds.length === 0 || (tenantIds.length === 1 && tenantIds[0] === 'default')) {
+      return false;
+    }
+    return true;
   }
 
   allowServerSwitch(): boolean {


### PR DESCRIPTION
## Description

Hide the tenant dropdown on the login page when `FINERACT_PLATFORM_TENANTS_IDENTIFIER` is not defined. When the variable contains at least 1 explicit tenant, the dropdown is shown with those values.

**Changes:**
- Replaced `displayTenantSelector()` method call with a `showTenantSelector` boolean property computed once in [ngOnInit()]— avoids recalculation on every Angular change detection cycle
- Dropdown is hidden when the tenant list is empty or contains only the implicit `'default'` fallback
- The `'default'` fallback in environment files is preserved, so login always works even without the env var

## Screenshots

<img width="2491" height="1261" alt="image" src="https://github.com/user-attachments/assets/c1c530ab-dd83-41b2-8cc9-3765edf16461" />

<img width="2492" height="1242" alt="image" src="https://github.com/user-attachments/assets/030891fc-8967-4625-bb25-4c5001c40c79" />

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tenant selector visibility on the login page. The selector now correctly evaluates OAuth enablement and environment configuration to determine when to display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->