### PR TITLE
WEB-893: Replace hardcoded 'Reload Settings' strings with translate p…

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -170,9 +170,9 @@
           mat-icon-button
           (click)="reloadSettings()"
           class="reload-button"
-          title="Reload Settings"
-          matTooltip="Reload Settings"
-          attr.aria-label="Reload Settings"
+          [title]="'labels.buttons.Reload Settings' | translate"
+          matTooltip="{{ 'labels.buttons.Reload Settings' | translate }}"
+          [attr.aria-label]="'labels.buttons.Reload Settings' | translate"
         >
           <mifosx-m3-icon name="refresh"></mifosx-m3-icon>
         </button>

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -9,7 +9,6 @@
 /** Angular Imports */
 import { Component, OnInit, OnDestroy, inject } from '@angular/core';
 import { Router } from '@angular/router';
-
 /** rxjs Imports */
 
 import { Subscription } from 'rxjs';
@@ -46,7 +45,7 @@ import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { M3IconComponent } from '../shared/m3-ui/m3-icon/m3-icon.component';
-
+import { MatTooltip } from '@angular/material/tooltip';
 import { VersionService } from '../system/version.service';
 
 /**
@@ -69,7 +68,8 @@ import { VersionService } from '../system/version.service';
     FaIconComponent,
     MatMenu,
     MatMenuItem,
-    M3IconComponent
+    M3IconComponent,
+    MatTooltip
   ]
 })
 export class LoginComponent implements OnInit, OnDestroy {

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -541,6 +541,7 @@
       "Remove": "Odstranit",
       "Request OTP": "Požádejte o OTP",
       "Reschedule": "Přeplánovat",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "Znovu odeslat jednorázové heslo",
       "Reset": "Resetovat",
       "Reset Password": "Obnovit heslo",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -542,6 +542,7 @@
       "Remove": "Entfernen",
       "Request OTP": "OTP anfordern",
       "Reschedule": "Neu planen",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "OTP erneut senden",
       "Reset": "Zurücksetzen",
       "Reset Password": "Passwort zurücksetzen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -619,7 +619,8 @@
       "Add Entry": "Add Entry",
       "PRINT": "Print",
       "DONE": "Done",
-      "Submitting": "Submitting"
+      "Submitting": "Submitting",
+      "Reload Settings": "Reload Settings"
     },
     "catalogs": {
       "Interest payment waiver": "Interest Payment Waiver",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -542,6 +542,7 @@
       "Remove": "Eliminar",
       "Request OTP": "Solicitar OTP",
       "Reschedule": "Reprogramar",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "Reenviar OTP",
       "Reset": "Reiniciar",
       "Reset Password": "Restablecer la contraseña",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -542,6 +542,7 @@
       "Remove": "Eliminar",
       "Request OTP": "Solicitar OTP",
       "Reschedule": "Reprogramar",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "Reenviar OTP",
       "Reset": "Reiniciar",
       "Reset Password": "Restablecer la contraseña",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -542,6 +542,7 @@
       "Remove": "Retirer",
       "Request OTP": "Demander un OTP",
       "Reschedule": "Reprogrammer",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "Renvoyer OTP",
       "Reset": "Réinitialiser",
       "Reset Password": "réinitialiser le mot de passe",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -542,6 +542,7 @@
       "Remove": "Rimuovere",
       "Request OTP": "Richiedi OTP",
       "Reschedule": "Riprogrammare",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "Invia nuovamente OTP",
       "Reset": "Ripristina",
       "Reset Password": "Resetta la password",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -542,6 +542,7 @@
       "Remove": "제거하다",
       "Request OTP": "OTP 요청",
       "Reschedule": "일정 변경",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "OTP 재전송",
       "Reset": "초기화",
       "Reset Password": "암호를 재설정",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -542,6 +542,7 @@
       "Remove": "Pašalinti",
       "Request OTP": "Prašyti OTP",
       "Reschedule": "Suplanuoti iš naujo",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "Iš naujo siųsti OTP",
       "Reset": "Nustatyti iš naujo",
       "Reset Password": "Atstatyti slaptažodį",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -542,6 +542,7 @@
       "Remove": "Noņemt",
       "Request OTP": "Pieprasīt OTP",
       "Reschedule": "Pārplānot",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "Atkārtoti sūtīt OTP",
       "Reset": "Atiestatīt",
       "Reset Password": "Atiestatīt paroli",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -542,6 +542,7 @@
       "Remove": "हटाउनुहोस्",
       "Request OTP": "OTP अनुरोध गर्नुहोस्",
       "Reschedule": "पुन: तालिका",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "OTP पुन: पठाउनुहोस्",
       "Reset": "रिसेट गर्नुहोस्",
       "Reset Password": "पासवर्ड रिसेट",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -542,6 +542,7 @@
       "Remove": "Remover",
       "Request OTP": "Solicitar OTP",
       "Reschedule": "Reprogramar",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "Reenviar OTP",
       "Reset": "Reiniciar",
       "Reset Password": "Redefinir senha",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -542,6 +542,7 @@
       "Remove": "Ondoa",
       "Request OTP": "Omba OTP",
       "Reschedule": "Panga upya",
+      "Reload Settings": "Reload Settings",
       "Resend OTP": "Tuma tena OTP",
       "Reset": "Weka upya",
       "Reset Password": "Weka upya Nenosiri",


### PR DESCRIPTION
## Description

The reload button in the login component footer had three hardcoded English strings that were not using the i18n translate pipe:
- `title="Reload Settings"`
- `matTooltip="Reload Settings"`
- `attr.aria-label="Reload Settings"`

These have been replaced with the translate pipe and the translation key `labels.buttons.Reload Settings` has been added to the i18n JSON file.

## Related issues and discussion

https://mifosforge.jira.com/jira/software/c/projects/WEB/issues/WEB-893

## Screenshots, if any

No UI changes — tooltip and aria-label behavior unchanged, now i18n compatible.

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tooltips, titles and accessibility labels for the "Reload Settings" button now use translation keys so the button displays localized text and tooltips.

* **Chores**
  * Added "Reload Settings" translation entries across multiple languages (including English and several locales) to support the new localized label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->