### PR TITLE
WEB-741 Fix the web application publication on GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: dist/web-app
+          FOLDER: dist/web-app/browser
           #without preserve it only builds if you have untracked files
           PRESERVE: true
           # github user name and email shows up in the logs,


### PR DESCRIPTION
**Changed Made :-** 

-Updated the GitHub Pages deploy action to use the correct Angular 20 build output folder (dist/web-app/browser) instead of dist/web-app to fix the 404 error on https://openmf.github.io/web-app/ .

[WEB-741](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-741)

[WEB-741]: https://mifosforge.jira.com/browse/WEB-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ