### PR TITLE
WEB-769 Add text labels to Edit and Delete buttons in Family Members tab

### DIFF
--- a/src/app/clients/clients-view/family-members-tab/family-members-tab.component.html
+++ b/src/app/clients/clients-view/family-members-tab/family-members-tab.component.html
@@ -14,7 +14,7 @@
       </div>
       <div class="action-button m-b-10 gap-25px">
         <button mat-raised-button color="primary" [routerLink]="['./add']">
-          <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
+          <fa-icon icon="plus" class="m-r-10" aria-hidden="true"></fa-icon>{{ 'labels.buttons.Add' | translate }}
         </button>
       </div>
     </div>
@@ -32,15 +32,22 @@
           </mat-expansion-panel-header>
           <mat-divider [inset]="true"></mat-divider>
           <div class="family-member-actions layout-row align-end">
-            <button mat-button color="primary">
-              <fa-icon icon="edit" [routerLink]="[member.id, 'edit']"></fa-icon>
+            <button
+              mat-raised-button
+              color="primary"
+              [routerLink]="[member.id, 'edit']"
+              [title]="'labels.buttons.Edit' | translate"
+            >
+              <fa-icon icon="edit" class="m-r-10" aria-hidden="true"></fa-icon>{{ 'labels.buttons.Edit' | translate }}
             </button>
             <button
-              mat-button
+              mat-raised-button
               color="warn"
               (click)="deleteFamilyMember(member.clientId, member.id, member.firstName, i)"
+              [title]="'labels.buttons.Delete' | translate"
             >
-              <fa-icon icon="trash"></fa-icon>
+              <fa-icon icon="trash" class="m-r-10" aria-hidden="true"></fa-icon
+              >{{ 'labels.buttons.Delete' | translate }}
             </button>
           </div>
           <p>


### PR DESCRIPTION
**Changes Made :-** 

-Updated Family Members tab to display Edit and Delete buttons with both icons and text labels .

[WEB-769](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-769)

Before :- 

<img width="640" height="304" alt="image" src="https://github.com/user-attachments/assets/ea076740-b581-4f3f-a826-634a5ef84f12" />

After :- 

<img width="1000" height="510" alt="image" src="https://github.com/user-attachments/assets/398e202c-cf3c-4d22-a252-7f127e18394e" />


[WEB-769]: https://mifosforge.jira.com/browse/WEB-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Refreshed button styling for Add, Edit, and Delete actions with an improved raised-button design, enhancing visual consistency and overall user experience in the family members management interface.

* **Accessibility**
  * Implemented accessibility improvements including icon labeling, descriptive button tooltips, and enhanced semantic markup to better support screen readers and assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->