### PR TITLE
WEB-743 fix: preserve status indicator colors in dark mode on Manage …

### DIFF
--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -165,7 +165,12 @@
   .ispenalty fa-icon,
   .nopenalty fa-icon,
   .enabled fa-icon,
-  .disabled fa-icon {
+  .disabled fa-icon,
+  .currently-running fa-icon,
+  .not-currently-running fa-icon,
+  .success fa-icon,
+  .fail fa-icon,
+  .errorlog fa-icon {
     color: inherit !important;
   }
 }


### PR DESCRIPTION
…Jobs page

This PR fixes a visual bug where status indicators on the Manage Jobs page (Scheduler Jobs, COB Workflow, etc.) were appearing white in dark mode instead of their intended colors (green for active/success, red for inactive/failure).


[WEB-743](https://mifosforge.jira.com/browse/WEB-743)

Before:
<img width="1623" height="899" alt="Screenshot 2026-02-17 050613" src="https://github.com/user-attachments/assets/a0583b52-4cc6-4e84-bfc9-c58a3da321f1" />
After:
<img width="1642" height="974" alt="image" src="https://github.com/user-attachments/assets/bab07813-061d-41fc-bdab-524ec22c59b4" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-743]: https://mifosforge.jira.com/browse/WEB-743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dark theme icon colors to properly inherit color values for various state indicators (disabled, running, success, failure, and error log states), ensuring consistent visual styling across these elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->