### PR TITLE
WEB-722 Standardize all action buttons in the checker inbox

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.html
@@ -28,13 +28,13 @@
     >
       <mat-icon>{{ showAdvancedSearch ? 'arrow_drop_up' : 'arrow_drop_down' }}</mat-icon>
     </button>
-    <button mat-raised-button class="action-button btn-success" (click)="approveChecker()">
+    <button mat-raised-button class="mat-success tasks-action-btn" (click)="approveChecker()">
       <fa-icon icon="check" class="m-r-10"></fa-icon>{{ 'labels.buttons.Approve' | translate }}
     </button>
     <button mat-raised-button color="warn" (click)="deleteChecker()" class="action-button">
       <fa-icon icon="trash" class="m-r-10"></fa-icon>{{ 'labels.buttons.Delete' | translate }}
     </button>
-    <button mat-raised-button class="action-button btn-reject" (click)="rejectChecker()">
+    <button mat-raised-button class="mat-reject tasks-action-btn" (click)="rejectChecker()">
       <fa-icon icon="times" class="m-r-10"></fa-icon>{{ 'labels.buttons.Reject' | translate }}
     </button>
   </div>

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.scss
@@ -63,16 +63,37 @@
     width: 48px;
     height: 48px;
     padding: 0;
+    background: #232323 !important;
+    color: #fff !important;
+    border-radius: 4px;
+    box-shadow:
+      0 2px 2px 0 rgb(0 0 0 / 14%),
+      0 1px 5px 0 rgb(0 0 0 / 12%),
+      0 3px 1px -2px rgb(0 0 0 / 20%);
   }
 
-  button.mat-mdc-raised-button.btn-success {
-    color: #000 !important;
-    background-color: #fff !important;
+  .mat-mdc-raised-button.mat-success,
+  .mat-mdc-raised-button.mat-reject {
+    color: #fff;
+    background-color: #424242;
   }
 
-  button.mat-mdc-raised-button.btn-reject {
-    color: #000 !important;
-    background-color: #fff !important;
+  .tasks-action-btn {
+    margin: 0;
+  }
+
+  button.mat-mdc-raised-button.action-button {
+    box-shadow:
+      0 2px 2px 0 rgb(0 0 0 / 14%),
+      0 1px 5px 0 rgb(0 0 0 / 12%),
+      0 3px 1px -2px rgb(0 0 0 / 20%);
+    border-radius: 4px;
+    font-weight: 500;
+    font-family: Roboto, 'Helvetica Neue', sans-serif;
+    letter-spacing: 0.5px;
+    transition:
+      background 0.3s,
+      color 0.3s;
   }
 
   /* ---------- SEARCH & LAYOUT ---------- */


### PR DESCRIPTION
**Changes Made :-** 

-Updated SCSS to set a solid black background for Approve, Reject, and dropdown buttons in the checker inbox. 

[WEB-722](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-722)

Before :- 

<img width="1056" height="280" alt="image" src="https://github.com/user-attachments/assets/fa36b977-b404-4561-88dd-6c4b582e4872" />


After :- 

<img width="871" height="230" alt="image" src="https://github.com/user-attachments/assets/0d1975ea-22fc-483a-9493-166f8cb0091e" />


[WEB-722]: https://mifosforge.jira.com/browse/WEB-722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified and refreshed action button styling in the checker inbox: Approve/Reject buttons updated for a cohesive look (darker background, white text), refined shadows, spacing, typography, and transitions. Visual-only change — functionality and event behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->