### PR TITLE
Resolution to Web-118.

### DIFF
--- a/src/app/loans/glim-account/create-glim-account/create-glim-account.component.ts
+++ b/src/app/loans/glim-account/create-glim-account/create-glim-account.component.ts
@@ -47,7 +47,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     LoansAccountScheduleStepComponent,
     LoansAccountDatatableStepComponent,
     LoansAccountPreviewStepComponent
-  ]
+  ],
+  providers: [I18nService]
 })
 export class CreateGlimAccountComponent {
   private route = inject(ActivatedRoute);

--- a/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.ts
@@ -199,7 +199,7 @@ export class LoansAccountDetailsStepComponent implements OnInit, OnDestroy {
         this.loanOfficerOptions = response.loanOfficerOptions;
         this.loanPurposeOptions = response.loanPurposeOptions;
         this.fundOptions = response.fundOptions;
-        this.accountLinkingOptions = response.accountLinkingOptions;
+        this.accountLinkingOptions = (response.accountLinkingOptions ?? []).filter((acc: any) => !acc.clientId);
         this.loanProductSelected = true;
         if (response.createStandingInstructionAtDisbursement) {
           this.loansAccountDetailsForm


### PR DESCRIPTION
## Description

The issue described in web-118 is resolved by implementing the two code changes in this commit.  The GLIM account application form appears correctly and the drop-down menu only lists parent accounts.  

#{Issue Number}

Web-118

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [*] If you have multiple commits please combine them into one commit by squashing them.

- [*] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Enhanced internationalization support in the loan account creation workflow.
  * Account linking options now exclude client-linked accounts from available selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->