### PR TITLE
WEB-759 Actions column displays white background in dark mode on data…

### DIFF
--- a/src/app/system/manage-data-tables/create-data-table/create-data-table.component.scss
+++ b/src/app/system/manage-data-tables/create-data-table/create-data-table.component.scss
@@ -40,7 +40,7 @@
   text-align: center;
   position: sticky;
   right: 0;
-  background: #fff;
+  background: var(--card-background, #fff);
   z-index: 1;
 }
 
@@ -73,4 +73,8 @@ th.mat-mdc-header-cell:not(.actions-column, :first-child),
 td.mat-mdc-cell:not(.actions-column, :first-child) {
   width: 80px;
   min-width: 80px;
+}
+
+:host-context(.dark-theme) {
+  --card-background: #2d2d2d;
 }

--- a/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.scss
+++ b/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.scss
@@ -27,7 +27,7 @@
   text-align: center;
   position: sticky;
   right: 0;
-  background: #fff;
+  background: var(--card-background, #fff);
   z-index: 1;
 }
 
@@ -60,4 +60,8 @@ th.mat-mdc-header-cell:not(.actions-column, :first-child),
 td.mat-mdc-cell:not(.actions-column, :first-child) {
   width: 80px;
   min-width: 80px;
+}
+
+:host-context(.dark-theme) {
+  --card-background: #2d2d2d;
 }


### PR DESCRIPTION
**Changes Made :-**

-Fixed Actions column background in data tables to support dark theme .

[WEB-759](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-759)

Before :- 

<img width="1012" height="312" alt="image" src="https://github.com/user-attachments/assets/51371da2-f7b9-49bf-a6d8-44d58ab7be76" />

After :-

<img width="923" height="312" alt="image" src="https://github.com/user-attachments/assets/2a28528f-5115-4095-b19e-fc73ce2787f1" />


[WEB-759]: https://mifosforge.jira.com/browse/WEB-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated styling for action columns in data table interfaces to use a CSS variable with a fallback, enabling better theme customization.
  * Added dark-theme support so action column backgrounds adapt in dark mode.
  * No structural or behavioral changes; visual theming only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->