### PR TITLE
WEB-824: Fix null handling in PrettyPrintPipe

### DIFF
--- a/src/app/pipes/pretty-print.pipe.ts
+++ b/src/app/pipes/pretty-print.pipe.ts
@@ -12,6 +12,9 @@ import * as vkbeautify from 'vkbeautify';
 @Pipe({ name: 'prettyPrint' })
 export class PrettyPrintPipe implements PipeTransform {
   transform(value: any) {
+    if (value == null || typeof value !== 'string') {
+      return '';
+    }
     if (value.charAt(0) === '{' && value.charAt(value.length - 1) === '}') {
       try {
         return vkbeautify.json(value);


### PR DESCRIPTION
Description:
PrettyPrintPipe calls value.charAt() without validating the input. If the value is null, undefined, or not a string (which can happen with malformed datatable JSON data), the view crashes with a TypeError.

Fix:
Add a guard clause to safely handle null, undefined, and non-string values. Return an empty string when the input is invalid.

Ticket -> https://mifosforge.jira.com/browse/WEB-824?atlOrigin=eyJpIjoiZWMzYTY1MmNiYWUxNDFhMDkyYmZhNTYyYTM4ZjM0NjYiLCJwIjoiaiJ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the pretty-print feature to gracefully handle invalid inputs, returning empty content for null or non-string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->