### PR TITLE
WEB-799 fix: load OIDC discovery document before login redirect

### DIFF
--- a/src/app/core/authentication/authentication.service.ts
+++ b/src/app/core/authentication/authentication.service.ts
@@ -10,8 +10,8 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams, HttpHeaders } from '@angular/common/http';
 /** rxjs Imports */
-import { BehaviorSubject, Observable, of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { BehaviorSubject, Observable, of, from } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
 
 /** 3rd party Imports */
 import { OAuthService } from 'angular-oauth2-oidc';
@@ -67,6 +67,9 @@ export class AuthenticationService {
   private dialogShown = false;
   private authMode: AuthMode = AuthMode.Basic;
 
+  /** Promise that resolves once the OIDC discovery document has been loaded. */
+  private discoveryDocumentLoaded: Promise<boolean> = Promise.resolve(false);
+
   /** Key to store credentials in storage. */
   private readonly credentialsStorageKey = 'mifosXCredentials';
   /** Key to store two factor authentication token in storage. */
@@ -97,7 +100,19 @@ export class AuthenticationService {
     this.oauthService.configure(getOAuthConfig());
     const oauthStorage = environment.enableRememberMe ? localStorage : sessionStorage;
     this.oauthService.setStorage(oauthStorage);
-    this.oauthService.setupAutomaticSilentRefresh();
+
+    // Load the OIDC discovery document so the library knows the authorization/token endpoints.
+    // This must complete before initCodeFlow() or tryLoginCodeFlow() can work.
+    this.discoveryDocumentLoaded = this.oauthService
+      .loadDiscoveryDocumentAndTryLogin()
+      .then(() => {
+        this.oauthService.setupAutomaticSilentRefresh();
+        return true;
+      })
+      .catch((err) => {
+        console.error('Failed to load OIDC discovery document:', err);
+        return false;
+      });
 
     this.oauthService.events.subscribe((event) => {
       if (event.type === 'token_received' || event.type === 'token_refreshed') {
@@ -180,9 +195,16 @@ export class AuthenticationService {
     this.alertService.alert({ type: 'Authentication Start', message: 'Please wait...' });
 
     if (this.authMode !== AuthMode.Basic) {
-      // OAuth2/OIDC: Redirect to authorization server with PKCE
-      this.oauthService.initCodeFlow();
-      return of(true);
+      // OAuth2/OIDC: Wait for the discovery document, then redirect to authorization server with PKCE
+      return from(
+        this.discoveryDocumentLoaded.then((loaded) => {
+          if (!loaded) {
+            throw new Error('OIDC discovery document failed to load. Cannot redirect to login.');
+          }
+          this.oauthService.initCodeFlow();
+          return true;
+        })
+      );
     }
 
     if (!loginContext) {
@@ -297,6 +319,9 @@ export class AuthenticationService {
    */
   async handleOAuthCallback(): Promise<boolean> {
     try {
+      // Ensure the discovery document is loaded so the library knows the token endpoint
+      await this.discoveryDocumentLoaded;
+
       // index.html preserves the OAuth callback query string in sessionStorage before redirecting to /#/callback, since Angular routing consumes query params before the OAuth library can process them.
       let queryString = sessionStorage.getItem('oauth_callback_query');
 

--- a/src/app/login/login-form/login-form.component.ts
+++ b/src/app/login/login-form/login-form.component.ts
@@ -99,8 +99,8 @@ export class LoginFormComponent implements OnInit {
         })
       )
       .subscribe({
-        error: () => {
-          // Error handling is managed by the authentication service
+        error: (err) => {
+          console.error('OAuth/OIDC login failed:', err);
         }
       });
   }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -134,7 +134,7 @@ export const environment = {
       loadedEnv['oidcServerEnabled'] === true ||
       loadedEnv['oidcServerEnabled'] === 'true' ||
       loadedEnv['FINERACT_PLUGIN_OIDC_ENABLED'] === 'true',
-    oidcBaseUrl: loadedEnv['oidcBaseUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_BASE_URL'] || '',
+    oidcBaseUrl: (loadedEnv['oidcBaseUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_BASE_URL'] || '').replace(/\/+$/, ''),
     oidcClientId: loadedEnv['oidcClientId'] || loadedEnv['FINERACT_PLUGIN_OIDC_CLIENT_ID'] || '',
     oidcApiUrl: loadedEnv['oidcApiUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_API_URL'] || '',
     oidcFrontUrl: loadedEnv['oidcFrontUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_FRONTEND_URL'] || ''

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -138,7 +138,7 @@ export const environment = {
       loadedEnv.oidcServerEnabled === true ||
       loadedEnv.oidcServerEnabled === 'true' ||
       loadedEnv.FINERACT_PLUGIN_OIDC_ENABLED === 'true',
-    oidcBaseUrl: loadedEnv.oidcBaseUrl || loadedEnv.FINERACT_PLUGIN_OIDC_BASE_URL || '',
+    oidcBaseUrl: (loadedEnv.oidcBaseUrl || loadedEnv.FINERACT_PLUGIN_OIDC_BASE_URL || '').replace(/\/+$/, ''),
     oidcClientId: loadedEnv.oidcClientId || loadedEnv.FINERACT_PLUGIN_OIDC_CLIENT_ID || '',
     oidcApiUrl: loadedEnv.oidcApiUrl || loadedEnv.FINERACT_PLUGIN_OIDC_API_URL || '',
     oidcFrontUrl: loadedEnv.oidcFrontUrl || loadedEnv.FINERACT_PLUGIN_OIDC_FRONTEND_URL || ''


### PR DESCRIPTION
Fixes the OIDC login redirect issue on https://oidc.mifos.community/ where clicking "Login" shows "Please wait" but fails to redirect the user to ZITADEL.

[WEB-799](https://mifosforge.jira.com/browse/WEB-799)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-799]: https://mifosforge.jira.com/browse/WEB-799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced OIDC discovery document handling to ensure proper readiness before login and callback processing
  * OAuth/OIDC login errors are now logged for improved debugging visibility
  * Fixed OIDC base URL configuration to properly normalize trailing slashes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->