### PR TITLE
WEB-879 Handle API response where report category returns '(NULL)' string

### DIFF
--- a/src/app/system/manage-reports/manage-reports.component.html
+++ b/src/app/system/manage-reports/manage-reports.component.html
@@ -42,7 +42,9 @@
 
       <ng-container matColumnDef="reportCategory">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Report Category' | translate }}</th>
-        <td mat-cell *matCellDef="let report">{{ report.reportCategory | translateKey: 'catalogs' }}</td>
+        <td mat-cell *matCellDef="let report">
+          {{ report.reportCategory ? (report.reportCategory | translateKey: 'catalogs') : '' }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="coreReport">

--- a/src/app/system/manage-reports/manage-reports.component.ts
+++ b/src/app/system/manage-reports/manage-reports.component.ts
@@ -118,7 +118,14 @@ export class ManageReportsComponent implements OnInit, AfterViewInit {
    * Initializes the data source, paginator and sorter for reports table.
    */
   setReports() {
-    this.dataSource = new MatTableDataSource(this.reportsData);
+    // Transform data to replace "(NULL)" strings with null
+    const transformedData = this.reportsData.map((report: any) => ({
+      ...report,
+      reportCategory: report.reportCategory === '(NULL)' ? null : report.reportCategory,
+      description: report.description === '(NULL)' ? null : report.description
+    }));
+
+    this.dataSource = new MatTableDataSource(transformedData);
     this.dataSource.paginator = this.paginator;
     this.dataSource.sort = this.sort;
   }


### PR DESCRIPTION
## Description

Handle API response where report category returns '(NULL)' string, displaying empty cell instead of null text in table.

## Screenshots, if any

before
<img width="1215" height="176" alt="image" src="https://github.com/user-attachments/assets/a4d18be4-67af-4295-8d72-5b7d6ead868b" />

after
<img width="1228" height="219" alt="image" src="https://github.com/user-attachments/assets/3ca7d5f2-22b6-40da-85be-92b0d8771e01" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of missing report categories in the manage reports view. Improved data normalization to properly display report information when categories or descriptions are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->