### PR TITLE
WEB-754 Add drop-down bar for name editing

### DIFF
--- a/src/app/system/manage-data-tables/create-data-table/create-data-table.component.html
+++ b/src/app/system/manage-data-tables/create-data-table/create-data-table.component.html
@@ -193,14 +193,32 @@
           </ng-container>
 
           <ng-container matColumnDef="actions">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Actions' | translate }}</th>
-            <td mat-cell *matCellDef="let column" class="gap-15percent">
-              <button type="button" color="primary" mat-icon-button (click)="editColumn(column)">
-                <fa-icon icon="edit" size="lg"></fa-icon>
-              </button>
-              <button type="button" color="warn" mat-icon-button (click)="deleteColumn(column)">
-                <fa-icon icon="trash" size="lg"></fa-icon>
-              </button>
+            <th mat-header-cell *matHeaderCellDef class="actions-column">
+              {{ 'labels.inputs.Actions' | translate }}
+            </th>
+            <td mat-cell *matCellDef="let column" class="actions-column">
+              <div class="actions-wrapper">
+                <button
+                  type="button"
+                  color="primary"
+                  mat-icon-button
+                  (click)="editColumn(column)"
+                  matTooltip="{{ 'labels.buttons.Edit' | translate }}"
+                  aria-label="{{ 'labels.buttons.Edit' | translate }}"
+                >
+                  <fa-icon icon="edit" size="sm"></fa-icon>
+                </button>
+                <button
+                  type="button"
+                  color="warn"
+                  mat-icon-button
+                  (click)="deleteColumn(column)"
+                  matTooltip="{{ 'labels.buttons.Delete' | translate }}"
+                  aria-label="{{ 'labels.buttons.Delete' | translate }}"
+                >
+                  <fa-icon icon="trash" size="sm"></fa-icon>
+                </button>
+              </div>
             </td>
           </ng-container>
 

--- a/src/app/system/manage-data-tables/create-data-table/create-data-table.component.scss
+++ b/src/app/system/manage-data-tables/create-data-table/create-data-table.component.scss
@@ -19,6 +19,58 @@
   }
 }
 
-table {
+.mat-mdc-table {
   width: 100%;
+  overflow-x: auto;
+  display: block;
+}
+
+.mat-mdc-header-row,
+.mat-mdc-row {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+  min-width: 800px;
+}
+
+.actions-column {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  text-align: center;
+  position: sticky;
+  right: 0;
+  background: #fff;
+  z-index: 1;
+}
+
+.actions-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+}
+
+.actions-wrapper .mat-mdc-icon-button {
+  width: 36px;
+  height: 36px;
+  padding: 6px;
+}
+
+.actions-wrapper fa-icon {
+  font-size: 14px;
+}
+
+th.mat-mdc-header-cell:first-child,
+td.mat-mdc-cell:first-child {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+th.mat-mdc-header-cell:not(.actions-column, :first-child),
+td.mat-mdc-cell:not(.actions-column, :first-child) {
+  width: 80px;
+  min-width: 80px;
 }

--- a/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.html
+++ b/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.html
@@ -168,19 +168,33 @@
           </ng-container>
 
           <ng-container matColumnDef="actions">
-            <th mat-header-cell *matHeaderCellDef mat-sort-header class="center">
+            <th mat-header-cell *matHeaderCellDef class="center actions-column">
               {{ 'labels.inputs.Actions' | translate }}
             </th>
-            <td mat-cell *matCellDef="let column" class="center gap-15percent">
+            <td mat-cell *matCellDef="let column" class="center actions-column">
               @if (!column.system) {
-                <button type="button" color="primary" mat-icon-button (click)="editColumn(column)">
-                  <fa-icon icon="edit" size="lg"></fa-icon>
-                </button>
-              }
-              @if (!column.system) {
-                <button type="button" color="warn" mat-icon-button (click)="deleteColumn(column)">
-                  <fa-icon icon="trash" size="lg"></fa-icon>
-                </button>
+                <div class="actions-wrapper">
+                  <button
+                    type="button"
+                    color="primary"
+                    mat-icon-button
+                    (click)="editColumn(column)"
+                    matTooltip="{{ 'labels.buttons.Edit' | translate }}"
+                    aria-label="{{ 'labels.buttons.Edit' | translate }}"
+                  >
+                    <fa-icon icon="edit" size="sm"></fa-icon>
+                  </button>
+                  <button
+                    type="button"
+                    color="warn"
+                    mat-icon-button
+                    (click)="deleteColumn(column)"
+                    matTooltip="{{ 'labels.buttons.Delete' | translate }}"
+                    aria-label="{{ 'labels.buttons.Delete' | translate }}"
+                  >
+                    <fa-icon icon="trash" size="sm"></fa-icon>
+                  </button>
+                </div>
               }
             </td>
           </ng-container>

--- a/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.scss
+++ b/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.scss
@@ -6,6 +6,58 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-table {
+.mat-mdc-table {
   width: 100%;
+  overflow-x: auto;
+  display: block;
+}
+
+.mat-mdc-header-row,
+.mat-mdc-row {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+  min-width: 800px;
+}
+
+.actions-column {
+  width: 100px !important;
+  min-width: 100px !important;
+  max-width: 100px !important;
+  text-align: center;
+  position: sticky;
+  right: 0;
+  background: #fff;
+  z-index: 1;
+}
+
+.actions-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+}
+
+.actions-wrapper .mat-mdc-icon-button {
+  width: 36px;
+  height: 36px;
+  padding: 6px;
+}
+
+.actions-wrapper fa-icon {
+  font-size: 14px;
+}
+
+th.mat-mdc-header-cell:first-child,
+td.mat-mdc-cell:first-child {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+th.mat-mdc-header-cell:not(.actions-column, :first-child),
+td.mat-mdc-cell:not(.actions-column, :first-child) {
+  width: 80px;
+  min-width: 80px;
 }


### PR DESCRIPTION
**Changes Made :-** 

-Fixed layout issues where long column names would push edit/delete action buttons off-screen by implementing sticky Actions column with text truncation and responsive table scrolling. 

[WEB-754](https://mifosforge.jira.com/browse/WEB-754?actionerId=712020%3Aed4cc2d4-9c78-4c5f-a4d3-433abbc432eb&sourceType=assign)

Before :- 

<img width="1024" height="858" alt="image" src="https://github.com/user-attachments/assets/cb952ac9-cc46-47b4-b9f6-6222e7074db7" />

<img width="1024" height="506" alt="image" src="https://github.com/user-attachments/assets/954b1bca-5009-4ad2-b4f7-8ac7f09ddc4b" />


After :- 

<img width="964" height="375" alt="image" src="https://github.com/user-attachments/assets/f8e6fb82-3d6d-4de1-adf9-f94fa330b55f" />


<img width="921" height="473" alt="image" src="https://github.com/user-attachments/assets/f8b8aaef-185c-4421-9bc0-c8c56d16ecc8" />



[WEB-754]: https://mifosforge.jira.com/browse/WEB-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Delete action alongside Edit, both with tooltips and accessible labels.
  * Action buttons are grouped in a dedicated wrapper for consistent alignment.

* **Style**
  * Redesigned table layout with a sticky, right-aligned actions column.
  * Reduced action icon/button sizes for a more compact appearance.
  * Enabled horizontal scrolling, fixed column widths, and text truncation for improved display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->