### PR TITLE
WEB-812: Fix the WebApp to show/hide the Menus, Submenus and buttons as per the grants of each profile

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -42,7 +42,7 @@
       [matMenuTriggerFor]="institutionMenu"
       #institutionMenuTrigger="matMenuTrigger"
       tabindex="0"
-      *mifosxHasPermission="'READ_INSTITUTION'"
+      *mifosxHasPermission="['READ_CLIENT', 'READ_GROUP', 'READ_CENTER']"
     >
       <fa-icon class="mr-05" icon="university" size="lg"></fa-icon>
       {{ 'labels.menus.Institution' | translate }}
@@ -54,7 +54,13 @@
         class="tab-link accounting-link"
         [routerLink]="['/accounting']"
         tabindex="0"
-        *mifosxHasPermission="'READ_ACCOUNTING'"
+        *mifosxHasPermission="[
+          'READ_JOURNALENTRY',
+          'READ_GLACCOUNT',
+          'READ_GLCLOSURE',
+          'READ_ACCOUNTINGRULE',
+          'READ_PROVISIONINGCRITERIA'
+        ]"
       >
         <fa-icon class="mr-05" icon="money-bill-alt" size="lg"></fa-icon>
         {{ 'labels.menus.Accounting' | translate }}
@@ -65,7 +71,7 @@
         [matMenuTriggerFor]="reportsMenu"
         #reportsMenuTrigger="matMenuTrigger"
         tabindex="0"
-        *mifosxHasPermission="'READ_REPORTS'"
+        *mifosxHasPermission="'READ_REPORT'"
       >
         <fa-icon class="mr-05" icon="chart-bar" size="lg"></fa-icon>
         {{ 'labels.menus.Reports' | translate }}
@@ -76,7 +82,7 @@
         [matMenuTriggerFor]="adminMenu"
         #adminMenuTrigger="matMenuTrigger"
         tabindex="0"
-        *mifosxHasPermission="'READ_ADMIN'"
+        *mifosxHasPermission="['READ_USER', 'READ_ROLE']"
       >
         <fa-icon class="mr-05" icon="shield-alt" size="lg"></fa-icon>
         {{ 'labels.menus.Admin' | translate }}
@@ -140,13 +146,31 @@
     {{ 'labels.menus.Centers' | translate }}
   </button>
   <span class="hide-lt-md">
-    <button mat-menu-item [routerLink]="['/accounting']" tabindex="0">
+    <button
+      mat-menu-item
+      [routerLink]="['/accounting']"
+      tabindex="0"
+      *mifosxHasPermission="[
+        'READ_JOURNALENTRY',
+        'READ_GLACCOUNT',
+        'READ_GLCLOSURE',
+        'READ_ACCOUNTINGRULE',
+        'READ_PROVISIONINGCRITERIA'
+      ]"
+    >
       {{ 'labels.menus.Accounting' | translate }}
     </button>
-    <button mat-menu-item [matMenuTriggerFor]="reportsMenu" tabindex="0">
+    <button mat-menu-item [matMenuTriggerFor]="reportsMenu" tabindex="0" *mifosxHasPermission="'READ_REPORT'">
       {{ 'labels.menus.Reports' | translate }}
     </button>
-    <button mat-menu-item [matMenuTriggerFor]="adminMenu" tabindex="0">{{ 'labels.menus.Admin' | translate }}</button>
+    <button
+      mat-menu-item
+      [matMenuTriggerFor]="adminMenu"
+      tabindex="0"
+      *mifosxHasPermission="['READ_USER', 'READ_ROLE']"
+    >
+      {{ 'labels.menus.Admin' | translate }}
+    </button>
   </span>
 </mat-menu>
 

--- a/src/app/directives/has-permission/has-permission.directive.ts
+++ b/src/app/directives/has-permission/has-permission.directive.ts
@@ -45,9 +45,9 @@ export class HasPermissionDirective {
    * Evaluates the condition to show template.
    */
   @Input()
-  set mifosxHasPermission(permission: any) {
-    if (typeof permission !== 'string') {
-      throw new Error('hasPermission value must be a string');
+  set mifosxHasPermission(permission: string | string[]) {
+    if (typeof permission !== 'string' && !Array.isArray(permission)) {
+      throw new Error('hasPermission value must be a string or an array of strings');
     }
     /** Clear the template beforehand to prevent overlap OnChanges. */
     this.viewContainer.clear();
@@ -59,7 +59,7 @@ export class HasPermissionDirective {
 
   /**
    * Checks if user is permitted.
-   * @param {string} permission Permission
+   * @param {string | string[]} permission Permission(s) to check
    * @returns {true}
    * - RBAC is disabled (backward compatibility mode)
    * -`ALL_FUNCTIONS`: user is a Super user.
@@ -69,16 +69,34 @@ export class HasPermissionDirective {
    * - Passed permission doesn't fall under either of above given permission grants.
    * - No value was passed to the has permission directive.
    */
-  private hasPermission(permission: string) {
+  private hasPermission(permission: string | string[]): boolean {
     // If RBAC is disabled, show all menus/buttons (backward compatibility)
     if (!this.rbacEnabled) {
       return true;
     }
 
-    permission = permission.trim();
     if (this.userPermissions.includes('ALL_FUNCTIONS')) {
       return true;
-    } else if (permission !== '') {
+    }
+
+    if (typeof permission === 'string') {
+      return this.checkSinglePermission(permission);
+    } else if (Array.isArray(permission)) {
+      // Return true if at least one permission in the array is granted
+      return permission.some((p) => this.checkSinglePermission(p));
+    }
+
+    return false;
+  }
+
+  /**
+   * Checks if user has a single specific permission.
+   * @param {string} permission Single permission string
+   * @returns {boolean} True if permitted, false otherwise
+   */
+  private checkSinglePermission(permission: string): boolean {
+    permission = permission.trim();
+    if (permission !== '') {
       if (permission.substring(0, 5) === 'READ_' && this.userPermissions.includes('ALL_FUNCTIONS_READ')) {
         return true;
       } else if (this.userPermissions.includes(permission)) {


### PR DESCRIPTION
JIRA TICKET: [WEB-812](https://mifosforge.jira.com/browse/WEB-812?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)

## Description

Modified the mifosxHasPermission directive to accept a string array of permissions. Updated the toolbar.component.html menu items (Institution, Accounting, Reports, Admin) to use arrays of specific Fineract read permissions rather than generic module strings. 
This ensures that restricted tenant roles like Ejecutivo, Cajero, and Tesorero do not see the Admin or Accounting tabs unless explicitly granted granular configuration or ledger permissions in the backend. 


## Screenshots, if any

<img width="2857" height="1463" alt="Screenshot 2026-03-11 172629" src="https://github.com/user-attachments/assets/0e1feca3-3403-4916-9e1c-181edf9c0e1c" />
<img width="2860" height="1460" alt="Screenshot 2026-03-11 173835" src="https://github.com/user-attachments/assets/3462f510-03ce-4f72-8004-65c305cc5087" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-812]: https://mifosforge.jira.com/browse/WEB-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Permission System Enhancement**
  * Updated permission checks across toolbar and institutional submenu items to support evaluation of multiple permission types, ensuring more precise access control and visibility of navigation elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->