### PR TITLE
WEB-720 Prevent negative values for interest rate in floating rate period form

### DIFF
--- a/src/app/products/floating-rates/floating-rate-period-dialog/floating-rate-period-dialog.component.html
+++ b/src/app/products/floating-rates/floating-rate-period-dialog/floating-rate-period-dialog.component.html
@@ -26,7 +26,7 @@
 
       <mat-form-field>
         <mat-label>{{ 'labels.inputs.Interest Rate' | translate }}</mat-label>
-        <input matInput type="number" required formControlName="interestRate" />
+        <input matInput type="number" required formControlName="interestRate" min="0" />
         @if (floatingRatePeriodForm.controls.interestRate.hasError('required')) {
           <mat-error>
             {{ 'labels.inputs.Interest Rate' | translate }} {{ 'labels.commons.is' | translate }}

--- a/src/app/products/floating-rates/floating-rate-period-dialog/floating-rate-period-dialog.component.ts
+++ b/src/app/products/floating-rates/floating-rate-period-dialog/floating-rate-period-dialog.component.ts
@@ -69,7 +69,10 @@ export class FloatingRatePeriodDialogComponent implements OnInit {
       ],
       interestRate: [
         { value: this.data ? this.data.interestRate : '', disabled: rowDisabled },
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)
+        ]
       ],
       isDifferentialToBaseLendingRate: [
         { value: this.data ? this.data.isDifferentialToBaseLendingRate : false, disabled: rowDisabled }]


### PR DESCRIPTION
**Changes Made :-** 

-Added validation to restrict the Interest Rate field in the Floating Rate Period form to zero or positive values .

[WEB-720](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-720)

Before :- 

<img width="640" height="212" alt="image" src="https://github.com/user-attachments/assets/909fe4d9-73e2-481e-9170-1aed2b7ead52" />

After :-

<img width="1348" height="465" alt="image" src="https://github.com/user-attachments/assets/420016e0-2f65-4eb0-b5ad-510e4f6ad8f4" />


[WEB-720]: https://mifosforge.jira.com/browse/WEB-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interest Rate input field now enforces non-negative values, preventing negative interest rates from being entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->