### PR TITLE
fix (settings): Replace default language dropdown with LanguageSelectorComponent.

### DIFF
--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -19,16 +19,7 @@
       </mat-expansion-panel-header>
 
       <div class="layout-column">
-        <mat-form-field>
-          <mat-label>{{ 'labels.inputs.Default Language' | translate }}</mat-label>
-          <mat-select [formControl]="language" [compareWith]="compareOptions">
-            @for (language of languages; track language) {
-              <mat-option [value]="language">
-                {{ language.name }}
-              </mat-option>
-            }
-          </mat-select>
-        </mat-form-field>
+        <mifosx-language-selector></mifosx-language-selector>
 
         <mat-form-field>
           <mat-label>{{ 'labels.inputs.Default Date Format' | translate }}</mat-label>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -22,6 +22,7 @@ import {
 } from '@angular/material/expansion';
 import { FileUploadComponent } from '../shared/file-upload/file-upload.component';
 import { ThemePickerComponent } from '../shared/theme-picker/theme-picker.component';
+import { LanguageSelectorComponent } from '../shared/language-selector/language-selector.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
 /**
@@ -38,20 +39,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatExpansionPanelHeader,
     MatExpansionPanelTitle,
     FileUploadComponent,
-    ThemePickerComponent
+    ThemePickerComponent,
+    LanguageSelectorComponent
   ]
 })
 export class SettingsComponent implements OnInit, OnDestroy {
   private settingsService = inject(SettingsService);
   private destroy$ = new Subject<void>();
 
-  /** Placeholder for languages. update once translations are set up */
-  languages: any[] = [
-    {
-      name: 'English',
-      code: 'en'
-    }
-  ];
   /** Date formats. */
   dateFormats: string[] = [
     'dd MMMM yyyy',
@@ -104,8 +99,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
   /** Placeholder for fonts. */
   fonts: any;
 
-  /** Language Setting */
-  language = new FormControl('');
   /** Date Format Setting */
   dateFormat = new FormControl('');
   /** Datetime Format Setting */
@@ -114,7 +107,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
   decimalsToDisplay = new FormControl('');
 
   ngOnInit() {
-    this.language.patchValue(this.settingsService.language);
     this.dateFormat.patchValue(this.settingsService.dateFormat);
     this.datetimeFormat.patchValue(this.settingsService.datetimeFormat);
     this.decimalsToDisplay.patchValue(this.settingsService.decimals);
@@ -125,9 +117,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
    * Subscribe to value changes.
    */
   buildDependencies() {
-    this.language.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((language: any) => {
-      this.settingsService.setLanguage(language);
-    });
     this.dateFormat.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((dateFormat: string) => {
       this.settingsService.setDateFormat(dateFormat);
     });
@@ -142,15 +131,5 @@ export class SettingsComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.destroy$.next();
     this.destroy$.complete();
-  }
-
-  /**
-   * Compare function for mat-select.
-   * Useful in patching values if value is an object.
-   * @param {any} option1 option 1
-   * @param {any} option2 option 2.
-   */
-  compareOptions(option1: any, option2: any) {
-    return option1 && option2 && option1.code === option2.code;
   }
 }


### PR DESCRIPTION
Fixes: [WEB-817](https://mifosforge.jira.com/browse/WEB-817)

## Description
The Default Language dropdown in Main Configuration was hardcoded with only English and did not change the app language when selected. Replaced it with the existing LanguageSelectorComponent which lists all supported languages and applies the selection instantly via ngx-translate. It follows proper i18n standards now and is consistent with the top bar language change option.

## Screenshots, if any

<img width="2691" height="1094" alt="Screenshot 2026-03-05 130957" src="https://github.com/user-attachments/assets/ce0799ac-4625-45e8-a8a0-9c6697d3e9e4" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-817]: https://mifosforge.jira.com/browse/WEB-817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored the language selection interface to use a custom component, improving code modularity and maintainability while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->