### PR TITLE
docs: add missing JSDoc and remove stale TODO comments

### DIFF
--- a/src/app/clients/clients-view/client-actions/take-survey/take-survey.component.ts
+++ b/src/app/clients/clients-view/client-actions/take-survey/take-survey.component.ts
@@ -75,7 +75,10 @@ export class TakeSurveyComponent {
     this.userId = savedCredentials.userId;
   }
 
-  // TODO: document the function
+  /**
+   * Handles survey selection change. Updates surveyData and groups
+   * questions by their componentKey for sectioned display.
+   */
   onSurveyChange(resEvent: any) {
     if (resEvent.value) {
       this.surveyData = resEvent.value;
@@ -87,7 +90,12 @@ export class TakeSurveyComponent {
     }
   }
 
-  // TODO: document the function
+  /**
+   * Groups an array of objects by the value returned from a key function.
+   * @param array The array to group.
+   * @param func A function returning the grouping key for each element.
+   * @returns An array of grouped sub-arrays.
+   */
   groupBy(array: any, func: any) {
     const groups: { [key: string]: any[] } = {};
     array.forEach((ele: any) => {

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -214,7 +214,6 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
           amortizationType: this.loansAccountTermsData.amortizationType.id,
           isEqualAmortization: this.loansAccountTermsData.isEqualAmortization,
           interestType: this.loansAccountTermsData.interestType.id,
-          // TODO: 2025-03-17: Is this correct?
           isFloatingInterestRate: this.loansAccountTermsData.isLoanProductLinkedToFloatingRate ? false : null,
           interestCalculationPeriodType: this.loansAccountTermsData.interestCalculationPeriodType.id,
           allowPartialPeriodInterestCalculation: this.loansAccountTermsData.allowPartialPeriodInterestCalculation,


### PR DESCRIPTION
## Description

Cleaned up technical debt by replacing outdated `TODO` comments with proper documentation, and removing a stale uncertainty comment whose logic is already consistent with the Fineract API.

**Changes Made:**
* **`take-survey.component.ts`**: Replaced the `// TODO: document the function` comments with proper JSDoc blocks for the `onSurveyChange` and `groupBy` methods, defining parameters and return types.
* **`loans-account-terms-step.component.ts`**: Removed the stale `// TODO: 2025-03-17: Is this correct?` comment. Verified that defaulting `isFloatingInterestRate` to `false` when a product is linked to a floating rate (and `null` otherwise) correctly aligns with Fineract's expected behavior.

*Note: This is my third and final introductory PR as I familiarize myself with the Angular codebase for my GSoC 2026 (MCP AI Assistant) proposal!*

## Related issues and discussion

N/A - Minor documentation and codebase cleanup.

## Screenshots, if any

N/A

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.