### PR TITLE
WEB-732 fix(floating-rates): align checkboxes with input field

### DIFF
--- a/src/app/products/floating-rates/create-floating-rate/create-floating-rate.component.scss
+++ b/src/app/products/floating-rates/create-floating-rate/create-floating-rate.component.scss
@@ -6,14 +6,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-@media (width >= 992px) {
+@media (width >=992px) {
   .checkbox-wrapper {
-    position: relative;
+    margin-top: 8px;
 
     .checkbox {
       padding: 0 0 17.5px;
-      position: absolute;
-      bottom: 0;
     }
   }
 }


### PR DESCRIPTION
The "Is Base Lending Rate?" and "Active" checkboxes on the "Create Floating Rate" screen were misaligned relative to the "Floating Rate Name" input field, appearing lower than intended. This change corrects their vertical positioning to ensure they align perfectly with the text input on desktop screens, improving the overall visual consistency of the form.

[WEB-732](https://mifosforge.jira.com/browse/WEB-732)

Before:
<img width="1916" height="1079" alt="image" src="https://github.com/user-attachments/assets/097586cf-501d-4d17-bd0f-20cf9374adf4" />
After:
<img width="1914" height="1076" alt="image" src="https://github.com/user-attachments/assets/64d65f46-30ff-4632-872a-1f420d9edb1e" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-732]: https://mifosforge.jira.com/browse/WEB-732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated checkbox layout and spacing for improved visual presentation in the floating rate creation form

<!-- end of auto-generated comment: release notes by coderabbit.ai -->