### PR TITLE
WEB-851 fix(gsim-account): prevent horizontal overflow by using layout-row-wrap

### DIFF
--- a/src/app/savings/gsim-account/gsim-account.component.html
+++ b/src/app/savings/gsim-account/gsim-account.component.html
@@ -13,11 +13,9 @@
     <!-- Group Summary Card -->
     @if (savingAccountData) {
       <mat-card class="m-b-20">
-        <mat-card-header>
-          <mat-card-title>{{ 'labels.heading.Group Summary' | translate }}</mat-card-title>
-        </mat-card-header>
         <mat-card-content>
-          <div class="layout-row layout-wrap">
+          <h3>{{ 'labels.heading.Group Summary' | translate }}</h3>
+          <div class="layout-row-wrap">
             <div class="flex-50 m-b-10">
               <strong>{{ 'labels.inputs.Group' | translate }}:</strong>
               {{ groupsData?.groupName || ('labels.inputs.N/A' | translate) }}

--- a/src/app/savings/gsim-account/gsim-account.component.ts
+++ b/src/app/savings/gsim-account/gsim-account.component.ts
@@ -25,7 +25,7 @@ import {
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { NgClass } from '@angular/common';
 import { MatTooltip } from '@angular/material/tooltip';
-import { MatCard, MatCardHeader, MatCardTitle, MatCardContent } from '@angular/material/card';
+import { MatCard, MatCardContent } from '@angular/material/card';
 import { StatusLookupPipe } from '../../pipes/status-lookup.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
@@ -68,8 +68,6 @@ interface GroupData {
     MatRow,
     MatPaginator,
     MatCard,
-    MatCardHeader,
-    MatCardTitle,
     MatCardContent,
     StatusLookupPipe
   ]


### PR DESCRIPTION
This PR fixes layout issues in the GSIM Account page related to horizontal overflow and header alignment.
[WEB-851](https://mifosforge.jira.com/browse/WEB-851)

Before:
<img width="1835" height="778" alt="image" src="https://github.com/user-attachments/assets/427555a0-8921-4eda-948c-8851ec2c3da5" />
After:
<img width="1915" height="972" alt="image" src="https://github.com/user-attachments/assets/05a21b3b-a9ac-48f9-bdd5-f4c81b0c19f4" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-851]: https://mifosforge.jira.com/browse/WEB-851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the Group Summary section header appearance with a simplified design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->