### PR TITLE
WEB-899: Fix tenant header dropped on absolute Fineract URLs

### DIFF
--- a/src/app/core/authentication/authentication.interceptor.ts
+++ b/src/app/core/authentication/authentication.interceptor.ts
@@ -41,8 +41,7 @@ export class AuthenticationInterceptor implements HttpInterceptor {
    * Intercepts a Http request and sets the request headers.
    */
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    // Skip Fineract auth headers for external API calls (e.g. remittance, national ID)
-    if (request.url.startsWith('http://') || request.url.startsWith('https://')) {
+    if (this.isExternalUrl(request.url)) {
       return next.handle(request);
     }
     if (this.settingsService.tenantIdentifier) {
@@ -50,6 +49,23 @@ export class AuthenticationInterceptor implements HttpInterceptor {
     }
     request = request.clone({ setHeaders: httpOptions.headers });
     return next.handle(request);
+  }
+
+  /**
+   * Absolute URLs pointing at our own Fineract server are internal — ApiPrefixInterceptor
+   * (in HttpService's dynamic chain) may have already converted relative URLs to absolute ones.
+   */
+  private isExternalUrl(url: string): boolean {
+    try {
+      const requestOrigin = new URL(url).origin;
+      const server = this.settingsService.server;
+      if (server) {
+        return requestOrigin !== new URL(server).origin;
+      }
+      return true;
+    } catch {
+      return false; // Relative URL (new URL() throws) → internal
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Replaced the blanket `startsWith('http://')` guard with `isExternalUrl()` that recognizes the configured Fineract server as internal while still skipping genuinely external APIs (remittance, interbank transfers, national ID).

## Related issues and discussion

[WEB-899](https://mifosforge.jira.com/browse/WEB-899)

## Screenshots, if any

N/A — no UI changes. This is a backend HTTP interceptor fix.

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-899]: https://mifosforge.jira.com/browse/WEB-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of internal vs external URLs so requests to the configured server now correctly receive authentication headers.
  * External, malformed, or otherwise non-matching absolute URLs are reliably bypassed, preventing unintended header injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->