### PR TITLE
WEB-834 fix: correct dark mode styling in Make Account Transfer benef…

### DIFF
--- a/src/app/account-transfers/make-account-transfers/make-account-transfers.component.scss
+++ b/src/app/account-transfers/make-account-transfers/make-account-transfers.component.scss
@@ -45,7 +45,6 @@
   display: flex;
   align-items: center;
   padding: 0.5rem;
-  background-color: rgb(0 0 0 / 2%);
   border-radius: 4px;
 
   &:hover {
@@ -55,13 +54,11 @@
 
 .info-label {
   flex: 0 0 40%;
-  color: rgb(0 0 0 / 70%);
   font-weight: 500;
 }
 
 .info-value {
   flex: 1;
-  color: rgb(0 0 0 / 87%);
 }
 
 // Divider styling


### PR DESCRIPTION
…iciary selection step

This PR fixes a dark mode styling issue in the Make Account Transfer Beneficiary Selection step.

[WEB-834](https://mifosforge.jira.com/browse/WEB-834)

Before:
<img width="807" height="421" alt="image" src="https://github.com/user-attachments/assets/a9490031-0e94-4326-830b-570e3f18ade8" />
After:
<img width="803" height="503" alt="image" src="https://github.com/user-attachments/assets/657e5517-f008-4523-b0c1-a3a26f29363f" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-834]: https://mifosforge.jira.com/browse/WEB-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed explicit styling from account transfer information rows to allow for cleaner theme application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->