### PR TITLE
WEB-697 fix(loan-products): ensure preview step is visible on edit

### DIFF
--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
@@ -138,17 +138,16 @@
       </mifosx-loan-product-accounting-step>
     </mat-step>
 
-    @if (loanProductFormValidAndNotPristine) {
-      <mat-step state="preview" completed>
-        <ng-template matStepLabel>{{ 'labels.inputs.PREVIEW' | translate }}</ng-template>
-        <mifosx-loan-product-preview-step
-          [loanProductsTemplate]="loanProductAndTemplate"
-          [accountingRuleData]="accountingRuleData"
-          [loanProduct]="loanProduct"
-          (submitEvent)="submit()"
-        >
-        </mifosx-loan-product-preview-step>
-      </mat-step>
-    }
+    <mat-step state="preview" completed>
+      <ng-template matStepLabel>{{ 'labels.inputs.PREVIEW' | translate }}</ng-template>
+      <mifosx-loan-product-preview-step
+        [loanProductsTemplate]="loanProductAndTemplate"
+        [accountingRuleData]="accountingRuleData"
+        [loanProduct]="loanProduct"
+        [isValid]="loanProductFormValid"
+        (submitEvent)="submit()"
+      >
+      </mifosx-loan-product-preview-step>
+    </mat-step>
   </mat-stepper>
 </div>

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
@@ -255,7 +255,7 @@ export class EditLoanProductComponent implements OnInit {
     return this.loanProductAccountingStep.loanProductAccountingForm;
   }
 
-  get loanProductFormValidAndNotPristine() {
+  get loanProductFormValid(): boolean {
     if (this.isAdvancedPaymentStrategy) {
       return (
         this.loanProductDetailsForm.valid &&
@@ -264,15 +264,7 @@ export class EditLoanProductComponent implements OnInit {
         this.loanProductSettingsForm.valid &&
         this.loanProductAccountingForm.valid &&
         this.loanIncomeCapitalizationForm != null &&
-        this.loanIncomeCapitalizationForm.valid &&
-        (!this.loanProductDetailsForm.pristine ||
-          !this.loanProductCurrencyForm.pristine ||
-          !this.loanProductTermsForm.pristine ||
-          !this.loanProductSettingsForm.pristine ||
-          !this.loanProductChargesStep.pristine ||
-          !this.loanProductAccountingForm.pristine ||
-          !this.loanIncomeCapitalizationForm.pristine ||
-          this.wasPaymentAllocationChanged)
+        this.loanIncomeCapitalizationForm.valid
       );
     } else {
       return (
@@ -280,16 +272,38 @@ export class EditLoanProductComponent implements OnInit {
         this.loanProductCurrencyForm.valid &&
         this.loanProductTermsForm.valid &&
         this.loanProductSettingsForm.valid &&
-        this.loanProductAccountingForm.valid &&
-        (!this.loanProductDetailsForm.pristine ||
-          !this.loanProductCurrencyForm.pristine ||
-          !this.loanProductTermsForm.pristine ||
-          !this.loanProductSettingsForm.pristine ||
-          !this.loanProductChargesStep.pristine ||
-          !this.loanProductAccountingForm.pristine ||
-          this.wasPaymentAllocationChanged)
+        this.loanProductAccountingForm.valid
       );
     }
+  }
+
+  get loanProductFormDirty(): boolean {
+    if (this.isAdvancedPaymentStrategy) {
+      return (
+        !this.loanProductDetailsForm.pristine ||
+        !this.loanProductCurrencyForm.pristine ||
+        !this.loanProductTermsForm.pristine ||
+        !this.loanProductSettingsForm.pristine ||
+        !this.loanProductChargesStep.pristine ||
+        !this.loanProductAccountingForm.pristine ||
+        !(this.loanIncomeCapitalizationForm?.pristine ?? true) ||
+        this.wasPaymentAllocationChanged
+      );
+    } else {
+      return (
+        !this.loanProductDetailsForm.pristine ||
+        !this.loanProductCurrencyForm.pristine ||
+        !this.loanProductTermsForm.pristine ||
+        !this.loanProductSettingsForm.pristine ||
+        !this.loanProductChargesStep.pristine ||
+        !this.loanProductAccountingForm.pristine ||
+        this.wasPaymentAllocationChanged
+      );
+    }
+  }
+
+  get loanProductFormValidAndNotPristine(): boolean {
+    return this.loanProductFormValid && this.loanProductFormDirty;
   }
 
   get loanProduct() {

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.html
@@ -25,7 +25,7 @@
   <button mat-raised-button [routerLink]="['../']">
     {{ 'labels.buttons.Cancel' | translate }}
   </button>
-  <button mat-raised-button color="primary" (click)="submitEvent.emit()">
+  <button mat-raised-button color="primary" [disabled]="!isValid" (click)="submitEvent.emit()">
     {{ 'labels.buttons.Submit' | translate }}
   </button>
 </div>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component.ts
@@ -28,6 +28,7 @@ export class LoanProductPreviewStepComponent implements OnInit, OnChanges {
   @Input() loanProductsTemplate: any;
   @Input() accountingRuleData: any;
   @Input() loanProduct: any;
+  @Input() isValid: boolean = true;
   @Output() submitEvent = new EventEmitter();
 
   isAdvancedPaymentAllocation = false;


### PR DESCRIPTION
This PR solves a bug where the Preview step on the Edit Loan Product screen was hidden if no changes were made to the form. This confused users who expected to see the product details and a submit option, especially for loan products created with older UI versions.

[WEB-697](https://mifosforge.jira.com/browse/WEB-697)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-697]: https://mifosforge.jira.com/browse/WEB-697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loan product preview is now always visible when editing loan products, appearing regardless of prior edit state.

* **Bug Fixes**
  * Submit button in the loan product preview now disables when the form is invalid.
  * Preview submit now correctly respects the current form validation state in real time, preventing submission of invalid changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->