### PR TITLE
WEB-730 fix: Make delete button icons red in workflow jobs

### DIFF
--- a/src/app/system/manage-jobs/workflow-jobs/workflow-jobs.component.scss
+++ b/src/app/system/manage-jobs/workflow-jobs/workflow-jobs.component.scss
@@ -42,3 +42,7 @@
 .cdk-drop-list-dragging .mat-row:not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
+
+.mat-warn fa-icon {
+  color: #e74c3c;
+}


### PR DESCRIPTION
This change improves the visual design of delete buttons in the workflow jobs interface by making the delete icons red. T

[WEB-730 ](https://mifosforge.jira.com/browse/WEB-730)

Before:
<img width="1645" height="877" alt="Screenshot 2026-02-16 024412" src="https://github.com/user-attachments/assets/6fa04282-3c51-4afd-9655-3c57fbc30d3b" />
After:
<img width="1665" height="720" alt="image" src="https://github.com/user-attachments/assets/911cac60-cb09-40e7-91dd-79aeba47d311" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual clarity of warning icons with an updated color scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->