### PR TITLE
WEB-778 fix(clients): align activate client form layout with standard…

### DIFF
--- a/src/app/clients/clients-view/client-actions/activate-client/activate-client.component.html
+++ b/src/app/clients/clients-view/client-actions/activate-client/activate-client.component.html
@@ -10,25 +10,27 @@
   <mat-card>
     <form [formGroup]="activateClientForm" (ngSubmit)="submit()">
       <mat-card-content>
-        <mat-form-field class="flex-fill" (click)="activationDatePicker.open()">
-          <mat-label>{{ 'labels.inputs.Activated On Date' | translate }}</mat-label>
-          <input
-            matInput
-            [min]="minDate"
-            [max]="maxDate"
-            [matDatepicker]="activationDatePicker"
-            required
-            formControlName="activationDate"
-          />
-          <mat-datepicker-toggle matSuffix [for]="activationDatePicker"></mat-datepicker-toggle>
-          <mat-datepicker #activationDatePicker></mat-datepicker>
-          @if (activateClientForm.controls.activationDate.hasError('required')) {
-            <mat-error>
-              {{ 'labels.inputs.Activated On Date' | translate }} {{ 'labels.commons.is' | translate }}
-              <strong>{{ 'labels.commons.required' | translate }}</strong>
-            </mat-error>
-          }
-        </mat-form-field>
+        <div class="layout-column">
+          <mat-form-field (click)="activationDatePicker.open()">
+            <mat-label>{{ 'labels.inputs.Activated On Date' | translate }}</mat-label>
+            <input
+              matInput
+              [min]="minDate"
+              [max]="maxDate"
+              [matDatepicker]="activationDatePicker"
+              required
+              formControlName="activationDate"
+            />
+            <mat-datepicker-toggle matSuffix [for]="activationDatePicker"></mat-datepicker-toggle>
+            <mat-datepicker #activationDatePicker></mat-datepicker>
+            @if (activateClientForm.controls.activationDate.hasError('required')) {
+              <mat-error>
+                {{ 'labels.inputs.Activated On Date' | translate }} {{ 'labels.commons.is' | translate }}
+                <strong>{{ 'labels.commons.required' | translate }}</strong>
+              </mat-error>
+            }
+          </mat-form-field>
+        </div>
       </mat-card-content>
 
       <mat-card-actions class="layout-row align-center gap-5px responsive-column">

--- a/src/app/clients/clients-view/client-actions/activate-client/activate-client.component.scss
+++ b/src/app/clients/clients-view/client-actions/activate-client/activate-client.component.scss
@@ -7,5 +7,5 @@
  */
 
 .container {
-  max-width: 37rem;
+  max-width: 30rem;
 }


### PR DESCRIPTION
… pattern

The "Activate Client" form has been aligned with the standard layout patterns used throughout the application for client actions (e.g., Close, Reject, Withdraw). Previously, the form was missing the standard layout-column wrapper and used a non-standard flex-fill class, which created visual inconsistencies in the UI.

[WEB-778](https://mifosforge.jira.com/browse/WEB-778)
Before:
<img width="841" height="235" alt="Screenshot 2026-02-23 053214" src="https://github.com/user-attachments/assets/9e007983-236a-4d6f-8a5e-562deb23963d" />
After:
<img width="766" height="508" alt="image" src="https://github.com/user-attachments/assets/c88a7c8b-f9ff-49f8-8de7-8f72e462b6f6" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the activate client form layout for improved visual presentation.
  * Adjusted container width to provide better spacing and proportions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WEB-778]: https://mifosforge.jira.com/browse/WEB-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ