### PR TITLE
WEB-842 Improve Browse button layout align icon and text side by side

### DIFF
--- a/src/app/shared/file-upload/file-upload.component.html
+++ b/src/app/shared/file-upload/file-upload.component.html
@@ -17,10 +17,9 @@
   </mat-form-field>
 
   <span class="flex-10 align-center">
-    <button mat-button (click)="uploadFile.click()">
+    <button mat-button (click)="uploadFile.click()" class="browse-button">
       <fa-icon icon="folder-open" size="lg"></fa-icon>
-      &nbsp;&nbsp;
-      {{ 'labels.buttons.Browse' | translate }}
+      <span>{{ 'labels.buttons.Browse' | translate }}</span>
     </button>
   </span>
 </div>

--- a/src/app/shared/file-upload/file-upload.component.scss
+++ b/src/app/shared/file-upload/file-upload.component.scss
@@ -5,3 +5,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+
+.browse-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}


### PR DESCRIPTION
Changes Made :- 

-Refactored Browse button in file-upload component to use flexbox for consistent icon-text alignment, replacing hardcoded non-breaking spaces with CSS gap property for cleaner, more maintainable styling. 

[WEB-842](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-842)

Before :- 

<img width="1041" height="408" alt="image" src="https://github.com/user-attachments/assets/e698aeed-0c85-4611-ba31-899789352b95" />


<img width="1156" height="438" alt="image" src="https://github.com/user-attachments/assets/fee99f38-2f1f-4f36-97b5-68b8702335b6" />


After :- 

<img width="1132" height="434" alt="image" src="https://github.com/user-attachments/assets/751b7c88-6fe1-4e19-96b9-76e67c608fda" />

<img width="1197" height="433" alt="image" src="https://github.com/user-attachments/assets/0565d24b-078c-45f5-98de-620c330f2e05" />



[WEB-842]: https://mifosforge.jira.com/browse/WEB-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the file upload browse button's layout and text structure for better alignment, spacing, and visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->