### PR TITLE
WEB-872 fix: include disabled form fields in client creation payload

### DIFF
--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
@@ -259,7 +259,7 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
    * Client General Details
    */
   get clientGeneralDetails() {
-    const generalDetails = this.createClientForm.value;
+    const generalDetails = this.createClientForm.getRawValue();
     const dateFormat = this.settingsService.dateFormat;
     const locale = this.settingsService.language.code;
     for (const key in generalDetails) {


### PR DESCRIPTION
This pr fixed a bug where auto-filled fields (firstname, lastname, dateOfBirth, genderId) from External National ID lookup were not included in the client creation API request.                                                             

[WEB-872](https://mifosforge.jira.com/browse/WEB-872)


Before:
<img width="1414" height="779" alt="image" src="https://github.com/user-attachments/assets/86517fee-678f-4e54-ad8f-174a3f81b981" />
After:
<img width="978" height="372" alt="image" src="https://github.com/user-attachments/assets/07c4df63-e352-4e30-84b8-40eccd67deb3" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-872]: https://mifosforge.jira.com/browse/WEB-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form data handling to ensure all field values, including disabled fields, are properly captured when creating client general details. This fixes potential data loss issues where disabled form controls were previously excluded from client information submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->