### PR TITLE
WEB-803: Fix incorrect pathRewrite in proxy.conf.js file for demo sandbox

### DIFF
--- a/proxy.conf.js
+++ b/proxy.conf.js
@@ -20,13 +20,11 @@ const proxyConfig = [
   {
     context: ['/fineract-provider'],
     target: 'https://demo.mifos.community',
-    pathRewrite: { '^/fineract-provider': '' },
     changeOrigin: true,
     secure: true,
     logLevel: 'debug',
     onProxyReq: function (proxyReq, req, res) {
-      const rewrittenPath = (req.url || '').replace(/^\/fineract-provider/, '');
-      console.log('[Proxy] Proxying:', req.method, req.url, '->', this.target + rewrittenPath);
+      console.log('[Proxy] Proxying:', req.method, req.url, '->', this.target + req.url);
     },
     onError: function (err, req, res) {
       console.error(


### PR DESCRIPTION
JIRA TICKET: [WEB-803](https://mifosforge.jira.com/browse/WEB-803)

## Description

The `pathRewrite` in the file `proxy.conf.js` strips `/fineract-provider` from URL path before forwarding to `demo.mifos.community`. But since, the demo server expects full path (including `/fineract-provider`), API requests were returning 404 when running `npm start` or `ng serve`. The `pathRewrite` is correct for raw Fineract backends (used in `proxy.localhost.conf.js`) but not for deployed instances like `demo.mifos.community` which have their own nginx that routes under `/fineract-provider`.

The fix removes `pathRewrite` from default proxy config and the `proxy.localhost.conf.js` (for local Fineract) is unaffected and correctly uses pathRewrite.

**Verified**: `demo.mifos.community/fineract-provider/api/v1/authentication` returns 401 
(endpoint exists), while `demo.mifos.community/api/v1/authentication` (stripped path) returns 404.

## Screenshots, if any

N/A 

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

[WEB-803]: https://mifosforge.jira.com/browse/WEB-803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed proxy configuration to properly route API requests to backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->