### PR TITLE
WEB-781 fix(shared): prevent label overlap in InputAmountComponent

### DIFF
--- a/src/app/shared/input-amount/input-amount.component.html
+++ b/src/app/shared/input-amount/input-amount.component.html
@@ -7,7 +7,7 @@
 -->
 
 @if (isRequired) {
-  <mat-form-field appearance="fill" class="flex-100 input-container">
+  <mat-form-field appearance="fill" class="flex-100 input-container" floatLabel="always">
     <mat-label>{{ 'labels.inputs.' + inputLabel | translate }}</mat-label>
     <div class="input-group">
       <span>{{ currency.code }}</span>
@@ -47,7 +47,7 @@
   </mat-form-field>
 }
 @if (!isRequired) {
-  <mat-form-field appearance="fill" class="flex-100">
+  <mat-form-field appearance="fill" class="flex-100" floatLabel="always">
     <mat-label>{{ 'labels.inputs.' + inputLabel | translate }}</mat-label>
     <span matTextSuffix class="m-l-10">{{ currency.code }}</span>
     <span class="flex-auto"></span>


### PR DESCRIPTION
This PR fixes a UI inconsistency in the InputAmountComponent where the field label (e.g., "Deposit Amount") would overlap with the currency code prefix (e.g., "INR") when the input was empty or unfocused.

[WEB-781](https://mifosforge.jira.com/browse/WEB-781)

Before:
<img width="1509" height="720" alt="Screenshot 2026-02-23 085614" src="https://github.com/user-attachments/assets/de536506-9426-4783-b240-59d945410e74" />
After:
<img width="1482" height="452" alt="image" src="https://github.com/user-attachments/assets/84c5e691-8033-4bd8-8aaa-da0b0ddc80b1" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-781]: https://mifosforge.jira.com/browse/WEB-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Form field labels now remain persistently visible at the top of input fields instead of only appearing on focus, improving overall form usability and visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->