### PR TITLE
WEB-734 Fix Delete Icon Color Integrity in Dark Mode

### DIFF
--- a/src/app/system/manage-jobs/workflow-jobs/workflow-jobs.component.scss
+++ b/src/app/system/manage-jobs/workflow-jobs/workflow-jobs.component.scss
@@ -42,7 +42,3 @@
 .cdk-drop-list-dragging .mat-row:not(.cdk-drag-placeholder) {
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
-
-.mat-warn fa-icon {
-  color: #e74c3c;
-}

--- a/src/main.scss
+++ b/src/main.scss
@@ -709,6 +709,12 @@ mifosx-notifications-page td {
   color: red;
 }
 
+// ===== Global Delete/Trash Icon Styling =====
+// Ensures delete icons are always red, including in dark theme
+.fa-trash {
+  color: #f44336 !important;
+}
+
 .full-width-flex {
   display: flex;
   justify-content: flex-start;


### PR DESCRIPTION
This pr fix Delete Icon Color Integrity in Dark Mode

[WEB-734](https://mifosforge.jira.com/browse/WEB-734)

Before:
<img width="834" height="449" alt="Screenshot 2026-02-16 044700" src="https://github.com/user-attachments/assets/5faba20a-3175-4a61-a809-5433dd3f9fb9" />
After:
<img width="820" height="448" alt="image" src="https://github.com/user-attachments/assets/b9d0dbf1-ce80-4ab7-832c-012cc4bb8ddc" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-734]: https://mifosforge.jira.com/browse/WEB-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated delete/trash icons to consistently display in red across the application.
  * Adjusted styling for warning icons in the job workflow management interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->