### PR TITLE
WEB-807 Add horizontal scrollbar to  datadable view

### DIFF
--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.html
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.html
@@ -24,116 +24,118 @@
     </div>
   </div>
 
-  <table mat-table #identifiersTable [dataSource]="clientIdentities" [ngStyle]="{ 'margin-top': '3%' }">
-    <ng-container matColumnDef="id">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Id' | translate }}</th>
-      <td mat-cell *matCellDef="let identity">{{ identity.id }}</td>
-    </ng-container>
+  <div class="table-container">
+    <table mat-table #identifiersTable [dataSource]="clientIdentities">
+      <ng-container matColumnDef="id">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Id' | translate }}</th>
+        <td mat-cell *matCellDef="let identity">{{ identity.id }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="type">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Type' | translate }}</th>
-      <td mat-cell *matCellDef="let identity">{{ identity.documentType.name }}</td>
-    </ng-container>
+      <ng-container matColumnDef="type">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Type' | translate }}</th>
+        <td mat-cell *matCellDef="let identity">{{ identity.documentType.name }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="documentKey">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Document Key' | translate }}</th>
-      <td mat-cell *matCellDef="let identity">{{ identity.documentKey }}</td>
-    </ng-container>
+      <ng-container matColumnDef="documentKey">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Document Key' | translate }}</th>
+        <td mat-cell *matCellDef="let identity">{{ identity.documentKey }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="description">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Description' | translate }}</th>
-      <td mat-cell *matCellDef="let identity">{{ identity.description }}</td>
-    </ng-container>
+      <ng-container matColumnDef="description">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Description' | translate }}</th>
+        <td mat-cell *matCellDef="let identity">{{ identity.description }}</td>
+      </ng-container>
 
-    <ng-container matColumnDef="documents">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Identity Documents' | translate }}</th>
-      <td mat-cell *matCellDef="let identity">
-        @if (identity.documents?.length) {
-          <div class="document-grid">
-            @for (document of identity.documents; track trackByDocumentId($index, document)) {
-              <div class="document-card">
-                <div
-                  class="thumb"
-                  [class.clickable]="isPreviewable(document)"
-                  role="button"
-                  tabindex="0"
-                  [attr.aria-label]="('labels.buttons.Preview' | translate) + ': ' + document.name"
-                  (keydown.enter)="isPreviewable(document) && openDocumentPreview(identity, document)"
-                  (keydown.space)="isPreviewable(document) && openDocumentPreview(identity, document)"
-                  (click)="isPreviewable(document) && openDocumentPreview(identity, document)"
-                >
-                  @if (previewThumbnails[document.id]) {
-                    <img
-                      [src]="previewThumbnails[document.id]"
-                      [alt]="document.name"
-                      [title]="document.name"
-                      loading="lazy"
-                    />
-                  } @else {
-                    <div class="placeholder">
-                      <fa-icon icon="file"></fa-icon>
-                      <span>{{ document.fileName || document.name }}</span>
-                    </div>
-                  }
-                  @if (isPreviewable(document)) {
-                    <div class="preview-overlay">
-                      <fa-icon icon="eye"></fa-icon>
-                    </div>
-                  }
+      <ng-container matColumnDef="documents">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Identity Documents' | translate }}</th>
+        <td mat-cell *matCellDef="let identity">
+          @if (identity.documents?.length) {
+            <div class="document-grid">
+              @for (document of identity.documents; track trackByDocumentId($index, document)) {
+                <div class="document-card">
+                  <div
+                    class="thumb"
+                    [class.clickable]="isPreviewable(document)"
+                    role="button"
+                    tabindex="0"
+                    [attr.aria-label]="('labels.buttons.Preview' | translate) + ': ' + document.name"
+                    (keydown.enter)="isPreviewable(document) && openDocumentPreview(identity, document)"
+                    (keydown.space)="isPreviewable(document) && openDocumentPreview(identity, document)"
+                    (click)="isPreviewable(document) && openDocumentPreview(identity, document)"
+                  >
+                    @if (previewThumbnails[document.id]) {
+                      <img
+                        [src]="previewThumbnails[document.id]"
+                        [alt]="document.name"
+                        [title]="document.name"
+                        loading="lazy"
+                      />
+                    } @else {
+                      <div class="placeholder">
+                        <fa-icon icon="file"></fa-icon>
+                        <span>{{ document.fileName || document.name }}</span>
+                      </div>
+                    }
+                    @if (isPreviewable(document)) {
+                      <div class="preview-overlay">
+                        <fa-icon icon="eye"></fa-icon>
+                      </div>
+                    }
+                  </div>
+                  <div class="card-body">
+                    <div class="title">{{ document.name }}</div>
+                    @if (document.fileName) {
+                      <div class="meta">{{ document.fileName }}</div>
+                    }
+                  </div>
                 </div>
-                <div class="card-body">
-                  <div class="title">{{ document.name }}</div>
-                  @if (document.fileName) {
-                    <div class="meta">{{ document.fileName }}</div>
-                  }
-                </div>
-              </div>
-            }
+              }
+            </div>
+          } @else {
+            <span class="muted">{{ 'labels.text.NoDocuments' | translate }}</span>
+          }
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Status' | translate }}</th>
+        <td mat-cell *matCellDef="let identity">
+          {{ identity.status === 'clientIdentifierStatusType.active' ? 'active' : 'inactive' }}
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+        <td mat-cell *matCellDef="let identity; let i = index">
+          <button
+            class="identity-action-button"
+            mat-raised-button
+            color="warn"
+            [title]="'labels.buttons.Delete' | translate"
+            [attr.aria-label]="'labels.buttons.Delete' | translate"
+            (click)="deleteIdentifier(identity.clientId, identity.id, i)"
+            *mifosxHasPermission="'DELETE_CLIENTIDENTIFIER'"
+          >
+            <fa-icon icon="times"></fa-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="no-data">
+        <td mat-footer-cell *matFooterCellDef [attr.colspan]="identitiesColumns.length">
+          <div class="table-empty-state">
+            <p>{{ 'labels.messages.No Identities Available' | translate }}</p>
           </div>
-        } @else {
-          <span class="muted">{{ 'labels.text.NoDocuments' | translate }}</span>
-        }
-      </td>
-    </ng-container>
+        </td>
+      </ng-container>
 
-    <ng-container matColumnDef="status">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Status' | translate }}</th>
-      <td mat-cell *matCellDef="let identity">
-        {{ identity.status === 'clientIdentifierStatusType.active' ? 'active' : 'inactive' }}
-      </td>
-    </ng-container>
-
-    <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-      <td mat-cell *matCellDef="let identity; let i = index">
-        <button
-          class="identity-action-button"
-          mat-raised-button
-          color="warn"
-          [title]="'labels.buttons.Delete' | translate"
-          [attr.aria-label]="'labels.buttons.Delete' | translate"
-          (click)="deleteIdentifier(identity.clientId, identity.id, i)"
-          *mifosxHasPermission="'DELETE_CLIENTIDENTIFIER'"
-        >
-          <fa-icon icon="times"></fa-icon>
-        </button>
-      </td>
-    </ng-container>
-
-    <ng-container matColumnDef="no-data">
-      <td mat-footer-cell *matFooterCellDef [attr.colspan]="identitiesColumns.length">
-        <div class="table-empty-state">
-          <p>{{ 'labels.messages.No Identities Available' | translate }}</p>
-        </div>
-      </td>
-    </ng-container>
-
-    <tr mat-header-row *matHeaderRowDef="identitiesColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: identitiesColumns"></tr>
-    @if (clientIdentities?.length === 0) {
-      <tr mat-footer-row *matFooterRowDef="['no-data']"></tr>
-    }
-  </table>
+      <tr mat-header-row *matHeaderRowDef="identitiesColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: identitiesColumns"></tr>
+      @if (clientIdentities?.length === 0) {
+        <tr mat-footer-row *matFooterRowDef="['no-data']"></tr>
+      }
+    </table>
+  </div>
 </div>
 
 <div #identityLightbox class="document-lightbox-host"></div>

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.scss
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.scss
@@ -20,8 +20,15 @@
     margin: 0;
   }
 
+  .table-container {
+    overflow-x: auto;
+    margin-top: 1rem;
+  }
+
   table {
     width: 100%;
+    min-width: 800px;
+    margin-top: 8px;
 
     .identity-action-button {
       min-width: 26px;


### PR DESCRIPTION
**Changes Made :-** 

-Added horizontal scrollbar to identities table by wrapping it in a scrollable container with overflow-x auto, enabling users to view all columns when the table has many fields without content being cut off or cramped. 

[WEB-807](http://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-807)

[WEB-807]: https://mifosforge.jira.com/browse/WEB-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Table wrapped in a scrollable container to enable horizontal scrolling and preserve layout on smaller screens.
  * Table minimum width enforced to maintain column structure.
  * Identity Documents column reorganized for clearer, nested presentation.
  * General markup formatting and indentation improved for more consistent structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->