### PR TITLE
WEB-844: Hamburguer menu grant-treasurer

### DIFF
--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -208,7 +208,17 @@
         </button>
 
         @if (isActive()) {
-          <button mat-menu-item [matMenuTriggerFor]="accountApplications">
+          <button
+            mat-menu-item
+            [matMenuTriggerFor]="accountApplications"
+            *mifosxHasPermission="[
+              'CREATE_LOAN',
+              'CREATE_SAVINGSACCOUNT',
+              'CREATE_SHAREACCOUNT',
+              'CREATE_RECURRINGDEPOSITACCOUNT',
+              'CREATE_FIXEDDEPOSITACCOUNT'
+            ]"
+          >
             <mat-icon matListIcon>
               <fa-icon icon="money-bill-alt" size="sm"></fa-icon>
             </mat-icon>


### PR DESCRIPTION
JIRA TICKET: [WEB-844](https://mifosforge.jira.com/browse/WEB-844)

## Description

Applications button in the client hamburger menu lacked permission guard on the parent trigger button. Child items inside had individual mifosxHasPermission checks, but the parent button always rendered when the client was active, regardless of the user's permissions. When RBAC is enabled, this causes the Applications button to appear even for roles that have none of the application creation permissions.

The treasurer role hamburger menu fix is complete.


## Screenshots, if any
<img width="2733" height="1461" alt="Screenshot 2026-03-15 105502" src="https://github.com/user-attachments/assets/224be761-c5e3-4f4b-a0f3-c110e1cc0806" />
<img width="2724" height="1458" alt="Screenshot 2026-03-15 105521" src="https://github.com/user-attachments/assets/5733e6b2-ec6e-4d92-8fd7-73b74f8735c6" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-844]: https://mifosforge.jira.com/browse/WEB-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added permission-based access control to account application creation features, restricting access to authorized users only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->