### PR TITLE
WEB-855 fix(transaction-dialog): apply dark mode styling to confirm transaction dialog in savings deposit/withdrawal flow

### DIFF
--- a/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.scss
+++ b/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.scss
@@ -42,11 +42,9 @@
   font-size: 1.1rem;
   font-weight: 500;
   margin-bottom: 1.5rem;
-  color: #333;
 }
 
 .confirmation-details {
-  background-color: #f5f5f5;
   border-radius: 4px;
   padding: 1rem;
   margin-bottom: 1.5rem;
@@ -56,14 +54,14 @@
   display: flex;
   justify-content: space-between;
   padding: 0.75rem 0;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--md-sys-color-outline-variant, #e0e0e0);
 
   &:last-child {
     border-bottom: none;
   }
 
   &.highlight {
-    background-color: #e8f5e9;
+    background-color: var(--md-sys-color-secondary-container, #e8f5e9);
     padding: 1rem;
     margin: 0.5rem -1rem;
     border-radius: 4px;
@@ -72,17 +70,16 @@
 
 .detail-label {
   font-weight: 500;
-  color: #666;
 }
 
 .detail-value {
-  color: #333;
+  color: var(--md-sys-color-on-surface, #333);
   text-align: right;
 
   &.amount {
     font-size: 1.2rem;
     font-weight: 600;
-    color: #2e7d32;
+    color: var(--md-sys-color-tertiary, #2e7d32);
   }
 }
 
@@ -100,20 +97,20 @@
 }
 
 .success-icon {
-  color: #4caf50;
+  color: var(--md-sys-color-tertiary, #4caf50);
   margin-bottom: 1rem;
 }
 
 .success-title {
   font-size: 1.3rem;
   font-weight: 500;
-  color: #333;
+  color: var(--md-sys-color-on-surface, #333);
   margin: 0;
 }
 
 .transaction-details {
-  background-color: #fff;
-  border: 1px solid #e0e0e0;
+  background-color: var(--md-sys-color-surface, #fff);
+  border: 1px solid var(--md-sys-color-outline-variant, #e0e0e0);
   border-radius: 4px;
   padding: 1.5rem;
   margin: 0 auto 2rem;


### PR DESCRIPTION
This PR fixes a UI inconsistency in the "Confirm Transaction Details" dialog used in the savings account deposit and withdrawal flow.
When the application is in dark mode, the dialog still appears with light mode colors, which creates an inconsistent user experience compared to the rest of the interface.

[WEB-855](https://mifosforge.jira.com/browse/WEB-855)

Before:
<img width="1299" height="970" alt="Screenshot 2026-03-13 202123" src="https://github.com/user-attachments/assets/ee112860-47b2-4d28-a613-be7bf678aa9b" />
After:
<img width="739" height="431" alt="image" src="https://github.com/user-attachments/assets/d488d217-080d-47f4-9ce4-5fe6ad91169a" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-855]: https://mifosforge.jira.com/browse/WEB-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Switched transaction screen colors to theme-aware variables, improving consistency with the app theming system.
  * Enhanced dark theme readability for savings account transactions, confirmation details, success states, and amount values while preserving existing layout and alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->