### PR TITLE
WEB-726 fix: display transactionId instead of systemMessage in interb…

### DIFF
--- a/src/app/account-transfers/make-account-transfers/make-account-transfers.component.ts
+++ b/src/app/account-transfers/make-account-transfers/make-account-transfers.component.ts
@@ -435,7 +435,7 @@ export class MakeAccountTransfersComponent implements OnInit, AfterViewInit {
         this.isLoading = false;
         this.transferComplete = true;
         this.transferSuccess = true;
-        this.transferReferenceId = trnsfr?.systemMessage || '';
+        this.transferReferenceId = trnsfr?.transactionId || trnsfr?.homeTransactionId || '';
         this.transferStepper.next();
       },
       (error) => {
@@ -444,7 +444,7 @@ export class MakeAccountTransfersComponent implements OnInit, AfterViewInit {
         this.transferComplete = true;
         this.transferSuccess = false;
         this.transferErrorMessage =
-          error?.error?.defaultUserMessage || error?.message || 'An unexpected error occurred.';
+          error?.error?.defaultUserMessage || 'An unexpected error occurred. Please try again.';
         this.transferStepper.next();
       }
     );


### PR DESCRIPTION
…ank transfer status

The "Transaction ID" field on the Interbank Transfer Status screen was incorrectly displaying `"success"` instead of the actual transaction UUID returned by the `/executetransfer` API.
This was caused by mapping `systemMessage` (which always returns `"success"`) to `transferReferenceId` instead of the `transactionId` field from the API response.
Additionally, on transfer failure the raw Angular `HttpErrorResponse` message was being shown to the user, which leaked the internal API URL. This has been replaced with a clean user-friendly fallback message.



[WEB-726](https://mifosforge.jira.com/browse/WEB-726)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-726]: https://mifosforge.jira.com/browse/WEB-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interbank transfer reference assignment for more accurate transaction tracking.
  * Enhanced error messaging for failed transfers with better error detail handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->