### PR TITLE
WEB-738 Fix approve and reject button in checker inbox for light and dark mode

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.scss
@@ -72,10 +72,25 @@
       0 3px 1px -2px rgb(0 0 0 / 20%);
   }
 
+  :host-context(.dark-theme) button.mat-mdc-icon-button {
+    background: #232323 !important;
+    color: #fff !important;
+  }
+
   .mat-mdc-raised-button.mat-success,
   .mat-mdc-raised-button.mat-reject {
-    color: #fff;
+    color: #232323;
+    background-color: #fff;
+    box-shadow:
+      0 2px 2px 0 rgb(0 0 0 / 14%),
+      0 1px 5px 0 rgb(0 0 0 / 12%),
+      0 3px 1px -2px rgb(0 0 0 / 20%);
+  }
+
+  :host-context(.dark-theme) .mat-mdc-raised-button.mat-success,
+  :host-context(.dark-theme) .mat-mdc-raised-button.mat-reject {
     background-color: #424242;
+    color: #fff;
   }
 
   .tasks-action-btn {


### PR DESCRIPTION
**Changes Made :-** 

-Update checker inbox approve and reject buttons to use distinct colors for light and dark modes for consistent theming.

[WEB-738](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-738)

Before :- 

<img width="1024" height="275" alt="image" src="https://github.com/user-attachments/assets/79f3cb7b-ade1-409a-b8f9-a02e3e585d41" />


<img width="970" height="271" alt="image" src="https://github.com/user-attachments/assets/96287445-7e00-4de4-972a-9f65880783d3" />

After :- 

<img width="949" height="272" alt="image" src="https://github.com/user-attachments/assets/aa998681-7b77-4de1-a0c8-9def8631ddb2" />


<img width="933" height="278" alt="image" src="https://github.com/user-attachments/assets/99bf0880-69f2-47f9-acb2-fd96bc162c9c" />


[WEB-738]: https://mifosforge.jira.com/browse/WEB-738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated button styles for improved light/dark theme contrast.
  * Icon buttons now default to white background with dark text in light mode and revert to dark background with white text in dark mode.
  * Raised success and reject buttons show dark text on white in light mode and switch to darker backgrounds with white text in dark mode, while preserving existing shadows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->