### PR TITLE
WEB-814 Make easier to upload client Identifiers

### DIFF
--- a/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.ts
+++ b/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.ts
@@ -107,16 +107,15 @@ export class UploadDocumentDialogComponent implements OnInit {
   }
 
   /**
-   * Sets file form control value and auto-fills fileName.
+   * Sets file form control value.
+   * and also sets the fileName
    * @param {any} $event file change event.
    */
   onFileSelect($event: any) {
     if ($event.target.files.length > 0) {
       const file = $event.target.files[0];
+      this.uploadDocumentForm.get('fileName').setValue(file.name);
       this.uploadDocumentForm.get('file').setValue(file);
-      if (!this.uploadDocumentForm.get('fileName').value) {
-        this.uploadDocumentForm.get('fileName').setValue(file.name);
-      }
     }
   }
 }


### PR DESCRIPTION
## Description
When adding a client identifier, the dialog required users to manually type the file name into a separate "File Name" field after already selecting a file via the Browse button. This was redundant and error-prone. The fix automatically populates the File Name field with the selected file's name when a file is chosen, improving the user experience and reducing unnecessary manual input.
## Related issues and discussion

#WEB-814 Make easier to upload client Identifiers

## Before


https://github.com/user-attachments/assets/c4d058d5-bafa-4a0a-9795-698c72ef21fb


## After 

https://github.com/user-attachments/assets/30b2e086-98cd-441e-8824-a53e8be013cb



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the document upload dialog so selecting a new file always refreshes the displayed file name.
  * Ensured the selected file is consistently assigned to the upload field.

* **Documentation**
  * Clarified file selection behavior in the document upload dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->