### PR TITLE
WEB-728 fix:apply change button position

### DIFF
--- a/src/app/system/manage-external-events/manage-external-events.component.scss
+++ b/src/app/system/manage-external-events/manage-external-events.component.scss
@@ -7,8 +7,13 @@
  */
 
 .container {
+  .layout-row {
+    gap: 16px;
+  }
+
   .action-button {
     margin-left: auto;
+    margin-top: 8px;
   }
 }
 


### PR DESCRIPTION
Adjusted the vertical position of the "Apply Changes" button in the Manage External Events page by adding a small top margin. This improves the visual alignment and spacing of the button within its container, providing better visual balance in the layout.
The button now sits slightly lower, creating more consistent spacing with the surrounding elements.

[WEB-72](https://mifosforge.jira.com/browse/WEB-728)

Before:
<img width="1766" height="871" alt="Screenshot 2026-02-16 022125" src="https://github.com/user-attachments/assets/68c570da-da29-4a69-84ce-075fced81a82" />
After:
<img width="1839" height="832" alt="image" src="https://github.com/user-attachments/assets/5b309819-99c6-43b1-99e6-d5b498bee52d" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-72]: https://mifosforge.jira.com/browse/WEB-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced spacing and layout consistency in the external events management interface with improved gaps and margins between UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->