### PR TITLE
(fix) WEB-715 Missing branding logo 

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -41,7 +41,12 @@
       </mat-autocomplete>
     </mat-card-content>
 
-    <img mat-card-image src="assets/images/{{ tenant }}_home.png" alt="Mifos X" />
+    <img
+      mat-card-image
+      [src]="'assets/images/' + tenant + '_home.png'"
+      (error)="onImageMissing($event)"
+      alt="Mifos X"
+    />
   </mat-card>
 </div>
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -206,4 +206,13 @@ export class HomeComponent implements OnInit, AfterViewInit {
     }
     return this.settingsService.tenantIdentifier;
   }
+
+  onImageMissing(event: Event): void {
+    const target = event.currentTarget;
+    if (!(target instanceof HTMLImageElement)) {
+      return;
+    }
+    target.onerror = null;
+    target.src = `assets/images/default_home.png`;
+  }
 }


### PR DESCRIPTION
## Description

Updated the home page tenant image to use the existing fallback mechanism instead of requiring a hardcoded tenant image.

## Related issues and discussion

[https://mifosforge.jira.com/issues:WEB-715](https://mifosforge.jira.com/issues?filter=-4&selectedIssue=WEB-715)

## Screenshots, if any
Before: 
<img width="1920" height="1020" alt="BeforeFix" src="https://github.com/user-attachments/assets/9d9c1f67-82e0-40c3-92e0-b9bf90b280b3" />

After:
<img width="1920" height="1020" alt="Fix_tenant_Logo" src="https://github.com/user-attachments/assets/87abec2d-6c24-4e63-9959-f203e70e4c19" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Home page image loading is now dynamic per tenant and includes graceful fallback handling: if a tenant-specific image fails to load, the UI automatically replaces it with a default home image to avoid broken image displays and improve visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->