### PR TITLE
WEB-740 fix: ensure trash icon remains visible in delete buttons

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -710,9 +710,13 @@ mifosx-notifications-page td {
 }
 
 // ===== Global Delete/Trash Icon Styling =====
-// Ensures delete icons are always red, including in dark theme
+// Makes standalone delete icons red, but keeps them white inside warn (red) buttons
 .fa-trash {
   color: #f44336 !important;
+}
+
+.mat-mdc-raised-button.mat-warn .fa-trash {
+  color: inherit !important;
 }
 
 .full-width-flex {


### PR DESCRIPTION
Fixed a UI issue where the trash icon (.fa-trash) became invisible inside "Delete" buttons.
The global style for trash icons was set to red (#f44336), which caused a conflict when used inside buttons with a red background (like mat-raised-button with color="warn"). This resulted in a red icon on a red background, making it indistinguishable.
The fix ensures that:
Standalone trash icons (e.g., in tables) remain red.
Trash icons inside raised delete buttons inherit the button's text color (white), making them visible again.

[WEB-740](https://mifosforge.jira.com/browse/WEB-740)

Before:
<img width="147" height="73" alt="Screenshot 2026-02-16 173004" src="https://github.com/user-attachments/assets/003c76cf-cdc4-4292-a3ad-515fae173a28" />
After:
<img width="156" height="74" alt="image" src="https://github.com/user-attachments/assets/af4b0b07-5521-49ff-af8b-2583be03eb88" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-740]: https://mifosforge.jira.com/browse/WEB-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved delete/trash icon styling to better adapt to different button contexts. Delete icons now display with appropriate colors based on their usage—white when inside warning buttons and red for standalone usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->