### PR TITLE
WEB-888 Add missing validation error messages for required fields in loan reage and foreclosure forms

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/foreclosure/foreclosure.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/foreclosure/foreclosure.component.html
@@ -58,7 +58,13 @@
 
           <mat-form-field>
             <mat-label>{{ 'labels.inputs.Note' | translate }}</mat-label>
-            <textarea matInput formControlName="note" cdkTextareaAutosize cdkAutosizeMinRows="2"></textarea>
+            <textarea matInput required formControlName="note" cdkTextareaAutosize cdkAutosizeMinRows="2"></textarea>
+            @if (foreclosureForm.controls.note.hasError('required')) {
+              <mat-error>
+                {{ 'labels.inputs.Note' | translate }} {{ 'labels.commons.is' | translate }}
+                <strong>{{ 'labels.commons.required' | translate }}</strong>
+              </mat-error>
+            }
           </mat-form-field>
         </div>
 

--- a/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.html
@@ -22,13 +22,19 @@
             </mat-form-field>
             <mat-form-field>
               <mat-label>{{ 'labels.inputs.Frequency Type' | translate }}</mat-label>
-              <mat-select formControlName="frequencyType">
+              <mat-select formControlName="frequencyType" required>
                 @for (frequencyType of periodFrequencyOptions; track frequencyType) {
                   <mat-option [value]="frequencyType">
                     {{ frequencyType }}
                   </mat-option>
                 }
               </mat-select>
+              @if (reagingLoanForm.controls.frequencyType.hasError('required')) {
+                <mat-error>
+                  {{ 'labels.inputs.Frequency Type' | translate }} {{ 'labels.commons.is' | translate }}
+                  <strong>{{ 'labels.commons.required' | translate }}</strong>
+                </mat-error>
+              }
             </mat-form-field>
             <mat-form-field (click)="startDatePicker.open()">
               <mat-label>{{ 'labels.inputs.Start Date' | translate }}</mat-label>


### PR DESCRIPTION
**Changes Made :-**

-Add validation error messages for required Frequency Type field in Loan Re-Age and Note field in Foreclosure forms .

[WEB-888](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-888)

Before :- 

<img width="1094" height="529" alt="image" src="https://github.com/user-attachments/assets/4602cf96-a195-4ca6-a9ac-6ecf7b2e9732" />

<img width="640" height="375" alt="image" src="https://github.com/user-attachments/assets/b1313e7c-423e-4c27-90b1-2ddd092b598c" />

After :- 

<img width="871" height="561" alt="image" src="https://github.com/user-attachments/assets/915228bf-07d0-4e86-8b7a-be0cc5494c31" />

<img width="904" height="570" alt="image" src="https://github.com/user-attachments/assets/7e8f9951-d27f-432a-a5e2-b4300ddae631" />


[WEB-888]: https://mifosforge.jira.com/browse/WEB-888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added required field validation to the Note field in the foreclosure form with error messaging displayed when the field is left empty
  * Added required field validation to the Frequency Type selection in the loan reaging form with error messaging displayed when no option is selected

<!-- end of auto-generated comment: release notes by coderabbit.ai -->