### PR TITLE
WEB-831: Fix Jest transformIgnorePatterns for @material/web ESM dependencies

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -80,7 +80,9 @@ const config: Config = {
   },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$|@angular|@fortawesome)']
+  transformIgnorePatterns: [
+    'node_modules/(?!.*\\.mjs$|@angular|@fortawesome|@material/web|lit|lit-element|lit-html|@lit|@lit-labs)'
+  ]
 };
 
 export default config;


### PR DESCRIPTION

## Description

Fixes a crash where Jest fails to parse raw ESM import statements from @material/web and its transitive dependency chain (lit, lit-element, lit-html, @lit, @lit-labs). These packages all ship ESM-only modules and must be listed in transformIgnorePatterns so Jest transpiles them before execution.

Without this fix, 4+ existing test suites fail with SyntaxError: Cannot use import statement outside a module whenever a component imports anything from @material/web.

Changed: jest.config.ts — extended transformIgnorePatterns to include the full @material/web ESM dependency tree.

## Related issues

Fixes #WEB-831

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.
- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing configuration to handle additional dependencies properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->