### PR TITLE
WEB-763 Restrict negative values in add slab fields for fixed deposit product

### DIFF
--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.ts
@@ -465,28 +465,32 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
         value: values ? values.fromPeriod : undefined,
         type: 'number',
         required: true,
-        order: 2
+        order: 2,
+        min: 0
       }),
       new InputBase({
         controlName: 'toPeriod',
         label: this.translateService.instant('labels.inputs.Period To'),
         value: values ? values.toPeriod : undefined,
         type: 'number',
-        order: 3
+        order: 3,
+        min: 0
       }),
       new InputBase({
         controlName: 'amountRangeFrom',
         label: this.translateService.instant('labels.inputs.Amount Range From'),
         value: values ? values.amountRangeFrom : undefined,
         type: 'number',
-        order: 4
+        order: 4,
+        min: 0
       }),
       new InputBase({
         controlName: 'amountRangeTo',
         label: this.translateService.instant('labels.inputs.Amount Range To'),
         value: values ? values.amountRangeTo : undefined,
         type: 'number',
-        order: 5
+        order: 5,
+        min: 0
       }),
       new InputBase({
         controlName: 'annualInterestRate',
@@ -494,7 +498,8 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
         value: values ? values.annualInterestRate : undefined,
         type: 'number',
         required: true,
-        order: 6
+        order: 6,
+        min: 0
       }),
       new InputBase({
         controlName: 'description',


### PR DESCRIPTION
**Changes Made :-** 

- Preventing negative inputs for all add Slab fields (Period From, Period To, Amount Range From, Amount Range To, and Interest) in the Fixed Deposit Product .

[WEB-763](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-763)

Before :- 

<img width="640" height="338" alt="image" src="https://github.com/user-attachments/assets/d3c57607-fbdb-4808-a8fe-f16fe3bdc28a" />



After :- 


<img width="420" height="492" alt="image" src="https://github.com/user-attachments/assets/47419022-39f2-4f56-84c8-7d6ae0e04e25" />




[WEB-763]: https://mifosforge.jira.com/browse/WEB-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent negative values in fixed deposit product interest rate and slab form fields (period ranges, amount ranges, and interest rates). Invalid entries now trigger validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->