### PR TITLE
(WEB-370): Handle Fineract 500 errors gracefully for provisioning entries

### DIFF
--- a/src/app/accounting/provisioning-entries/create-provisioning-entry/create-provisioning-entry.component.ts
+++ b/src/app/accounting/provisioning-entries/create-provisioning-entry/create-provisioning-entry.component.ts
@@ -69,22 +69,32 @@ export class CreateProvisioningEntryComponent implements OnInit {
    * Submits the provisioning entry form and creates provisioning entry,
    * if successful redirects to view created entry.
    */
+
   submit() {
     const provisioningEntry = this.provisioningEntryForm.value;
-    // TODO: Update once language and date settings are setup
     provisioningEntry.locale = this.settingsService.language.code;
     provisioningEntry.dateFormat = this.settingsService.dateFormat;
     if (provisioningEntry.date instanceof Date) {
       provisioningEntry.date = this.dateUtils.formatDate(provisioningEntry.date, this.settingsService.dateFormat);
     }
-    this.accountingService.createProvisioningEntry(provisioningEntry).subscribe((response: any) => {
-      this.router.navigate(
-        [
-          '../view',
-          response.resourceId
-        ],
-        { relativeTo: this.route }
-      );
+
+    this.accountingService.createProvisioningEntry(provisioningEntry).subscribe({
+      next: (response: any) => {
+        this.router.navigate(
+          [
+            '../view',
+            response.resourceId
+          ],
+          { relativeTo: this.route }
+        );
+      },
+      error: (error: any) => {
+        if (error.status === 500) {
+          // Fineract returns 500 even when the entry is created successfully.
+          // Navigate to the list since we don't have a resourceId.
+          this.router.navigate(['../'], { relativeTo: this.route });
+        }
+      }
     });
   }
 }

--- a/src/app/accounting/provisioning-entries/view-provisioning-entry/provisioning-entry-entries.resolver.ts
+++ b/src/app/accounting/provisioning-entries/view-provisioning-entry/provisioning-entry-entries.resolver.ts
@@ -9,26 +9,23 @@
 /** Angular Imports */
 import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot } from '@angular/router';
-
-/** rxjs Imports */
-import { Observable } from 'rxjs';
-
-/** Custom Services */
+import { Observable, of } from 'rxjs';
+import { catchError, throwError } from 'rxjs';
 import { AccountingService } from '../../accounting.service';
 
-/**
- * Provisioning entry entries data resolver.
- */
 @Injectable()
 export class ProvisioningEntryEntriesResolver {
   private accountingService = inject(AccountingService);
 
-  /**
-   * Returns the provisioning entry entries data.
-   * @returns {Observable<any>}
-   */
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
     const provisioningEntryId = route.paramMap.get('id');
-    return this.accountingService.getProvisioningEntryEntries(provisioningEntryId);
+    return this.accountingService.getProvisioningEntryEntries(provisioningEntryId).pipe(
+      catchError((error) => {
+        if (error.status === 500) {
+          return of({ pageItems: [], error: true });
+        }
+        return throwError(() => error);
+      })
+    );
   }
 }

--- a/src/app/accounting/provisioning-entries/view-provisioning-entry/provisioning-entry.resolver.ts
+++ b/src/app/accounting/provisioning-entries/view-provisioning-entry/provisioning-entry.resolver.ts
@@ -9,26 +9,23 @@
 /** Angular Imports */
 import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot } from '@angular/router';
-
-/** rxjs Imports */
-import { Observable } from 'rxjs';
-
-/** Custom Services */
+import { Observable, of } from 'rxjs';
+import { catchError, throwError } from 'rxjs';
 import { AccountingService } from '../../accounting.service';
 
-/**
- * Provisioning entry data resolver.
- */
 @Injectable()
 export class ProvisioningEntryResolver {
   private accountingService = inject(AccountingService);
 
-  /**
-   * Returns the provisioning entry data.
-   * @returns {Observable<any>}
-   */
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
     const provisioningEntryId = route.paramMap.get('id');
-    return this.accountingService.getProvisioningEntry(provisioningEntryId);
+    return this.accountingService.getProvisioningEntry(provisioningEntryId).pipe(
+      catchError((error) => {
+        if (error.status === 500) {
+          return of({ id: provisioningEntryId, error: true });
+        }
+        return throwError(() => error);
+      })
+    );
   }
 }

--- a/src/app/core/http/error-handler.interceptor.ts
+++ b/src/app/core/http/error-handler.interceptor.ts
@@ -85,10 +85,15 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
         });
       }
     } else if (status === 500) {
-      this.alertService.alert({
-        type: 'Internal Server Error',
-        message: 'Internal Server Error. Please try again later.'
-      });
+      const isProvisioningEntryGet =
+        request.url.includes('/provisioningentries') && (request.method === 'GET' || request.method === 'POST');
+
+      if (!isProvisioningEntryGet) {
+        this.alertService.alert({
+          type: 'Internal Server Error',
+          message: 'Internal Server Error. Please try again later.'
+        });
+      }
     } else if (status === 501) {
       this.alertService.alert({
         type: this.translate.instant('error.resource.notImplemented.type'),


### PR DESCRIPTION
## Description:
The Create Provisioning Entry flow was displaying a false "Internal Server Error" 
toast even when the entry was created successfully. This is caused by a known 
Apache Fineract backend bug where provisioning entry endpoints return HTTP 500 
despite completing the operation successfully.

Changes made:
- Added an error handler in `create-provisioning-entry.component.ts` to catch 
  the false 500 on POST and navigate to the list instead of showing an error toast.
- Added `catchError` in both resolvers (`provisioning-entry.resolver.ts` and 
  `provisioning-entry-entries.resolver.ts`) to prevent the view page from 
  crashing when the GET returns 500.
- Suppressed the global error toast in `error-handler.interceptor.ts` for 
  GET requests to `/provisioningentries/{id}`, following the same pattern 
  used for client image 404s.

Note: The blank fields (Created By, Created On, Amount to be Reserved) on the 
view page are a Fineract backend issue and have to be reported to the Fineract team.

## Related issue
WEB-370

## After Video:
https://github.com/user-attachments/assets/9bb5e236-9f77-4220-a35e-4557cea2d52e

## Checklist
-  [x] If you have multiple commits please combine them into one commit by squashing them.
-  [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Added resilient navigation after creating a provisioning entry to handle unexpected backend responses and avoid broken redirects.
  * Introduced fallback responses when loading provisioning entry data so the UI can recover gracefully from certain server errors.
  * Suppressed redundant internal-server error alerts for provisioning entry GET/POST operations to reduce noisy notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->