### PR TITLE
WEB-775 Validation message not displayed for existing meeting date field in edit meeting schedule

### DIFF
--- a/src/app/groups/groups-view/group-actions/edit-group-meeting-schedule/edit-group-meeting-schedule.component.html
+++ b/src/app/groups/groups-view/group-actions/edit-group-meeting-schedule/edit-group-meeting-schedule.component.html
@@ -20,7 +20,7 @@
                 </mat-option>
               }
             </mat-select>
-            @if (groupEditMeetingScheduleForm.controls.presentMeetingDate.hasError('repeatsOnDay')) {
+            @if (groupEditMeetingScheduleForm.controls.presentMeetingDate.hasError('required')) {
               <mat-error>
                 {{ 'labels.inputs.Existing Meeting Date' | translate }} {{ 'labels.commons.is' | translate }}
                 <strong>{{ 'labels.commons.required' | translate }}</strong>


### PR DESCRIPTION
**Changes Made :-** 

-Fixed validation error check for "Existing Meeting Date" field in edit meeting schedule by changing hasError condition from 'repeatsOnDay' to 'required', ensuring proper validation feedback when users attempt to submit without selecting an existing meeting date. 

[WEB-775](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-775)

Before :-

<img width="640" height="202" alt="image" src="https://github.com/user-attachments/assets/7fdc9284-02c5-4a7c-b611-0aca66d8e415" />

After :- 

<img width="838" height="243" alt="image" src="https://github.com/user-attachments/assets/948068c4-1884-4a48-b99a-737e8105c43f" />


[WEB-775]: https://mifosforge.jira.com/browse/WEB-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation error message display for the "Existing Meeting Date" field when scheduling group meetings, ensuring users see appropriate required field indicators when the field is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->