### PR TITLE
WEB-750 Move postal code section

### DIFF
--- a/src/app/clients/client-stepper/client-address-step/client-address-step.component.ts
+++ b/src/app/clients/client-stepper/client-address-step/client-address-step.component.ts
@@ -200,6 +200,17 @@ export class ClientAddressStepComponent {
         : null
     );
     formfields.push(
+      this.isFieldEnabled('postalCode')
+        ? new InputBase({
+            controlName: 'postalCode',
+            label: this.translateService.instant('labels.inputs.Postal Code'),
+            value: address ? address.postalCode : '',
+            type: 'text',
+            order: 2
+          })
+        : null
+    );
+    formfields.push(
       this.isFieldEnabled('street')
         ? new InputBase({
             controlName: 'street',
@@ -207,7 +218,7 @@ export class ClientAddressStepComponent {
             value: address ? address.street : '',
             type: 'text',
             required: true,
-            order: 2
+            order: 3
           })
         : null
     );
@@ -296,17 +307,6 @@ export class ClientAddressStepComponent {
             value: address ? address.countryId : '',
             options: { label: 'name', value: 'id', data: this.clientTemplate.address[0].countryIdOptions },
             order: 10
-          })
-        : null
-    );
-    formfields.push(
-      this.isFieldEnabled('postalCode')
-        ? new InputBase({
-            controlName: 'postalCode',
-            label: this.translateService.instant('labels.inputs.Postal Code'),
-            value: address ? address.postalCode : '',
-            type: 'text',
-            order: 11
           })
         : null
     );

--- a/src/app/clients/clients-view/address-tab/address-tab.component.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.ts
@@ -204,6 +204,17 @@ export class AddressTabComponent {
       );
     }
     formfields.push(
+      this.isFieldEnabled('postalCode')
+        ? new InputBase({
+            controlName: 'postalCode',
+            label: this.translateService.instant('labels.inputs.Postal Code'),
+            value: address ? address.postalCode : '',
+            type: 'text',
+            order: 2
+          })
+        : null
+    );
+    formfields.push(
       this.isFieldEnabled('street')
         ? new InputBase({
             controlName: 'street',
@@ -211,7 +222,7 @@ export class AddressTabComponent {
             value: address ? address.street : '',
             type: 'text',
             required: false,
-            order: 2
+            order: 3
           })
         : null
     );
@@ -300,17 +311,6 @@ export class AddressTabComponent {
             value: address ? address.countryId : '',
             options: { label: 'name', value: 'id', data: this.clientAddressTemplate.countryIdOptions },
             order: 10
-          })
-        : null
-    );
-    formfields.push(
-      this.isFieldEnabled('postalCode')
-        ? new InputBase({
-            controlName: 'postalCode',
-            label: this.translateService.instant('labels.inputs.Postal Code'),
-            value: address ? address.postalCode : '',
-            type: 'text',
-            order: 11
           })
         : null
     );


### PR DESCRIPTION
**Changes Made :-** 

-Move the postal code field to appear immediately below the address type in the client address form dialog.

[WEB-750](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-750)

Before :- 

<img width="406" height="497" alt="image" src="https://github.com/user-attachments/assets/8ee72fb7-55bc-45b3-bb1f-4384f802b18f" />


<img width="462" height="478" alt="image" src="https://github.com/user-attachments/assets/e627e90d-b513-40ad-864c-babf0117cecb" />


After :- 

<img width="391" height="501" alt="image" src="https://github.com/user-attachments/assets/993e6961-e5e3-46f9-8dc6-edf5a478b042" />


<img width="396" height="481" alt="image" src="https://github.com/user-attachments/assets/f816d722-8b5d-4631-966a-1e7c03563cc3" />


[WEB-750]: https://mifosforge.jira.com/browse/WEB-750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Postal Code field added to address creation, shown conditionally when enabled.

* **Refactor**
  * Moved Postal Code earlier in the address form flow and adjusted Street field order accordingly.

* **Bug Fixes**
  * Removed duplicate/late Postal Code entry to prevent redundant inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->