### PR TITLE
WEB-733 fix: ensure status icon colors visible in dark mode

### DIFF
--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -159,6 +159,15 @@
   mat-checkbox {
     color: white;
   }
+
+  .true fa-icon,
+  .false fa-icon,
+  .ispenalty fa-icon,
+  .nopenalty fa-icon,
+  .enabled fa-icon,
+  .disabled fa-icon {
+    color: inherit !important;
+  }
 }
 
 body.dark-theme {


### PR DESCRIPTION
This pr fixed an issue where "is Active?" (Green) and "is Penalty?" (Green/Pink) status icons were invisible in dark mode.

[WEB-733](https://mifosforge.jira.com/browse/WEB-733)

Before:
<img width="1646" height="795" alt="Screenshot 2026-02-16 041625" src="https://github.com/user-attachments/assets/c01615d7-3a0a-4f3a-a453-fb69dc157c52" />
After:
<img width="1538" height="832" alt="image" src="https://github.com/user-attachments/assets/037518e3-4df6-4111-8bb7-ec7dcee6391b" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-733]: https://mifosforge.jira.com/browse/WEB-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dark theme styling for status indicator icons. Icons representing states (true/false, enabled/disabled, penalty states) now properly inherit their parent's color in dark mode for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->