### PR TITLE
WEB-753 The cell field should be in numeric format only

### DIFF
--- a/src/app/core/utils/datatables.ts
+++ b/src/app/core/utils/datatables.ts
@@ -257,4 +257,25 @@ export class Datatables {
       return false;
     }
   }
+
+  public isPhoneNumberField(columnName: string): boolean {
+    if (!columnName) {
+      return false;
+    }
+    const normalizedName = columnName.toLowerCase().replace(/[_\s]+/g, '');
+    const phonePatterns = [
+      /\bphone\b/,
+      /\btelefono\b/,
+      /\bcelular\b/,
+      /\bmobile(?:phone|no|num|number)?\b/,
+      /\bfijo\b/,
+      /\blandline\b/,
+      /\bcellphone\b/,
+      /\bofficephone\b/,
+      /\bhomephone\b/,
+      /\bmtn\b/,
+      /\bairtel\b/
+    ];
+    return phonePatterns.some((pattern) => pattern.test(normalizedName));
+  }
 }

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
@@ -250,7 +250,9 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
             value = this.dateTimeFormat.transform(value);
           } else if (columnDisplayType === 'INTEGER' || columnDisplayType === 'DECIMAL') {
             if (typeof value === 'number') {
-              value = this.numberFormat.transform(value);
+              if (!this.datatables.isPhoneNumberField(columnName)) {
+                value = this.numberFormat.transform(value);
+              }
             }
           } else if (columnDisplayType === 'CODELOOKUP') {
             if (columnHeader.columnValues && value !== null && value !== undefined) {

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
@@ -56,7 +56,11 @@
                   }
                   @case ('DECIMAL') {
                     <span>
-                      {{ dataObject.data[0].row[i] | formatNumber }}
+                      @if (datatables.isPhoneNumberField(columnHeader.columnName)) {
+                        {{ dataObject.data[0].row[i] }}
+                      } @else {
+                        {{ dataObject.data[0].row[i] | formatNumber }}
+                      }
                     </span>
                   }
                   @case ('CODELOOKUP') {


### PR DESCRIPTION
**Changes Made :-**

-Fix phone number formatting in datatables to display as plain numeric values without commas or decimals .

[WEB-753](https://mifosforge.jira.com/browse/WEB-753)

Before :- 

<img width="1060" height="474" alt="image" src="https://github.com/user-attachments/assets/c37980a1-8a2c-4ee9-8a72-1325f12deb7a" />


After :- 
<img width="1118" height="494" alt="image" src="https://github.com/user-attachments/assets/64ca0cb7-71e7-4c95-9a77-e68a15f7d6c2" />



[WEB-753]: https://mifosforge.jira.com/browse/WEB-753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added phone-number detection for datatables to recognize various phone column names.

* **Bug Fixes**
  * Phone number columns now skip numeric formatting in single-row and multi-row table views, preventing phone numbers from being displayed as regular formatted numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->