### PR TITLE
WEB-876 :- Fix manage reports sass style

### DIFF
--- a/src/app/system/manage-reports/create-report/create-report.component.html
+++ b/src/app/system/manage-reports/create-report/create-report.component.html
@@ -10,7 +10,7 @@
   <mat-card>
     <form [formGroup]="reportForm" (ngSubmit)="submit()">
       <mat-card-content>
-        <div class="layout-row-wrap responsive-column">
+        <div class="layout-row-wrap responsive-column gap-2percent">
           <mat-form-field class="flex-100">
             <mat-label>{{ 'labels.inputs.Report Name' | translate }}</mat-label>
             <input matInput required formControlName="reportName" />
@@ -22,7 +22,7 @@
             }
           </mat-form-field>
 
-          <mat-form-field class="flex-50">
+          <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Report Type' | translate }}</mat-label>
             <mat-select required formControlName="reportType">
               @for (allowedReportType of reportTemplateData.allowedReportTypes; track allowedReportType) {
@@ -39,7 +39,7 @@
             }
           </mat-form-field>
 
-          <mat-form-field class="flex-50">
+          <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Report Sub Type' | translate }}</mat-label>
             <mat-select formControlName="reportSubType">
               @for (allowedReportSubType of reportTemplateData.allowedReportSubTypes; track allowedReportSubType) {
@@ -50,7 +50,7 @@
             </mat-select>
           </mat-form-field>
 
-          <mat-form-field class="flex-50">
+          <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Report Category' | translate }}</mat-label>
             <mat-select formControlName="reportCategory">
               @for (reportCategoryType of reportCategoryTypeOptions; track reportCategoryType) {
@@ -61,8 +61,8 @@
             </mat-select>
           </mat-form-field>
 
-          <div class="user-report-wrapper flex-50">
-            <mat-checkbox class="user-report" labelPosition="after" formControlName="useReport">
+          <div class="flex-48">
+            <mat-checkbox labelPosition="after" formControlName="useReport">
               {{ 'labels.inputs.User Report (UI)' | translate }}
             </mat-checkbox>
           </div>

--- a/src/app/system/manage-reports/create-report/create-report.component.scss
+++ b/src/app/system/manage-reports/create-report/create-report.component.scss
@@ -5,20 +5,3 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
-@media (width >= 992px) {
-  .user-report-wrapper {
-    position: relative;
-
-    .user-report {
-      padding: 0 0 17.5px;
-      position: absolute;
-      bottom: 0;
-    }
-  }
-}
-
-table {
-  width: 100%;
-  margin-top: 20px;
-}

--- a/src/app/system/manage-reports/edit-report/edit-report.component.html
+++ b/src/app/system/manage-reports/edit-report/edit-report.component.html
@@ -10,7 +10,7 @@
   <mat-card>
     <form [formGroup]="reportForm" (ngSubmit)="submit()">
       <mat-card-content>
-        <div class="layout-row-wrap responsive-column">
+        <div class="layout-row-wrap responsive-column gap-2percent">
           <mat-form-field class="flex-100">
             <mat-label>{{ 'labels.inputs.Report Name' | translate }}</mat-label>
             <input matInput required formControlName="reportName" />
@@ -22,7 +22,7 @@
             }
           </mat-form-field>
 
-          <mat-form-field class="flex-50">
+          <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Report Type' | translate }}</mat-label>
             <mat-select required formControlName="reportType">
               @for (allowedReportType of reportData.allowedReportTypes; track allowedReportType) {
@@ -39,7 +39,7 @@
             }
           </mat-form-field>
 
-          <mat-form-field class="flex-50">
+          <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Report Sub Type' | translate }}</mat-label>
             <mat-select formControlName="reportSubType">
               @for (allowedReportSubType of reportData.allowedReportSubTypes; track allowedReportSubType) {
@@ -50,7 +50,7 @@
             </mat-select>
           </mat-form-field>
 
-          <mat-form-field class="flex-50">
+          <mat-form-field class="flex-48">
             <mat-label>{{ 'labels.inputs.Report Category' | translate }}</mat-label>
             <mat-select formControlName="reportCategory">
               @for (reportCategoryType of reportCategoryTypeOptions; track reportCategoryType) {
@@ -61,8 +61,8 @@
             </mat-select>
           </mat-form-field>
 
-          <div class="flex-50">
-            <mat-checkbox class="user-report" labelPosition="after" formControlName="useReport">
+          <div class="flex-48">
+            <mat-checkbox labelPosition="after" formControlName="useReport">
               {{ 'labels.inputs.User Report (UI)' | translate }}
             </mat-checkbox>
           </div>

--- a/src/app/system/manage-reports/edit-report/edit-report.component.scss
+++ b/src/app/system/manage-reports/edit-report/edit-report.component.scss
@@ -5,19 +5,3 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
-@media (width >= 992px) {
-  .user-report-wrapper {
-    position: relative;
-
-    .user-report {
-      padding: 0 0 17.5px;
-      position: absolute;
-      bottom: 0;
-    }
-  }
-}
-
-table {
-  width: 100%;
-}


### PR DESCRIPTION
## Description

Fix manage reports sass style

before
<img width="1454" height="795" alt="image" src="https://github.com/user-attachments/assets/b1d21ec1-9817-4111-9caf-600124f0b89c" />
<img width="1395" height="809" alt="image" src="https://github.com/user-attachments/assets/db4e46b9-d9dc-4c08-9437-02dcf7999c20" />

after
<img width="1481" height="818" alt="after 2" src="https://github.com/user-attachments/assets/65d1a1a5-3936-40d3-8859-67d5b9420bc5" />
<img width="1468" height="822" alt="after" src="https://github.com/user-attachments/assets/c44d8813-707a-41b0-8183-0e8cc47b9996" />

mobile screens after
<img width="515" height="845" alt="image" src="https://github.com/user-attachments/assets/5715951b-507c-4b6f-a2c6-fd31fbfa976f" />
<img width="533" height="801" alt="image" src="https://github.com/user-attachments/assets/d941bbf0-f140-406d-b52e-7b84b639458c" />


## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced form layout spacing in report management forms with improved column width distribution for better visual balance.
  * Refined form structure across report creation and editing interfaces for cleaner, more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->