### PR TITLE
fix: no-op assignment before deleting allowPartialPeriodInterestCalcu…

### DIFF
--- a/src/app/loans/edit-loans-account/edit-loans-account.component.ts
+++ b/src/app/loans/edit-loans-account/edit-loans-account.component.ts
@@ -203,11 +203,6 @@ export class EditLoansAccountComponent {
     delete loansAccountData.principalAmount;
     delete loansAccountData.multiDisburseLoan;
 
-    // In Fineract, the POST and PUT endpoints for /v1/loans have a typo in the field
-    // allowPartialPeriodInterestCalculation. Until that is fixed, we need to replace the field name in the payload.
-    loansAccountData.allowPartialPeriodInterestCalculation = loansAccountData.allowPartialPeriodInterestCalculation;
-    delete loansAccountData.allowPartialPeriodInterestCalculation;
-
     this.loansService.updateLoansAccount(this.loanId, loansAccountData).subscribe((response: any) => {
       this.router.navigate(['../'], { relativeTo: this.route });
     });

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { Injectable, inject } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 
 /** rxjs Imports */
@@ -767,10 +767,6 @@ export class LoansService {
     delete loansAccountData.principalAmount;
     delete loansAccountData.multiDisburseLoan; // this was just added so that disbursement data can be send in the backend
 
-    // In Fineract, the POST and PUT endpoints for /v1/loans have a typo in the field
-    // allowPartialPeriodInterestCalculation. Until that is fixed, we need to replace the field name in the payload.
-    loansAccountData.allowPartialPeriodInterestCalculation = loansAccountData.allowPartialPeriodInterestCalculation;
-    delete loansAccountData.allowPartialPeriodInterestCalculation;
     return loansAccountData;
   }
 

--- a/src/app/products/loan-products/loan-products.ts
+++ b/src/app/products/loan-products/loan-products.ts
@@ -81,11 +81,6 @@ export class LoanProducts {
     delete loanProduct.allowAttributeConfiguration;
     delete loanProduct.advancedAccountingRules;
 
-    // In Fineract, the POST and PUT endpoints for /v1/loanproducts have a typo in the field
-    // allowPartialPeriodInterestCalculation. Until that is fixed, we need to replace the field name in the payload.
-    loanProduct.allowPartialPeriodInterestCalculation = loanProduct.allowPartialPeriodInterestCalculation;
-    delete loanProduct.allowPartialPeriodInterestCalculation;
-
     // Set Default values If they were not set
     itemsByDefault.forEach((config: GlobalConfiguration) => {
       const propertyName = this.resolvePropertyName(config.name);


### PR DESCRIPTION
…lation

## Description
Remove redundant no-op assignment that was immediately deleted.

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ x ] If you have multiple commits please combine them into one commit by squashing them.

- [ x ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified loan account editing and product management payload handling by removing redundant field transformations, resulting in cleaner data submission with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->