### PR TITLE
WEB-773 Validation message not displayed for select client members for transfer field in group transfer clients

### DIFF
--- a/src/app/groups/groups-view/group-actions/group-transfer-clients/group-transfer-clients.component.html
+++ b/src/app/groups/groups-view/group-actions/group-transfer-clients/group-transfer-clients.component.html
@@ -20,6 +20,13 @@
                 </mat-option>
               }
             </mat-select>
+            @if (transferClientsForm.controls.clients.hasError('required')) {
+              <mat-error>
+                {{ 'labels.inputs.Select Client Members for Transfer' | translate }}
+                {{ 'labels.commons.is' | translate }}
+                <strong>{{ 'labels.commons.required' | translate }}</strong>
+              </mat-error>
+            }
           </mat-form-field>
 
           <mat-checkbox


### PR DESCRIPTION
**Changes Made :-** 

-Added missing mat-error validation message to the "Select Client Members for Transfer" mat-select field to display required field error when users attempt to submit the form without selecting any clients .

[WEB-773](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-773)

Before :- 

<img width="841" height="284" alt="image" src="https://github.com/user-attachments/assets/30b9550d-1eae-4b4d-a96b-c8f0d14e2467" />


After :- 

<img width="807" height="278" alt="image" src="https://github.com/user-attachments/assets/ba7759b3-c27f-48d8-897b-91414e9ef6dc" />


[WEB-773]: https://mifosforge.jira.com/browse/WEB-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form validation with a clear error message displayed when the required Client Members field is not selected during the client transfer process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->