### PR TITLE
WEB-792 Self service user status displaying incorrectly in user details view

### DIFF
--- a/src/app/users/view-user/view-user.component.html
+++ b/src/app/users/view-user/view-user.component.html
@@ -63,10 +63,10 @@
           <div class="value">
             <span class="self-service-container">
               <span
-                [ngClass]="userData.selfService ? 'self-service-true' : 'self-service-false'"
+                [ngClass]="userData.isSelfServiceUser ? 'self-service-true' : 'self-service-false'"
                 class="self-service-indicator"
               ></span>
-              {{ userData.selfService ? ('labels.buttons.Yes' | translate) : ('labels.buttons.No' | translate) }}
+              {{ userData.isSelfServiceUser ? ('labels.buttons.Yes' | translate) : ('labels.buttons.No' | translate) }}
             </span>
           </div>
         </div>


### PR DESCRIPTION
**Changes Made :-** 

-Fix self-service user status display by correcting property name from userData.selfService to userData.isSelfServiceUser in view-user.component.html to match the API response structure .

[WEB-792](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-792)

[WEB-792]: https://mifosforge.jira.com/browse/WEB-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the property used to determine and display the self-service user status in the user view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->