### PR TITLE
WEB-764 Default Deposit Amount field shows incorrect label labels.inp…

### DIFF
--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-terms-step/fixed-deposit-product-terms-step.component.html
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-terms-step/fixed-deposit-product-terms-step.component.html
@@ -32,8 +32,8 @@
         required
       />
       <mat-error>
-        {{ 'labels.inputs.Default Deposit Amount' | translate }} {{ 'labels.commons.is' | translate }}
-        <strong>{{ 'labels.commons.required' | translate }}</strong>
+        {{ 'labels.inputs.Default' | translate }} {{ 'labels.inputs.Deposit Amount' | translate }}
+        {{ 'labels.commons.is' | translate }} <strong>{{ 'labels.commons.required' | translate }}</strong>
       </mat-error>
     </mat-form-field>
 


### PR DESCRIPTION
**Changes Made :-** 

-Fix incorrect error label for Default Deposit Amount field in fixed deposit product to match recurring deposit product. 

[WEB-764](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-764)

Before :-

<img width="640" height="319" alt="image" src="https://github.com/user-attachments/assets/c809494e-8b2a-4411-8657-d2cc3d2817bb" />



After :-

<img width="1006" height="313" alt="image" src="https://github.com/user-attachments/assets/43127602-8813-4482-b29a-1c940e49d61e" />


[WEB-764]: https://mifosforge.jira.com/browse/WEB-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the error message display for the Deposit Amount field validation in the fixed deposit product form to enhance clarity when validation errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->