### PR TITLE
WEB-819 Fix validation and translation issues in working capital product creation

### DIFF
--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
@@ -92,7 +92,7 @@
         >
         <mifosx-loan-product-payment-strategy-step
           [advancedPaymentAllocations]="advancedPaymentAllocations"
-          [advancedCreditAllocations]="advancedCreditAllocations"
+          [advancedCreditAllocations]="loanProductService.isLoanProduct ? advancedCreditAllocations : []"
           [advancedPaymentAllocationTransactionTypes]="loanProductsTemplate.advancedPaymentAllocationTransactionTypes"
           [paymentAllocationOrderDefault]="loanProductsTemplate.advancedPaymentAllocationTypes"
           [advancedCreditAllocationTransactionTypes]="loanProductsTemplate.creditAllocationTransactionTypes"

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
@@ -92,7 +92,7 @@
         >
         <mifosx-loan-product-payment-strategy-step
           [advancedPaymentAllocations]="advancedPaymentAllocations"
-          [advancedCreditAllocations]="advancedCreditAllocations"
+          [advancedCreditAllocations]="loanProductService.isLoanProduct ? advancedCreditAllocations : []"
           [advancedPaymentAllocationTransactionTypes]="loanProductAndTemplate.advancedPaymentAllocationTransactionTypes"
           [paymentAllocationOrderDefault]="loanProductAndTemplate.advancedPaymentAllocationTypes"
           [advancedCreditAllocationTransactionTypes]="loanProductAndTemplate.creditAllocationTransactionTypes"

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
@@ -43,10 +43,18 @@ export class LoanProductCurrencyStepComponent implements OnInit {
   ngOnInit() {
     this.currencyData = this.loanProductsTemplate.currencyOptions;
     const currency = this.loanProductsTemplate.currency ? this.loanProductsTemplate.currency : this.currencyData[0];
+
+    let decimalPlacesValue = '';
+    if (this.loanProductService.isWorkingCapital && !this.loanProductsTemplate.id) {
+      decimalPlacesValue = '';
+    } else {
+      decimalPlacesValue =
+        currency.decimalPlaces === undefined || currency.decimalPlaces === null ? '' : currency.decimalPlaces;
+    }
+
     this.loanProductCurrencyForm.patchValue({
       currencyCode: currency.code,
-      digitsAfterDecimal:
-        currency.decimalPlaces === undefined || currency.decimalPlaces === null ? '' : currency.decimalPlaces,
+      digitsAfterDecimal: decimalPlacesValue,
       inMultiplesOf:
         currency.inMultiplesOf === 0 || currency.inMultiplesOf === undefined || currency.inMultiplesOf === null
           ? ''

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-payment-strategy-step/loan-product-payment-strategy-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-payment-strategy-step/loan-product-payment-strategy-step.component.ts
@@ -96,13 +96,15 @@ export class LoanProductPaymentStrategyStepComponent implements OnInit {
         transactionTypesOptions.push(option);
       }
     });
-    this.advancedCreditAllocationTransactionTypes.forEach((option: PaymentAllocationTransactionType) => {
-      if (transactionTypesCurrent.indexOf(option.code) < 0) {
-        option.credit = true;
-        option.value = this.translateService.instant('labels.catalogs.' + option.value);
-        transactionTypesOptions.push(option);
-      }
-    });
+    if (this.advancedCreditAllocationTransactionTypes) {
+      this.advancedCreditAllocationTransactionTypes.forEach((option: PaymentAllocationTransactionType) => {
+        if (transactionTypesCurrent.indexOf(option.code) < 0) {
+          option.credit = true;
+          option.value = this.translateService.instant('labels.catalogs.' + option.value);
+          transactionTypesOptions.push(option);
+        }
+      });
+    }
 
     const formfields: FormfieldBase[] = [
       new SelectBase({

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -35,7 +35,7 @@
           (loanProductSettingsForm.get('npvDayCount')?.touched || loanProductSettingsForm.get('npvDayCount')?.dirty)
         ) {
           <mat-error>
-            {{ 'labels.inputs.NPV day count' | translate }} {{ 'labels.commons.is' | translate }}
+            {{ 'labels.inputs.Net Present Value day count' | translate }} {{ 'labels.commons.is' | translate }}
             <strong>{{ 'labels.commons.required' | translate }}</strong>
           </mat-error>
         }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -116,7 +116,7 @@
         <input type="number" matInput formControlName="minPeriodPaymentRate" [min]="0.01" step="0.01" />
         <mat-error *ngIf="loanProductTermsForm.get('minPeriodPaymentRate')?.hasError('min')">
           {{ 'labels.commons.Minimum Value must be' | translate }}
-          <strong>{{ loanProductTermsForm.get('minPeriodPaymentRate')?.errors?.['min']?.min || 1 }}</strong>
+          <strong>{{ loanProductTermsForm.get('minPeriodPaymentRate')?.errors?.['min']?.min || 0.01 }}</strong>
         </mat-error>
       </mat-form-field>
 
@@ -136,16 +136,16 @@
         <mat-error *ngIf="loanProductTermsForm.get('periodPaymentRate')?.hasError('min')">
           {{ 'labels.catalogs.Default' | translate }} {{ 'labels.inputs.Period Payment Rate' | translate }}
           {{ 'labels.commons.is' | translate }}
-          <strong>{{ loanProductTermsForm.get('periodPaymentRate')?.errors?.['min']?.min || 1 }}</strong>
+          <strong>{{ loanProductTermsForm.get('periodPaymentRate')?.errors?.['min']?.min || 0.01 }}</strong>
         </mat-error>
       </mat-form-field>
 
       <mat-form-field class="flex-31">
         <mat-label>{{ 'labels.inputs.Maximum' | translate }}</mat-label>
-        <input type="number" matInput formControlName="maxPeriodPaymentRate" [min]="1" step="0.01" />
+        <input type="number" matInput formControlName="maxPeriodPaymentRate" [min]="0.01" step="0.01" />
         <mat-error *ngIf="loanProductTermsForm.get('maxPeriodPaymentRate')?.hasError('min')">
           {{ 'labels.commons.Minimum Value must be' | translate }}
-          <strong>{{ loanProductTermsForm.get('maxPeriodPaymentRate')?.errors?.['min']?.min || 1 }}</strong>
+          <strong>{{ loanProductTermsForm.get('maxPeriodPaymentRate')?.errors?.['min']?.min || 0.01 }}</strong>
         </mat-error>
       </mat-form-field>
     }
@@ -646,7 +646,7 @@
         }
       </mat-select>
       <mat-error>
-        {{ 'labels.inputs.Repaid every type' | translate }} {{ 'labels.commons.is' | translate }}
+        {{ 'labels.inputs.Frequency Type' | translate }} {{ 'labels.commons.is' | translate }}
         <strong>{{ 'labels.commons.required' | translate }}</strong>
       </mat-error>
     </mat-form-field>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -323,20 +323,20 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
         minPeriodPaymentRate: [
           '',
           [
-            Validators.min(1)
+            Validators.min(0.01)
           ]
         ],
         periodPaymentRate: [
           '',
           [
             Validators.required,
-            Validators.min(1)
+            Validators.min(0.01)
           ]
         ],
         maxPeriodPaymentRate: [
           '',
           [
-            Validators.min(1)
+            Validators.min(0.01)
           ]
         ],
         repaymentEvery: [


### PR DESCRIPTION
**Changes Made :-** 

Changes Made:

-Updated validators from [Validators.min(1)] to [Validators.min(0.01)] for all period payment rate fields
 . Updated HTML min attributes and error messages to reflect 0.01 minimum .
 -Fixed Frequency Type error message to use correct translation key (labels.inputs.Frequency Type instead of [labels.inputs.Repaid every type] .
-Fixed NPV day count error message to use correct translation key (labels.inputs.Net Present Value day count instead of labels.inputs.NPV day count) .
-Made decimal places field empty by default for new Working Capital products .
-Added conditional logic to pass empty array for credit allocations in Working Capital products .
-Added null check before iterating credit allocation transaction types to prevent errors .

Before :-

<img width="1022" height="484" alt="image" src="https://github.com/user-attachments/assets/db76ec0f-275f-4b9f-a9f4-5313b83a1a6b" />

<img width="640" height="209" alt="image" src="https://github.com/user-attachments/assets/5e4fb925-57d2-4819-8e93-e7b17f73f18a" />

<img width="640" height="224" alt="image" src="https://github.com/user-attachments/assets/b5801c29-506b-4e4a-8f4a-4f7cdc5aa253" />

After :-

<img width="1092" height="322" alt="image" src="https://github.com/user-attachments/assets/79931444-af00-4a35-b907-a7115383e9fe" />

<img width="1087" height="317" alt="image" src="https://github.com/user-attachments/assets/82dae099-a94f-463c-a5e5-55947600d3e9" />

<img width="992" height="366" alt="image" src="https://github.com/user-attachments/assets/c96e1da1-4bcb-467f-bd54-8e1c5683c485" />
