### PR TITLE
WEB-841 Update Cancel button styling in Floating Rate Periods dialog

### DIFF
--- a/src/app/products/floating-rates/floating-rate-period-dialog/floating-rate-period-dialog.component.html
+++ b/src/app/products/floating-rates/floating-rate-period-dialog/floating-rate-period-dialog.component.html
@@ -43,7 +43,7 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
+  <button mat-raised-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
   <button
     mat-raised-button
     color="primary"

--- a/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.html
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.html
@@ -44,7 +44,7 @@
       </mat-card-content>
 
       <mat-card-actions class="layout-row align-center gap-5px responsive-column">
-        <button type="button" mat-raised-button [routerLink]="['../']">
+        <button type="button" mat-button [routerLink]="['../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button


### PR DESCRIPTION
**Changes Made :-** 

-Changed Cancel button from mat-button to mat-raised-button in Floating Rate Periods dialog to maintain consistent styling across dialogs .

[WEB- 841 ](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-841)

Before :- 

<img width="1140" height="449" alt="image" src="https://github.com/user-attachments/assets/a2fc7147-2578-4191-9042-1dd1763e361d" />


After :- 

<img width="1114" height="454" alt="image" src="https://github.com/user-attachments/assets/7eb8a296-f8dd-4be1-9008-fd83cdb8bc78" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Cancel button styling in the Floating Rate Period dialog to use a raised button style for enhanced visual emphasis.
  * Modified Cancel button styling in the Create Range dialog to use a standard text button style for a streamlined appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->