### PR TITLE
WEB-823: fix OIDC race conditions and issuer validation

### DIFF
--- a/src/app/core/authentication/authentication.service.ts
+++ b/src/app/core/authentication/authentication.service.ts
@@ -137,16 +137,19 @@ export class AuthenticationService {
     }
 
     if (this.authMode !== AuthMode.Basic) {
-      // OAuth2/OIDC: Use angular-oauth2-oidc library for token management
-      if (this.oauthService.hasValidAccessToken()) {
-        this.authenticationInterceptor.setAuthorizationToken(this.oauthService.getAccessToken());
-        this.userLoggedIn$.next(true);
-      } else if (this.oauthService.getRefreshToken()) {
-        this.oauthService
-          .refreshToken()
-          .then(() => this.userLoggedIn$.next(true))
-          .catch(() => this.logout().subscribe());
-      }
+      // OAuth2/OIDC: Wait for discovery document before attempting token refresh
+      this.discoveryDocumentLoaded.then((loaded) => {
+        if (!loaded) return;
+        if (this.oauthService.hasValidAccessToken()) {
+          this.authenticationInterceptor.setAuthorizationToken(this.oauthService.getAccessToken());
+          this.userLoggedIn$.next(true);
+        } else if (this.oauthService.getRefreshToken()) {
+          this.oauthService
+            .refreshToken()
+            .then(() => this.userLoggedIn$.next(true))
+            .catch(() => this.logout().subscribe());
+        }
+      });
     } else {
       // Basic Auth
       this.authenticationInterceptor.setAuthorizationToken(savedCredentials.base64EncodedAuthenticationKey);
@@ -320,7 +323,11 @@ export class AuthenticationService {
   async handleOAuthCallback(): Promise<boolean> {
     try {
       // Ensure the discovery document is loaded so the library knows the token endpoint
-      await this.discoveryDocumentLoaded;
+      const discoveryLoaded = await this.discoveryDocumentLoaded;
+      if (!discoveryLoaded) {
+        console.error('OIDC discovery document not loaded. Cannot process OAuth callback.');
+        return false;
+      }
 
       // index.html preserves the OAuth callback query string in sessionStorage before redirecting to /#/callback, since Angular routing consumes query params before the OAuth library can process them.
       let queryString = sessionStorage.getItem('oauth_callback_query');

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -134,7 +134,7 @@ export const environment = {
       loadedEnv['oidcServerEnabled'] === true ||
       loadedEnv['oidcServerEnabled'] === 'true' ||
       loadedEnv['FINERACT_PLUGIN_OIDC_ENABLED'] === 'true',
-    oidcBaseUrl: (loadedEnv['oidcBaseUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_BASE_URL'] || '').replace(/\/+$/, ''),
+    oidcBaseUrl: loadedEnv['oidcBaseUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_BASE_URL'] || '',
     oidcClientId: loadedEnv['oidcClientId'] || loadedEnv['FINERACT_PLUGIN_OIDC_CLIENT_ID'] || '',
     oidcApiUrl: loadedEnv['oidcApiUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_API_URL'] || '',
     oidcFrontUrl: loadedEnv['oidcFrontUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_FRONTEND_URL'] || ''

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -138,7 +138,7 @@ export const environment = {
       loadedEnv.oidcServerEnabled === true ||
       loadedEnv.oidcServerEnabled === 'true' ||
       loadedEnv.FINERACT_PLUGIN_OIDC_ENABLED === 'true',
-    oidcBaseUrl: (loadedEnv.oidcBaseUrl || loadedEnv.FINERACT_PLUGIN_OIDC_BASE_URL || '').replace(/\/+$/, ''),
+    oidcBaseUrl: loadedEnv.oidcBaseUrl || loadedEnv.FINERACT_PLUGIN_OIDC_BASE_URL || '',
     oidcClientId: loadedEnv.oidcClientId || loadedEnv.FINERACT_PLUGIN_OIDC_CLIENT_ID || '',
     oidcApiUrl: loadedEnv.oidcApiUrl || loadedEnv.FINERACT_PLUGIN_OIDC_API_URL || '',
     oidcFrontUrl: loadedEnv.oidcFrontUrl || loadedEnv.FINERACT_PLUGIN_OIDC_FRONTEND_URL || ''


### PR DESCRIPTION
Wraps OAuth token refresh in `discoveryDocumentLoaded.then()` to prevent calling `refreshToken()` before discovery completes Prevents silent auth failures on app startup with cached refresh tokens

[WEB-823](https://mifosforge.jira.com/browse/WEB-823)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-823]: https://mifosforge.jira.com/browse/WEB-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2/OIDC token initialization to prevent potential timing issues.

* **Chores**
  * Updated OIDC base URL configuration handling in development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->