### PR TITLE
WEB-874 Prevent negative values in numeric fields of Group

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
@@ -47,6 +47,7 @@
           matInput
           required
           formControlName="repaymentEvery"
+          min="0"
           matTooltip="{{ 'tooltips.Fields are input to calculating the repayment schedule' | translate }}"
         />
         @if (loansAccountTermsForm.controls.repaymentEvery.hasError('required')) {
@@ -54,6 +55,9 @@
             {{ 'labels.inputs.Repaid every' | translate }} {{ 'labels.commons.is' | translate }}
             <strong>{{ 'labels.commons.required' | translate }}</strong>
           </mat-error>
+        }
+        @if (loansAccountTermsForm.controls.repaymentEvery.hasError('min')) {
+          <mat-error> {{ 'labels.inputs.Repaid every' | translate }} must be at least <strong>0</strong> </mat-error>
         }
       </mat-form-field>
 
@@ -72,12 +76,15 @@
     @if (loanProductService.isLoanProduct) {
       <mat-form-field class="flex-fill flex-23">
         <mat-label>{{ 'labels.inputs.Loan Term' | translate }}</mat-label>
-        <input type="number" matInput required formControlName="loanTermFrequency" />
+        <input type="number" matInput required formControlName="loanTermFrequency" min="0" />
         @if (loansAccountTermsForm.controls.loanTermFrequency.hasError('required')) {
           <mat-error>
             {{ 'labels.inputs.Loan Term' | translate }} {{ 'labels.commons.is' | translate }}
             <strong>{{ 'labels.commons.required' | translate }}</strong>
           </mat-error>
+        }
+        @if (loansAccountTermsForm.controls.loanTermFrequency.hasError('min')) {
+          <mat-error> {{ 'labels.inputs.Loan Term' | translate }} must be at least <strong>0</strong> </mat-error>
         }
       </mat-form-field>
 
@@ -118,12 +125,18 @@
           type="number"
           matInput
           formControlName="numberOfRepayments"
+          min="0"
           matTooltip="{{ 'tooltips.Enter the total count of repayments' | translate }}"
         />
         @if (loansAccountTermsForm.controls.numberOfRepayments.hasError('required')) {
           <mat-error>
             {{ 'labels.inputs.Number of repayments' | translate }} {{ 'labels.commons.is' | translate }}
             <strong>{{ 'labels.commons.required' | translate }}</strong>
+          </mat-error>
+        }
+        @if (loansAccountTermsForm.controls.numberOfRepayments.hasError('min')) {
+          <mat-error>
+            {{ 'labels.inputs.Number of repayments' | translate }} must be at least <strong>0</strong>
           </mat-error>
         }
       </mat-form-field>
@@ -178,6 +191,7 @@
           matInput
           required
           formControlName="repaymentEvery"
+          min="0"
           matTooltip="{{ 'tooltips.Fields are input to calculating the repayment schedule' | translate }}"
         />
         @if (loansAccountTermsForm.controls.repaymentEvery.hasError('required')) {
@@ -185,6 +199,9 @@
             {{ 'labels.inputs.Repaid every' | translate }} {{ 'labels.commons.is' | translate }}
             <strong>{{ 'labels.commons.required' | translate }}</strong>
           </mat-error>
+        }
+        @if (loansAccountTermsForm.controls.repaymentEvery.hasError('min')) {
+          <mat-error> {{ 'labels.inputs.Repaid every' | translate }} must be at least <strong>0</strong> </mat-error>
         }
       </mat-form-field>
 
@@ -247,7 +264,12 @@
       @if (!loansAccountTermsData?.isLoanProductLinkedToFloatingRate) {
         <mat-form-field class="flex-fill flex-23">
           <mat-label>{{ 'labels.inputs.Nominal interest rate' | translate }} %</mat-label>
-          <input type="number" matInput formControlName="interestRatePerPeriod" />
+          <input type="number" matInput formControlName="interestRatePerPeriod" min="0.01" step="0.01" />
+          @if (loansAccountTermsForm.controls.interestRatePerPeriod.hasError('min')) {
+            <mat-error>
+              {{ 'labels.inputs.Nominal interest rate' | translate }} must be at least <strong>0.01</strong>
+            </mat-error>
+          }
         </mat-form-field>
         <mat-form-field class="flex-fill flex-23">
           <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
@@ -428,17 +450,30 @@
           matInput
           type="number"
           formControlName="inArrearsTolerance"
+          min="0"
           matTooltip="{{ 'tooltips.With Arrears tolerance' | translate }}"
         />
+        @if (loansAccountTermsForm.controls.inArrearsTolerance.hasError('min')) {
+          <mat-error>
+            {{ 'labels.inputs.Arrears tolerance' | translate }} must be at least <strong>0</strong>
+          </mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field class="flex-48">
         <mat-label>{{ 'labels.inputs.Interest free period' | translate }}</mat-label>
         <input
           matInput
+          type="number"
           formControlName="graceOnInterestCharged"
+          min="0"
           matTooltip="{{ 'tooltips.If the Interest Free Period' | translate }}"
         />
+        @if (loansAccountTermsForm.controls.graceOnInterestCharged.hasError('min')) {
+          <mat-error>
+            {{ 'labels.inputs.Interest free period' | translate }} must be at least <strong>0</strong>
+          </mat-error>
+        }
       </mat-form-field>
 
       <h4 class="mat-h4 flex-98">
@@ -448,17 +483,32 @@
 
       <mat-form-field class="flex-fill flex-23">
         <mat-label>{{ 'labels.inputs.Grace on principal payment' | translate }}</mat-label>
-        <input type="number" matInput formControlName="graceOnPrincipalPayment" />
+        <input type="number" matInput formControlName="graceOnPrincipalPayment" min="0" />
+        @if (loansAccountTermsForm.controls.graceOnPrincipalPayment.hasError('min')) {
+          <mat-error>
+            {{ 'labels.inputs.Grace on principal payment' | translate }} must be at least <strong>0</strong>
+          </mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field class="flex-fill flex-23">
         <mat-label>{{ 'labels.inputs.Grace on interest payment' | translate }}</mat-label>
-        <input type="number" matInput formControlName="graceOnInterestPayment" />
+        <input type="number" matInput formControlName="graceOnInterestPayment" min="0" />
+        @if (loansAccountTermsForm.controls.graceOnInterestPayment.hasError('min')) {
+          <mat-error>
+            {{ 'labels.inputs.Grace on interest payment' | translate }} must be at least <strong>0</strong>
+          </mat-error>
+        }
       </mat-form-field>
 
       <mat-form-field class="flex-48">
         <mat-label>{{ 'labels.inputs.On arrears ageing' | translate }}</mat-label>
-        <input type="number" matInput formControlName="graceOnArrearsAgeing" />
+        <input type="number" matInput formControlName="graceOnArrearsAgeing" min="0" />
+        @if (loansAccountTermsForm.controls.graceOnArrearsAgeing.hasError('min')) {
+          <mat-error>
+            {{ 'labels.inputs.On arrears ageing' | translate }} must be at least <strong>0</strong>
+          </mat-error>
+        }
       </mat-form-field>
 
       @if (isDelinquencyEnabled()) {

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -454,6 +454,36 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         repaymentFrequencyDayOfWeekType.updateValueAndValidity();
       });
     });
+    const numericFieldsWithMinZero = [
+      'graceOnPrincipalPayment',
+      'graceOnInterestPayment',
+      'graceOnArrearsAgeing',
+      'inArrearsTolerance',
+      'graceOnInterestCharged',
+      'loanTermFrequency',
+      'numberOfRepayments',
+      'repaymentEvery'
+    ];
+
+    numericFieldsWithMinZero.forEach((fieldName) => {
+      const control = this.loansAccountTermsForm.get(fieldName);
+      if (control) {
+        control.valueChanges.subscribe((value) => {
+          if (typeof value === 'number' && value < 0) {
+            control.setValue(0, { emitEvent: false });
+          }
+        });
+      }
+    });
+
+    const interestRateControl = this.loansAccountTermsForm.get('interestRatePerPeriod');
+    if (interestRateControl) {
+      interestRateControl.valueChanges.subscribe((value) => {
+        if (typeof value === 'number' && value < 0.01) {
+          interestRateControl.setValue(0.01, { emitEvent: false });
+        }
+      });
+    }
   }
 
   /** Custom Listeners for the form to calculate Loan Term */
@@ -527,7 +557,10 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         ],
         loanTermFrequency: [
           { value: '', disabled: true },
-          Validators.required
+          [
+            Validators.required,
+            Validators.min(0)
+          ]
         ],
         loanTermFrequencyType: [
           '',
@@ -535,11 +568,17 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         ],
         numberOfRepayments: [
           '',
-          Validators.required
+          [
+            Validators.required,
+            Validators.min(0)
+          ]
         ],
         repaymentEvery: [
           '',
-          Validators.required
+          [
+            Validators.required,
+            Validators.min(0)
+          ]
         ],
         repaymentFrequencyType: [
           { value: '', disabled: true },
@@ -549,7 +588,10 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         repaymentFrequencyDayOfWeekType: [''],
         repaymentsStartingFromDate: [''],
         interestChargedFromDate: [''],
-        interestRatePerPeriod: [''],
+        interestRatePerPeriod: [
+          '',
+          Validators.min(0.01)
+        ],
         interestType: [''],
         isFloatingInterestRate: [null],
         isEqualAmortization: [''],
@@ -559,11 +601,26 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         ],
         interestCalculationPeriodType: [''],
         allowPartialPeriodInterestCalculation: [''],
-        inArrearsTolerance: [''],
-        graceOnInterestCharged: [''],
-        graceOnPrincipalPayment: [''],
-        graceOnInterestPayment: [''],
-        graceOnArrearsAgeing: [''],
+        inArrearsTolerance: [
+          '',
+          Validators.min(0)
+        ],
+        graceOnInterestCharged: [
+          '',
+          Validators.min(0)
+        ],
+        graceOnPrincipalPayment: [
+          '',
+          Validators.min(0)
+        ],
+        graceOnInterestPayment: [
+          '',
+          Validators.min(0)
+        ],
+        graceOnArrearsAgeing: [
+          '',
+          Validators.min(0)
+        ],
         loanIdToClose: [''],
         fixedEmiAmount: [''],
         isTopup: [''],

--- a/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.html
+++ b/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.html
@@ -20,11 +20,16 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Nominal Annual Interest' | translate }}</mat-label>
-      <input type="number" matInput formControlName="nominalAnnualInterestRate" required />
-      <mat-error>
-        {{ 'labels.inputs.Nominal Annual Interest' | translate }} {{ 'labels.commons.is' | translate }}
-        <strong>{{ 'labels.commons.required' | translate }}</strong>
-      </mat-error>
+      <input type="number" matInput formControlName="nominalAnnualInterestRate" required min="0" step="0.01" />
+      @if (savingsAccountTermsForm.controls.nominalAnnualInterestRate.hasError('required')) {
+        <mat-error>
+          {{ 'labels.inputs.Nominal Annual Interest' | translate }} {{ 'labels.commons.is' | translate }}
+          <strong>{{ 'labels.commons.required' | translate }}</strong>
+        </mat-error>
+      }
+      @if (savingsAccountTermsForm.controls.nominalAnnualInterestRate.hasError('min')) {
+        <mat-error> {{ 'labels.inputs.Nominal Annual Interest' | translate }} must be zero or greater </mat-error>
+      }
     </mat-form-field>
 
     <mat-form-field class="flex-48">
@@ -92,7 +97,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Minimum Opening Balance' | translate }}</mat-label>
-      <input type="number" matInput formControlName="minRequiredOpeningBalance" />
+      <input type="number" matInput formControlName="minRequiredOpeningBalance" min="0" />
     </mat-form-field>
 
     <mat-checkbox labelPosition="before" formControlName="withdrawalFeeForTransfers" class="margin-v flex-48">
@@ -103,7 +108,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="lockinPeriodFrequency" />
+      <input type="number" matInput formControlName="lockinPeriodFrequency" min="0" />
     </mat-form-field>
 
     <mat-form-field class="flex-48">
@@ -129,15 +134,15 @@
       <div class="flex-fill layout-row-wrap gap-2percent responsive-column">
         <mat-form-field class="flex-31">
           <mat-label>{{ 'labels.inputs.Minimum Overdraft Required for Interest Calculation' | translate }}</mat-label>
-          <input type="number" matInput formControlName="minOverdraftForInterestCalculation" />
+          <input type="number" matInput formControlName="minOverdraftForInterestCalculation" min="0" />
         </mat-form-field>
         <mat-form-field class="flex-31">
           <mat-label>{{ 'labels.inputs.Nominal Annual Interest for Overdraft' | translate }}</mat-label>
-          <input type="number" matInput formControlName="nominalAnnualInterestRateOverdraft" />
+          <input type="number" matInput formControlName="nominalAnnualInterestRateOverdraft" min="0" />
         </mat-form-field>
         <mat-form-field class="flex-31">
           <mat-label>{{ 'labels.inputs.Maximum Overdraft Amount Limit' | translate }}</mat-label>
-          <input type="number" matInput formControlName="overdraftLimit" />
+          <input type="number" matInput formControlName="overdraftLimit" min="0" />
         </mat-form-field>
       </div>
     }
@@ -150,13 +155,13 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Minimum Balance' | translate }}</mat-label>
-      <input type="number" matInput formControlName="minRequiredBalance" />
+      <input type="number" matInput formControlName="minRequiredBalance" min="0" />
     </mat-form-field>
 
     @if (savingsAccountTermsForm.controls.minBalanceForInterestCalculation.value) {
       <mat-form-field class="flex-48">
         <mat-label>{{ 'labels.inputs.Balance Required for Interest Calculation' | translate }}</mat-label>
-        <input type="number" matInput formControlName="minBalanceForInterestCalculation" />
+        <input type="number" matInput formControlName="minBalanceForInterestCalculation" min="0" />
       </mat-form-field>
     }
   </div>

--- a/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.ts
@@ -128,7 +128,10 @@ export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
       decimal: [{ value: '', disabled: true }],
       nominalAnnualInterestRate: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)
+        ]
       ],
       interestCompoundingPeriodType: [
         '',
@@ -146,13 +149,22 @@ export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
         '',
         Validators.required
       ],
-      minRequiredOpeningBalance: [''],
+      minRequiredOpeningBalance: [
+        '',
+        Validators.min(0)
+      ],
       withdrawalFeeForTransfers: [false],
-      lockinPeriodFrequency: [''],
+      lockinPeriodFrequency: [
+        '',
+        Validators.min(0)
+      ],
       lockinPeriodFrequencyType: [''],
       allowOverdraft: [false],
       enforceMinRequiredBalance: [false],
-      minRequiredBalance: [''],
+      minRequiredBalance: [
+        '',
+        Validators.min(0)
+      ],
       minBalanceForInterestCalculation: [{ value: '', disabled: true }]
     });
   }
@@ -173,11 +185,26 @@ export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
    * Subscribes to value changes and sets new form controls accordingly.
    */
   buildDependencies() {
+    const nominalInterestControl = this.savingsAccountTermsForm.get('nominalAnnualInterestRate');
+    if (nominalInterestControl) {
+      nominalInterestControl.valueChanges.subscribe((value) => {
+        if (typeof value === 'number' && value < 0) {
+          nominalInterestControl.setValue(0, { emitEvent: false });
+        }
+      });
+    }
+
     this.savingsAccountTermsForm.get('allowOverdraft').valueChanges.subscribe((allowOverdraft: any) => {
       if (allowOverdraft) {
-        this.savingsAccountTermsForm.addControl('minOverdraftForInterestCalculation', new UntypedFormControl(''));
-        this.savingsAccountTermsForm.addControl('nominalAnnualInterestRateOverdraft', new UntypedFormControl(''));
-        this.savingsAccountTermsForm.addControl('overdraftLimit', new UntypedFormControl(''));
+        this.savingsAccountTermsForm.addControl(
+          'minOverdraftForInterestCalculation',
+          new UntypedFormControl('', Validators.min(0))
+        );
+        this.savingsAccountTermsForm.addControl(
+          'nominalAnnualInterestRateOverdraft',
+          new UntypedFormControl('', Validators.min(0))
+        );
+        this.savingsAccountTermsForm.addControl('overdraftLimit', new UntypedFormControl('', Validators.min(0)));
       } else {
         this.savingsAccountTermsForm.removeControl('minOverdraftForInterestCalculation');
         this.savingsAccountTermsForm.removeControl('nominalAnnualInterestRateOverdraft');


### PR DESCRIPTION
**Changes Made :-** 

-Add min(0) validation to numeric fields in Savings Account Terms, Loans Account Terms, and GLIM account in GROUP . 

[WEB-874](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-874)

Before :- 

<img width="808" height="295" alt="image" src="https://github.com/user-attachments/assets/453978b2-888d-4215-849d-209feb63579c" />



<img width="1006" height="481" alt="image" src="https://github.com/user-attachments/assets/912bf52c-f11c-4bf2-980d-aa1102bd6589" />


<img width="935" height="312" alt="image" src="https://github.com/user-attachments/assets/74f4e806-1fb0-4184-8249-9851ab4d7a2a" />


<img width="920" height="443" alt="image" src="https://github.com/user-attachments/assets/05e3b957-e968-4576-91de-e0a636370384" />


<img width="856" height="201" alt="image" src="https://github.com/user-attachments/assets/4db8ab77-5bf0-463d-bbae-d10b5377c5fa" />


<img width="956" height="536" alt="image" src="https://github.com/user-attachments/assets/b25d4117-4eb0-4691-83e8-83a1f54df7fa" />


<img width="949" height="363" alt="image" src="https://github.com/user-attachments/assets/c99db92f-7c14-4ffb-af4f-eb7104b2a33e" />


After :-

<img width="909" height="368" alt="image" src="https://github.com/user-attachments/assets/2733748f-aaf8-4494-824b-dd2348f57cb6" />


<img width="930" height="305" alt="image" src="https://github.com/user-attachments/assets/ce8889c7-c3e6-4ef5-b8ea-2f186d073c37" />


<img width="932" height="218" alt="image" src="https://github.com/user-attachments/assets/2d2215cf-1b87-480a-abce-c750e7f50983" />


<img width="881" height="317" alt="image" src="https://github.com/user-attachments/assets/007722ef-fe3a-401f-8ed3-3d2fa84cc8c3" />


<img width="949" height="207" alt="image" src="https://github.com/user-attachments/assets/fc32f6ae-b189-4303-ba4b-58f426c273ea" />


<img width="1153" height="399" alt="image" src="https://github.com/user-attachments/assets/2ddfaf88-9976-418f-b588-fcb2129466de" />


<img width="857" height="355" alt="image" src="https://github.com/user-attachments/assets/4cbe4fc5-966b-4cb2-ba95-3b4e08a64ba2" />


[WEB-874]: https://mifosforge.jira.com/browse/WEB-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened numeric validation across loan and savings account setup: inputs now enforce non-negative minimums (interest rates, repayment terms, grace periods, balances, tolerance and overdraft values). Negative entries are prevented or automatically clamped and clear inline error messages are shown. Loan interest rate now requires at least 0.01, preventing near-zero invalid rates and improving form reliability during account setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->