### PR TITLE
WEB-853 fix(unassign-staff-dialog): resolve styling inconsistency in Unassign Staff dialog

### DIFF
--- a/src/app/savings/saving-account-actions/savings-account-unassign-staff/savings-account-unassign-staff.component.html
+++ b/src/app/savings/saving-account-actions/savings-account-unassign-staff/savings-account-unassign-staff.component.html
@@ -10,25 +10,27 @@
   <mat-card>
     <form [formGroup]="savingsUnassignStaffForm" (ngSubmit)="submit()">
       <mat-card-content>
-        <mat-form-field class="flex-fill" (click)="unassignedDatePicker.open()">
-          <mat-label>{{ 'labels.inputs.Unassignment Date' | translate }}</mat-label>
-          <input
-            matInput
-            [min]="minDate"
-            [max]="maxDate"
-            [matDatepicker]="unassignedDatePicker"
-            required
-            formControlName="unassignedDate"
-          />
-          <mat-datepicker-toggle matSuffix [for]="unassignedDatePicker"></mat-datepicker-toggle>
-          <mat-datepicker #unassignedDatePicker></mat-datepicker>
-          @if (savingsUnassignStaffForm.controls.unassignedDate.hasError('required')) {
-            <mat-error>
-              {{ 'labels.inputs.Unassignment Date' | translate }} {{ 'labels.commons.is' | translate }}
-              <strong>{{ 'labels.commons.required' | translate }}</strong>
-            </mat-error>
-          }
-        </mat-form-field>
+        <div class="layout-column">
+          <mat-form-field class="flex-fill" (click)="unassignedDatePicker.open()">
+            <mat-label>{{ 'labels.inputs.Unassignment Date' | translate }}</mat-label>
+            <input
+              matInput
+              [min]="minDate"
+              [max]="maxDate"
+              [matDatepicker]="unassignedDatePicker"
+              required
+              formControlName="unassignedDate"
+            />
+            <mat-datepicker-toggle matSuffix [for]="unassignedDatePicker"></mat-datepicker-toggle>
+            <mat-datepicker #unassignedDatePicker></mat-datepicker>
+            @if (savingsUnassignStaffForm.controls.unassignedDate.hasError('required')) {
+              <mat-error>
+                {{ 'labels.inputs.Unassignment Date' | translate }} {{ 'labels.commons.is' | translate }}
+                <strong>{{ 'labels.commons.required' | translate }}</strong>
+              </mat-error>
+            }
+          </mat-form-field>
+        </div>
       </mat-card-content>
 
       <mat-card-actions class="layout-row align-center gap-5px responsive-column">


### PR DESCRIPTION
This PR fixes the styling inconsistency in the Savings Account Unassign Staff dialog. The dialog was not following the same layout pattern as other action dialogs in the application.

[WEB-853](https://mifosforge.jira.com/browse/WEB-853)

Before:
<img width="840" height="260" alt="image" src="https://github.com/user-attachments/assets/9e5190a6-b4ec-4d37-9b0e-0ed0fa00fda4" />
After:
<img width="870" height="264" alt="image" src="https://github.com/user-attachments/assets/789e1d42-ffbc-4fa7-93ad-84936f60c3bd" />



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-853]: https://mifosforge.jira.com/browse/WEB-853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor layout restructuring for the savings account unassign feature with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->