### PR TITLE
WEB-711: WC Product with discount attribute

### DIFF
--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -103,6 +103,10 @@
           }})
         </span>
       </div>
+      <div class="flex-fill layout-row">
+        <span class="flex-40">{{ 'labels.inputs.Discount' | translate }}:</span>
+        <span class="flex-60">{{ loanProduct.discount | formatNumber }}</span>
+      </div>
     }
     @if (loanProductService.isLoanProduct) {
       <div class="flex-fill layout-row">

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -148,6 +148,16 @@
           <strong>{{ loanProductTermsForm.get('maxPeriodPaymentRate')?.errors?.['min']?.min || 0.01 }}</strong>
         </mat-error>
       </mat-form-field>
+
+      <mat-form-field class="flex-31">
+        <mat-label>{{ 'labels.inputs.Discount' | translate }}</mat-label>
+        <input type="number" matInput formControlName="discount" [min]="0" step="0.01" />
+        <mat-error *ngIf="loanProductTermsForm.get('discount')?.hasError('min')">
+          {{ 'labels.commons.Minimum Value must be' | translate }}
+          <strong>{{ loanProductTermsForm.get('discount')?.errors?.['min']?.min || 0 }}</strong>
+        </mat-error>
+      </mat-form-field>
+      <mat-divider class="flex-98"></mat-divider>
     }
 
     @if (loanProductService.isLoanProduct) {

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -203,7 +203,8 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
         repaymentEvery: this.loanProductsTemplate.repaymentEvery,
         repaymentFrequencyType: this.loanProductsTemplate.repaymentFrequencyType
           ? this.loanProductsTemplate.repaymentFrequencyType.id
-          : null
+          : null,
+        discount: this.loanProductsTemplate.discount
       });
     }
   }
@@ -349,6 +350,12 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
         repaymentFrequencyType: [
           '',
           Validators.required
+        ],
+        discount: [
+          '',
+          [
+            Validators.min(0)
+          ]
         ]
       });
     }


### PR DESCRIPTION
## Description

The Working Capital Product has the discount value that must be a kind of rate 

[WEB-711](https://mifosforge.jira.com/browse/WEB-711)

## Screenshots
<img width="1496" height="860" alt="Screenshot 2026-03-30 at 9 44 04 AM" src="https://github.com/user-attachments/assets/2d93708c-545a-48ed-b7ac-33b656763399" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-711]: https://mifosforge.jira.com/browse/WEB-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a discount field to working capital loan product configuration, allowing users to input discount values with validation for minimum value of 0 and support for decimal amounts.
  * Discount values are now displayed in the loan product summary view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->