### PR TITLE
WEB-707 Allowing Negative Values in Loan Product Numeric Fields

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
@@ -615,7 +615,7 @@
         <div class="flex-100 layout-row">
           <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Maximum allowed outstanding balance' | translate }}</mat-label>
-            <input matInput type="number" formControlName="maxOutstandingLoanBalance" />
+            <input matInput type="number" formControlName="maxOutstandingLoanBalance" min="0" />
             @if (loansAccountTermsForm.controls.maxOutstandingLoanBalance.hasError('required')) {
               <mat-error>
                 {{ 'labels.inputs.Maximum allowed outstanding balance' | translate }}

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -305,12 +305,15 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         if (this.allowAddDisbursementDetails()) {
           this.loansAccountTermsForm.addControl(
             'maxOutstandingLoanBalance',
-            new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null, Validators.required)
+            new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null, [
+              Validators.required,
+              Validators.min(0)
+            ])
           );
         } else {
           this.loansAccountTermsForm.addControl(
             'maxOutstandingLoanBalance',
-            new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null)
+            new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null, [Validators.min(0)])
           );
         }
       }
@@ -409,12 +412,15 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         this.loansAccountTermsForm.removeControl('maxOutstandingLoanBalance');
         this.loansAccountTermsForm.addControl(
           'maxOutstandingLoanBalance',
-          new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null, Validators.required)
+          new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null, [
+            Validators.required,
+            Validators.min(0)
+          ])
         );
       } else {
         this.loansAccountTermsForm.addControl(
           'maxOutstandingLoanBalance',
-          new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null)
+          new UntypedFormControl(this.loansAccountTermsData?.maxOutstandingLoanBalance ?? null, [Validators.min(0)])
         );
       }
     } else if (this.loanProductService.isWorkingCapital) {

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -187,6 +187,7 @@
               matTooltip="{{ 'tooltips.Maximum number of disbursements' | translate }}"
               formControlName="maxTrancheCount"
               required
+              min="0"
             />
             @if (loanProductSettingsForm.controls.maxTrancheCount.hasError('required')) {
               <mat-error>
@@ -202,6 +203,7 @@
               matInput
               matTooltip="{{ 'tooltips.Maximum outstanding loan account balance' | translate }}"
               formControlName="outstandingLoanBalance"
+              min="0"
             />
           </mat-form-field>
           <mat-checkbox class="flex-48 margin-v" labelPosition="before" formControlName="disallowExpectedDisbursements">
@@ -470,7 +472,7 @@
           <h4 class="mat-h4 flex-98">{{ 'labels.inputs.Variable Installments' | translate }}</h4>
           <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Minimum gap between Installments' | translate }}</mat-label>
-            <input type="number" matInput formControlName="minimumGap" required />
+            <input type="number" matInput formControlName="minimumGap" required min="0" />
             <mat-error>
               {{ 'labels.inputs.Minimum gap between Installments' | translate }} {{ 'labels.commons.is' | translate }}
               <strong>{{ 'labels.commons.required' | translate }}</strong>
@@ -478,7 +480,7 @@
           </mat-form-field>
           <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Maximum gap between Installments' | translate }}</mat-label>
-            <input type="number" matInput formControlName="maximumGap" required />
+            <input type="number" matInput formControlName="maximumGap" required min="0" />
             <mat-error>
               {{ 'labels.inputs.Maximum gap between Installments' | translate }} {{ 'labels.commons.is' | translate }}
               <strong>{{ 'labels.commons.required' | translate }}</strong>
@@ -758,7 +760,7 @@
         <div class="flex-fill layout-row-wrap gap-2percent responsive-column">
           <mat-form-field class="flex-31">
             <mat-label>{{ 'labels.inputs.Mandatory Guarantee(%)' | translate }}</mat-label>
-            <input type="number" matInput formControlName="mandatoryGuarantee" required />
+            <input type="number" matInput formControlName="mandatoryGuarantee" required min="0" />
             <mat-error>
               {{ 'labels.inputs.Mandatory Guarantee' | translate }} {{ 'labels.commons.is' | translate }}
               <strong>{{ 'labels.commons.required' | translate }}</strong>
@@ -766,11 +768,11 @@
           </mat-form-field>
           <mat-form-field class="flex-31">
             <mat-label>{{ 'labels.inputs.Minimum Guarantee from Own Funds(%)' | translate }}</mat-label>
-            <input type="number" matInput formControlName="minimumGuaranteeFromOwnFunds" />
+            <input type="number" matInput formControlName="minimumGuaranteeFromOwnFunds" min="0" />
           </mat-form-field>
           <mat-form-field class="flex-31">
             <mat-label>{{ 'labels.inputs.Minimum Guarantee from Guarantor Funds(%)' | translate }}</mat-label>
-            <input type="number" matInput formControlName="minimumGuaranteeFromGuarantor" />
+            <input type="number" matInput formControlName="minimumGuaranteeFromGuarantor" min="0" />
           </mat-form-field>
         </div>
       }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -497,8 +497,20 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
         .get('allowVariableInstallments')
         .valueChanges.subscribe((allowVariableInstallments: any) => {
           if (allowVariableInstallments) {
-            this.loanProductSettingsForm.addControl('minimumGap', new UntypedFormControl('', Validators.required));
-            this.loanProductSettingsForm.addControl('maximumGap', new UntypedFormControl('', Validators.required));
+            this.loanProductSettingsForm.addControl(
+              'minimumGap',
+              new UntypedFormControl('', [
+                Validators.required,
+                Validators.min(0)
+              ])
+            );
+            this.loanProductSettingsForm.addControl(
+              'maximumGap',
+              new UntypedFormControl('', [
+                Validators.required,
+                Validators.min(0)
+              ])
+            );
           } else {
             this.loanProductSettingsForm.removeControl('minimumGap');
             this.loanProductSettingsForm.removeControl('maximumGap');
@@ -662,10 +674,19 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
         if (holdGuaranteeFunds) {
           this.loanProductSettingsForm.addControl(
             'mandatoryGuarantee',
-            new UntypedFormControl('', Validators.required)
+            new UntypedFormControl('', [
+              Validators.required,
+              Validators.min(0)
+            ])
           );
-          this.loanProductSettingsForm.addControl('minimumGuaranteeFromOwnFunds', new UntypedFormControl(''));
-          this.loanProductSettingsForm.addControl('minimumGuaranteeFromGuarantor', new UntypedFormControl(''));
+          this.loanProductSettingsForm.addControl(
+            'minimumGuaranteeFromOwnFunds',
+            new UntypedFormControl('', [Validators.min(0)])
+          );
+          this.loanProductSettingsForm.addControl(
+            'minimumGuaranteeFromGuarantor',
+            new UntypedFormControl('', [Validators.min(0)])
+          );
         } else {
           this.loanProductSettingsForm.removeControl('mandatoryGuarantee');
           this.loanProductSettingsForm.removeControl('minimumGuaranteeFromOwnFunds');
@@ -675,8 +696,17 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
 
       this.loanProductSettingsForm.get('multiDisburseLoan').valueChanges.subscribe((multiDisburseLoan) => {
         if (multiDisburseLoan) {
-          this.loanProductSettingsForm.addControl('maxTrancheCount', new UntypedFormControl('', Validators.required));
-          this.loanProductSettingsForm.addControl('outstandingLoanBalance', new UntypedFormControl(''));
+          this.loanProductSettingsForm.addControl(
+            'maxTrancheCount',
+            new UntypedFormControl('', [
+              Validators.required,
+              Validators.min(0)
+            ])
+          );
+          this.loanProductSettingsForm.addControl(
+            'outstandingLoanBalance',
+            new UntypedFormControl('', [Validators.min(0)])
+          );
         } else {
           this.loanProductSettingsForm.removeControl('maxTrancheCount');
           this.loanProductSettingsForm.removeControl('outstandingLoanBalance');


### PR DESCRIPTION
**Changes Made :-** 

-Prevent negative values in loan product numeric input fields .

[WEB-707](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-707)

Before :- 

<img width="640" height="65" alt="image" src="https://github.com/user-attachments/assets/807d1816-9413-4e43-b555-ebd52f4854a1" />


<img width="640" height="49" alt="image" src="https://github.com/user-attachments/assets/9a0a983c-4cf5-446d-9c33-e4c994607050" />


<img width="640" height="84" alt="image" src="https://github.com/user-attachments/assets/6827b583-4082-41b8-ae6d-11706389bbf8" />


After :- 


<img width="942" height="120" alt="image" src="https://github.com/user-attachments/assets/2fa3f927-8f01-44b4-97ea-b7b7e190afb8" />


<img width="1063" height="157" alt="image" src="https://github.com/user-attachments/assets/3ae5b0fa-5e44-4197-9bc3-af4a15feef99" />


<img width="1036" height="163" alt="image" src="https://github.com/user-attachments/assets/1ffda437-91dc-467c-8b69-b91458129508" />


[WEB-707]: https://mifosforge.jira.com/browse/WEB-707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Enhancements**
  * Numeric inputs in loan account and product configuration forms now enforce non-negative values (min 0) for fields like tranche counts, outstanding balances, installment gaps, and guarantee amounts.
  * Validation adjustments ensure these constraints apply consistently when controls are shown or hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->