### PR TITLE
WEB-780 fix: use inheritance for dark mode icon colors to support sta…

### DIFF
--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -157,21 +157,7 @@
   fa-icon,
   mat-icon,
   mat-checkbox {
-    color: white;
-  }
-
-  .true fa-icon,
-  .false fa-icon,
-  .ispenalty fa-icon,
-  .nopenalty fa-icon,
-  .enabled fa-icon,
-  .disabled fa-icon,
-  .currently-running fa-icon,
-  .not-currently-running fa-icon,
-  .success fa-icon,
-  .fail fa-icon,
-  .errorlog fa-icon {
-    color: inherit !important;
+    color: inherit;
   }
 }
 


### PR DESCRIPTION
…tus indicators

This pr fixes a visibility issue where status indicator icons (the colored squares next to "Pending", "Active", etc.) were appearing as white in dark mode. This made it difficult for users to distinguish entity statuses at a glance, as the semantic color coding was being lost.

[WEB-780](https://mifosforge.jira.com/browse/WEB-780)

Before:
<img width="1486" height="956" alt="Screenshot 2026-02-23 084128" src="https://github.com/user-attachments/assets/149c42b2-2b89-4000-b5cd-4bba49b4ce97" />
After:
<img width="1486" height="969" alt="image" src="https://github.com/user-attachments/assets/6a6f48a4-07f9-44c0-9bc1-3c9b6154b7e6" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-780]: https://mifosforge.jira.com/browse/WEB-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark theme icon color handling by removing forced color overrides and enabling icons to inherit colors from their context instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->