### PR TITLE
WEB-222: Family Members in Create Client stepper preview page not rendered correctly.

### DIFF
--- a/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.html
+++ b/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.html
@@ -166,7 +166,7 @@
   }
 
   @if (client.familyMembers.length) {
-    <div class="layout-row-wrap responsive-column flex-fill m-b-20">
+    <div class="layout-column flex-100 m-b-20">
       <h3 class="mat-h3 flex-fill">{{ 'labels.heading.Family Members' | translate }}</h3>
       <mat-divider class="flex-fill"></mat-divider>
       <mat-accordion class="flex-fill m-t-5">


### PR DESCRIPTION
## Description

This PR fixes a layout regression introduced during the Angular 14 to 19 update. When creating a new client and adding family members, the preview page was rendering the family members section too far on the right instead of displaying it as a left-aligned list below the general information.

The fix changes the CSS class on the family members wrapper div from `layout-row-wrap responsive-column flex-fill m-b-20` to `layout-column flex-100 m-b-20`. The `layout-row-wrap` class was causing the heading, divider, and accordion to be laid out as horizontal flex items in a row. The new `layout-column` class ensures the children stack vertically (column direction), and `flex-100` ensures the section takes full width and is left-aligned.

No new dependencies are required for this change.

## Related issues and discussion

#WEB-222

## After Video:

https://github.com/user-attachments/assets/e6c1160f-2012-4183-9b9c-0d6a7a585392

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
