### PR TITLE
WEB-797 Implement Eclipse BIRT reporting support

### DIFF
--- a/src/app/reports/reports.service.ts
+++ b/src/app/reports/reports.service.ts
@@ -133,4 +133,45 @@ export class ReportsService {
       params: httpParams
     });
   }
+
+  /**
+   * @param {number} reportId
+   * @returns {Observable<any>}
+   */
+  getBirtParams(reportId: number): Observable<any> {
+    const httpParams = new HttpParams().set('fields', 'reportParameters');
+    return this.http
+      .get(`/reports/${reportId}`, { params: httpParams })
+      .pipe(map((response: any) => response.reportParameters));
+  }
+
+  /**
+   * Run Report Data for BIRT.
+   * @param {any} reportName
+   * @param {object} formData
+   * @returns {Observable<any>}
+   */
+  getBirtRunReportData(
+    reportName: string,
+    formData: object,
+    tenantIdentifier: string,
+    locale: string,
+    dateFormat: string
+  ): Observable<any> {
+    let httpParams = new HttpParams()
+      .set('tenantIdentifier', tenantIdentifier)
+      .set('locale', locale)
+      .set('dateFormat', dateFormat);
+    for (const [
+      key,
+      value
+    ] of Object.entries(formData)) {
+      httpParams = httpParams.set(key, value);
+    }
+    return this.http.get(`/runreports/${reportName}`, {
+      responseType: 'arraybuffer',
+      observe: 'response',
+      params: httpParams
+    });
+  }
 }

--- a/src/app/reports/run-report/birt/birt.component.html
+++ b/src/app/reports/run-report/birt/birt.component.html
@@ -1,0 +1,18 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+@if (!hideOutput) {
+  <iframe
+    [src]="birtUrl"
+    [title]="'BIRT report: ' + (dataObject?.report?.name || 'report')"
+    sandbox="allow-same-origin allow-forms"
+    frameborder="0"
+    width="100%"
+    height="750px;"
+  ></iframe>
+}

--- a/src/app/reports/run-report/birt/birt.component.ts
+++ b/src/app/reports/run-report/birt/birt.component.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { Component, OnChanges, Input, inject } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+
+/** rxjs Imports */
+import { finalize, catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+
+/** Custom Services */
+import { ReportsService } from '../../reports.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { ProgressBarService } from 'app/core/progress-bar/progress-bar.service';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+/**
+ * BIRT Component
+ */
+@Component({
+  selector: 'mifosx-birt',
+  templateUrl: './birt.component.html',
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS
+  ]
+})
+export class BirtComponent implements OnChanges {
+  private sanitizer = inject(DomSanitizer);
+  private reportsService = inject(ReportsService);
+  private settingsService = inject(SettingsService);
+  private progressBarService = inject(ProgressBarService);
+
+  /** Run Report Data */
+  @Input() dataObject: any;
+
+  /** substitute for resolver */
+  hideOutput = true;
+  /** trusted resource url for BIRT output */
+  birtUrl: any;
+
+  /**
+   * Fetches run report data post changes in run report form.
+   */
+  ngOnChanges() {
+    this.hideOutput = true;
+    this.getRunReportData();
+  }
+
+  getRunReportData() {
+    this.reportsService
+      .getBirtRunReportData(
+        this.dataObject.report.name,
+        this.dataObject.formData,
+        'default',
+        this.settingsService.language.code,
+        this.settingsService.dateFormat
+      )
+      .pipe(
+        finalize(() => this.progressBarService.decrease()),
+        catchError((error) => {
+          console.error('Error loading BIRT report:', error);
+          this.hideOutput = true;
+          this.birtUrl = null;
+          return of(null);
+        })
+      )
+      .subscribe((res: any) => {
+        if (res) {
+          const contentType = res.headers.get('Content-Type');
+          const file = new Blob([res.body], { type: contentType });
+          const filecontent = URL.createObjectURL(file);
+          this.birtUrl = this.sanitizer.bypassSecurityTrustResourceUrl(filecontent);
+          this.hideOutput = false;
+        }
+      });
+  }
+}

--- a/src/app/reports/run-report/run-report.component.html
+++ b/src/app/reports/run-report/run-report.component.html
@@ -68,7 +68,7 @@
           </mat-select>
         </mat-form-field>
 
-        <mat-form-field class="form-field" *ngIf="isPentahoReport()">
+        <mat-form-field class="form-field" *ngIf="isPentahoReport() || isBirtReport()">
           <mat-label>{{ 'labels.inputs.Output Type' | translate }}</mat-label>
           <mat-select required formControlName="outputType">
             <mat-option *ngFor="let option of outputTypeOptions" [value]="option.value">
@@ -129,6 +129,7 @@
       <mifosx-table-and-sms *ngIf="!hideTable" [dataObject]="dataObject"></mifosx-table-and-sms>
       <mifosx-chart *ngIf="!hideChart" [dataObject]="dataObject"></mifosx-chart>
       <mifosx-pentaho *ngIf="!hidePentaho" [dataObject]="dataObject"></mifosx-pentaho>
+      <mifosx-birt *ngIf="!hideBirt" [dataObject]="dataObject"></mifosx-birt>
     </div>
   </mat-card>
 </div>

--- a/src/app/reports/run-report/run-report.component.ts
+++ b/src/app/reports/run-report/run-report.component.ts
@@ -36,6 +36,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TableAndSmsComponent } from './table-and-sms/table-and-sms.component';
 import { ChartComponent } from './chart/chart.component';
 import { PentahoComponent } from './pentaho/pentaho.component';
+import { BirtComponent } from './birt/birt.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
 /**
@@ -53,7 +54,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     FaIconComponent,
     TableAndSmsComponent,
     ChartComponent,
-    PentahoComponent
+    PentahoComponent,
+    BirtComponent
   ]
 })
 export class RunReportComponent implements OnInit {
@@ -92,6 +94,8 @@ export class RunReportComponent implements OnInit {
   hideChart = true;
   /** Toggles Pentaho output */
   hidePentaho = true;
+  /** Toggles BIRT output */
+  hideBirt = true;
   /** Report uses dates */
   reportUsesDates = false;
   exportToS3Allowed = false;
@@ -146,6 +150,10 @@ export class RunReportComponent implements OnInit {
     return this.report.type === 'Pentaho';
   }
 
+  isBirtReport(): boolean {
+    return this.report.type === 'BIRT';
+  }
+
   /**
    * Creates and sets the run report form.
    */
@@ -186,6 +194,17 @@ export class RunReportComponent implements OnInit {
       ];
       this.mapPentahoParams();
     }
+    if (this.isBirtReport()) {
+      this.reportForm.addControl('outputType', new UntypedFormControl('', Validators.required));
+      this.outputTypeOptions = [
+        { name: 'PDF format', value: 'PDF' },
+        { name: 'Normal format', value: 'HTML' },
+        { name: 'Excel format', value: 'XLS' },
+        { name: 'Excel 2007 format', value: 'XLSX' },
+        { name: 'CSV format', value: 'CSV' }
+      ];
+      this.mapBirtParams();
+    }
     if (this.exportToS3Allowed) {
       this.reportForm.addControl('exportOutputToS3', new UntypedFormControl(false));
     }
@@ -217,7 +236,27 @@ export class RunReportComponent implements OnInit {
     this.reportsService.getPentahoParams(this.report.id).subscribe((data: any) => {
       data.forEach((entry: any) => {
         const param: ReportParameter = this.paramData.find((_entry: any) => _entry.name === entry.parameterName);
-        param.pentahoName = `R_${entry.reportParameterName}`;
+        if (param && entry.reportParameterName) {
+          param.pentahoName = `R_${entry.reportParameterName}`;
+        } else if (!param) {
+          console.warn('Pentaho parameter not found in paramData:', entry.parameterName);
+        }
+      });
+    });
+  }
+
+  /**
+   * Maps BIRT specific names to form-control names.
+   */
+  mapBirtParams() {
+    this.reportsService.getBirtParams(this.report.id).subscribe((data: any) => {
+      data.forEach((entry: any) => {
+        const param: ReportParameter = this.paramData.find((_entry: any) => _entry.name === entry.parameterName);
+        if (param && entry.reportParameterName) {
+          param.pentahoName = `R_${entry.reportParameterName}`;
+        } else if (!param) {
+          console.warn('BIRT parameter not found in paramData:', entry.parameterName);
+        }
       });
     });
   }
@@ -334,7 +373,12 @@ export class RunReportComponent implements OnInit {
       }
 
       const param: ReportParameter = this.paramData.find((_entry: any) => _entry.name === key);
-      newKey = this.isPentahoReport() ? param.pentahoName : param.inputName;
+      if (!param) {
+        console.warn('Parameter not found in paramData:', key);
+        continue;
+      }
+      newKey =
+        (this.isPentahoReport() || this.isBirtReport()) && param.pentahoName ? param.pentahoName : param.inputName;
       switch (param.displayType) {
         case 'text':
           formattedResponse[newKey] = value;
@@ -396,6 +440,9 @@ export class RunReportComponent implements OnInit {
         break;
       case 'Pentaho':
         this.hidePentaho = false;
+        break;
+      case 'BIRT':
+        this.hideBirt = false;
         break;
     }
   }

--- a/src/app/system/manage-reports/create-report/create-report.component.html
+++ b/src/app/system/manage-reports/create-report/create-report.component.html
@@ -112,7 +112,7 @@
 
           <ng-container matColumnDef="parameterNamePassed">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>
-              {{ 'labels.inputs.Parameter Name Passed to Pentaho' | translate }}
+              {{ 'labels.inputs.Parameter Name Passed to Report Engine' | translate }}
             </th>
             <td mat-cell *matCellDef="let reportParameter">
               {{ reportParameter.reportParameterName }}

--- a/src/app/system/manage-reports/create-report/create-report.component.ts
+++ b/src/app/system/manage-reports/create-report/create-report.component.ts
@@ -247,6 +247,7 @@ export class CreateReportComponent implements OnInit {
           this.reportForm.get('reportSql').enable();
           break;
         case 'Pentaho':
+        case 'BIRT':
           this.reportForm.get('reportSql').disable();
           this.reportForm.get('reportSubType').disable();
           break;

--- a/src/app/system/manage-reports/edit-report/edit-report.component.html
+++ b/src/app/system/manage-reports/edit-report/edit-report.component.html
@@ -111,7 +111,7 @@
 
           <ng-container matColumnDef="parameterNamePassed">
             <th mat-header-cell *matHeaderCellDef mat-sort-header>
-              {{ 'labels.inputs.Parameter Name Passed to Pentaho' | translate }}
+              {{ 'labels.inputs.Parameter Name Passed to Report Engine' | translate }}
             </th>
             <td mat-cell *matCellDef="let reportParameter">{{ reportParameter.reportParameterName }}</td>
           </ng-container>

--- a/src/app/system/manage-reports/edit-report/edit-report.component.ts
+++ b/src/app/system/manage-reports/edit-report/edit-report.component.ts
@@ -182,7 +182,10 @@ export class EditReportComponent implements OnInit {
       reportSql: [
         {
           value: this.reportData.reportSql,
-          disabled: this.reportData.coreReport || this.reportData.reportType === 'Pentaho'
+          disabled:
+            this.reportData.coreReport ||
+            this.reportData.reportType === 'Pentaho' ||
+            this.reportData.reportType === 'BIRT'
         },
         Validators.required
       ]
@@ -268,6 +271,7 @@ export class EditReportComponent implements OnInit {
           this.reportForm.get('reportSql').enable();
           break;
         case 'Pentaho':
+        case 'BIRT':
           this.reportForm.get('reportSql').disable();
           this.reportForm.get('reportSubType').disable();
           break;

--- a/src/app/system/manage-reports/report-parameter-dialog/report-parameter-dialog.component.html
+++ b/src/app/system/manage-reports/report-parameter-dialog/report-parameter-dialog.component.html
@@ -32,7 +32,7 @@
       </mat-form-field>
 
       <mat-form-field>
-        <mat-label>{{ 'labels.inputs.Parameter Name Passed to Pentaho' | translate }}</mat-label>
+        <mat-label>{{ 'labels.inputs.Parameter Name Passed to Report Engine' | translate }}</mat-label>
         <input matInput formControlName="reportParameterName" />
       </mat-form-field>
     </div>

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -2293,6 +2293,7 @@
       "Paid Date": "Datum výplaty",
       "Parameter": "Parametr",
       "Parameter Name Passed to Pentaho": "Název parametru sestavy",
+      "Parameter Name Passed to Report Engine": "Název parametru sestavy",
       "Parent": "Rodič",
       "Parent Account Name": "Název nadřazeného účtu",
       "Parent Name": "Jméno rodiče",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -2294,6 +2294,7 @@
       "Paid Date": "Bezahltes Datum",
       "Parameter": "Parameter",
       "Parameter Name Passed to Pentaho": "Berichtsparametername",
+      "Parameter Name Passed to Report Engine": "Berichtsparametername",
       "Parent": "Elternteil",
       "Parent Account Name": "Name des übergeordneten Kontos",
       "Parent Name": "Elternname",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2312,6 +2312,7 @@
       "Paid Date": "Paid Date",
       "Parameter": "Parameter",
       "Parameter Name Passed to Pentaho": "Report Parameter Name",
+      "Parameter Name Passed to Report Engine": "Report Parameter Name",
       "Parent": "Parent",
       "Parent Account Name": "Parent Account Name",
       "Parent Name": "Parent Name",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -2295,6 +2295,7 @@
       "Paid Date": "Fecha de pago",
       "Parameter": "Parámetro",
       "Parameter Name Passed to Pentaho": "Nombre del parámetro del informe",
+      "Parameter Name Passed to Report Engine": "Nombre del parámetro del informe",
       "Parent": "Cuenta de Mayor",
       "Parent Account Name": "Nombre de la cuenta principal",
       "Parent Name": "Nombre del padre",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -2299,6 +2299,7 @@
       "Paid Date": "Fecha de pago",
       "Parameter": "Parámetro",
       "Parameter Name Passed to Pentaho": "Nombre del parámetro del informe",
+      "Parameter Name Passed to Report Engine": "Nombre del parámetro del informe",
       "Parent": "Cuenta de Mayor",
       "Parent Account Name": "Nombre de la cuenta principal",
       "Parent Name": "Nombre del padre",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -2297,6 +2297,7 @@
       "Paid Date": "La date de paiement",
       "Parameter": "Paramètre",
       "Parameter Name Passed to Pentaho": "Nom du paramètre de rapport",
+      "Parameter Name Passed to Report Engine": "Nom du paramètre de rapport",
       "Parent": "Parent",
       "Parent Account Name": "Nom du compte parent",
       "Parent Name": "Nom du parent",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -2293,6 +2293,7 @@
       "Paid Date": "Data di pagamento",
       "Parameter": "Parametro",
       "Parameter Name Passed to Pentaho": "Nome parametro report",
+      "Parameter Name Passed to Report Engine": "Nome parametro report",
       "Parent": "Genitore",
       "Parent Account Name": "Nome dell'account genitore",
       "Parent Name": "Nome del genitore",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -2295,6 +2295,7 @@
       "Paid Date": "지급일",
       "Parameter": "매개변수",
       "Parameter Name Passed to Pentaho": "보고서 매개변수 이름",
+      "Parameter Name Passed to Report Engine": "보고서 매개변수 이름",
       "Parent": "부모의",
       "Parent Account Name": "상위 계정 이름",
       "Parent Name": "부모님 성함",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -2292,6 +2292,7 @@
       "Paid Date": "Apmokėjimo data",
       "Parameter": "Parametras",
       "Parameter Name Passed to Pentaho": "Ataskaitos parametro pavadinimas",
+      "Parameter Name Passed to Report Engine": "Ataskaitos parametro pavadinimas",
       "Parent": "Tėvas",
       "Parent Account Name": "Tėvų paskyros pavadinimas",
       "Parent Name": "Tėvo vardas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -2294,6 +2294,7 @@
       "Paid Date": "Apmaksas datums",
       "Parameter": "Parametrs",
       "Parameter Name Passed to Pentaho": "Atskaites parametra nosaukums",
+      "Parameter Name Passed to Report Engine": "Atskaites parametra nosaukums",
       "Parent": "Vecāks",
       "Parent Account Name": "Vecāku konta nosaukums",
       "Parent Name": "Vecāku vārds",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -2292,6 +2292,7 @@
       "Paid Date": "भुक्तानी मिति",
       "Parameter": "प्यारामिटर",
       "Parameter Name Passed to Pentaho": "रिपोर्ट प्यारामिटर नाम",
+      "Parameter Name Passed to Report Engine": "रिपोर्ट प्यारामिटर नाम",
       "Parent": "अभिभावक",
       "Parent Account Name": "अभिभावक खाता नाम",
       "Parent Name": "अभिभावकको नाम",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -2294,6 +2294,7 @@
       "Paid Date": "Data de pagamento",
       "Parameter": "Parâmetro",
       "Parameter Name Passed to Pentaho": "Nome do parâmetro do relatório",
+      "Parameter Name Passed to Report Engine": "Nome do parâmetro do relatório",
       "Parent": "Pai",
       "Parent Account Name": "Nome da conta principal",
       "Parent Name": "Nome dos pais",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -2292,6 +2292,7 @@
       "Paid Date": "Tarehe ya Kulipwa",
       "Parameter": "Kigezo",
       "Parameter Name Passed to Pentaho": "Jina la Kigezo cha Ripoti",
+      "Parameter Name Passed to Report Engine": "Jina la Kigezo cha Ripoti",
       "Parent": "Mzazi",
       "Parent Account Name": "Jina la Akaunti ya Mzazi",
       "Parent Name": "Jina la Mzazi",


### PR DESCRIPTION
**Changes Made :-** 

-Implement Eclipse BIRT reporting support alongside Pentaho with multiple output formats .

[WEB-797](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-797)

[WEB-797]: https://mifosforge.jira.com/browse/WEB-797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BIRT report engine support with embedded report rendering and new run options in the report UI.
  * Run reports can now produce downloadable BIRT output and display it inline.

* **Refactor**
  * Parameter handling and labels updated to be report-engine agnostic.
  * Updated UI text and added translations for the new "Parameter Name Passed to Report Engine" label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->