### PR TITLE
WEB-739 Standardize dropdown arrow button color in checker inbox for light mode and dark mode

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.scss
@@ -63,8 +63,8 @@
     width: 48px;
     height: 48px;
     padding: 0;
-    background: #232323 !important;
-    color: #fff !important;
+    background: #232323;
+    color: #fff;
     border-radius: 4px;
     box-shadow:
       0 2px 2px 0 rgb(0 0 0 / 14%),
@@ -127,6 +127,13 @@
 
   .icon-button {
     margin: 0;
+    background: #f5f5f5;
+    color: #232323;
+  }
+
+  :host-context(.dark-theme) .icon-button {
+    background: #424242;
+    color: #fff;
   }
 
   .action-button {


### PR DESCRIPTION
**Changed Made :-**

-Update checker inbox dropdown arrow button to use distinct colors for light and dark modes for consistent theming.

[WEB-739](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-739)

Befrore :-
<img width="640" height="187" alt="image" src="https://github.com/user-attachments/assets/d30dbb4f-be0d-455c-aa9b-aa475acaaf32" />


<img width="970" height="271" alt="image" src="https://github.com/user-attachments/assets/76805d36-fe26-4148-8b1e-723b6c1ae837" />



After :-

<img width="995" height="290" alt="image" src="https://github.com/user-attachments/assets/2f6e6ca7-95bc-4c61-93e7-fd258931c4fe" />

<img width="885" height="270" alt="image" src="https://github.com/user-attachments/assets/52a451e4-ce96-4197-bd51-1bb16939b66e" />


[WEB-739]: https://mifosforge.jira.com/browse/WEB-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced icon button styling with improved light and dark theme support for better visual consistency across different theme modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->