### PR TITLE
WEB-729 Improve Pending Tasks text visibility in dark mode

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
@@ -9,7 +9,7 @@
 <div class="container">
   <mat-card class="tasks-card">
     <mat-card-content>
-      <div class="card-heading">{{ 'labels.heading.Pending Tasks' | translate }}</div>
+      <div class="card-heading pending-tasks-heading">{{ 'labels.heading.Pending Tasks' | translate }}</div>
       <mat-divider></mat-divider>
       <nav mat-tab-nav-bar class="navigation-tabs" [tabPanel]="tabPanel">
         <a

--- a/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.scss
@@ -13,6 +13,11 @@
   margin-bottom: 16px;
 }
 
+:host-context(.dark-theme) .pending-tasks-heading {
+  color: #fff;
+  text-shadow: 0 1px 4px rgb(0 0 0 / 70%);
+}
+
 mat-divider {
   margin-bottom: 16px;
 }


### PR DESCRIPTION
**Changes Made :-** 

- Updated Pending Tasks heading visibility in dark mode .

Before :- 

<img width="1362" height="581" alt="image" src="https://github.com/user-attachments/assets/625e6328-08ea-42ce-8b6e-0b494049b29b" />


<img width="1365" height="579" alt="image" src="https://github.com/user-attachments/assets/f354f6f5-1105-47aa-bb1a-4e7b357dd6d6" />



After :- 

<img width="1352" height="579" alt="image" src="https://github.com/user-attachments/assets/3a6b39bb-5154-4c75-89c0-023452d6e9b0" />


<img width="1340" height="578" alt="image" src="https://github.com/user-attachments/assets/5fd27fd4-6a52-42f6-b049-854ac81615df" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Pending Tasks heading styling for dark mode to improve readability: increased text contrast and added a subtle shadow for better legibility against dark backgrounds. This is a visual-only change and does not affect behavior or content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->