### PR TITLE
WEB-770 Validation message not displayed for payment type in deposit and withdrawal forms

### DIFF
--- a/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.html
+++ b/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.html
@@ -59,6 +59,12 @@
                 </mat-option>
               }
             </mat-select>
+            @if (savingAccountTransactionForm.controls.paymentTypeId.hasError('required')) {
+              <mat-error>
+                {{ 'labels.inputs.Payment Type' | translate }} {{ 'labels.commons.is' | translate }}
+                <strong>{{ 'labels.commons.required' | translate }}</strong>
+              </mat-error>
+            }
           </mat-form-field>
 
           <div class="flex-fill">

--- a/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.ts
+++ b/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.ts
@@ -115,7 +115,10 @@ export class SavingsAccountTransactionsComponent implements OnInit {
         0,
         Validators.required
       ],
-      paymentTypeId: [''],
+      paymentTypeId: [
+        '',
+        Validators.required
+      ],
       note: ['']
     });
   }


### PR DESCRIPTION
**Changes Made :-**

-Add validation message for required Payment Type field in deposit and withdrawal forms. 

[WEB-770](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-770)

Before :-

<img width="640" height="290" alt="image" src="https://github.com/user-attachments/assets/e354c220-3141-4316-aeab-3b9f7ee927f8" />

<img width="640" height="308" alt="image" src="https://github.com/user-attachments/assets/48d71d23-7d5c-4dde-a00a-57219d101c24" />

After :-

<img width="874" height="434" alt="image" src="https://github.com/user-attachments/assets/7273212c-b94c-49de-937a-bdb70adf3de2" />

<img width="760" height="440" alt="image" src="https://github.com/user-attachments/assets/b111773a-c497-4f2b-b348-3c3f24b832c6" />


[WEB-770]: https://mifosforge.jira.com/browse/WEB-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the Payment Type field in savings account transactions with required field validation and error messaging. Users will now receive clear feedback when attempting to submit the form without selecting a payment type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->