### PR TITLE
WEB-901 Page title for fixed deposits shows raw translation key instead of text

### DIFF
--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3347,6 +3347,7 @@
       "Fixed Deposit Account Interest Rate Chart": "Tabulka úrokových sazeb na účtu s pevným vkladem",
       "Fixed Deposit Account Standing Instructions": "Pokyny k trvalému vkladovému účtu",
       "Fixed Deposit Account Transactions": "Transakce na pevném vkladovém účtu",
+      "Fixed Deposit Account Details": "Detaily účtu terminovaného vkladu",
       "Fixed Deposit Account View": "Pohled na účet s pevným vkladem",
       "Fixed Deposit Products": "Produkty s pevným vkladem",
       "Fixed Deposit Products defines the rules, default settings": "Produkty s pevným vkladem definují pravidla, výchozí nastavení a omezení pro nabídky finančních <br> pevných vkladů (také označované jako termínované vklady). Produkt s pevným vkladem poskytuje pro klienty finanční instituce šablonu pro více účtů s pevným vkladem.",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3348,6 +3348,7 @@
       "Fineract": "Apache Fineract®",
       "Fixed Deposit Account Standing Instructions": "Anweisungen zum Festgeldkonto",
       "Fixed Deposit Account Transactions": "Transaktionen mit Festgeldkonten",
+      "Fixed Deposit Account Details": "Festgeldkonto-Details",
       "Fixed Deposit Account View": "Ansicht Festgeldkonto",
       "Fixed Deposit Products": "Festgeldprodukte",
       "Fixed Deposit Products defines the rules, default settings": "Festgeldprodukte definiert die Regeln, Standardeinstellungen und Einschränkungen für die Festgeldangebote eines Finanzinstituts (auch als Termineinlagen bezeichnet). Ein Festgeldprodukt bietet eine Vorlage für mehrere Festgeldkonten für die Kunden des Finanzinstituts.",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3382,6 +3382,7 @@
       "FilterByLoanIdOrError": "Filter by loan Id or error",
       "Fineract": "Apache Fineract®",
       "Fixed Deposit Account Charges": "Fixed Deposit Account Charges",
+      "Fixed Deposit Account Details": "Fixed Deposit Account Details",
       "Fixed Deposit Account Interest Rate Chart": "Fixed Deposit Account Interest Rate Chart",
       "Fixed Deposit Account Standing Instructions": "Fixed Deposit Account Standing Instructions",
       "Fixed Deposit Account Transactions": "Fixed Deposit Account Transactions",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3348,6 +3348,7 @@
       "Fixed Deposit Account Interest Rate Chart": "Tabla de tasas de interés de cuentas de Depósito Fijo",
       "Fixed Deposit Account Standing Instructions": "Instrucciones para la situación de la cuenta de Depósito Fijo",
       "Fixed Deposit Account Transactions": "Transacciones de cuenta de Depósito Fijo",
+      "Fixed Deposit Account Details": "Detalles de cuenta de depósito a plazo",
       "Fixed Deposit Account View": "Vista de cuenta de Depósito Fijo",
       "Fixed Deposit Products": "Productos de Depósito Fijo",
       "Fixed Deposit Products defines the rules, default settings": "Los productos de Depósito Fijo definen las reglas, la configuración predeterminada y las restricciones para las ofertas de Depósito Fijo de una institución financiera (también conocidos como depósitos a plazo). Un producto de Depósito Fijo proporciona una plantilla para múltiples cuentas de Depósito Fijo para los clientes de la institución financiera.",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3381,6 +3381,7 @@
       "Fixed Deposit Account Interest Rate Chart": "Tabla de tasas de interés de cuentas de Depósito Fijo",
       "Fixed Deposit Account Standing Instructions": "Instrucciones para la situación de la cuenta de Depósito Fijo",
       "Fixed Deposit Account Transactions": "Transacciones de cuenta de Depósito Fijo",
+      "Fixed Deposit Account Details": "Detalles de cuenta de depósito a plazo",
       "Fixed Deposit Account View": "Vista de cuenta de Depósito Fijo",
       "Fixed Deposit Products": "Productos de Depósito Fijo",
       "Fixed Deposit Products defines the rules, default settings": "Los productos de Depósito Fijo definen las reglas, la configuración predeterminada y las restricciones para las ofertas de Depósito Fijo de una institución financiera (también conocidos como depósitos a plazo). Un producto de Depósito Fijo proporciona una plantilla para múltiples cuentas de Depósito Fijo para los clientes de la institución financiera.",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3350,6 +3350,7 @@
       "Fixed Deposit Account Interest Rate Chart": "Tableau des taux d’intérêt des comptes de dépôt fixe",
       "Fixed Deposit Account Standing Instructions": "Instructions permanentes pour les comptes de dépôt à terme",
       "Fixed Deposit Account Transactions": "Opérations sur compte de dépôt fixe",
+      "Fixed Deposit Account Details": "Détails du compte de dépôt à terme",
       "Fixed Deposit Account View": "Vue du compte de dépôt fixe",
       "Fixed Deposit Products": "Produits de dépôt fixe",
       "Fixed Deposit Products defines the rules, default settings": "Les produits de dépôt fixe définissent les règles, les paramètres par défaut et les contraintes pour les offres de dépôt fixe d'une institution financière (également appelées dépôts à terme). Un produit de dépôt à terme fournit un modèle pour plusieurs comptes de dépôt à terme pour les clients de l'institution financière.",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3345,6 +3345,7 @@
       "Fixed Deposit Account Interest Rate Chart": "Grafico dei tassi di interesse del conto di deposito fisso",
       "Fixed Deposit Account Standing Instructions": "Istruzioni per la permanenza del Conto di Deposito Fisso",
       "Fixed Deposit Account Transactions": "Operazioni di Conto Deposito Fisso",
+      "Fixed Deposit Account Details": "Dettagli conto deposito vincolato",
       "Fixed Deposit Account View": "Visualizzazione del conto di deposito fisso",
       "Fixed Deposit Products": "Prodotti a deposito fisso",
       "Fixed Deposit Products defines the rules, default settings": "Prodotti a deposito fisso definisce le regole, le impostazioni predefinite e i vincoli per le offerte di deposito fisso di un istituto finanziario (noti anche come depositi a termine). Un prodotto di deposito fisso fornisce un modello per più conti di deposito fisso per i clienti dell'istituto finanziario.",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3346,6 +3346,7 @@
       "Fixed Deposit Account Interest Rate Chart": "정기예금 이자율 차트",
       "Fixed Deposit Account Standing Instructions": "정기예금 계좌 예금 안내",
       "Fixed Deposit Account Transactions": "정기예금 거래",
+      "Fixed Deposit Account Details": "정기 예금 계좌 세부 정보",
       "Fixed Deposit Account View": "정기예금계좌조회",
       "Fixed Deposit Products": "정기예금 상품",
       "Fixed Deposit Products defines the rules, default settings": "정기 예금 상품은 금융 기관의 <br> 정기 예금 상품(정기 예금이라고도 함)에 대한 규칙, 기본 설정 및 제약 조건을 정의합니다. 정기 예금 상품은 금융 기관의 고객을 위해 여러 정기 예금 계좌에 대한 템플릿을 제공합니다.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3347,6 +3347,7 @@
       "Fixed Deposit Account Interest Rate Chart": "Fiksuoto indėlio sąskaitos palūkanų normos diagrama",
       "Fixed Deposit Account Standing Instructions": "Fiksuoto indėlio sąskaitos nuolatinės instrukcijos",
       "Fixed Deposit Account Transactions": "Fiksuoto indėlio sąskaitos operacijos",
+      "Fixed Deposit Account Details": "Terminuotojo indėlio sąskaitos rekvizitai",
       "Fixed Deposit Account View": "Fiksuoto indėlio sąskaitos vaizdas",
       "Fixed Deposit Products": "Fiksuoto indėlio produktai",
       "Fixed Deposit Products defines the rules, default settings": "Terminuotųjų indėlių produktai apibrėžia finansų įstaigos <br> terminuotųjų indėlių pasiūlymų (taip pat vadinamų terminuotais indėliais) taisykles, numatytuosius nustatymus ir apribojimus. Terminuoto indėlio produktas suteikia šabloną kelioms terminuoto indėlio sąskaitoms finansų įstaigos klientams.",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3346,6 +3346,7 @@
       "Fixed Deposit Account Interest Rate Chart": "Fiksētā depozīta konta procentu likmju diagramma",
       "Fixed Deposit Account Standing Instructions": "Fiksētā depozīta konta pastāvēšanas instrukcijas",
       "Fixed Deposit Account Transactions": "Fiksētā depozīta konta darījumi",
+      "Fixed Deposit Account Details": "Termiņnoguldījuma konta informācija",
       "Fixed Deposit Account View": "Fiksētā depozīta konta skats",
       "Fixed Deposit Products": "Fiksētā depozīta produkti",
       "Fixed Deposit Products defines the rules, default settings": "Fiksēto depozītu produkti definē noteikumus, noklusējuma iestatījumus un ierobežojumus finanšu iestādes <br> fiksēto noguldījumu piedāvājumiem (saukti arī par termiņnoguldījumiem). Fiksētā depozīta produkts nodrošina veidni vairākiem fiksēto depozītu kontiem finanšu iestādes klientiem.",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3344,6 +3344,7 @@
       "Fixed Deposit Account Interest Rate Chart": "फिक्स्ड डिपोजिट खाता ब्याज दर चार्ट",
       "Fixed Deposit Account Standing Instructions": "फिक्स्ड डिपोजिट खाता स्थायी निर्देशनहरू",
       "Fixed Deposit Account Transactions": "फिक्स्ड डिपोजिट खाता लेनदेन",
+      "Fixed Deposit Account Details": "मुद्दती निक्षेप खाता विवरण",
       "Fixed Deposit Account View": "फिक्स्ड डिपोजिट खाता दृश्य",
       "Fixed Deposit Products": "फिक्स्ड डिपोजिट उत्पादनहरू",
       "Fixed Deposit Products defines the rules, default settings": "फिक्स्ड डिपोजिट उत्पादनहरूले नियमहरू, पूर्वनिर्धारित सेटिङहरू, र वित्तीय संस्थाको <br> फिक्स्ड डिपोजिट प्रस्तावहरू (समय निक्षेपहरू पनि भनिन्छ) को लागि बाधाहरू परिभाषित गर्दछ। एक फिक्स्ड डिपोजिट उत्पादनले वित्तीय संस्थाका ग्राहकहरूको लागि बहु मुद्दती निक्षेप खाताहरूको लागि टेम्प्लेट प्रदान गर्दछ।",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3346,6 +3346,7 @@
       "Fixed Deposit Account Interest Rate Chart": "Gráfico de taxas de juros de contas de depósito fixo",
       "Fixed Deposit Account Standing Instructions": "Instruções permanentes da conta de depósito fixo",
       "Fixed Deposit Account Transactions": "Transações de conta de depósito fixo",
+      "Fixed Deposit Account Details": "Detalhes da conta de depósito a prazo",
       "Fixed Deposit Account View": "Visualização de conta de depósito fixo",
       "Fixed Deposit Products": "Produtos de Depósito Fixo",
       "Fixed Deposit Products defines the rules, default settings": "Produtos de Depósito Fixo definem as regras, configurações padrão e restrições para as ofertas de depósito fixo de uma instituição financeira (também chamados de depósitos a prazo). Um produto de depósito fixo fornece um modelo para múltiplas contas de depósito fixo para os clientes da instituição financeira.",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3342,6 +3342,7 @@
       "Fixed Deposit Account Interest Rate Chart": "Chati ya Kiwango cha Riba cha Akaunti ya Amana isiyobadilika",
       "Fixed Deposit Account Standing Instructions": "Maelekezo ya Kudumu ya Akaunti ya Amana",
       "Fixed Deposit Account Transactions": "Miamala ya Akaunti ya Amana isiyobadilika",
+      "Fixed Deposit Account Details": "Maelezo ya Akaunti ya Amana ya Kudumu",
       "Fixed Deposit Account View": "Mtazamo wa Akaunti ya Amana isiyobadilika",
       "Fixed Deposit Products": "Bidhaa za Amana zisizohamishika",
       "Fixed Deposit Products defines the rules, default settings": "Bidhaa za Amana Isiyobadilika hufafanua sheria, mipangilio chaguo-msingi na vikwazo kwa <br> matoleo ya amana isiyobadilika ya taasisi ya fedha (pia hujulikana kama amana za muda). Bidhaa ya amana isiyobadilika hutoa kiolezo cha akaunti nyingi za amana zisizobadilika kwa wateja wa taasisi ya fedha.",


### PR DESCRIPTION
**Changes Made :-** 

-Added the missing "Fixed Deposit Account Details" translation key to en-US.json so the page title renders correctly without the "labels.text" prefix..

[WEB-901 ](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-901)

Before :- 
<img width="1364" height="679" alt="image" src="https://github.com/user-attachments/assets/06942f23-c7f0-49ac-964d-e0148ea4cec8" />

After :- 
<img width="1365" height="644" alt="image" src="https://github.com/user-attachments/assets/18dd642d-4a05-472b-a563-57bf17f4d15e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added localized UI text "Fixed Deposit Account Details" across multiple languages (en, cs, de, es-CL, es-MX, fr, it, ko, lt, lv, ne, pt-PT, sw) to improve translation coverage and user-facing consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->