### PR TITLE
WEB-873 Improve Cancel button styling in Delinquency Range create form

### DIFF
--- a/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.html
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.html
@@ -44,7 +44,7 @@
       </mat-card-content>
 
       <mat-card-actions class="layout-row align-center gap-5px responsive-column">
-        <button type="button" mat-button [routerLink]="['../']">
+        <button type="button" mat-raised-button [routerLink]="['../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button


### PR DESCRIPTION
**Changes Made :-** 

-Changed the Cancel button in the Create Delinquency Range component from mat-button to mat-raised-button to match the standard button styling used in other dialogs .

[WEB-873](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-873)

Before :- 

<img width="935" height="297" alt="image" src="https://github.com/user-attachments/assets/3ed8c9d7-92b3-4d41-9b2c-ddb237944a17" />


After :- 

<img width="816" height="304" alt="image" src="https://github.com/user-attachments/assets/8077bcad-f853-4c17-bdc3-4fb39aaa898a" />


[WEB-873]: https://mifosforge.jira.com/browse/WEB-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the cancel button styling in the delinquency range creation form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->