### PR TITLE
WEB-767 Fix Actions column background in dark mode for data table pages

### DIFF
--- a/src/app/system/manage-data-tables/create-data-table/create-data-table.component.scss
+++ b/src/app/system/manage-data-tables/create-data-table/create-data-table.component.scss
@@ -76,5 +76,7 @@ td.mat-mdc-cell:not(.actions-column, :first-child) {
 }
 
 :host-context(.dark-theme) {
-  --card-background: #2d2d2d;
+  .actions-column {
+    background: #424242 !important;
+  }
 }

--- a/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.scss
+++ b/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.scss
@@ -63,5 +63,7 @@ td.mat-mdc-cell:not(.actions-column, :first-child) {
 }
 
 :host-context(.dark-theme) {
-  --card-background: #2d2d2d;
+  .actions-column {
+    background: #424242 !important;
+  }
 }


### PR DESCRIPTION
**Changes Made :-** 

-Updated Actions column styling in dark theme .

[WEB-767](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-767)

Before :- 

<img width="1083" height="578" alt="image" src="https://github.com/user-attachments/assets/968f5f13-61bb-44f1-a8b7-e9eacecbbe92" />

After :- 

<img width="953" height="531" alt="image" src="https://github.com/user-attachments/assets/b017583c-93b7-40cc-a85a-4cfc70be8840" />


[WEB-767]: https://mifosforge.jira.com/browse/WEB-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ