### PR TITLE
WEB-761 Add missing icons to edit and delete buttons in notes tab for clients and groups

### DIFF
--- a/src/app/shared/tabs/entity-notes-tab/entity-notes-tab.component.html
+++ b/src/app/shared/tabs/entity-notes-tab/entity-notes-tab.component.html
@@ -27,7 +27,7 @@
         ></textarea>
       </mat-form-field>
       <button type="submit" mat-raised-button class="flex-1" color="primary" [disabled]="!noteForm.valid">
-        <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
+        <fa-icon icon="plus" class="m-r-10" aria-hidden="true"></fa-icon>{{ 'labels.buttons.Add' | translate }}
       </button>
     </form>
   </div>
@@ -57,7 +57,8 @@
                   (click)="editNote(entityNote.id, entityNote.note, i)"
                   [title]="'labels.heading.Edit Note' | translate"
                 >
-                  {{ 'labels.buttons.Edit' | translate }}
+                  <fa-icon icon="edit" class="m-r-10" aria-hidden="true"></fa-icon
+                  >{{ 'labels.buttons.Edit' | translate }}
                 </button>
                 <button
                   type="button"
@@ -66,7 +67,8 @@
                   (click)="deleteNote(entityNote.id, i)"
                   [title]="('labels.inputs.Note' | translate) + ': ' + ('labels.buttons.Delete' | translate)"
                 >
-                  {{ 'labels.buttons.Delete' | translate }}
+                  <fa-icon icon="trash" class="m-r-10" aria-hidden="true"></fa-icon
+                  >{{ 'labels.buttons.Delete' | translate }}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
**Changes Made :-** 

-Added font  icons to Edit and Delete buttons in the Notes tab component to maintain visual consistency across the application.

[WEB-761](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-761)

Before :- 

<img width="640" height="338" alt="image" src="https://github.com/user-attachments/assets/c1db72f7-570a-446d-b882-9c3caecd4f8c" />

<img width="640" height="328" alt="image" src="https://github.com/user-attachments/assets/695317f9-d1c0-4c5d-87cb-6752248a786e" />

After :- 

<img width="992" height="481" alt="image" src="https://github.com/user-attachments/assets/85afaeca-69fb-4c22-b34f-868e002de10f" />

<img width="1028" height="533" alt="image" src="https://github.com/user-attachments/assets/6953f374-4e9b-4a7e-9c2a-af956b40fb79" />



[WEB-761]: https://mifosforge.jira.com/browse/WEB-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Decorative icons on Entity Notes' Add/Edit/Delete buttons are now hidden from screen readers (improved accessibility) while remaining visually visible; no functional changes to button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->