### PR TITLE
WEB-832 fix: reposition delete button in interest rate chart form

### DIFF
--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.html
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.html
@@ -24,18 +24,6 @@
       <div class="flex-fill layout-row-wrap responsive-column" formArrayName="charts">
         <mat-divider class="flex-98"></mat-divider>
         <div class="flex-fill layout-row-wrap responsive-column" [formGroupName]="chartIndex">
-          <div class="flex-100" align="end">
-            <button
-              type="button"
-              mat-icon-button
-              color="warn"
-              (click)="delete(charts, chartIndex)"
-              matTooltip="{{ 'tooltips.Delete Interest Rate Chart' | translate }}"
-              matTooltipPosition="left"
-            >
-              <fa-icon icon="trash"></fa-icon>
-            </button>
-          </div>
           <mat-form-field class="flex-28 m-r-5">
             <mat-label>{{ 'labels.inputs.Name' | translate }}</mat-label>
             <input matInput formControlName="name" required />
@@ -84,10 +72,21 @@
               {{ 'labels.inputs.Is primary grouping by amount?' | translate }}
             </mat-checkbox>
           </div>
-          <div class="center flex-100">
+          <div class="center flex-100 layout-row align-center m-b-10">
             <button type="button" mat-raised-button color="primary" (click)="addChartSlab(chart.controls.chartSlabs)">
               <fa-icon icon="plus" class="m-r-10"></fa-icon>
               {{ 'labels.buttons.Submit' | translate }}
+            </button>
+            <button
+              type="button"
+              mat-icon-button
+              color="warn"
+              class="m-l-5"
+              (click)="delete(charts, chartIndex)"
+              matTooltip="{{ 'tooltips.Delete Interest Rate Chart' | translate }}"
+              matTooltipPosition="right"
+            >
+              <fa-icon icon="trash"></fa-icon>
             </button>
           </div>
           @if (chart.value.chartSlabs.length === 0) {


### PR DESCRIPTION

This Pr repositioned the delete button in the Fixed Deposit Product Interest Rate Chart form to improve user experience and prevent accidental deletions.

[WEB-832 ](https://mifosforge.jira.com/browse/WEB-832)

Before:
<img width="1481" height="713" alt="Screenshot 2026-03-09 202423" src="https://github.com/user-attachments/assets/a7434647-5de3-4f00-9497-e3404e0cb4c2" />

After:
<img width="1483" height="484" alt="image" src="https://github.com/user-attachments/assets/78498b3f-1cbd-457d-9a5a-643f1a30116e" />


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized delete button placement from top to bottom of chart items.
  * Enhanced layout structure with improved alignment and spacing for better visual organization.
  * Adjusted tooltip positioning for delete functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->