### PR TITLE
WEB-898 fix: correct footer layout alignment for improved UI consistency

### DIFF
--- a/src/app/shared/footer/footer.component.html
+++ b/src/app/shared/footer/footer.component.html
@@ -72,7 +72,7 @@
           @if (isBusinessDateDefined) {
             <tr>
               <td class="footer-content">{{ 'labels.text.Current Business Date' | translate }}:</td>
-              <td class="center footer-content business-date">
+              <td class="right footer-content business-date">
                 <b>{{ businessDate | date: 'EEEE, MMMM dd, y' }}</b>
               </td>
             </tr>


### PR DESCRIPTION
This pr correct footer layout alignment for improved UI consistency

[WEB-898](https://mifosforge.jira.com/browse/WEB-898)


Before:
<img width="803" height="233" alt="image" src="https://github.com/user-attachments/assets/28ae1f01-ce36-499a-8461-463c415d2f42" />
After:
<img width="726" height="233" alt="image" src="https://github.com/user-attachments/assets/4024b8f7-3e68-4f1a-89e7-2254f27d607c" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-898]: https://mifosforge.jira.com/browse/WEB-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the alignment of "Current Business Date" in the footer from center to right alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->