### PR TITLE
WEB-828: Add null checks for dialog responses

### DIFF
--- a/src/app/loans/loans-view/reschedule-loan-tab/reschedule-loan-tab.component.ts
+++ b/src/app/loans/loans-view/reschedule-loan-tab/reschedule-loan-tab.component.ts
@@ -97,7 +97,7 @@ export class RescheduleLoanTabComponent {
       }
     });
     approveLoanRescheduleDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         const payload: {

--- a/src/app/organization/holidays/view-holidays/view-holidays.component.ts
+++ b/src/app/organization/holidays/view-holidays/view-holidays.component.ts
@@ -63,7 +63,7 @@ export class ViewHolidaysComponent {
       data: { deleteContext: `holiday ${this.holidayData.id}` }
     });
     deleteHolidayDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.organizationService.deleteHoliday(this.holidayData.id).subscribe(() => {
           this.router.navigate(['../'], { relativeTo: this.route });
         });
@@ -85,7 +85,7 @@ export class ViewHolidaysComponent {
       }
     });
     unAssignStaffDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         this.organizationService.activateHoliday(this.holidayData.id).subscribe(() => {
           this.router.navigate(['/organization/holidays']);
         });

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
@@ -168,7 +168,7 @@ export class DatatableSingleRowComponent implements OnInit {
       data: { deleteContext: ` the contents of ${formatTabLabel(this.datatableName)}` }
     });
     deleteDataTableDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.systemService.deleteDatatableContent(this.entityId, this.datatableName).subscribe(() => {
           this.systemService.getEntityDatatable(this.entityId, this.datatableName).subscribe((dataObject: any) => {
             this.dataObject = dataObject;
@@ -233,6 +233,6 @@ export class DatatableSingleRowComponent implements OnInit {
   }
 
   openSite(siteUrl: string) {
-    window.open(siteUrl, '_blank');
+    window.open(siteUrl, '_blank', 'noopener,noreferrer');
   }
 }

--- a/src/app/system/codes/view-code/view-code.component.ts
+++ b/src/app/system/codes/view-code/view-code.component.ts
@@ -192,7 +192,7 @@ export class ViewCodeComponent implements OnInit {
       data: { deleteContext: this.translateService.instant('labels.inputs.Code') + ' ' + this.codeData.name }
     });
     deleteCodeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.systemService.deleteCode(this.codeData.id).subscribe(() => {
           this.router.navigate(['/system/codes']);
         });

--- a/src/app/system/manage-reports/view-report/view-report.component.ts
+++ b/src/app/system/manage-reports/view-report/view-report.component.ts
@@ -65,7 +65,7 @@ export class ViewReportComponent {
       data: { deleteContext: `report ${this.reportData.id}` }
     });
     deleteReportDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.systemService.deleteReport(this.reportData.id).subscribe(() => {
           this.router.navigate(['/system/reports']);
         });

--- a/src/app/templates/view-template/view-template.component.ts
+++ b/src/app/templates/view-template/view-template.component.ts
@@ -61,7 +61,7 @@ export class ViewTemplateComponent {
       data: { deleteContext: `template ${this.templateData.id}` }
     });
     deleteTemplateDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.templatesService.deleteTemplate(this.templateData.id).subscribe(() => {
           this.router.navigate(['/templates']);
         });


### PR DESCRIPTION
Description:
MatDialog.afterClosed() emits undefined when a dialog is cancelled (Escape key, clicking outside, or Cancel). Some components access properties like response.delete or response.confirm without checking if response exists.

Fix:
Add optional chaining to safely handle undefined responses.

Affected components:

view-template.component.ts

view-code.component.ts

view-report.component.ts

reschedule-loan-tab.component.ts

view-holidays.component.ts


ticket -> https://mifosforge.jira.com/browse/WEB-828?atlOrigin=eyJpIjoiZTZhZDAzMWYwYzM1NDUyNjg3MzZiYWJiZmRjZDEyNGUiLCJwIjoiaiJ9