### PR TITLE
WEB-721 fix:footer responsiveness on mobile devices and small screens

### DIFF
--- a/src/app/shared/footer/footer.component.scss
+++ b/src/app/shared/footer/footer.component.scss
@@ -113,7 +113,7 @@
 }
 
 // ===== Responsive for Compact Mode =====
-@media (width <= 480px) {
+@media (width <=480px) {
   .footer-compact {
     font-size: 0.7rem;
 
@@ -124,5 +124,18 @@
     .footer-copyright {
       font-size: 0.8rem;
     }
+  }
+}
+
+// ===== Responsive for Default Mode (Shell) =====
+@media (width <=599px) {
+  #footer {
+    min-width: 100%;
+  }
+
+  .main-page {
+    max-width: 100%;
+    min-width: 100%;
+    padding-left: 2%;
   }
 }


### PR DESCRIPTION
The footer section is now responsive on mobile devices and smaller screens, adapting to the viewport size instead of having a fixed minimum width. This ensures readability and prevents horizontal


[WEB-721](https://mifosforge.jira.com/browse/WEB-721)

Before:
<img width="475" height="836" alt="Screenshot 2026-02-14 070041" src="https://github.com/user-attachments/assets/9b16e2ac-2d0a-45a8-9ba9-722a90d9c1c5" />
After:
<img width="388" height="859" alt="Screenshot 2026-02-14 070205" src="https://github.com/user-attachments/assets/19fc0a3f-6fae-497a-a0b9-fa7e63912c04" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-721]: https://mifosforge.jira.com/browse/WEB-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized footer layout and spacing for improved responsiveness across different screen sizes, including adjustments to element gaps and typography for both compact and standard display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->