### PR TITLE
WEB-766 Plus button box misaligned in Manage Currencies

### DIFF
--- a/src/app/organization/currencies/manage-currencies/manage-currencies.component.html
+++ b/src/app/organization/currencies/manage-currencies/manage-currencies.component.html
@@ -33,7 +33,7 @@
         </mat-form-field>
 
         <button
-          type="button"
+          type="submit"
           mat-raised-button
           class="add-currency-button"
           color="primary"

--- a/src/app/organization/currencies/manage-currencies/manage-currencies.component.scss
+++ b/src/app/organization/currencies/manage-currencies/manage-currencies.component.scss
@@ -29,8 +29,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  align-self: flex-end;
-  margin-bottom: 2.1em;
+  align-self: center;
+  margin-bottom: 35px;
 }
 
 .currency-grid {


### PR DESCRIPTION
**Changes Made :-** 

-Aligned the "+" button box with the search bar in Manage Currencies .

[WEB-766](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-766)

Before :- 

<img width="977" height="401" alt="image" src="https://github.com/user-attachments/assets/85e99bcc-778e-4f54-a208-d6e4fc95d6e7" />

After :- 

<img width="918" height="402" alt="image" src="https://github.com/user-attachments/assets/dd921a2e-0b42-4b84-889b-50d7b1a19e64" />



[WEB-766]: https://mifosforge.jira.com/browse/WEB-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed add currency button to properly submit the form
* **Style**
  * Updated add currency button alignment and spacing for improved layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->