### PR TITLE
WEB-829: Add alt text to placeholder images (Accessibility)

### DIFF
--- a/src/app/centers/centers-view/centers-view.component.html
+++ b/src/app/centers/centers-view/centers-view.component.html
@@ -11,7 +11,12 @@
     <mat-card-title-group class="header-title-group">
       <div>
         <div>
-          <img mat-card-md-image class="profile-image" src="assets/images/center_placeholder.png" />
+          <img
+            mat-card-md-image
+            class="profile-image"
+            src="assets/images/center_placeholder.png"
+            alt="{{ 'labels.alt.Center profile placeholder' | translate }}"
+          />
         </div>
       </div>
 

--- a/src/app/groups/groups-view/groups-view.component.html
+++ b/src/app/groups/groups-view/groups-view.component.html
@@ -11,7 +11,12 @@
     <mat-card-title-group class="header-title-group">
       <div class="profile-image-container">
         <div>
-          <img mat-card-md-image class="profile-image" src="assets/images/group_placeholder.png" />
+          <img
+            mat-card-md-image
+            class="profile-image"
+            src="assets/images/group_placeholder.png"
+            alt="{{ 'labels.alt.Group profile placeholder' | translate }}"
+          />
         </div>
       </div>
 

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "Částka jistiny {{params[0].value}} je neplatná. Musí být částka menší nebo rovna maximální částce jistiny {{params[1].value}}.",
     "validation.msg.loan.principal.is.less.than.min": "Částka jistiny {{params[0].value}} je neplatná. Musí být částka větší nebo rovna minimální částce jistiny {{params[1].value}}.",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "Typ účetnictví je povinný.",
+    "labels.alt.Center profile placeholder": "Zástupný symbol profilu střediska",
+    "labels.alt.Group profile placeholder": "Zástupný symbol profilu skupiny",
     "labels.commons.Only up to 6 decimal places allowed": "Povoleno je maximálně 6 desetinných míst.",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "Účetní typ je neplatný. Musí to být číslo mezi {{params[1].value}} a {{params[2].value}} včetně.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Povolit výpočet částečných splátek nelze pro denní výpočet nastavit jako true",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "Der Kapitalbetrag {{params[0].value}} ist ungültig. Muss ein Betrag sein, der kleiner oder gleich dem maximalen Kapitalbetrag {{params[1].value}} ist.",
     "validation.msg.loan.principal.is.less.than.min": "Der Kapitalbetrag {{params[0].value}} ist ungültig. Muss ein Betrag sein, der größer oder gleich dem Mindestkapitalbetrag {{params[1].value}} ist.",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "Der Abrechnungstyp ist obligatorisch.",
+    "labels.alt.Center profile placeholder": "Zentrums-Profilplatzhalter",
+    "labels.alt.Group profile placeholder": "Gruppen-Profilplatzhalter",
     "labels.commons.Only up to 6 decimal places allowed": "Nur bis zu 6 Dezimalstellen erlaubt.",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "Der Abrechnungstyp ist ungültig. Muss eine Zahl zwischen {{params[1].value}} und {{params[2].value}} (einschließlich) sein.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Teilzahlungsberechnung zulassen kann für die tägliche Berechnung nicht auf „Wahr“ gesetzt werden",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "Principal amount {{params[0].value}} is invalid. Must be an amount less than or equal to Maximum principal amount {{params[1].value}}.",
     "validation.msg.loan.principal.is.less.than.min": "Principal amount {{params[0].value}} is invalid. Must be an amount greater than or equal to Minimum Principal amount {{params[1].value}}.",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "Accounting type is mandatory.",
+    "labels.alt.Center profile placeholder": "Center profile placeholder",
+    "labels.alt.Group profile placeholder": "Group profile placeholder",
     "labels.commons.Only up to 6 decimal places allowed": "Only up to 6 decimal places allowed.",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "Accounting type is invalid. Must be a number between {{params[1].value}} and {{params[2].value}} inclusive.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Allow Partial Installment Calculation cannot be set as true for daily calculation",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "El importe principal {{params[0].value}} no es válido. Debe ser un monto menor o igual al monto principal máximo {{params[1].value}}.",
     "validation.msg.loan.principal.is.less.than.min": "El importe principal {{params[0].value}} no es válido. Debe ser un monto mayor o igual al monto mínimo de capital {{params[1].value}}.",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "El tipo de contabilidad es obligatorio.",
+    "labels.alt.Center profile placeholder": "Marcador de posición de perfil de centro",
+    "labels.alt.Group profile placeholder": "Marcador de posición de perfil de grupo",
     "labels.commons.Only up to 6 decimal places allowed": "Solo se permiten hasta 6 decimales.",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "El tipo de contabilidad no es válido. Debe ser un número entre {{params[1].value}} y {{params[2].value}} inclusive.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Permitir el cálculo de cuotas parciales no se puede establecer como verdadero para el cálculo diario",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "El importe del capital {{params[0].value}} no es válido. Debe ser un monto menor o igual al monto del capital máximo {{params[1].value}}.",
     "validation.msg.loan.principal.is.less.than.min": "El importe del capital {{params[0].value}} no es válido. Debe ser un monto mayor o igual al monto mínimo del capital {{params[1].value}}.",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "El tipo de contabilidad es obligatorio.",
+    "labels.alt.Center profile placeholder": "Marcador de posición de perfil de centro",
+    "labels.alt.Group profile placeholder": "Marcador de posición de perfil de grupo",
     "labels.commons.Only up to 6 decimal places allowed": "Solo se permiten hasta 6 decimales.",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "El tipo de contabilidad no es válido. Debe ser un número entre {{params[1].value}} y {{params[2].value}} inclusive.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Permitir el cálculo de cuotas parciales no se puede establecer como verdadero para el cálculo diario",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "Le montant principal {{params[0].value}} n'est pas valide. Doit être un montant inférieur ou égal au montant principal maximum {{params[1].value}}.",
     "validation.msg.loan.principal.is.less.than.min": "Le montant principal {{params[0].value}} n'est pas valide. Doit être un montant supérieur ou égal au montant principal minimum {{params[1].value}}.",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "Le type de comptabilité est obligatoire.",
+    "labels.alt.Center profile placeholder": "Image de profil du centre par défaut",
+    "labels.alt.Group profile placeholder": "Image de profil du groupe par défaut",
     "labels.commons.Only up to 6 decimal places allowed": "Jusqu'à 6 décimales autorisées.",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "Le type de comptabilité n'est pas valide. Doit être un nombre compris entre {{params[1].value}} et {{params[2].value}} inclus.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Autoriser le calcul des versements partiels ne peut pas être défini comme vrai pour le calcul quotidien",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -85,6 +85,8 @@
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "Il tipo di contabilità non è valido. Deve essere un numero compreso tra {{params[1].value}} e {{params[2].value}} inclusi.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Consenti calcolo rata parziale non può essere impostato su vero per il calcolo giornaliero",
     "validation.msg.loanproduct.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "La rata variabile deve essere utilizzata con il calcolo dell'interesse giornaliero o con il calcolo dell'interesse parziale vero",
+    "labels.alt.Center profile placeholder": "Segnaposto profilo centro",
+    "labels.alt.Group profile placeholder": "Segnaposto profilo gruppo",
     "labels.commons.Only up to 6 decimal places allowed": "Sono consentiti solo fino a 6 decimali.",
     "validation.msg.loanproduct.amortizationType.cannot.be.blank": "La tipologia di ammortamento è obbligatoria.",
     "validation.msg.loanproduct.amortizationType.is.not.within.expected.range": "Il tipo di ammortamento non è valido. Deve essere un numero compreso tra {{params[1].value}} e {{params[2].value}} inclusi.",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -85,6 +85,8 @@
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "회계 유형이 잘못되었습니다. {{params[1].value}}와 {{params[2].value}} 사이의 숫자여야 합니다.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "일일 계산에서는 부분 할부 계산 허용을 true로 설정할 수 없습니다.",
     "validation.msg.loanproduct.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "변액할부는 일일이자 계산과 함께 사용하거나 부분이자 계산을 허용해야 합니다.",
+    "labels.alt.Center profile placeholder": "센터 프로필 자리 표시자",
+    "labels.alt.Group profile placeholder": "그룹 프로필 자리 표시자",
     "labels.commons.Only up to 6 decimal places allowed": "6자리 이하의 소수점만 허용됩니다.",
     "validation.msg.loanproduct.amortizationType.cannot.be.blank": "분할 상환 유형은 필수입니다.",
     "validation.msg.loanproduct.amortizationType.is.not.within.expected.range": "할부 상환 유형이 잘못되었습니다. {{params[1].value}}와 {{params[2].value}} 사이의 숫자여야 합니다.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "Pagrindinė suma {{params[0].value}} yra neteisinga. Turi būti suma, mažesnė arba lygi didžiausiai pagrindinei sumai {{params[1].value}}.",
     "validation.msg.loan.principal.is.less.than.min": "Pagrindinė suma {{params[0].value}} yra neteisinga. Turi būti suma, didesnė arba lygi minimaliajai pagrindinei sumai {{params[1].value}}.",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "Apskaitos tipas yra privalomas.",
+    "labels.alt.Center profile placeholder": "Centro profilio rezervuota vieta",
+    "labels.alt.Group profile placeholder": "Grupės profilio rezervuota vieta",
     "labels.commons.Only up to 6 decimal places allowed": "Leidžiama iki 6 dešimtainių skaičių.",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "Netinkamas apskaitos tipas. Turi būti skaičius tarp {{params[1].value}} ir {{params[2].value}} imtinai.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Leisti dalinį įmokos apskaičiavimą negali būti nustatyta kaip teisinga atliekant kasdienį skaičiavimą",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "Pamatsumma {{params[0].value}} nav derīga. Jābūt summai, kas ir mazāka vai vienāda ar maksimālo pamatsummu {{params[1].value}}.",
     "validation.msg.loan.principal.is.less.than.min": "Pamatsumma {{params[0].value}} nav derīga. Jābūt summai, kas ir lielāka vai vienāda ar minimālo pamatsummu {{params[1].value}}.",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "Uzskaites veids ir obligāts.",
+    "labels.alt.Center profile placeholder": "Centra profila aizpildītājs",
+    "labels.alt.Group profile placeholder": "Grupas profila aizpildītājs",
     "labels.commons.Only up to 6 decimal places allowed": "Atļauts tikai līdz 6 zīmēm aiz komata.",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "Uzskaites veids nav derīgs. Jābūt skaitlim starp {{params[1].value}} un {{params[2].value}} ieskaitot.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Atļaut daļējas iemaksas aprēķinu nevar iestatīt kā patiesu ikdienas aprēķinam",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "मूल रकम {{params[0].value}} अमान्य छ। अधिकतम मूल रकम {{params[1].value}} भन्दा कम वा बराबरको रकम हुनुपर्छ।",
     "validation.msg.loan.principal.is.less.than.min": "मूल रकम {{params[0].value}} अमान्य छ। न्यूनतम प्रिन्सिपल रकम {{params[1].value}} भन्दा बढी वा बराबरको रकम हुनुपर्छ।",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "लेखा प्रकार अनिवार्य छ।",
+    "labels.alt.Center profile placeholder": "केन्द्र प्रोफाइल प्लेसहोल्डर",
+    "labels.alt.Group profile placeholder": "समूह प्रोफाइल प्लेसहोल्डर",
     "labels.commons.Only up to 6 decimal places allowed": "अधिकतम ६ दशमलव स्थानहरू मात्र अनुमति छ।",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "लेखा प्रकार अमान्य छ। समावेशी {{params[1].value}} र {{params[2].value}} बीचको संख्या हुनुपर्छ।",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "अनुमति दिनुहोस् आंशिक किस्ता गणना दैनिक गणनाको लागि सत्यको रूपमा सेट गर्न सकिँदैन",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "O valor principal {{params[0].value}} é inválido. Deve ser um valor menor ou igual ao valor principal máximo {{params[1].value}}.",
     "validation.msg.loan.principal.is.less.than.min": "O valor principal {{params[0].value}} é inválido. Deve ser um valor maior ou igual ao valor principal mínimo {{params[1].value}}.",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "O tipo de contabilidade é obrigatório.",
+    "labels.alt.Center profile placeholder": "Placeholder de perfil do centro",
+    "labels.alt.Group profile placeholder": "Placeholder de perfil do grupo",
     "labels.commons.Only up to 6 decimal places allowed": "Apenas até 6 casas decimais permitidas.",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "O tipo de contabilidade é inválido. Deve ser um número entre {{params[1].value}} e {{params[2].value}} inclusive.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Permitir cálculo de parcela parcial não pode ser definido como verdadeiro para cálculo diário",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -82,6 +82,8 @@
     "validation.msg.loan.principal.is.greater.than.max": "Kiasi kikuu {{params[0].value}} si sahihi. Ni lazima kiwe kiasi kidogo kuliko au sawa na Kiwango cha juu kabisa cha msingi {{params[1].value}}.",
     "validation.msg.loan.principal.is.less.than.min": "Kiasi kikuu {{params[0].value}} si sahihi. Ni lazima kiwe kiasi kikubwa kuliko au sawa na Kiasi cha Chini cha Msingi {{params[1].value}}.",
     "validation.msg.loanproduct.accountingType.cannot.be.blank": "Aina ya uhasibu ni ya lazima.",
+    "labels.alt.Center profile placeholder": "Kibina cha wasilishi wa kituo",
+    "labels.alt.Group profile placeholder": "Kibina cha wasilishi wa kikundi",
     "labels.commons.Only up to 6 decimal places allowed": "Inaruhusiwa hadi sehemu 6 za desimali pekee.",
     "validation.msg.loanproduct.accountingType.is.not.within.expected.range": "Aina ya uhasibu ni batili. Lazima iwe nambari kati ya {{params[1].value}} na {{params[2].value}} zikijumlishwa.",
     "validation.msg.loanproduct.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Ruhusu Ukokotoaji wa Usawa wa Kiasi hauwezi kuwekwa kuwa kweli kwa hesabu ya kila siku",


### PR DESCRIPTION
Description:
Placeholder images for groups and centers are missing alt attributes, which fails WCAG 1.1.1 (Non-text Content) accessibility guidelines.

Fix:
Add descriptive alt text so screen readers can properly interpret these images.

ticket -> https://mifosforge.jira.com/browse/WEB-829?atlOrigin=eyJpIjoiOTM2ZTZiMTZmZmNiNDJiNWJiMDVkNWNkMTY1MDdjZmMiLCJwIjoiaiJ9