### PR TITLE
WEB-796 Add horizontal Scrollbar to Data Table View - Person

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
@@ -31,86 +31,88 @@
   @if (dataObject.data.length > 0) {
     <mat-card class="data-display-card m-t-20">
       <mat-card-content>
-        <div class="data-grid">
-          @for (columnHeader of dataObject.columnHeaders; track columnHeader; let i = $index) {
-            <div class="data-item" [ngClass]="setAttributeClass(columnHeader.columnName)">
-              <div class="data-label mat-body-strong">
-                {{ datatables.toDisplayLabel(columnHeader.columnName) }}
+        <div class="table-scroll-wrapper">
+          <div class="data-grid">
+            @for (columnHeader of dataObject.columnHeaders; track columnHeader; let i = $index) {
+              <div class="data-item" [ngClass]="setAttributeClass(columnHeader.columnName)">
+                <div class="data-label mat-body-strong">
+                  {{ datatables.toDisplayLabel(columnHeader.columnName) }}
+                </div>
+                <div class="data-value">
+                  @switch (getColumnType(columnHeader.columnDisplayType, columnHeader.columnType)) {
+                    @case ('DATE') {
+                      <span>
+                        {{ dataObject.data[0].row[i] | dateFormat }}
+                      </span>
+                    }
+                    @case ('DATETIME') {
+                      <span>
+                        {{ dataObject.data[0].row[i] | datetimeFormat }}
+                      </span>
+                    }
+                    @case ('INTEGER') {
+                      <span>
+                        {{ dataObject.data[0].row[i] }}
+                      </span>
+                    }
+                    @case ('DECIMAL') {
+                      <span>
+                        @if (datatables.isPhoneNumberField(columnHeader.columnName)) {
+                          {{ dataObject.data[0].row[i] }}
+                        } @else {
+                          {{ dataObject.data[0].row[i] | formatNumber }}
+                        }
+                      </span>
+                    }
+                    @case ('CODELOOKUP') {
+                      <span>
+                        {{ datatables.getCodeLookupValue(columnHeader, dataObject.data[0].row[i]) }}
+                      </span>
+                    }
+                    @case ('TEXT') {
+                      <span class="long-text">
+                        {{ dataObject.data[0].row[i] }}
+                      </span>
+                    }
+                    @case ('JSON') {
+                      <textarea
+                        cdkTextareaAutosize="true"
+                        cdkAutosizeMaxRows="20"
+                        cdkAutosizeMinRows="1"
+                        class="json-textarea"
+                        [innerHTML]="dataObject.data[0].row[i].value | prettyPrint"
+                      >
+                      </textarea>
+                    }
+                    @default {
+                      <div class="default-value">
+                        @if (columnHeader.columnName === 'created_at' || columnHeader.columnName === 'updated_at') {
+                          <span>
+                            {{ dataObject.data[0].row[i] | datetimeFormat }}
+                          </span>
+                        } @else if (isValidUrl(dataObject.data[0].row[i])) {
+                          <span class="m-r-5">
+                            <button
+                              mat-icon-button
+                              matTooltip="{{ 'tooltips.View Link' | translate }}"
+                              (click)="openSite(dataObject.data[0].row[i])"
+                              matTooltipPosition="right"
+                              class="small-icon"
+                            >
+                              <fa-icon icon="eye" size="lg"></fa-icon>
+                            </button>
+                          </span>
+                          {{ dataObject.data[0].row[i] }}
+                        } @else {
+                          {{ dataObject.data[0].row[i] }}
+                        }
+                      </div>
+                    }
+                  }
+                </div>
               </div>
-              <div class="data-value">
-                @switch (getColumnType(columnHeader.columnDisplayType, columnHeader.columnType)) {
-                  @case ('DATE') {
-                    <span>
-                      {{ dataObject.data[0].row[i] | dateFormat }}
-                    </span>
-                  }
-                  @case ('DATETIME') {
-                    <span>
-                      {{ dataObject.data[0].row[i] | datetimeFormat }}
-                    </span>
-                  }
-                  @case ('INTEGER') {
-                    <span>
-                      {{ dataObject.data[0].row[i] }}
-                    </span>
-                  }
-                  @case ('DECIMAL') {
-                    <span>
-                      @if (datatables.isPhoneNumberField(columnHeader.columnName)) {
-                        {{ dataObject.data[0].row[i] }}
-                      } @else {
-                        {{ dataObject.data[0].row[i] | formatNumber }}
-                      }
-                    </span>
-                  }
-                  @case ('CODELOOKUP') {
-                    <span>
-                      {{ datatables.getCodeLookupValue(columnHeader, dataObject.data[0].row[i]) }}
-                    </span>
-                  }
-                  @case ('TEXT') {
-                    <span class="long-text">
-                      {{ dataObject.data[0].row[i] }}
-                    </span>
-                  }
-                  @case ('JSON') {
-                    <textarea
-                      cdkTextareaAutosize="true"
-                      cdkAutosizeMaxRows="20"
-                      cdkAutosizeMinRows="1"
-                      class="json-textarea"
-                      [innerHTML]="dataObject.data[0].row[i].value | prettyPrint"
-                    >
-                    </textarea>
-                  }
-                  @default {
-                    <div class="default-value">
-                      @if (columnHeader.columnName === 'created_at' || columnHeader.columnName === 'updated_at') {
-                        <span>
-                          {{ dataObject.data[0].row[i] | datetimeFormat }}
-                        </span>
-                      } @else if (isValidUrl(dataObject.data[0].row[i])) {
-                        <span class="m-r-5">
-                          <button
-                            mat-icon-button
-                            matTooltip="{{ 'tooltips.View Link' | translate }}"
-                            (click)="openSite(dataObject.data[0].row[i])"
-                            matTooltipPosition="right"
-                            class="small-icon"
-                          >
-                            <fa-icon icon="eye" size="lg"></fa-icon>
-                          </button>
-                        </span>
-                        {{ dataObject.data[0].row[i] }}
-                      } @else {
-                        {{ dataObject.data[0].row[i] }}
-                      }
-                    </div>
-                  }
-                }
-              </div>
-            </div>
-          }
+            }
+          </div>
         </div>
       </mat-card-content>
     </mat-card>

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.scss
@@ -25,9 +25,10 @@
 
 .data-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 100%));
   gap: 20px;
   padding: 12px 0;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(220px, 220px);
 }
 
 .data-item {
@@ -120,5 +121,12 @@
   .data-grid {
     grid-template-columns: 100%;
     gap: 16px;
+    grid-auto-flow: initial;
+    grid-auto-columns: initial;
   }
+}
+
+.table-scroll-wrapper {
+  overflow-x: auto;
+  width: 100%;
 }


### PR DESCRIPTION
**Changes Made :-** 

-: Add horizontal scrollbar to client/person datatable view so wide column sets are scrollable. 

[WEB-796](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-796)

[WEB-796]: https://mifosforge.jira.com/browse/WEB-796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Data table grid layout enhanced with horizontal scrolling support on larger viewports, featuring fixed 220px column widths for consistent rendering.
  * Mobile and tablet displays (≤768px) now revert to default grid behavior for optimized responsiveness on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->