### PR TITLE
WEB-776 Incorrect label displaying labels inputs mandatory guarantee is required in loan account guarantee requirements

### DIFF
--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -707,17 +707,17 @@
     </div>
     @if (loanProduct.holdGuaranteeFunds) {
       <div class="flex-fill layout-row-wrap responsive-column">
-        <span class="flex-40">{{ 'labels.inputs.Mandatory Guarantee' | translate }} (%):</span>
+        <span class="flex-40">{{ 'labels.inputs.Mandatory Guarantee(%)' | translate }}:</span>
         <span class="flex-60">{{ loanProduct.productGuaranteeData.mandatoryGuarantee }}</span>
         @if (loanProduct.productGuaranteeData.minimumGuaranteeFromOwnFunds) {
           <div class="flex-fill layout-row">
-            <span class="flex-40">{{ 'labels.inputs.Minimum Guarantee from Own Funds' | translate }} (%):</span>
+            <span class="flex-40">{{ 'labels.inputs.Minimum Guarantee from Own Funds(%)' | translate }}:</span>
             <span class="flex-60">{{ loanProduct.productGuaranteeData.minimumGuaranteeFromOwnFunds }}</span>
           </div>
         }
         @if (loanProduct.productGuaranteeData.minimumGuaranteeFromGuarantor) {
           <div class="flex-fill layout-row">
-            <span class="flex-40">{{ 'labels.inputs.Minimum Guarantee from Guarantor Funds' | translate }} (%):</span>
+            <span class="flex-40">{{ 'labels.inputs.Minimum Guarantee from Guarantor Funds(%)' | translate }}:</span>
             <span class="flex-60">{{ loanProduct.productGuaranteeData.minimumGuaranteeFromGuarantor }}</span>
           </div>
         }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -720,7 +720,7 @@
           <mat-label>{{ 'labels.inputs.Mandatory Guarantee(%)' | translate }}</mat-label>
           <input type="number" matInput formControlName="mandatoryGuarantee" required />
           <mat-error>
-            {{ 'labels.inputs.Mandatory Guarantee' | translate }} {{ 'labels.commons.is' | translate }}
+            {{ 'labels.inputs.Mandatory Guarantee(%)' | translate }} {{ 'labels.commons.is' | translate }}
             <strong>{{ 'labels.commons.required' | translate }}</strong>
           </mat-error>
         </mat-form-field>


### PR DESCRIPTION
**Changes Made :-** 

-Fix incorrect translation keys for Guarantee fields in Loan Account settings and summary.

[WEB-776](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-776)

Before :- 

<img width="640" height="96" alt="image" src="https://github.com/user-attachments/assets/c8d7ecec-107c-44aa-a0bf-72f03de88cb0" />

After :- 

<img width="1062" height="149" alt="image" src="https://github.com/user-attachments/assets/35c1b158-a7f9-42b6-a914-08ff877e096f" />


[WEB-776]: https://mifosforge.jira.com/browse/WEB-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated guarantee-related field labels to remove spacing before percentage symbols
  * Aligned error message formatting with input field labels for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->