### PR TITLE
WEB-757 refactor: update default API endpoint to demo.mifos.community

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Mifos® X Web App is a modern single-page application (SPA) built on top of the 
 
 ## Quick Links
 
-- [Live Demo](https://sandbox.mifos.community/#/login) (Updated nightly — sandbox data is reset every 6 hours; test data and transient state may be cleared.)
+- [Live Demo](https://demo.mifos.community/#/login) (Updated nightly — sandbox data is reset every 6 hours; test data and transient state may be cleared.)
 - [GitHub Repository](https://github.com/openMF/web-app)
 - [Slack Channel](https://app.slack.com/client/T0F5GHE8Y/CJJGJLN10)
 - [Jira Board of Mifos](https://mifosforge.jira.com/jira/your-work)
@@ -31,8 +31,7 @@ Before installing the web app, you need to set up the Apache Fineract® backend 
 
 1. **Choose ONE of these backend options:**
    - **Option A: Use existing remote server**
-   - Use the [sandbox (MariaDB)](https://sandbox.mifos.community) — sandbox data is reset every 6 hours; test data and transient state may be cleared.
-   - Use the [demo (MariaDB)](https://demo.mifos.community)
+   - Use the [demo (MariaDB)](https://demo.mifos.community) — sandbox data is reset every 6 hours; test data and transient state may be cleared.
    - Use the [demo (Keycloak)](https://oauth.mifos.community)
    - Use the [demo (2FA)](https://2fa.mifos.community)
    - Use the [demo (Oidc)](https://oidc.mifos.community)
@@ -140,9 +139,9 @@ The web app includes a proxy configuration (`proxy.conf.js`) that allows you to 
 
 By default, the proxy forwards `/fineract-provider` requests to the Mifos sandbox environment:
 
-- **Target:** `https://sandbox.mifos.community`
-- **API Endpoint:** `https://apis.mifos.community` (exposed in the sandbox)
-- **System Reset:** Sandbox test data and transient state are reset every 6 hours (expect data to be periodically cleared).
+- **Target:** `https://demo.mifos.community`
+- **API Endpoint:** `https://apis.mifos.community` (exposed in the demo environment)
+- **System Reset:** Demo test data and transient state are reset every 6 hours (expect data to be periodically cleared).
 
 **Sandbox Environment Variables:**
 
@@ -197,10 +196,10 @@ To verify the proxy is working correctly, start the development server (`ng serv
 curl -i "http://localhost:4200/fineract-provider/api/v1/runreports/FullClientReport?R_officeId=1&output-type=HTML&R_loanOfficerId=-1"
 ```
 
-Expected: HTTP 200 response with proxied data from the sandbox. Server console shows:
+Expected: HTTP 200 response with proxied data from the demo environment. Server console shows:
 
 ```text
-[Proxy] Proxying: GET /fineract-provider/api/v1/runreports/... -> https://sandbox.mifos.community/api/v1/runreports/...
+[Proxy] Proxying: GET /fineract-provider/api/v1/runreports/... -> https://demo.mifos.community/api/v1/runreports/...
 ```
 
 **Simulated proxy error (backend unreachable):**
@@ -215,7 +214,7 @@ If the backend is unreachable or returns an error, the proxy returns HTTP 502:
 Server console (example):
 
 ```text
-[Proxy] Error while proxying request: GET /fineract-provider/... -> https://sandbox.mifos.community - ECONNREFUSED
+[Proxy] Error while proxying request: GET /fineract-provider/... -> https://demo.mifos.community - ECONNREFUSED
 ```
 
 HTTP response:
@@ -235,13 +234,13 @@ All these environment variables can be set when using Docker or Docker Compose:
 
 #### Fineract Backend Settings
 
-| Variable                             | Description                                                          | Default Value                                                                       |
-| ------------------------------------ | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| FINERACT_API_URLS                    | Fineract server list                                                 | https://sandbox.mifos.community,https://demo.mifos.community,https://localhost:8443 |
-| FINERACT_API_URL                     | Default Fineract server                                              | https://localhost:8443                                                              |
-| FINERACT_API_ACTUATOR                | Default Fineract Actuator endpoint                                   | /fineract-provider                                                                  |
-| FINERACT_PLATFORM_TENANT_IDENTIFIER  | Default tenant identifier (must align with Fineract `tenants` table) | default                                                                             |
-| FINERACT_PLATFORM_TENANTS_IDENTIFIER | Tenant identifier list (must align with Fineract `tenants` table)    | -                                                                                   |
+| Variable                             | Description                                                          | Default Value                                       |
+| ------------------------------------ | -------------------------------------------------------------------- | --------------------------------------------------- |
+| FINERACT_API_URLS                    | Fineract server list                                                 | https://demo.mifos.community,https://localhost:8443 |
+| FINERACT_API_URL                     | Default Fineract server                                              | https://localhost:8443                              |
+| FINERACT_API_ACTUATOR                | Default Fineract Actuator endpoint                                   | /fineract-provider                                  |
+| FINERACT_PLATFORM_TENANT_IDENTIFIER  | Default tenant identifier (must align with Fineract `tenants` table) | default                                             |
+| FINERACT_PLATFORM_TENANTS_IDENTIFIER | Tenant identifier list (must align with Fineract `tenants` table)    | -                                                   |
 
 #### Language Settings (i18n)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - '4200:80'
     environment:
-      - FINERACT_API_URLS=https://sandbox.mifos.community,https://demo.mifos.community,https://localhost:8443
+      - FINERACT_API_URLS=https://demo.mifos.community,https://localhost:8443
       - FINERACT_API_URL=https://localhost:8443
       - FINERACT_API_PROVIDER=/fineract-provider/api
       - FINERACT_API_VERSION=/v1

--- a/docs/backend-proxy.md
+++ b/docs/backend-proxy.md
@@ -19,7 +19,7 @@ The interesting part is there:
 const proxyConfig = [
   {
     context: ['/fineract-provider'],
-    target: 'https://sandbox.mifos.community',
+    target: 'https://demo.mifos.community',
     pathRewrite: { '^/fineract-provider': '' },
     changeOrigin: true,
     secure: true,
@@ -42,8 +42,8 @@ const proxyConfig = [
 ```
 
 This forwards requests sent to `/fineract-provider/...` on the dev server to the Fineract backend root (for example,
-`/fineract-provider/1.0/...` becomes `https://sandbox.mifos.community/1.0/...`). Use `pathRewrite` to strip the prefix
-because the sandbox exposes Fineract APIs at the root path.
+`/fineract-provider/1.0/...` becomes `https://demo.mifos.community/1.0/...`). Use `pathRewrite` to strip the prefix
+because the demo exposes Fineract APIs at the root path.
 
 **Error Handling:**
 
@@ -55,7 +55,7 @@ The `onError` handler captures proxy failures (network errors, backend unreachab
 Example server console output when proxy fails:
 
 ```text
-[Proxy] Error while proxying request: GET /fineract-provider/api/v1/clients -> https://sandbox.mifos.community - ECONNREFUSED
+[Proxy] Error while proxying request: GET /fineract-provider/api/v1/clients -> https://demo.mifos.community - ECONNREFUSED
 ```
 
 Example client response:
@@ -81,7 +81,7 @@ the dev server forward requests through a corporate proxy when required.
 **Behavior:**
 
 - **When `HTTP_PROXY` is set:** Logs `"Using proxy server: <url>"` and configures the agent for corporate proxy forwarding
-- **When `HTTP_PROXY` is not set:** Logs `"No proxy server configured. API requests will not be proxied."` — note that this refers only to corporate proxy forwarding; the Angular dev server proxy (forwarding `/fineract-provider` to the sandbox) still works normally
+- **When `HTTP_PROXY` is not set:** Logs `"No proxy server configured. API requests will not be proxied."` — note that this refers only to corporate proxy forwarding; the Angular dev server proxy (forwarding `/fineract-provider` to the demo) still works normally
 
 See `proxy.conf.js` for the exact implementation.
 

--- a/env.sample
+++ b/env.sample
@@ -1,6 +1,6 @@
 
 # Fineract URLs list delimited by colon
-FINERACT_API_URLS=https://sandbox.mifos.community,https://demo.mifos.community,https://localhost:8443
+FINERACT_API_URLS=https://demo.mifos.community,https://localhost:8443
 
 FINERACT_API_URL=https://localhost:8443
 

--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -19,7 +19,7 @@ const { HttpsProxyAgent } = require('https-proxy-agent');
 const proxyConfig = [
   {
     context: ['/fineract-provider'],
-    target: 'https://sandbox.mifos.community',
+    target: 'https://demo.mifos.community',
     pathRewrite: { '^/fineract-provider': '' },
     changeOrigin: true,
     secure: true,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -23,8 +23,7 @@ export const environment = {
   fineractPlatformTenantIds: loadedEnv['fineractPlatformTenantIds'] || 'default',
   // For connecting to others servers running elsewhere update the base API URL
   baseApiUrls:
-    loadedEnv['fineractApiUrls'] ||
-    'https://sandbox.mifos.community,https://demo.mifos.community,https://localhost:8443,' + window.location.origin,
+    loadedEnv['fineractApiUrls'] || 'https://demo.mifos.community,https://localhost:8443,' + window.location.origin,
   // For connecting to server running elsewhere set the base API URL
   baseApiUrl:
     loadedEnv['fineractApiUrl'] ||

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -26,8 +26,7 @@ export const environment = {
   fineractPlatformTenantIds: loadedEnv.fineractPlatformTenantIds || 'default',
   // For connecting to others servers running elsewhere update the base API URL
   baseApiUrls:
-    loadedEnv.fineractApiUrls ||
-    'https://sandbox.mifos.community,https://demo.mifos.community,https://localhost:8443,' + window.location.origin,
+    loadedEnv.fineractApiUrls || 'https://demo.mifos.community,https://localhost:8443,' + window.location.origin,
   // For connecting to server running elsewhere set the base API URL
   baseApiUrl:
     loadedEnv.fineractApiUrl ||


### PR DESCRIPTION
This PR updates the default Fineract API endpoint from sandbox.mifos.community to demo.mifos.community across the application's configuration files and documentation.

[WEB-757](https://mifosforge.jira.com/browse/WEB-757)


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-757]: https://mifosforge.jira.com/browse/WEB-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated API endpoints and defaults across configs from sandbox to demo environment.
  * Removed sandbox URL references from environment variables and proxy defaults.
  * Simplified default API endpoint listings to include demo and localhost only.
* **Documentation**
  * Updated docs and examples to reference the demo environment and clarified proxy success/error messaging (including 502 examples).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->