### PR TITLE
WEB-802: Document password configuration variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,30 @@ Available languages:
 | MIFOS_DEFAULT_CHAR_DELIMITER      | Character delimiter for CSV exports                  | ,             |
 | MIFOS_WAIT_TIME_FOR_NOTIFICATIONS | Wait time in seconds for reading notifications       | 60            |
 | MIFOS_WAIT_TIME_FOR_CATCHUP       | Wait time in seconds for reading COB Catch-Up status | 30            |
-| MIFOS_MIN_PASSWORD_LENGTH         | Minimum length for user passwords                    | 12            |
 | MIFOS_HTTP_CACHE_ENABLED          | whether to use HTTP Get calls with cache             | false         |
+
+#### Password Policy Settings
+
+Password validation for Basic Authentication can be configured via environment variables.
+
+| Variable                  | Description                                      | Default Value  |
+| ------------------------- | ------------------------------------------------ | -------------- |
+| MIFOS_MIN_PASSWORD_LENGTH | Minimum required password length                 | 8              |
+| MIFOS_PASSWORD_REGEX      | Regex pattern used to validate password strength | Default policy |
+
+**Behavior:**
+
+- If `MIFOS_MIN_PASSWORD_LENGTH` is not set, it defaults to `8`.
+- If `MIFOS_PASSWORD_REGEX` is not set, the application falls back to the built-in password validation policy.
+- These settings apply only to Basic Authentication login and user password validation.
+- OAuth/OIDC flows are not affected.
+
+**Docker Example:**
+
+```bash
+MIFOS_MIN_PASSWORD_LENGTH=8
+MIFOS_PASSWORD_REGEX=^(?=.*[A-Z])(?=.*[a-z])(?=.*\d).{8,50}$
+```
 
 #### UI Display Settings
 


### PR DESCRIPTION
## Description

This PR updates the README.md to document the password configuration variables introduced in WEB-628.

Specifically, it adds documentation for:

- `MIFOS_MIN_PASSWORD_LENGTH`
- Password validation configuration behavior
- Default value (8) maintained for backward compatibility

The purpose of this change is to ensure that deployment and Docker environment variables are clearly documented for administrators and contributors. No functional or code-level changes are included in this PR.

## Related issues and discussion

#WEB-802  
Related to #WEB-628

## Screenshots, if any

N/A (Documentation-only change)

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated password policy docs with configurable minimum length, regex-based rules, behavioral notes, and a Docker example for configuration.
* **New Features**
  * Added documentation and toggles for additional UI display and compliance settings (tenant selector, backend info, production mode, server switch, data-hiding and RBAC enablement).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->