### PR TITLE
fix: WEB-875 Inconsistent top margin in Select Currency dropdown

### DIFF
--- a/src/app/organization/tellers/cashiers/transactions/transactions.component.html
+++ b/src/app/organization/tellers/cashiers/transactions/transactions.component.html
@@ -62,14 +62,14 @@
 
 <div class="container">
   <mat-card class="layout-column gap-2percent mat-elevation-z8">
-    <div class="layout-row gap-2percent">
+    <div class="layout-row gap-2percent layout-align-start-center">
       <mat-form-field class="flex-fill">
         <mat-label>{{ 'labels.inputs.Filter' | translate }}</mat-label>
         <input matInput (keyup)="applyFilter($event.target.value)" />
       </mat-form-field>
 
-      <mat-form-field>
-        <mat-label> {{ 'labels.inputs.Select Currency' | translate }} </mat-label>
+      <mat-form-field class="flex-fill">
+        <mat-label>{{ 'labels.inputs.Select Currency' | translate }}</mat-label>
         <mat-select [formControl]="currencySelector" required>
           @for (currency of currencyData; track currency) {
             <mat-option [value]="currency.code">


### PR DESCRIPTION
Fixes WEB-875

Changes:
- Added layout-align-start-center to fix inconsistent top margin
- Added flex-fill class to Select Currency dropdown
- Removed extra whitespace in mat-label

Closes WEB-875

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the layout alignment and spacing of transaction filter controls and currency selector for improved visual consistency and responsive behavior across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->