### PR TITLE
WEB-718 Show required error message for days till field in delinquency range form

### DIFF
--- a/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.html
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.html
@@ -38,7 +38,7 @@
 
           <mat-form-field>
             <mat-label>{{ 'labels.inputs.Days Till' | translate }}</mat-label>
-            <input matInput type="number" required formControlName="maximumAgeDays" min="1" />
+            <input matInput type="number" formControlName="maximumAgeDays" min="1" />
           </mat-form-field>
         </div>
       </mat-card-content>

--- a/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.ts
@@ -55,7 +55,6 @@ export class CreateRangeComponent implements OnInit {
       maximumAgeDays: [
         '',
         [
-          Validators.required,
           Validators.pattern('^(0*[1-9][0-9]*)$'),
           Validators.max(10000)
         ]


### PR DESCRIPTION
**Changed Made :-** 

- Made 'Days Till' field optional in Delinquency Range creation form to allow null values for the last range in delinquency buckets

[WEB-718](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-718)

Before :- 

<img width="1360" height="356" alt="image" src="https://github.com/user-attachments/assets/ea543d73-9a70-4da6-9ba1-51e5014cddfe" />

After :- 

<img width="862" height="296" alt="image" src="https://github.com/user-attachments/assets/aaab125c-5a51-4dd9-8a4a-4e87699b93af" />



[WEB-718]: https://mifosforge.jira.com/browse/WEB-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "maximum age" field in delinquency range creation is now optional; users can leave it blank while format and upper-limit checks remain enforced, reducing unnecessary required-field validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->