### PR TITLE
WEB-760 Validation and error message improvements for Add Column dialog

### DIFF
--- a/src/app/system/manage-data-tables/column-dialog/column-dialog.component.html
+++ b/src/app/system/manage-data-tables/column-dialog/column-dialog.component.html
@@ -49,9 +49,16 @@
             matInput
             required
             type="number"
+            min="1"
             formControlName="length"
             placeholder="{{ 'labels.inputs.Column Length' | translate }}"
           />
+          @if (columnForm.controls.length.hasError('required')) {
+            <mat-error>
+              {{ 'labels.inputs.Column Length' | translate }} {{ 'labels.commons.is' | translate }}
+              <strong>{{ 'labels.commons.required' | translate }}</strong>
+            </mat-error>
+          }
         </mat-form-field>
       }
 
@@ -65,6 +72,12 @@
               </mat-option>
             }
           </mat-select>
+          @if (columnForm.controls.code.hasError('required')) {
+            <mat-error>
+              {{ 'labels.inputs.Column Code' | translate }} {{ 'labels.commons.is' | translate }}
+              <strong>{{ 'labels.commons.required' | translate }}</strong>
+            </mat-error>
+          }
         </mat-form-field>
       }
 

--- a/src/app/system/manage-data-tables/column-dialog/column-dialog.component.ts
+++ b/src/app/system/manage-data-tables/column-dialog/column-dialog.component.ts
@@ -76,7 +76,10 @@ export class ColumnDialogComponent implements OnInit {
           value: this.data ? +this.data.columnLength : '',
           disabled: this.getColumnType(this.data.columnDisplayType) !== 'String' || this.data.type === 'existing'
         },
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(1)
+        ]
       ],
       mandatory: [{ value: this.data.isColumnNullable, disabled: this.data.type === 'existing' }],
       unique: [


### PR DESCRIPTION
**Changes Made :-** 

-Adds a required error message for the "Column Code" field in the Dropdown type and improves validation for the "Column Length" field in the Add Column dialog .

Before :- 

<img width="463" height="390" alt="image" src="https://github.com/user-attachments/assets/8d988f78-e56a-4d67-8498-75e13eb72085" />


<img width="360" height="398" alt="image" src="https://github.com/user-attachments/assets/2ff5cb9f-d9d7-4c48-a873-349c29555793" />


After :- 

<img width="425" height="403" alt="image" src="https://github.com/user-attachments/assets/01e8fc60-6922-41c8-a05c-3e48480d21c9" />


<img width="385" height="404" alt="image" src="https://github.com/user-attachments/assets/bd2c17b3-cb12-4209-867a-248dbbf7b7de" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents negative values for column length by enforcing a minimum of zero, avoiding invalid inputs.
  * Improves required-field error messaging for the column code when configuring dropdown-type columns, making missing codes clearer to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->