### PR TITLE
WEB-852 fix(glim-account): resolve empty page when opening GLIM application create route

### DIFF
--- a/src/app/core/i18n/i18n.service.ts
+++ b/src/app/core/i18n/i18n.service.ts
@@ -13,7 +13,9 @@ import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class I18nService {
   // eslint-disable-next-line @angular-eslint/prefer-inject
   constructor(private translateService: TranslateService) {}


### PR DESCRIPTION
This pr fixed a critical issue where the GLIM (Group Loan Individual Monitoring) Application creation page was rendering blank when accessed via the Groups module. The root cause was a missing dependency injection provider for I18nService in the standalone CreateGlimAccountComponent.

[WEB-852](https://mifosforge.jira.com/browse/WEB-852)

Before:
<img width="1908" height="1064" alt="image" src="https://github.com/user-attachments/assets/dbcc8015-0588-48e8-97e1-f50e5d23dbf5" />
After:
<img width="1914" height="1065" alt="image" src="https://github.com/user-attachments/assets/bbb07e25-6233-4b43-b2aa-8d15fb258335" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-852]: https://mifosforge.jira.com/browse/WEB-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized application service configuration for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->