### PR TITLE
WEB-134: Fix floating rates creation bugs

### DIFF
--- a/src/app/products/floating-rates/create-floating-rate/create-floating-rate.component.html
+++ b/src/app/products/floating-rates/create-floating-rate/create-floating-rate.component.html
@@ -57,10 +57,6 @@
         <div class="layout-row-wrap gap-70percent m-b-10 layout-lt-md-column">
           <p class="mat-title flex-25">
             {{ 'labels.inputs.Floating Rate Periods' | translate }}
-            <i
-              class="fas fa-question"
-              matTooltip="{{ 'tooltips.Floating interest rate and start date' | translate }}"
-            ></i>
           </p>
 
           <button mat-mini-fab type="button" color="primary" (click)="addFloatingRatePeriod()">
@@ -167,7 +163,7 @@
           mat-raised-button
           type="submit"
           color="primary"
-          [disabled]="!floatingRateForm.valid"
+          [disabled]="!floatingRateForm.valid || floatingRatePeriodsData.length === 0"
           *mifosxHasPermission="'CREATE_FLOATINGRATE'"
         >
           {{ 'labels.buttons.Submit' | translate }}

--- a/src/app/products/floating-rates/create-floating-rate/create-floating-rate.component.ts
+++ b/src/app/products/floating-rates/create-floating-rate/create-floating-rate.component.ts
@@ -89,8 +89,6 @@ export class CreateFloatingRateComponent implements OnInit {
 
   /** Floating Rate Period Data. */
   floatingRatePeriodsData: any[] = [];
-  /** Minimum floating rate period date allowed. */
-  minDate = new Date();
   /** Floating Rate Form. */
   floatingRateForm: UntypedFormGroup;
   /** Columns to be displayed in floating rate periods table. */
@@ -164,9 +162,7 @@ export class CreateFloatingRateComponent implements OnInit {
    */
   addFloatingRatePeriod() {
     const floatingRatePeriodDialogRef = this.dialog.open(FloatingRatePeriodDialogComponent, {
-      data: {
-        fromDate: this.settingsService.businessDate
-      }
+      data: {}
     });
     floatingRatePeriodDialogRef.afterClosed().subscribe((response: any) => {
       if (response) {

--- a/src/app/products/floating-rates/edit-floating-rate/edit-floating-rate.component.html
+++ b/src/app/products/floating-rates/edit-floating-rate/edit-floating-rate.component.html
@@ -59,12 +59,6 @@
         <div class="layout-row-wrap gap-70percent m-b-10 layout-lt-md-column">
           <p class="mat-title flex-25">
             {{ 'labels.inputs.Floating Rate Periods' | translate }}
-            <i
-              class="fas fa-question"
-              matTooltip="{{
-                'tooltips.Floating interest rate and start date for this floating rate scheme' | translate
-              }}"
-            ></i>
           </p>
 
           <button mat-mini-fab type="button" color="primary" (click)="addFloatingRatePeriod()">

--- a/src/app/products/floating-rates/edit-floating-rate/edit-floating-rate.component.ts
+++ b/src/app/products/floating-rates/edit-floating-rate/edit-floating-rate.component.ts
@@ -89,8 +89,6 @@ export class EditFloatingRateComponent implements OnInit {
   floatingRateForm: UntypedFormGroup;
   /** Floating Rate Data. */
   floatingRateData: any;
-  /** Minimum floating rate period date allowed. */
-  minDate = new Date();
   /** Form Pristine Status. */
   isFloatingRateFormPristine = true;
   /** Columns to be displayed in floating rate periods table. */
@@ -192,7 +190,8 @@ export class EditFloatingRateComponent implements OnInit {
       data: {
         fromDate: ratePeriod.fromDate,
         interestRate: ratePeriod.interestRate,
-        isDifferentialToBaseLendingRate: ratePeriod.isDifferentialToBaseLendingRate
+        isDifferentialToBaseLendingRate: ratePeriod.isDifferentialToBaseLendingRate,
+        isNew: true
       }
     });
     editFloatingRatePeriodDialogRef.afterClosed().subscribe((response: any) => {

--- a/src/app/products/floating-rates/floating-rate-period-dialog/floating-rate-period-dialog.component.ts
+++ b/src/app/products/floating-rates/floating-rate-period-dialog/floating-rate-period-dialog.component.ts
@@ -54,28 +54,33 @@ export class FloatingRatePeriodDialogComponent implements OnInit {
    * Creates the floating rate period form.
    */
   ngOnInit() {
-    this.minDate = this.settingsService.businessDate;
+    // Set minDate to tomorrow based on server business date (floating rates must always be in the future)
+    const tomorrow = new Date(this.settingsService.businessDate);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(0, 0, 0, 0);
+    this.minDate = tomorrow;
+
     let rowDisabled = false;
-    if (this.data && new Date(this.data.fromDate) < this.minDate) {
+    if (this.data?.fromDate && new Date(this.data.fromDate) < this.minDate) {
       rowDisabled = true;
     }
-    if (this.data.isNew) {
+    if (this.data?.isNew) {
       rowDisabled = false;
     }
     this.floatingRatePeriodForm = this.formBuilder.group({
       fromDate: [
-        { value: this.data ? new Date(this.data.fromDate) : '', disabled: rowDisabled },
+        { value: this.data?.fromDate ? new Date(this.data.fromDate) : '', disabled: rowDisabled },
         Validators.required
       ],
       interestRate: [
-        { value: this.data ? this.data.interestRate : '', disabled: rowDisabled },
+        { value: this.data?.interestRate ?? '', disabled: rowDisabled },
         [
           Validators.required,
           Validators.min(0)
         ]
       ],
       isDifferentialToBaseLendingRate: [
-        { value: this.data ? this.data.isDifferentialToBaseLendingRate : false, disabled: rowDisabled }]
+        { value: this.data?.isDifferentialToBaseLendingRate ?? false, disabled: rowDisabled }]
     });
   }
 


### PR DESCRIPTION
## Description
This PR fixes several usability issues in the Create Floating Rate form:

Removed unnecessary question mark icon from the "Floating Rate Periods" label - the icon served no functional purpose and was confusing in this context

Set minimum selectable date to tomorrow - Fineract requires floating rate
periods to be in the future (not today). Previously users could select today's date which would result in a backend validation error. Now the date picker prevents selecting dates earlier than tomorrow.

Disabled submit button until at least one rate period is configured - Fineract requires at least one floating rate period record. Previously users could submit without any periods and receive an unhelpful backend error.

Added null safety checks in the floating rate period dialog to prevent potential runtime errors when data is empty

No new dependencies required.

## Related issues and discussion
#WEB-134

## Screenshots
After: Date picker only allows tomorrow onwards, submit button disabled until rate period added
https://github.com/user-attachments/assets/15636f14-32b1-4768-8eaf-60fd496c4118

## Checklist
-  [x] If you have multiple commits please combine them into one commit by squashing them.
-  [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Changes**
  * Removed the informational icon and tooltip from the Floating Rate Periods header on create and edit screens.

* **Form Validation**
  * Submission is blocked until at least one floating rate period is added.

* **Date Selection**
  * Floating rate period start dates must be tomorrow or later.

* **Dialog Stability**
  * Adding/editing period dialogs handle missing or partial data more safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->