### PR TITLE
WEB-869 Standardize cancel button styling to mat raised button across different dialogs

### DIFF
--- a/src/app/system/manage-data-tables/column-dialog/column-dialog.component.html
+++ b/src/app/system/manage-data-tables/column-dialog/column-dialog.component.html
@@ -103,7 +103,7 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
+  <button mat-raised-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
   <button mat-raised-button color="primary" [disabled]="!columnForm.valid || columnForm.pristine" (click)="submit()">
     {{ 'labels.buttons.Submit' | translate }}
   </button>

--- a/src/app/system/manage-hooks/add-event-dialog/add-event-dialog.component.html
+++ b/src/app/system/manage-hooks/add-event-dialog/add-event-dialog.component.html
@@ -66,7 +66,7 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
+  <button mat-raised-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
   <button mat-raised-button color="primary" [disabled]="!eventForm.valid || eventForm.pristine" (click)="submit()">
     {{ 'labels.buttons.Submit' | translate }}
   </button>

--- a/src/app/system/manage-reports/report-parameter-dialog/report-parameter-dialog.component.html
+++ b/src/app/system/manage-reports/report-parameter-dialog/report-parameter-dialog.component.html
@@ -40,7 +40,7 @@
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  <button mat-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
+  <button mat-raised-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
   <button
     mat-raised-button
     color="primary"


### PR DESCRIPTION
**Changes Made :-** 

-Updated Cancel button styling from mat-button to mat-raised-button in three dialog components to maintain consistent styling across the application:

Report Parameter Dialog (manage-reports)
Add Event Dialog (manage-hooks)
Column Dialog (manage-data-tables) .

[WEB-869](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-869)

Before :- 

<img width="1365" height="526" alt="image" src="https://github.com/user-attachments/assets/5cb8dde7-4a88-4760-bda1-6d0790fea769" />


<img width="1365" height="701" alt="image" src="https://github.com/user-attachments/assets/caf1d1ff-6b06-4de8-adbd-3e911199ad4d" />

<img width="1361" height="700" alt="image" src="https://github.com/user-attachments/assets/33964df8-0c41-4790-860b-23b77e4c9f6b" />


After :- 

<img width="1365" height="533" alt="image" src="https://github.com/user-attachments/assets/70b70905-8c90-4147-97f4-914a14e344bc" />

<img width="1365" height="501" alt="image" src="https://github.com/user-attachments/assets/d4260f56-da69-4d28-aad9-3514eb069e96" />

<img width="1354" height="531" alt="image" src="https://github.com/user-attachments/assets/fd225527-85d1-44a8-a465-99f91a302437" />


[WEB-869]: https://mifosforge.jira.com/browse/WEB-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Cancel button styling in dialog components across column management, event management, and report parameter features to use raised button appearance for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->