### PR TITLE
fix: WEB-860 Present Globalisation Code translated to local languages …

### DIFF
--- a/src/app/core/http/error-handler.interceptor.ts
+++ b/src/app/core/http/error-handler.interceptor.ts
@@ -11,7 +11,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpErrorResponse } from '@angular/common/http';
 
 /** rxjs Imports */
-import { EMPTY, Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 
 /** Environment Configuration */
@@ -20,7 +20,7 @@ import { environment } from '../../../environments/environment';
 /** Custom Services */
 import { Logger } from '../logger/logger.service';
 import { AlertService } from '../alert/alert.service';
-import { TranslateService } from '@ngx-translate/core'; // Added import for TranslateService
+import { TranslateService } from '@ngx-translate/core';
 
 /** Initialize Logger */
 const log = new Logger('ErrorHandlerInterceptor');
@@ -33,24 +33,33 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
   private alertService = inject(AlertService);
   private translate = inject(TranslateService);
 
-  /**
-   * Intercepts a Http request and adds a default error handler.
-   */
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(request).pipe(catchError((error) => this.handleError(error, request)));
   }
 
-  /**
-   * Error handler.
-   */
   private handleError(response: HttpErrorResponse, request: HttpRequest<any>): Observable<HttpEvent<any>> {
     const status = response.status;
-    let errorMessage = response.error.developerMessage || response.message;
-    if (response.error.errors) {
-      if (response.error.errors[0]) {
-        errorMessage = response.error.errors[0].defaultUserMessage || response.error.errors[0].developerMessage;
+
+    // Translate top-level globalisation code if present
+    let topLevelMessage = response.error?.defaultUserMessage || response.error?.developerMessage || response.message;
+    if (response.error?.userMessageGlobalisationCode) {
+      const topCode = response.error.userMessageGlobalisationCode;
+      const translated = this.translate.instant(topCode, response.error || {});
+      if (translated !== topCode) {
+        topLevelMessage = translated;
       }
     }
+
+    // Translate nested globalisation code if present
+    let nestedMessage: string | null = null;
+    if (response.error?.errors?.[0]?.userMessageGlobalisationCode) {
+      const nestedCode = response.error.errors[0].userMessageGlobalisationCode;
+      const translated = this.translate.instant(nestedCode, response.error.errors[0] || {});
+      nestedMessage = translated !== nestedCode ? translated : response.error.errors[0].defaultUserMessage || null;
+    }
+
+    // Combine both messages if both exist
+    const errorMessage = nestedMessage ? `${topLevelMessage} ${nestedMessage}` : topLevelMessage;
 
     const isClientImage404 = status === 404 && request.url.includes('/clients/') && request.url.includes('/images');
 
@@ -59,43 +68,52 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
     }
 
     if (status === 401 || (environment.oauth.enabled && status === 400)) {
-      this.alertService.alert({ type: 'Authentication Error', message: 'Invalid User Details. Please try again!' });
-    } else if (status === 403 && errorMessage === 'The provided one time token is invalid') {
-      this.alertService.alert({ type: 'Invalid Token', message: 'Invalid Token. Please try again!' });
+      this.alertService.alert({
+        type: this.translate.instant('errors.error.auth.type'),
+        message: this.translate.instant('errors.error.auth.message')
+      });
+    } else if (
+      status === 403 &&
+      response.error?.errors?.[0]?.defaultUserMessage === 'The provided one time token is invalid'
+    ) {
+      this.alertService.alert({
+        type: this.translate.instant('errors.error.token.invalid.type'),
+        message: this.translate.instant('errors.error.token.invalid.message')
+      });
     } else if (status === 400) {
       this.alertService.alert({
-        type: 'Bad Request',
-        message: errorMessage || 'Invalid parameters were passed in the request!'
+        type: this.translate.instant('errors.error.bad.request.type'),
+        message: errorMessage || this.translate.instant('errors.error.bad.request.message')
       });
     } else if (status === 403) {
       this.alertService.alert({
-        type: 'Unauthorized Request',
-        message: errorMessage || 'You are not authorized for this request!'
+        type: this.translate.instant('errors.error.unauthorized.type'),
+        message: errorMessage || this.translate.instant('errors.error.unauthorized.message')
       });
     } else if (status === 404) {
-      // Check if this is an image request that should be silently handled (client profile image)
       if (isClientImage404) {
-        // Don't show alerts for missing client images
-        // This is an expected condition, not an error
-        return EMPTY;
+        return throwError(() => response);
       } else {
         this.alertService.alert({
-          type: this.translate.instant('error.resource.not.found'),
-          message: errorMessage || 'Resource does not exist!'
+          type: this.translate.instant('errors.error.resource.not.found.type'),
+          message: errorMessage || this.translate.instant('errors.error.resource.not.found.message')
         });
       }
     } else if (status === 500) {
       this.alertService.alert({
-        type: 'Internal Server Error',
-        message: 'Internal Server Error. Please try again later.'
+        type: this.translate.instant('errors.error.server.internal.type'),
+        message: this.translate.instant('errors.error.server.internal.message')
       });
     } else if (status === 501) {
       this.alertService.alert({
-        type: this.translate.instant('error.resource.notImplemented.type'),
-        message: this.translate.instant('error.resource.notImplemented.message')
+        type: this.translate.instant('errors.error.resource.notImplemented.type'),
+        message: this.translate.instant('errors.error.resource.notImplemented.message')
       });
     } else {
-      this.alertService.alert({ type: 'Unknown Error', message: 'Unknown Error. Please try again later.' });
+      this.alertService.alert({
+        type: this.translate.instant('errors.error.unknown.type'),
+        message: errorMessage || this.translate.instant('errors.error.unknown.message')
+      });
     }
 
     throw response;


### PR DESCRIPTION
## Description

Error messages in the Mifos Web App were showing generic fixed text like 
"Unknown Error. Please try again later." instead of the actual meaningful 
error from the backend.

Apache Fineract sends `user Message Globalisation erInterceptor to:

- Translate top-level `user Message Globalisation Code` using Translate Service
- Translate nested `errors[0].user Message Globalisation Code` using Translate Service
- Combine both translated messages into one display message
- Fall back to `defaultUserMessage` if translation key not found

## Example
**Before:** `Unknown Error. Please try again later.`

**After:** `The server is currently unable to handle the request, please try 
after some time. Data type 'BOOLEAN' is not supported`

## Related
WEB-860: https://mifosforge.jira.com/browse/WEB-860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message handling with improved translation support.
  * Error messages now display more complete information by combining nested and top-level fields.
  * Improved error handling for HTTP status codes (401, 400, 403, 404, 500, 501).
  * Fixed behavior for failed client image requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->