### PR TITLE
WEB-745: Fix unable to assign staff to active savings account

### DIFF
--- a/src/app/organization/organization.service.ts
+++ b/src/app/organization/organization.service.ts
@@ -720,12 +720,16 @@ export class OrganizationService {
     return this.http.get(`/groups`, { params: httpParams });
   }
 
-  /*
-   * @param {any} officeId ID of office to retrieve staff from.
+  /**
+   * @param {number | string} officeId ID of office to retrieve staff from.
+   * @param {boolean} [isLoanOfficer] Optional flag to filter by loan officer status.
    * @returns {Observable<any>} Staff data.
    */
-  getStaff(officeId: any): Observable<any> {
-    const httpParams = new HttpParams().set('officeId', officeId.toString());
+  getStaff(officeId: number | string, isLoanOfficer?: boolean): Observable<any> {
+    let httpParams = new HttpParams().set('officeId', officeId.toString()).set('status', 'active');
+    if (isLoanOfficer !== undefined) {
+      httpParams = httpParams.set('isLoanOfficer', isLoanOfficer.toString());
+    }
     return this.http.get('/staff', { params: httpParams });
   }
 

--- a/src/app/savings/common-resolvers/savings-account-actions.resolver.ts
+++ b/src/app/savings/common-resolvers/savings-account-actions.resolver.ts
@@ -11,10 +11,14 @@ import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot } from '@angular/router';
 
 /** rxjs Imports */
-import { Observable, forkJoin } from 'rxjs';
+import { Observable, forkJoin, of } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 
 /** Custom Services */
 import { SavingsService } from '../savings.service';
+import { ClientsService } from 'app/clients/clients.service';
+import { GroupsService } from 'app/groups/groups.service';
+import { OrganizationService } from 'app/organization/organization.service';
 
 /**
  * Savings Account Actions data resolver.
@@ -22,6 +26,9 @@ import { SavingsService } from '../savings.service';
 @Injectable()
 export class SavingsAccountActionsResolver {
   private savingsService = inject(SavingsService);
+  private clientsService = inject(ClientsService);
+  private groupsService = inject(GroupsService);
+  private organizationService = inject(OrganizationService);
 
   /**
    * Returns the Savings account actions data.
@@ -34,7 +41,23 @@ export class SavingsAccountActionsResolver {
       route.paramMap.get('savingAccountId') || route.parent.parent.paramMap.get('savingAccountId');
     switch (actionName) {
       case 'Assign Staff':
-        return this.savingsService.getSavingsAccountAndTemplate(savingAccountId, true);
+        return this.savingsService.getSavingsAccountData(savingAccountId).pipe(
+          switchMap((account: any) => {
+            if (!account.clientId && !account.groupId) {
+              return of({ ...account, fieldOfficerOptions: [] });
+            }
+            const entityObs = account.clientId
+              ? this.clientsService.getClientData(account.clientId)
+              : this.groupsService.getGroupData(account.groupId);
+            return entityObs.pipe(
+              switchMap((entity: any) => this.organizationService.getStaff(entity.officeId, true)),
+              map((staff: any) => ({
+                ...account,
+                fieldOfficerOptions: staff
+              }))
+            );
+          })
+        );
       case 'Add Charge':
         return this.savingsService.getSavingsChargeTemplateResource(savingAccountId);
       case 'Withdrawal':

--- a/src/app/savings/saving-account-actions/savings-account-assign-staff/savings-account-assign-staff.component.html
+++ b/src/app/savings/saving-account-actions/savings-account-assign-staff/savings-account-assign-staff.component.html
@@ -20,6 +20,12 @@
                 </mat-option>
               }
             </mat-select>
+            @if (savingsAssignStaffForm.controls.toSavingsOfficerId.hasError('required')) {
+              <mat-error>
+                {{ 'labels.inputs.To Savings Officer' | translate }} {{ 'labels.commons.is' | translate }}
+                <strong>{{ 'labels.commons.required' | translate }}</strong>
+              </mat-error>
+            }
           </mat-form-field>
 
           <mat-form-field (click)="assignmentDatePicker.open()">

--- a/src/app/savings/saving-account-actions/savings-account-assign-staff/savings-account-assign-staff.component.ts
+++ b/src/app/savings/saving-account-actions/savings-account-assign-staff/savings-account-assign-staff.component.ts
@@ -7,9 +7,9 @@
  */
 
 /** Angular Imports */
-import { Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { Component, OnInit, inject } from '@angular/core';
+import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
 /** Custom Services */
@@ -78,7 +78,10 @@ export class SavingsAccountAssignStaffComponent implements OnInit {
    */
   createSavingsAssignStaffForm() {
     this.savingsAssignStaffForm = this.formBuilder.group({
-      toSavingsOfficerId: [''],
+      toSavingsOfficerId: [
+        '',
+        Validators.required
+      ],
       assignmentDate: [
         '',
         Validators.required
@@ -91,16 +94,16 @@ export class SavingsAccountAssignStaffComponent implements OnInit {
    * if successful redirects to the saving account.
    */
   submit() {
-    const savingsAssignStaffFormData = this.savingsAssignStaffForm.value;
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;
-    const prevAssignmentDate: Date = this.savingsAssignStaffForm.value.assignmentDate;
-    if (savingsAssignStaffFormData.assignmentDate instanceof Date) {
-      savingsAssignStaffFormData.assignmentDate = this.dateUtils.formatDate(prevAssignmentDate, dateFormat);
-    }
+    const formValue = this.savingsAssignStaffForm.value;
+    const assignmentDate =
+      formValue.assignmentDate instanceof Date
+        ? this.dateUtils.formatDate(formValue.assignmentDate, dateFormat)
+        : formValue.assignmentDate;
     const data = {
-      ...savingsAssignStaffFormData,
-      fromSavingsOfficerId: '',
+      toSavingsOfficerId: formValue.toSavingsOfficerId,
+      assignmentDate,
       dateFormat,
       locale
     };

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -2697,6 +2697,7 @@
       "Working with Code": "Práce s kódem"
     },
     "menus": {
+      "Unassign Staff": "Zrušit přidělení personálu",
       "Accounting": "Účetnictví",
       "Account Overview": "Přehled účtu",
       "Activate": "aktivovat",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -2698,6 +2698,7 @@
       "Working with Code": "Arbeiten mit Code"
     },
     "menus": {
+      "Unassign Staff": "Personalzuweisung aufheben",
       "Accounting": "Buchhaltung",
       "Account Overview": "Kontoübersicht",
       "Activate": "aktivieren Sie",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2707,6 +2707,7 @@
       "Working with Code": "Working with Code"
     },
     "menus": {
+      "Unassign Staff": "Unassign Staff",
       "Accounting": "Accounting",
       "Account Overview": "Account Overview",
       "Activate": "Activate",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -2697,6 +2697,7 @@
       "Working with Code": "Trabajar con código"
     },
     "menus": {
+      "Unassign Staff": "Desasignar Asesor",
       "Accounting": "Contabilidad",
       "Account Overview": "Descripción de cuenta",
       "Activate": "Activar",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -2700,6 +2700,7 @@
       "Working with Code": "Trabajar con código"
     },
     "menus": {
+      "Unassign Staff": "Desasignar Asesor",
       "Accounting": "Contabilidad",
       "Account Overview": "Descripción de cuenta",
       "Activate": "Activar",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -2699,6 +2699,7 @@
       "Working with Code": "Travailler avec du code"
     },
     "menus": {
+      "Unassign Staff": "Annuler l'affectation du personnel",
       "Accounting": "Comptabilité",
       "Account Overview": "Aperçu du compte",
       "Activate": "Activer",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -2695,6 +2695,7 @@
       "Working with Code": "Lavorare con il codice"
     },
     "menus": {
+      "Unassign Staff": "Annulla assegnazione del personale",
       "Accounting": "Contabilità",
       "Account Overview": "Panoramica dell'Account",
       "Activate": "Attivare",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -2697,6 +2697,7 @@
       "Working with Code": "코드 작업"
     },
     "menus": {
+      "Unassign Staff": "직원 할당 해제",
       "Accounting": "회계",
       "Account Overview": "계정 개요",
       "Activate": "활성화",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -2696,6 +2696,7 @@
       "Working with Code": "Darbas su kodu"
     },
     "menus": {
+      "Unassign Staff": "Atšaukti personalo priskyrimą",
       "Accounting": "Apskaita",
       "Account Overview": "Sąskaitos apžvalga",
       "Activate": "Suaktyvinti",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -2696,6 +2696,7 @@
       "Working with Code": "Darbs ar kodu"
     },
     "menus": {
+      "Unassign Staff": "Atcelt personāla piešķiršanu",
       "Accounting": "Grāmatvedība",
       "Account Overview": "Konta pārskats",
       "Activate": "Aktivizēt",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -2694,6 +2694,7 @@
       "Working with Code": "Code मा काम गर्नुहुन्छ"
     },
     "menus": {
+      "Unassign Staff": "कर्मचारी नियुक्ति रद्द गर्नुहोस्",
       "Accounting": "लेखा",
       "Account Overview": "खाता अवलोकन",
       "Activate": "अलग गर्नु",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -2695,6 +2695,7 @@
       "Working with Code": "Trabalhando com código"
     },
     "menus": {
+      "Unassign Staff": "Cancelar atribuição de equipe",
       "Accounting": "Contabilidade",
       "Account Overview": "visão geral da conta",
       "Activate": "Ativar",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -2693,6 +2693,7 @@
       "Working with Code": "Kufanya kazi na Kanuni"
     },
     "menus": {
+      "Unassign Staff": "Batilisha Wafanyikazi",
       "Accounting": "Uhasibu",
       "Account Overview": "Muhtasari wa akaunti",
       "Activate": "Amilisha",


### PR DESCRIPTION

## Description

Fixed an issue where assigning a staff member to an active savings account would fail with a `400 Bad Request` error. This was caused by the backend failing to serialize the template response (NPE) when certain accounting rules were present.

To resolve this, I implemented a "Manual Chain" strategy in the resolver to bypass the faulty template endpoint. The resolver now sequentially fetches:
1. Savings Account Data
2. Associated Client or Group Data (to get the `officeId`)
3. Active Loan Officers for that office

Additionally, I fixed a UI issue where the "toSavingsOfficer" payload was incorrect (previously sending an empty `fromSavingsOfficerId`), added validation to the assignment form, and fixed a missing translation label for the "Unassign Staff" menu item across all supported languages.


## Screenshots

<details>
  <summary><b>Staff Assignment Dialog</b></summary>
  <br>
  <img width="873" alt="Staff Assignment Dialog" src="https://github.com/user-attachments/assets/559538e3-c420-4974-9007-155d19e22503" />
</details>

<details>
  <summary><b>Successful Assignment & Menu Fix</b></summary>
  <br>
  <img width="1200" alt="Successful Assignment" src="https://github.com/user-attachments/assets/a81021e9-4b03-4fd3-8ba4-ea5388bfd8dd" />
</details>

_Verified manually: The "Assign Staff" dialog now populates correctly with active loan officers, and the assignment action succeeds without error._

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Unassign Staff" menu label across multiple languages.
  * Assign Staff flow now provides populated staff options for selection and improved filtering for loan officers.

* **Bug Fixes**
  * Displayed validation error for the To Savings Officer field.
  * Made the To Savings Officer field required to prevent incomplete submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->