### PR TITLE
WEB-717 Prevent negative values for nominal unit price in market price period

### DIFF
--- a/src/app/products/share-products/share-product-stepper/share-product-market-price-step/share-product-market-price-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-market-price-step/share-product-market-price-step.component.ts
@@ -175,6 +175,7 @@ export class ShareProductMarketPriceStepComponent implements OnInit {
         value: values ? values.shareValue : undefined,
         type: 'number',
         required: true,
+        min: 1,
         order: 2
       })
     ];


### PR DESCRIPTION
**Changes Made :-**

-The Nominal/Unit Price field in the Market Price Period dialog now accept positive numbers (minimum value 1) .

[WEB-717](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-717)

Before :- 

<img width="640" height="239" alt="image" src="https://github.com/user-attachments/assets/ff5996c6-a073-472a-a492-b8ab5db2b5d2" />


After :- 

<img width="1365" height="457" alt="image" src="https://github.com/user-attachments/assets/7e4920cb-51f8-4ecd-a86a-9498967699c9" />


[WEB-717]: https://mifosforge.jira.com/browse/WEB-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added minimum value validation to the Nominal/Unit Price field in the product sharing flow, ensuring prices cannot be set below 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->