### PR TITLE
WEB-710 Loan Cycle Fields Allow Negative Values

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -85,7 +85,7 @@
         @if (loanProductTermsForm.value.allowApprovedDisbursedAmountsOverApplied) {
           <mat-form-field class="flex-fill flex-32">
             <mat-label>{{ 'labels.inputs.Over Amount' | translate }}</mat-label>
-            <input type="number" matInput formControlName="overAppliedNumber" required />
+            <input type="number" matInput formControlName="overAppliedNumber" required [min]="0" />
             <mat-error
               *ngIf="
                 loanProductTermsForm.get('overAppliedNumber')?.hasError('required') &&
@@ -345,7 +345,7 @@
           </mat-form-field>
           <mat-form-field class="flex-31">
             <mat-label>{{ 'labels.inputs.Differential Rate' | translate }}</mat-label>
-            <input type="number" matInput formControlName="interestRateDifferential" required />
+            <input type="number" matInput formControlName="interestRateDifferential" required [min]="0" />
             <mat-error>
               {{ 'labels.inputs.Differential rate' | translate }} {{ 'labels.commons.is' | translate }}
               <strong>{{ 'labels.commons.required' | translate }}</strong>
@@ -368,7 +368,7 @@
           </mat-form-field>
           <mat-form-field class="flex-31">
             <mat-label>{{ 'labels.inputs.Default' | translate }}</mat-label>
-            <input type="number" matInput formControlName="defaultDifferentialLendingRate" required />
+            <input type="number" matInput formControlName="defaultDifferentialLendingRate" required [min]="0" />
             <mat-error>
               {{ 'labels.catalogs.Default' | translate }} {{ 'labels.inputs.Interest rate' | translate }}
               {{ 'labels.commons.is' | translate }}
@@ -377,7 +377,7 @@
           </mat-form-field>
           <mat-form-field class="flex-31">
             <mat-label>{{ 'labels.inputs.Maximum' | translate }}</mat-label>
-            <input type="number" matInput formControlName="maxDifferentialLendingRate" required />
+            <input type="number" matInput formControlName="maxDifferentialLendingRate" required [min]="0" />
             <mat-error>
               {{ 'labels.inputs.Maximum interest rate' | translate }} {{ 'labels.commons.is' | translate }}
               <strong>{{ 'labels.commons.required' | translate }}</strong>
@@ -665,7 +665,7 @@
       @if (allowFixedLength()) {
         <mat-form-field class="flex-30">
           <mat-label>{{ 'labels.inputs.Fixed Length' | translate }}</mat-label>
-          <input type="number" matInput formControlName="fixedLength" />
+          <input type="number" matInput formControlName="fixedLength" [min]="0" />
         </mat-form-field>
       }
       @if (allowFixedLength()) {

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -587,6 +587,7 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
         value: values ? values.borrowerCycleNumber : undefined,
         type: 'number',
         required: true,
+        min: 0,
         order: 2
       }),
       new InputBase({
@@ -594,6 +595,7 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
         label: this.translateService.instant('labels.inputs.Minimum'),
         value: values ? values.minValue : undefined,
         type: 'number',
+        min: 0,
         order: 3
       }),
       new InputBase({
@@ -602,6 +604,7 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
         value: values ? values.defaultValue : undefined,
         type: 'number',
         required: true,
+        min: 0,
         order: 4
       }),
       new InputBase({
@@ -609,6 +612,7 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
         label: this.translateService.instant('labels.inputs.Maximum'),
         value: values ? values.maxValue : undefined,
         type: 'number',
+        min: 0,
         order: 5
       })
     ];


### PR DESCRIPTION
**Changes Made :-**

-Fixed validation in loan cycle dialogs (Principal, Number of Repayments, Nominal Interest Rate) by adding min:0 constraints to prevent negative values in numeric fields (minValue, defaultValue, maxValue, borrowerCycleNumber, overAppliedNumber, interestRateDifferential, and related fields).

[WEB-710](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-710)

[WEB-710]: https://mifosforge.jira.com/browse/WEB-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation on the loan product configuration form. Numeric input fields including over amounts, interest rate differentials, default and maximum lending rates, borrower cycle numbers, and fixed length parameters now prevent negative value entry, ensuring more accurate and consistent data input across the entire loan product setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->