### PR TITLE
WEB-765 Restrict negative values in add slab fields for recurring deposit product

### DIFF
--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-interest-rate-chart-step/recurring-deposit-product-interest-rate-chart-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-interest-rate-chart-step/recurring-deposit-product-interest-rate-chart-step.component.ts
@@ -468,28 +468,32 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
         value: values ? values.fromPeriod : undefined,
         type: 'number',
         required: true,
-        order: 2
+        order: 2,
+        min: 0
       }),
       new InputBase({
         controlName: 'toPeriod',
         label: this.translateService.instant('labels.inputs.Period To'),
         value: values ? values.toPeriod : undefined,
         type: 'number',
-        order: 3
+        order: 3,
+        min: 0
       }),
       new InputBase({
         controlName: 'amountRangeFrom',
         label: this.translateService.instant('labels.inputs.Amount Range From'),
         value: values ? values.amountRangeFrom : undefined,
         type: 'number',
-        order: 4
+        order: 4,
+        min: 0
       }),
       new InputBase({
         controlName: 'amountRangeTo',
         label: this.translateService.instant('labels.inputs.Amount Range To'),
         value: values ? values.amountRangeTo : undefined,
         type: 'number',
-        order: 5
+        order: 5,
+        min: 0
       }),
       new InputBase({
         controlName: 'annualInterestRate',
@@ -497,7 +501,8 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
         value: values ? values.annualInterestRate : undefined,
         type: 'number',
         required: true,
-        order: 6
+        order: 6,
+        min: 0
       }),
       new InputBase({
         controlName: 'description',


### PR DESCRIPTION
**Changes Made :-**

- Preventing negative inputs for all add Slab fields (Period From, Period To, Amount Range From, Amount Range To, and Interest) in the Recurring Deposit Product .

[WEB-765](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-765)

Before :- 

<img width="412" height="497" alt="image" src="https://github.com/user-attachments/assets/00d464c4-0bdb-43f5-b79f-21b7728991ca" />

After :- 

<img width="420" height="492" alt="image" src="https://github.com/user-attachments/assets/a8c3f61a-f7e6-4240-a024-2434e1bfb667" />


[WEB-765]: https://mifosforge.jira.com/browse/WEB-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation for recurring deposit product configuration to prevent negative values in period, amount range, and interest rate fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->