### PR TITLE
WEB-777 Negative values allowed in add data for savings account transaction in group

### DIFF
--- a/src/app/core/utils/datatables.ts
+++ b/src/app/core/utils/datatables.ts
@@ -54,6 +54,7 @@ export class Datatables {
         'office_phone',
         'office phone'
       ].some((name) => colName.includes(name.replace(/[_\s]+/g, '')));
+      const isNumericField = column.columnDisplayType === 'INTEGER' || column.columnDisplayType === 'DECIMAL';
       switch (column.columnDisplayType) {
         case 'INTEGER':
         case 'STRING':
@@ -66,7 +67,7 @@ export class Datatables {
             type: column.columnDisplayType === 'INTEGER' || column.columnDisplayType === 'DECIMAL' ? 'number' : 'text',
             required: column.isColumnNullable ? false : true
           };
-          if (isMinSavingsAmount || isPriceOneShare || isRestrictedField) {
+          if (isMinSavingsAmount || isPriceOneShare || isRestrictedField || isNumericField) {
             inputOptions.min = 0;
           }
           return new InputBase(inputOptions);


### PR DESCRIPTION
**Changes Made :-** 

-Prevent negative values in all numeric datatable fields, including Savings Account Transaction "Add Data" dialog. 

[WEB-777](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-777)

Before :- 

<img width="640" height="218" alt="image" src="https://github.com/user-attachments/assets/bb6fb24b-24ff-4c5a-b64f-e7601be103bf" />

After :- 

<img width="884" height="353" alt="image" src="https://github.com/user-attachments/assets/b98b7dc2-4957-418d-80b2-03448aa442d7" />


[WEB-777]: https://mifosforge.jira.com/browse/WEB-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced numeric field minimum value constraint handling to ensure consistent validation across different numeric field types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->