### PR TITLE
WEB-850 fix(button): correct icon spacing and remove ineffective CSS ruel

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -719,22 +719,9 @@ mifosx-notifications-page td {
   color: inherit !important;
 }
 
-// ===== Global Button Icon Alignment =====
-// Handles the span + mat-icon pattern used throughout the application
-.mat-mdc-button,
-.mat-mdc-raised-button,
-.mat-mdc-outlined-button {
-  span {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-
-    mat-icon {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-    }
-  }
+// Keep tighter icon spacing only inside Material buttons
+.mat-mdc-button-base .m-r-10 {
+  margin-right: 4px;
 }
 
 .full-width-flex {


### PR DESCRIPTION
This PR fixes the spacing between button icons and text.


[WEB-850](https://mifosforge.jira.com/browse/WEB-850)



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-850]: https://mifosforge.jira.com/browse/WEB-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined icon spacing within Material buttons for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->