### PR TITLE
WEB-856 fix(gsim-account): simplify onRowClick navigation logic

### DIFF
--- a/src/app/savings/gsim-account/gsim-account.component.html
+++ b/src/app/savings/gsim-account/gsim-account.component.html
@@ -139,7 +139,10 @@
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr
         mat-row
-        [routerLink]="['/savings-accounts', row.id, 'transactions']"
+        (click)="onRowClick(row)"
+        (keydown.enter)="onRowClick(row)"
+        tabindex="0"
+        class="select-row"
         *matRowDef="let row; columns: displayedColumns"
       ></tr>
     </table>

--- a/src/app/savings/gsim-account/gsim-account.component.ts
+++ b/src/app/savings/gsim-account/gsim-account.component.ts
@@ -22,7 +22,7 @@ import {
   MatRowDef,
   MatRow
 } from '@angular/material/table';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { NgClass } from '@angular/common';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatCard, MatCardContent } from '@angular/material/card';
@@ -38,6 +38,21 @@ interface SavingAccount {
   };
   summary?: {
     accountBalance: number;
+  };
+}
+
+interface ChildGsimAccount {
+  id: number;
+  displayName: string;
+  accountNo: string;
+  productName: string;
+  clientId?: number;
+  status: {
+    code: string;
+    value: string;
+    active: boolean;
+    submittedAndPendingApproval: boolean;
+    approved: boolean;
   };
 }
 
@@ -74,6 +89,7 @@ interface GroupData {
 })
 export class GsimAccountComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private router = inject(Router);
   dialog = inject(MatDialog);
 
   /** Columns to be displayed in charge overview table. */
@@ -85,9 +101,9 @@ export class GsimAccountComponent implements OnInit {
     'Actions'
   ];
   /** Data source for charge overview table. */
-  dataSource: MatTableDataSource<any>;
+  dataSource: MatTableDataSource<ChildGsimAccount>;
   /** Charge Overview data */
-  gsimOverviewData: any;
+  gsimOverviewData: ChildGsimAccount[];
 
   savingAccountData: SavingAccount | null = null;
 
@@ -134,5 +150,35 @@ export class GsimAccountComponent implements OnInit {
    */
   routeEdit($event: MouseEvent) {
     $event.stopPropagation();
+  }
+
+  /**
+   * Navigates to the savings account transactions page if the account is active,
+   * otherwise navigates to the client detail page.
+   * @param row Member account row data
+   */
+  onRowClick(row: ChildGsimAccount) {
+    if (row.status?.active) {
+      this.router.navigate([
+        '/savings-accounts',
+        row.id,
+        'transactions'
+      ]);
+      return;
+    }
+
+    // Prefer explicit clientId if available from API, otherwise parse from displayName format "(clientId) clientName"
+    const clientId = row.clientId ?? row.displayName?.match(/^\((\d+)\)/)?.[1];
+    if (clientId) {
+      this.router.navigate([
+        '/clients',
+        clientId
+      ]);
+    } else {
+      this.router.navigate([
+        '/groups',
+        this.groupId
+      ]);
+    }
   }
 }


### PR DESCRIPTION
This change improves and simplifies the GSIM account member row navigation logic.
The previous implementation attempted to access row.clientId, which is not returned by the GSIM API. This caused incorrect navigation behavior and made the logic harder to maintain.
The navigation logic has been refactored to make it clearer, safer, and more reliable.

[WEB-856](https://mifosforge.jira.com/browse/WEB-856)

https://github.com/user-attachments/assets/c049cf4a-844a-40ef-9379-71c8842c9541


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-856]: https://mifosforge.jira.com/browse/WEB-856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated table row selection to use event-driven navigation; row activation now triggers conditional navigation to transactions or to client/group pages based on account status.

* **Accessibility**
  * Made table rows keyboard-focusable and selectable (supports Enter key and click) for improved keyboard navigation and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->