### PR TITLE
WEB-782 Remove Two-Factor Authentication menu item from System page

### DIFF
--- a/src/app/system/system.component.html
+++ b/src/app/system/system.component.html
@@ -535,40 +535,6 @@
             </div>
           </mat-list-item>
 
-          <mat-list-item [ngClass]="{ 'disabled-item': isDisabled }">
-            <div class="menu-list-item-content">
-              <div class="menu-left-section">
-                <mat-icon matListIcon>
-                  <fa-icon icon="key" size="sm"></fa-icon>
-                </mat-icon>
-                <div matLine>
-                  {{ 'labels.heading.Two-Factor Authentication' | translate }}
-                  @if (arrowBooleans[14]) {
-                    <p matLine class="menu-explanation">
-                      {{ 'labels.text.Two-factor authentication configuration' | translate }}
-                    </p>
-                  }
-                </div>
-              </div>
-              <div class="menu-right-section">
-                @if (!arrowBooleans[14]) {
-                  <fa-icon
-                    (click)="arrowBooleansToggle(14); $event.stopPropagation()"
-                    icon="arrow-down"
-                    size="md"
-                  ></fa-icon>
-                }
-                @if (arrowBooleans[14]) {
-                  <fa-icon
-                    (click)="arrowBooleansToggle(14); $event.stopPropagation()"
-                    icon="arrow-up"
-                    size="md"
-                  ></fa-icon>
-                }
-              </div>
-            </div>
-          </mat-list-item>
-
           <mat-list-item [routerLink]="['about-us']">
             <div class="menu-list-item-content">
               <div class="menu-left-section" [routerLink]="['about-us']">


### PR DESCRIPTION
**Changes Made :-** 

-Removes the "Two-Factor Authentication" menu item from the System page as the feature is not available from the UI. 

[WEB-782](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-782)

Before :- 

<img width="640" height="261" alt="image" src="https://github.com/user-attachments/assets/930f5e5d-7b74-42ef-a72f-83580a103a49" />


After :- 


<img width="995" height="376" alt="image" src="https://github.com/user-attachments/assets/975efd83-b029-4942-994d-3ee45bfd1850" />







[WEB-782]: https://mifosforge.jira.com/browse/WEB-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Revert**
  * Removed the Two-Factor Authentication entry from the System settings menu, including its explanatory help text and the expand/collapse control that showed additional details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->