### PR TITLE
WEB-827: Prevent tabnabbing in window.open

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
@@ -233,6 +233,6 @@ export class DatatableSingleRowComponent implements OnInit {
   }
 
   openSite(siteUrl: string) {
-    window.open(siteUrl, '_blank');
+    window.open(siteUrl, '_blank', 'noopener,noreferrer');
   }
 }


### PR DESCRIPTION
Description:
External links are opened using window.open(url, '_blank'). Without noopener or noreferrer, the opened page can access window.opener, creating a potential tabnabbing vulnerability.

Fix:
Update window.open calls to include 'noopener,noreferrer'

ticket -> https://mifosforge.jira.com/browse/WEB-827?atlOrigin=eyJpIjoiNjM1YmU1YjExZDlmNDk3NWJlNDhlMGY1YTRjODMzYmEiLCJwIjoiaiJ9