### PR TITLE
WEB-815 automatically the Filename

### DIFF
--- a/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.ts
+++ b/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.ts
@@ -106,13 +106,16 @@ export class UploadDocumentDialogComponent implements OnInit {
   }
 
   /**
-   * Sets file form control value.
+   * Sets file form control value and auto-fills fileName.
    * @param {any} $event file change event.
    */
   onFileSelect($event: any) {
     if ($event.target.files.length > 0) {
       const file = $event.target.files[0];
       this.uploadDocumentForm.get('file').setValue(file);
+      if (!this.uploadDocumentForm.get('fileName').value) {
+        this.uploadDocumentForm.get('fileName').setValue(file.name);
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

when a file is selected, the File Name field gets auto-filled using the selected file’s name. Earlier, users had to type it manually, which felt unnecessary and confusing.

-made sure not to overwrite the file name if it's already set

-tried and tested feature

## Related issues and discussion

[WEB-815](https://mifosforge.jira.com/browse/WEB-815)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [*] If you have multiple commits please combine them into one commit by squashing them.

- [*] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

[WEB-815]: https://mifosforge.jira.com/browse/WEB-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File uploads now automatically populate the filename field when a file is selected, eliminating the need for manual entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->