### PR TITLE
WEB-822: remove unused MatLine import from BulkImportComponent

### DIFF
--- a/src/app/organization/bulk-import/bulk-import.component.ts
+++ b/src/app/organization/bulk-import/bulk-import.component.ts
@@ -11,7 +11,6 @@ import { Component } from '@angular/core';
 import { MatNavList, MatListItem } from '@angular/material/list';
 import { MatIcon } from '@angular/material/icon';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { MatLine } from '@angular/material/grid-list';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
 /**
@@ -26,8 +25,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatNavList,
     MatListItem,
     MatIcon,
-    FaIconComponent,
-    MatLine
+    FaIconComponent
   ]
 })
 export class BulkImportComponent {


### PR DESCRIPTION
This Pr Removed `MatLine` from the ES import statement in `bulk-import.component.ts.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused Material design dependencies from the bulk import component, reducing package overhead with no impact to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->