### PR TITLE
WEB-902 Page title for loan accounts displays generic general instead of loan account details

### DIFF
--- a/src/app/loans/loans-routing.module.ts
+++ b/src/app/loans/loans-routing.module.ts
@@ -112,7 +112,7 @@ const routes: Routes = [
           {
             path: 'general',
             component: GeneralTabComponent,
-            data: { title: 'General', breadcrumb: 'General', routeParamBreadcrumb: false },
+            data: { title: 'Loan Account Details', breadcrumb: 'General', routeParamBreadcrumb: false },
             resolve: {}
           },
           {

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3402,6 +3402,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "LoanAccountCustomSnapshotBusinessEvent",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "LoanAccount DelikvencePauseChangedBusinessEvent",
       "LoanAccountSnapshotBusinessEvent": "LoanAccountSnapshotBusinessEvent",
+      "Loan Account Details": "Detaily úvěrového účtu",
       "Loan Account Actions": "Akce na úvěrovém účtu",
       "Loan Collateral Details": "Podrobnosti o zajištění úvěru",
       "Loan Disbursal": "Vyplacení půjčky",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3403,6 +3403,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "LoanAccountCustomSnapshotBusinessEvent",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "LoanAccountDelinquencyPauseChangedBusinessEvent",
       "LoanAccountSnapshotBusinessEvent": "LoanAccountSnapshotBusinessEvent",
+      "Loan Account Details": "Details zum Kreditkonto",
       "Loan Account Actions": "Aktionen zum Kreditkonto",
       "Loan Collateral Details": "Details zur Kreditsicherheit",
       "Loan Disbursal": "Kreditauszahlung",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3536,6 +3536,7 @@
       "LoanWithdrawnByApplicantBusinessEvent": "Loan Withdrawn By Applicant Business Event",
       "LoanWrittenOffPostBusinessEvent": "Loan Written Off Post Business Event",
       "LoanWrittenOffPreBusinessEvent": "Loan Written Off Pre Business Event",
+      "Loan Account Details": "Loan Account Details",
       "Loan Account Actions": "Loan Account Actions",
       "Loan Collateral Details": "Loan Collateral Details",
       "Loan Disbursal": "Loan Disbursal",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3403,6 +3403,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "PréstamoCuentaPersonalizadoInstantáneaNegocioEvento",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "PréstamoCuentaMorosidadPausaCambiadoNegocioEvento",
       "LoanAccountSnapshotBusinessEvent": "PréstamoCuentaInstantáneaNegocioEvento",
+      "Loan Account Details": "Detalles de la cuenta de Crédito",
       "Loan Account Actions": "Acciones de la cuenta de Crédito",
       "Loan Collateral Details": "Detalles de la garantía del Crédito",
       "Loan Disbursal": "Curso del Crédito",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3436,6 +3436,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "PréstamoCuentaPersonalizadoInstantáneaNegocioEvento",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "PréstamoCuentaMorosidadPausaCambiadoNegocioEvento",
       "LoanAccountSnapshotBusinessEvent": "PréstamoCuentaInstantáneaNegocioEvento",
+      "Loan Account Details": "Detalles de la cuenta de préstamo",
       "Loan Account Actions": "Acciones de la cuenta de Crédito",
       "Loan Collateral Details": "Detalles de la garantía del Crédito",
       "Loan Disbursal": "Dispersión del Crédito",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3404,6 +3404,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "LoanAccountCustomSnapshotBusinessEvent",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "LoanAccountDelinquencyPauseChangedBusinessEvent",
       "LoanAccountSnapshotBusinessEvent": "LoanAccountSnapshotBusinessEvent",
+      "Loan Account Details": "Détails du compte de prêt",
       "Loan Account Actions": "Actions sur le compte de prêt",
       "Loan Collateral Details": "Détails de la garantie de prêt",
       "Loan Disbursal": "Décaissement du prêt",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3400,6 +3400,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "LoanAccountCustomSnapshotBusinessEvent",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "LoanAccountDelinquencyPauseChangedBusinessEvent",
       "LoanAccountSnapshotBusinessEvent": "LoanAccountSnapshotBusinessEvent",
+      "Loan Account Details": "Dettagli del conto di prestito",
       "Loan Account Actions": "Azioni del conto di prestito",
       "Loan Collateral Details": "Dettagli della garanzia del prestito",
       "Loan Disbursal": "Erogazione del prestito",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3401,6 +3401,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "대출계정CustomSnapshotBusinessEvent",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "대출계정연체 일시중지ChangedBusinessEvent",
       "LoanAccountSnapshotBusinessEvent": "대출계정스냅샷비즈니스이벤트",
+      "Loan Account Details": "대출 계좌 세부 정보",
       "Loan Account Actions": "대출 계정 작업",
       "Loan Collateral Details": "대출 담보 세부정보",
       "Loan Disbursal": "대출금 지급",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3402,6 +3402,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "LoanAccountCustomSnapshotBusinessEvent",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "LoanAccountDelinquencyPauseChangedBusinessEvent",
       "LoanAccountSnapshotBusinessEvent": "LoanAccountSnapshotBusinessEvent",
+      "Loan Account Details": "Paskolos sąskaitos rekvizitai",
       "Loan Account Actions": "Paskolos sąskaitos veiksmai",
       "Loan Collateral Details": "Paskolos užstato informacija",
       "Loan Disbursal": "Paskolos išmokėjimas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3401,6 +3401,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "LoanAccountCustomSnapshotBusinessEvent",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "LoanAccountDelinquencyPauseChangedBusinessEvent",
       "LoanAccountSnapshotBusinessEvent": "LoanAccountSnapshotBusinessEvent",
+      "Loan Account Details": "Kredītkonta informācija",
       "Loan Account Actions": "Aizdevuma konta darbības",
       "Loan Collateral Details": "Sīkāka informācija par aizdevuma nodrošinājumu",
       "Loan Disbursal": "Aizdevuma izsniegšana",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3399,6 +3399,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "LoanAccountCustomSnapshotBusinessEvent",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "LoanAccountDelinquencyPauseChangedBusinessEvent",
       "LoanAccountSnapshotBusinessEvent": "LoanAccountSnapshotBusinessEvent",
+      "Loan Account Details": "ऋण खाता विवरण",
       "Loan Account Actions": "ऋण खाता कार्यहरू",
       "Loan Collateral Details": "ऋण संपार्श्विक विवरण",
       "Loan Disbursal": "ऋण वितरण",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3401,6 +3401,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "LoanAccountCustomSnapshotBusinessEvent",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "LoanAccountDelinquencyPauseChangedBusinessEvent",
       "LoanAccountSnapshotBusinessEvent": "LoanAccountSnapshotBusinessEvent",
+      "Loan Account Details": "Detalhes da conta de empréstimo",
       "Loan Account Actions": "Ações de conta de empréstimo",
       "Loan Collateral Details": "Detalhes da garantia do empréstimo",
       "Loan Disbursal": "Desembolso de empréstimo",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3397,6 +3397,7 @@
       "LoanAccountCustomSnapshotBusinessEvent": "LoanAccountCustomSnapshotBusinessEvent",
       "LoanAccountDelinquencyPauseChangedBusinessEvent": "LoanAccountDelinquencyPauseChangedBusinessEvent",
       "LoanAccountSnapshotBusinessEvent": "LoanAccountSnapshotBusinessEvent",
+      "Loan Account Details": "Maelezo ya Akaunti ya Mkopo",
       "Loan Account Actions": "Vitendo vya Akaunti ya Mkopo",
       "Loan Collateral Details": "Maelezo ya Dhamana ya Mkopo",
       "Loan Disbursal": "Utoaji wa mkopo",


### PR DESCRIPTION
**Changes Made :-**

-Updates the route configuration in  loans-routing.module.ts for the general tab, changing the title data property from 'General' to 'Loan Account Details'.
-Injects the new translation mapping for "Loan Account Details" into  en-US.json and all 12 supported non-English locale JSON files.

[WEB-902](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-902)

Before :- 
<img width="640" height="327" alt="image" src="https://github.com/user-attachments/assets/49b7a2a2-efac-4809-bac4-2c40beb3c280" />

After :- 
<img width="1365" height="719" alt="image" src="https://github.com/user-attachments/assets/af74988f-c338-4dee-9bc7-12ce9ed1bcbe" />


[WEB-902]: https://mifosforge.jira.com/browse/WEB-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated loan account tab label to "Loan Account Details".

* **Documentation**
  * Added translations for the new label across 13 supported languages (Czech, German, English, Chilean Spanish, Mexican Spanish, French, Italian, Korean, Lithuanian, Latvian, Nepali, Portuguese, Swahili).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->