### PR TITLE
WEB-762 Display No Data Available message instead of table on Identities table

### DIFF
--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -114,7 +114,7 @@
 
     <ng-container matColumnDef="no-data">
       <td mat-footer-cell *matFooterCellDef [attr.colspan]="upcomingChargesColumns.length">
-        <div class="no-data-message">
+        <div class="table-empty-state">
           <p>{{ 'labels.messages.No Upcoming Charges Available' | translate }}</p>
         </div>
       </td>
@@ -268,7 +268,7 @@
 
       <ng-container matColumnDef="no-data">
         <td mat-footer-cell *matFooterCellDef [attr.colspan]="openLoansColumns.length">
-          <div class="no-data-message">
+          <div class="table-empty-state">
             <p>{{ 'labels.messages.No Active Loan Accounts Available' | translate }}</p>
           </div>
         </td>
@@ -357,7 +357,7 @@
 
       <ng-container matColumnDef="no-data">
         <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedLoansColumns.length">
-          <div class="no-data-message">
+          <div class="table-empty-state">
             <p>{{ 'labels.messages.No Closed Loan Accounts Available' | translate }}</p>
           </div>
         </td>
@@ -479,7 +479,7 @@
 
       <ng-container matColumnDef="no-data">
         <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
-          <div class="no-data-message">
+          <div class="table-empty-state">
             <p>{{ 'labels.messages.No Active Saving Accounts Available' | translate }}</p>
           </div>
         </td>
@@ -523,7 +523,7 @@
 
       <ng-container matColumnDef="no-data">
         <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
-          <div class="no-data-message">
+          <div class="table-empty-state">
             <p>{{ 'labels.messages.No Closed Saving Accounts Available' | translate }}</p>
           </div>
         </td>
@@ -622,7 +622,7 @@
 
       <ng-container matColumnDef="no-data">
         <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
-          <div class="no-data-message">
+          <div class="table-empty-state">
             <p>{{ 'labels.messages.No Active Fixed Deposit Accounts Available' | translate }}</p>
           </div>
         </td>
@@ -667,7 +667,7 @@
 
       <ng-container matColumnDef="no-data">
         <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
-          <div class="no-data-message">
+          <div class="table-empty-state">
             <p>{{ 'labels.messages.No Closed Fixed Deposit Accounts Available' | translate }}</p>
           </div>
         </td>
@@ -770,7 +770,7 @@
 
       <ng-container matColumnDef="no-data">
         <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
-          <div class="no-data-message">
+          <div class="table-empty-state">
             <p>{{ 'labels.messages.No Active Recurring Deposit Accounts Available' | translate }}</p>
           </div>
         </td>
@@ -815,7 +815,7 @@
 
       <ng-container matColumnDef="no-data">
         <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
-          <div class="no-data-message">
+          <div class="table-empty-state">
             <p>{{ 'labels.messages.No Closed Recurring Deposit Accounts Available' | translate }}</p>
           </div>
         </td>
@@ -917,7 +917,7 @@
 
       <ng-container matColumnDef="no-data">
         <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSharesColumns.length">
-          <div class="no-data-message">
+          <div class="table-empty-state">
             <p>{{ 'labels.messages.No Active Share Accounts Available' | translate }}</p>
           </div>
         </td>
@@ -965,7 +965,7 @@
 
       <ng-container matColumnDef="no-data">
         <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSharesColumns.length">
-          <div class="no-data-message">
+          <div class="table-empty-state">
             <p>{{ 'labels.messages.No Closed Share Accounts Available' | translate }}</p>
           </div>
         </td>
@@ -1039,7 +1039,7 @@
 
     <ng-container matColumnDef="no-data">
       <td mat-footer-cell *matFooterCellDef [attr.colspan]="collateralsColumns.length">
-        <div class="no-data-message">
+        <div class="table-empty-state">
           <p>{{ 'labels.messages.No Collateral Data Available' | translate }}</p>
         </div>
       </td>

--- a/src/app/clients/clients-view/general-tab/general-tab.component.scss
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.scss
@@ -56,15 +56,3 @@
   align-items: center; /* Ensure buttons are vertically aligned */
   gap: 0.5rem; /* Add spacing between buttons if needed */
 }
-
-.no-data-message {
-  text-align: center;
-  padding: 40px 20px;
-  color: var(--mdc-theme-text-secondary-on-background, #666);
-  font-size: 14px;
-  cursor: auto;
-
-  p {
-    margin: 0;
-  }
-}

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.html
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.html
@@ -120,8 +120,19 @@
       </td>
     </ng-container>
 
+    <ng-container matColumnDef="no-data">
+      <td mat-footer-cell *matFooterCellDef [attr.colspan]="identitiesColumns.length">
+        <div class="table-empty-state">
+          <p>{{ 'labels.messages.No Identities Available' | translate }}</p>
+        </div>
+      </td>
+    </ng-container>
+
     <tr mat-header-row *matHeaderRowDef="identitiesColumns"></tr>
     <tr mat-row *matRowDef="let row; columns: identitiesColumns"></tr>
+    @if (clientIdentities?.length === 0) {
+      <tr mat-footer-row *matFooterRowDef="['no-data']"></tr>
+    }
   </table>
 </div>
 

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
@@ -20,7 +20,11 @@ import {
   MatHeaderRowDef,
   MatHeaderRow,
   MatRowDef,
-  MatRow
+  MatRow,
+  MatFooterCellDef,
+  MatFooterCell,
+  MatFooterRowDef,
+  MatFooterRow
 } from '@angular/material/table';
 import { ActivatedRoute } from '@angular/router';
 
@@ -60,7 +64,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatHeaderRowDef,
     MatHeaderRow,
     MatRowDef,
-    MatRow
+    MatRow,
+    MatFooterCellDef,
+    MatFooterCell,
+    MatFooterRowDef,
+    MatFooterRow
   ]
 })
 export class IdentitiesTabComponent implements OnDestroy {

--- a/src/assets/styles/_misc.scss
+++ b/src/assets/styles/_misc.scss
@@ -87,3 +87,15 @@ mat-card-title {
   padding-left: 20px;
   padding-top: 20px;
 }
+
+.table-empty-state {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--mdc-theme-text-secondary-on-background, #666);
+  font-size: 14px;
+  cursor: auto;
+
+  p {
+    margin: 0;
+  }
+}

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3629,7 +3629,8 @@
     "No Closed Recurring Deposit Accounts Available": "Žádné uzavřené opakující se účty s vkladem k dispozici",
     "No Active Share Accounts Available": "Žádné aktivní účty podílů k dispozici",
     "No Closed Share Accounts Available": "Žádné uzavřené účty podílů k dispozici",
-    "No Collateral Data Available": "Žádná data o kolaterálu k dispozici"
+    "No Collateral Data Available": "Žádná data o kolaterálu k dispozici",
+    "No Identities Available": "Žádné identity k dispozici"
   },
   "languages": {
     "cs-CS": "Čeština",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3629,7 +3629,8 @@
     "No Closed Recurring Deposit Accounts Available": "Keine geschlossenen wiederkehrenden Einlagenkonten verfügbar",
     "No Active Share Accounts Available": "Keine aktiven Aktienkonten verfügbar",
     "No Closed Share Accounts Available": "Keine geschlossenen Aktienkonten verfügbar",
-    "No Collateral Data Available": "Keine Sicherheiten verfügbar"
+    "No Collateral Data Available": "Keine Sicherheiten verfügbar",
+    "No Identities Available": "Keine Identitäten verfügbar"
   },
   "languages": {
     "cs-CS": "Čeština (Tschechisch)",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3740,7 +3740,8 @@
       "No Closed Recurring Deposit Accounts Available": "No Closed Recurring Deposit Accounts Available",
       "No Active Share Accounts Available": "No Active Share Accounts Available",
       "No Closed Share Accounts Available": "No Closed Share Accounts Available",
-      "No Collateral Data Available": "No Collateral Data Available"
+      "No Collateral Data Available": "No Collateral Data Available",
+      "No Identities Available": "No Identities Available"
     }
   },
   "languages": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3631,7 +3631,8 @@
       "No Closed Recurring Deposit Accounts Available": "No hay cuentas de depósito recurrente cerradas disponibles",
       "No Active Share Accounts Available": "No hay cuentas de acciones activas disponibles",
       "No Closed Share Accounts Available": "No hay cuentas de acciones cerradas disponibles",
-      "No Collateral Data Available": "No hay datos de garantía disponibles"
+      "No Collateral Data Available": "No hay datos de garantía disponibles",
+      "No Identities Available": "No hay identidades disponibles"
     }
   },
   "languages": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3634,7 +3634,8 @@
       "No Closed Recurring Deposit Accounts Available": "No hay cuentas de depósito recurrente cerradas disponibles",
       "No Active Share Accounts Available": "No hay cuentas de acciones activas disponibles",
       "No Closed Share Accounts Available": "No hay cuentas de acciones cerradas disponibles",
-      "No Collateral Data Available": "No hay datos de garantía disponibles"
+      "No Collateral Data Available": "No hay datos de garantía disponibles",
+      "No Identities Available": "No hay identidades disponibles"
     }
   },
   "languages": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3632,7 +3632,8 @@
       "No Closed Recurring Deposit Accounts Available": "Aucun compte de dépôt récurrent fermé disponible",
       "No Active Share Accounts Available": "Aucun compte d'actions actif disponible",
       "No Closed Share Accounts Available": "Aucun compte d'actions fermé disponible",
-      "No Collateral Data Available": "Aucune donnée de garantie disponible"
+      "No Collateral Data Available": "Aucune donnée de garantie disponible",
+      "No Identities Available": "Aucune identité disponible"
     }
   },
   "languages": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3629,7 +3629,8 @@
       "No Closed Recurring Deposit Accounts Available": "Nessun conto di deposito ricorrente chiuso disponibile",
       "No Active Share Accounts Available": "Nessun conto di azioni attivo disponibile",
       "No Closed Share Accounts Available": "Nessun conto di azioni chiuso disponibile",
-      "No Collateral Data Available": "Nessun dato collaterale disponibile"
+      "No Collateral Data Available": "Nessun dato collaterale disponibile",
+      "No Identities Available": "Nessuna identità disponibile"
     }
   },
   "languages": {

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3630,7 +3630,8 @@
       "No Closed Recurring Deposit Accounts Available": "해지된 적립식 예금 계정이 없습니다",
       "No Active Share Accounts Available": "활성 주식 계정이 없습니다",
       "No Closed Share Accounts Available": "해지된 주식 계정이 없습니다",
-      "No Collateral Data Available": "담보 데이터가 없습니다"
+      "No Collateral Data Available": "담보 데이터가 없습니다",
+      "No Identities Available": "신원이 없습니다"
     }
   },
   "languages": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3630,7 +3630,8 @@
       "No Closed Recurring Deposit Accounts Available": "Nėra uždarytų pasikartojančių indėlių sąskaitų",
       "No Active Share Accounts Available": "Nėra aktyvių akcijų sąskaitų",
       "No Closed Share Accounts Available": "Nėra uždarytų akcijų sąskaitų",
-      "No Collateral Data Available": "Nėra užstato duomenų"
+      "No Collateral Data Available": "Nėra užstato duomenų",
+      "No Identities Available": "Nėra galimų tapatybių"
     }
   },
   "languages": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3630,7 +3630,8 @@
       "No Closed Recurring Deposit Accounts Available": "Nav slēgtu periodisku noguldījumu kontu",
       "No Active Share Accounts Available": "Nav aktīvu akciju kontu",
       "No Closed Share Accounts Available": "Nav slēgtu akciju kontu",
-      "No Collateral Data Available": "Nav pieejamu nodrošinājuma datu"
+      "No Collateral Data Available": "Nav pieejamu nodrošinājuma datu",
+      "No Identities Available": "Nav pieejamu identitāšu"
     }
   },
   "languages": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3628,7 +3628,8 @@
       "No Closed Recurring Deposit Accounts Available": "कुनै बन्द आवर्ती जम्मा खाताहरू उपलब्ध छैनन्",
       "No Active Share Accounts Available": "कुनै सक्रिय शेयर खाताहरू उपलब्ध छैनन्",
       "No Closed Share Accounts Available": "कुनै बन्द शेयर खाताहरू उपलब्ध छैनन्",
-      "No Collateral Data Available": "कुनै संपार्श्विक डाटा उपलब्ध छैन"
+      "No Collateral Data Available": "कुनै संपार्श्विक डाटा उपलब्ध छैन",
+      "No Identities Available": "कुनै पहिचान उपलब्ध छैन"
     }
   },
   "languages": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3629,7 +3629,8 @@
       "No Closed Recurring Deposit Accounts Available": "Nenhuma conta de depósito recorrente encerrada disponível",
       "No Active Share Accounts Available": "Nenhuma conta de ações ativa disponível",
       "No Closed Share Accounts Available": "Nenhuma conta de ações encerrada disponível",
-      "No Collateral Data Available": "Nenhum dado de garantia disponível"
+      "No Collateral Data Available": "Nenhum dado de garantia disponível",
+      "No Identities Available": "Nenhuma identidade disponível"
     }
   },
   "languages": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3627,7 +3627,8 @@
       "No Closed Recurring Deposit Accounts Available": "Hakuna akaunti za amana za mara kwa mara zilizofungwa zinapatikana",
       "No Active Share Accounts Available": "Hakuna akaunti za hisa zinazofanya kazi zinapatikana",
       "No Closed Share Accounts Available": "Hakuna akaunti za hisa zilizofungwa zinapatikana",
-      "No Collateral Data Available": "Hakuna data ya dhamana inayopatikana"
+      "No Collateral Data Available": "Hakuna data ya dhamana inayopatikana",
+      "No Identities Available": "Hakuna Vitambulisho Vinavyopatikana"
     }
   },
   "languages": {


### PR DESCRIPTION
## Description

WEB-762: Replaced the Identities table with a “No Data Available” message when no records are found.
Additionally, I converted the table-empty-state style into a global utility so it can be reused across the entire application for better maintainability.
While implementing this change, I discovered an existing class named no-data-message, so I updated and standardized it to table-empty-state within the General Tab component as well.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

before
<img width="1765" height="774" alt="image" src="https://github.com/user-attachments/assets/720c9dc0-3a9d-4d4b-986d-df391298b175" />


after 
<img width="1766" height="828" alt="image" src="https://github.com/user-attachments/assets/13312af5-0b9c-4982-ba2b-836167d8bf9b" />

Related PR :- https://github.com/openMF/web-app/pull/3070#event-22810200772
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added empty state messaging to the identities table

* **Improvements**
  * Enhanced consistency of empty state messages across all data tables

* **Localization**
  * Added translations for empty state messages in 12 supported languages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->