### PR TITLE
WEB-903 Page title for recurring deposit account shows raw translation key instead of text

### DIFF
--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3527,6 +3527,7 @@
       "Provisioning criteria definitions": "Vyplňte všechny definice kritérií poskytování.",
       "Precedes of": "Předchází",
       "Recurring Deposit Account Charges": "Opakované poplatky za vkladový účet",
+      "Recurring Deposit Account Details": "Detaily účtu opakovaného vkladu",
       "Recurring Deposit Account Interest Rate Chart": "Graf úrokových sazeb pro opakující se vkladový účet",
       "Recurring Deposit Account Standing Instructions": "Pokyny k trvalému vkladovému účtu",
       "Recurring Deposit Account Transactions": "Opakující se transakce na vkladovém účtu",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3528,6 +3528,7 @@
       "Provisioning criteria definitions": "Bitte füllen Sie alle Definitionen der Bereitstellungskriterien aus.",
       "Precedes of": "Präzedenzfälle von",
       "Recurring Deposit Account Charges": "Wiederkehrende Kontogebühren",
+      "Recurring Deposit Account Details": "Details zum wiederkehrenden Einzahlungskonto",
       "Recurring Deposit Account Interest Rate Chart": "Zinssatztabelle für wiederkehrende Einlagenkonten",
       "Recurring Deposit Account Standing Instructions": "Anweisungen zum Kontostand für wiederkehrende Einlagen",
       "Recurring Deposit Account Transactions": "Wiederkehrende Transaktionen auf dem Einlagenkonto",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3649,6 +3649,7 @@
       "Precedes of": "Precedes of",
       "RecurringDepositAccountCreateBusinessEvent": "Recurring Deposit Account Create Business Event",
       "Recurring Deposit Account Charges": "Recurring Deposit Account Charges",
+      "Recurring Deposit Account Details": "Recurring Deposit Account Details",
       "Recurring Deposit Account Interest Rate Chart": "Recurring Deposit Account Interest Rate Chart",
       "Recurring Deposit Account Standing Instructions": "Recurring Deposit Account Standing Instructions",
       "Recurring Deposit Account Transactions": "Recurring Deposit Account Transactions",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3529,6 +3529,7 @@
       "Provisioning criteria definitions": "Complete todas las definiciones de criterios de aprovisionamiento.",
       "Precedes of": "Precede de",
       "Recurring Deposit Account Charges": "Comisiones recurrentes de la cuenta de depósito",
+      "Recurring Deposit Account Details": "Detalles de la cuenta de depósito recurrente",
       "Recurring Deposit Account Interest Rate Chart": "Tabla de tasas de interés de cuentas de Depósito Recurrentes",
       "Recurring Deposit Account Standing Instructions": "Instrucciones para la situación de la cuenta de Depósito Recurrente",
       "Recurring Deposit Account Transactions": "Transacciones recurrentes en cuentas de depósito",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3562,6 +3562,7 @@
       "Provisioning criteria definitions": "Complete todas las definiciones de criterios de aprovisionamiento.",
       "Precedes of": "Precede de",
       "Recurring Deposit Account Charges": "Comisiones recurrentes de la cuenta de depósito",
+      "Recurring Deposit Account Details": "Detalles de la cuenta de depósito recurrente",
       "Recurring Deposit Account Interest Rate Chart": "Tabla de tasas de interés de cuentas de Depósito Recurrentes",
       "Recurring Deposit Account Standing Instructions": "Instrucciones para la situación de la cuenta de Depósito Recurrente",
       "Recurring Deposit Account Transactions": "Transacciones recurrentes en cuentas de depósito",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3530,6 +3530,7 @@
       "Provisioning criteria definitions": "Veuillez remplir toutes les définitions des critères de provisionnement.",
       "Precedes of": "Précède de",
       "Recurring Deposit Account Charges": "Frais de compte de dépôt récurrents",
+      "Recurring Deposit Account Details": "Détails du compte de dépôt récurrent",
       "Recurring Deposit Account Interest Rate Chart": "Tableau des taux d’intérêt des comptes de dépôt récurrents",
       "Recurring Deposit Account Standing Instructions": "Instructions permanentes pour les comptes de dépôt récurrents",
       "Recurring Deposit Account Transactions": "Opérations récurrentes sur le compte de dépôt",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3526,6 +3526,7 @@
       "Provisioning criteria definitions": "Compila tutte le definizioni dei criteri di provisioning.",
       "Precedes of": "Precede di",
       "Recurring Deposit Account Charges": "Spese ricorrenti sul conto di deposito",
+      "Recurring Deposit Account Details": "Dettagli del conto di deposito ricorrente",
       "Recurring Deposit Account Interest Rate Chart": "Grafico del tasso di interesse del conto di deposito ricorrente",
       "Recurring Deposit Account Standing Instructions": "Istruzioni per la permanenza del conto di deposito ricorrente",
       "Recurring Deposit Account Transactions": "Transazioni ricorrenti del conto di deposito",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3527,6 +3527,7 @@
       "Provisioning criteria definitions": "모든 프로비저닝 기준 정의를 입력하세요.",
       "Precedes of": "앞선",
       "Recurring Deposit Account Charges": "반복 예금 계좌 수수료",
+      "Recurring Deposit Account Details": "정기 적금 계좌 세부 정보",
       "Recurring Deposit Account Interest Rate Chart": "정기예금 계좌 이자율 차트",
       "Recurring Deposit Account Standing Instructions": "정기예금 계좌 유지 지침",
       "Recurring Deposit Account Transactions": "반복 예금 계좌 거래",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3528,6 +3528,7 @@
       "Provisioning criteria definitions": "Užpildykite visus teikimo kriterijų apibrėžimus.",
       "Precedes of": "Prieštaravimai",
       "Recurring Deposit Account Charges": "Pasikartojantys indėlio sąskaitos mokesčiai",
+      "Recurring Deposit Account Details": "Reguliariųjų indėlių sąskaitos rekvizitai",
       "Recurring Deposit Account Interest Rate Chart": "Periodinio indėlio sąskaitos palūkanų normų diagrama",
       "Recurring Deposit Account Standing Instructions": "Periodinio indėlio sąskaitos nuolatinės instrukcijos",
       "Recurring Deposit Account Transactions": "Periodinės indėlio sąskaitos operacijos",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3527,6 +3527,7 @@
       "Provisioning criteria definitions": "Lūdzu, aizpildiet visas nodrošināšanas kritēriju definīcijas.",
       "Precedes of": "Iepriekšējie",
       "Recurring Deposit Account Charges": "Periodiskas depozīta konta izmaksas",
+      "Recurring Deposit Account Details": "Regulārā noguldījuma konta informācija",
       "Recurring Deposit Account Interest Rate Chart": "Atkārtota depozīta konta procentu likmju diagramma",
       "Recurring Deposit Account Standing Instructions": "Atkārtota depozīta konta pastāvīgās lietošanas instrukcijas",
       "Recurring Deposit Account Transactions": "Atkārtoti depozīta konta darījumi",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3525,6 +3525,7 @@
       "Provisioning criteria definitions": "कृपया सबै प्रावधान मापदण्ड परिभाषाहरू भर्नुहोस्।",
       "Precedes of": "को पूर्ववर्ती",
       "Recurring Deposit Account Charges": "आवर्ती जम्मा खाता शुल्कहरू",
+      "Recurring Deposit Account Details": "आवर्ती निक्षेप खाता विवरण",
       "Recurring Deposit Account Interest Rate Chart": "आवर्ती जम्मा खाता ब्याज दर चार्ट",
       "Recurring Deposit Account Standing Instructions": "आवर्ती जम्मा खाता स्थायी निर्देशनहरू",
       "Recurring Deposit Account Transactions": "आवर्ती जम्मा खाता लेनदेन",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3527,6 +3527,7 @@
       "Provisioning criteria definitions": "Preencha todas as definições de critérios de provisionamento.",
       "Precedes of": "Precede de",
       "Recurring Deposit Account Charges": "Cobranças recorrentes da conta de depósito",
+      "Recurring Deposit Account Details": "Detalhes da conta de depósito recorrente",
       "Recurring Deposit Account Interest Rate Chart": "Gráfico de taxas de juros de contas de depósito recorrente",
       "Recurring Deposit Account Standing Instructions": "Instruções sobre a situação da conta de depósito recorrente",
       "Recurring Deposit Account Transactions": "Transações recorrentes em contas de depósito",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3523,6 +3523,7 @@
       "Provisioning criteria definitions": "Tafadhali jaza ufafanuzi wa vigezo vyote vya utoaji.",
       "Precedes of": "Hutangulia",
       "Recurring Deposit Account Charges": "Malipo ya Akaunti ya Amana ya Mara kwa Mara",
+      "Recurring Deposit Account Details": "Maelezo ya Akaunti ya Amana Inayojirudia",
       "Recurring Deposit Account Interest Rate Chart": "Chati ya Kiwango cha Riba cha Akaunti ya Amana ya Mara kwa Mara",
       "Recurring Deposit Account Standing Instructions": "Maagizo ya Kudumu ya Akaunti ya Amana",
       "Recurring Deposit Account Transactions": "Miamala ya Akaunti ya Amana ya Mara kwa Mara",


### PR DESCRIPTION
**Changes Made :-** 

-Added the missing "Recurring Deposit Account Details" translation keys across all localization files to ensure the page title correctly displays the localized string instead of the raw key.

[WEB-903](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-903)

Before :- 
<img width="640" height="311" alt="image" src="https://github.com/user-attachments/assets/45289d7c-5c09-4cb5-a041-ef358ef511b4" />

After :- 
<img width="1365" height="666" alt="image" src="https://github.com/user-attachments/assets/085d13ec-450e-4345-bcae-bdeb48428641" />


[WEB-903]: https://mifosforge.jira.com/browse/WEB-903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added recurring deposit account details label translations across 12 languages: Czech, German, Spanish (Chile & Mexico), French, Italian, Korean, Lithuanian, Latvian, Nepali, Portuguese, and Swahili.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->