### PR TITLE
WEB-904 Missing localization key for Share Account Details page title

### DIFF
--- a/src/app/shares/shares-routing.module.ts
+++ b/src/app/shares/shares-routing.module.ts
@@ -59,7 +59,7 @@ const routes: Routes = [
               {
                 path: 'general',
                 component: GeneralTabComponent,
-                data: { title: 'Shares Account General', breadcrumb: 'General', routeParamBreadcrumb: false },
+                data: { title: 'Shares Account Details', breadcrumb: 'General', routeParamBreadcrumb: false },
                 resolve: {
                   sharesAccountData: SharesAccountViewResolver
                 }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3592,6 +3592,7 @@
       "Share Products Dividends": "Sdílejte produkty Dividendy",
       "Share products define the rules, default settings": "Sdílené produkty definují pravidla, výchozí nastavení a omezení pro akcie a dividendy finanční instituce. Sdílený produkt poskytuje šablonu pro více účtů, které jsou nebo budou drženy klienty finanční instituce.",
       "Shares": "akcie",
+      "Shares Account Details": "Detaily účtu akcií",
       "Shares Account Actions": "Akce na účtu akcií",
       "Shares Account Charges": "Poplatky na účtu akcií",
       "Shares Account Dividends": "Akcie Účet Dividendy",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3593,6 +3593,7 @@
       "Share Products Dividends": "Dividenden für Aktienprodukte",
       "Share products define the rules, default settings": "Aktienprodukte definieren die Regeln, Standardeinstellungen und Einschränkungen für die Aktien und Dividenden eines Finanzinstituts. Ein Aktienprodukt bietet eine Vorlage für mehrere Konten, die von den Kunden des Finanzinstituts geführt werden oder werden.",
       "Shares": "Anteile",
+      "Shares Account Details": "Details zum Aktienkonto",
       "Shares Account Actions": "Gibt Kontoaktionen frei",
       "Shares Account Charges": "Gebühren für das Aktienkonto",
       "Shares Account Dividends": "Dividenden auf dem Aktienkonto",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3727,6 +3727,7 @@
       "Share Products Dividends": "Share Products Dividends",
       "Share products define the rules, default settings": "Share products define the rules, default settings, and constraints for a financial institution's Shares and dividends. A share product provides a template for multiple accounts that are or will be held by the financial institution's clients.",
       "Shares": "Shares",
+      "Shares Account Details": "Shares Account Details",
       "Shares Account Actions": "Shares Account Actions",
       "Shares Account Charges": "Shares Account Charges",
       "Shares Account Dividends": "Shares Account Dividends",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3594,6 +3594,7 @@
       "Share Products Dividends": "Dividendos de Productos de Acciones",
       "Share products define the rules, default settings": "Los productos de acciones definen las reglas, la configuración predeterminada y las restricciones para las acciones y los dividendos de una institución financiera. Un producto de acciones proporciona una plantilla para múltiples cuentas que son o serán propiedad de los clientes de la institución financiera.",
       "Shares": "Acciones",
+      "Shares Account Details": "Detalles de la cuenta de acciones",
       "Shares Account Actions": "Acciones de la cuenta de acciones",
       "Shares Account Charges": "Comisiones de la cuenta de acciones",
       "Shares Account Dividends": "Dividendos de cuentas de acciones",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3627,6 +3627,7 @@
       "Share Products Dividends": "Dividendos de Productos de Acciones",
       "Share products define the rules, default settings": "Los productos de acciones definen las reglas, la configuración predeterminada y las restricciones para las acciones y los dividendos de una institución financiera. Un producto de acciones proporciona una plantilla para múltiples cuentas que son o serán propiedad de los clientes de la institución financiera.",
       "Shares": "Acciones",
+      "Shares Account Details": "Detalles de la cuenta de acciones",
       "Shares Account Actions": "Acciones de la cuenta de acciones",
       "Shares Account Charges": "Comisiones de la cuenta de acciones",
       "Shares Account Dividends": "Dividendos de cuentas de acciones",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3595,6 +3595,7 @@
       "Share Products Dividends": "Partager les dividendes des produits",
       "Share products define the rules, default settings": "Les produits d'actions définissent les règles, les paramètres par défaut et les contraintes applicables aux actions et aux dividendes d'une institution financière. Un produit d'actions fournit un modèle pour plusieurs comptes qui sont ou seront détenus par les clients de l'institution financière.",
       "Shares": "Actions",
+      "Shares Account Details": "Détails du compte d'actions",
       "Shares Account Actions": "Actions sur le compte de partage",
       "Shares Account Charges": "Frais de compte d’actions",
       "Shares Account Dividends": "Dividendes du compte d'actions",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3591,6 +3591,7 @@
       "Share Products Dividends": "Condividi i dividendi dei prodotti",
       "Share products define the rules, default settings": "I prodotti azionari definiscono le regole, le impostazioni predefinite e i vincoli per le azioni e i dividendi di un istituto finanziario. Un prodotto azionario fornisce un modello per più conti che sono o saranno detenuti dai clienti dell'istituto finanziario.",
       "Shares": "Azioni",
+      "Shares Account Details": "Dettagli del conto azioni",
       "Shares Account Actions": "Condivide le azioni dell'account",
       "Shares Account Charges": "Condivide le spese del conto",
       "Shares Account Dividends": "Dividendi del conto azionario",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3592,6 +3592,7 @@
       "Share Products Dividends": "제품 배당금 공유",
       "Share products define the rules, default settings": "주식 상품은 금융 기관의 주식 및 배당금에 대한 규칙, 기본 설정 및 제약 조건을 정의합니다. 공유 상품은 금융 기관의 고객이 보유하고 있거나 보유하게 될 여러 계좌에 대한 템플릿을 제공합니다.",
       "Shares": "주식",
+      "Shares Account Details": "주식 계좌 세부 정보",
       "Shares Account Actions": "공유 계정 작업",
       "Shares Account Charges": "주식 계정 비용",
       "Shares Account Dividends": "주식 계좌 배당금",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3593,6 +3593,7 @@
       "Share Products Dividends": "Dalintis produktais dividendais",
       "Share products define the rules, default settings": "Bendrinimo produktai apibrėžia taisykles, numatytuosius nustatymus ir apribojimus finansų įstaigos akcijoms ir dividendams. Dalijimosi produktas suteikia šabloną kelioms paskyroms, kurias turi arba turės finansų įstaigos klientai.",
       "Shares": "Akcijos",
+      "Shares Account Details": "Akcijų sąskaitos informacija",
       "Shares Account Actions": "Bendrina paskyros veiksmus",
       "Shares Account Charges": "Dalijasi sąskaitos mokesčiais",
       "Shares Account Dividends": "Dalina sąskaitos dividendus",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3592,6 +3592,7 @@
       "Share Products Dividends": "Dalieties Produkti Dividendes",
       "Share products define the rules, default settings": "Kopīgošanas produkti nosaka noteikumus, noklusējuma iestatījumus un ierobežojumus finanšu iestādes akcijām un dividendēm. Dalīšanas produkts nodrošina veidni vairākiem kontiem, kas pieder vai būs finanšu iestādes klientiem.",
       "Shares": "Akcijas",
+      "Shares Account Details": "Akciju konta informācija",
       "Shares Account Actions": "Kopīgošanas konta darbības",
       "Shares Account Charges": "Akciju konta izmaksas",
       "Shares Account Dividends": "Akciju konta dividendes",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3590,6 +3590,7 @@
       "Share Products Dividends": "शेयर उत्पादन लाभांश",
       "Share products define the rules, default settings": "शेयर उत्पादनहरूले वित्तीय संस्थाको शेयर र लाभांशका लागि नियमहरू, पूर्वनिर्धारित सेटिङहरू, र अवरोधहरू परिभाषित गर्दछ। एक सेयर उत्पादनले वित्तीय संस्थाका ग्राहकहरूद्वारा आयोजित वा राख्ने बहु खाताहरूको लागि टेम्प्लेट प्रदान गर्दछ।",
       "Shares": "सेयरहरू",
+      "Shares Account Details": "सेयर खाता विवरण",
       "Shares Account Actions": "साझेदारी खाता कार्यहरू",
       "Shares Account Charges": "शेयर खाता शुल्कहरू",
       "Shares Account Dividends": "शेयर खाता लाभांश",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3592,6 +3592,7 @@
       "Share Products Dividends": "Compartilhe dividendos de produtos",
       "Share products define the rules, default settings": "Os produtos de ações definem as regras, configurações padrão e restrições para as ações e dividendos de uma instituição financeira. Um produto de ações fornece um modelo para várias contas que são ou serão mantidas pelos clientes da instituição financeira.",
       "Shares": "Ações",
+      "Shares Account Details": "Detalhes da conta de ações",
       "Shares Account Actions": "Compartilha ações da conta",
       "Shares Account Charges": "Encargos da conta de ações",
       "Shares Account Dividends": "Dividendos da conta de ações",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3588,6 +3588,7 @@
       "Share Products Dividends": "Shiriki Gawio la Bidhaa",
       "Share products define the rules, default settings": "Bidhaa zinazoshirikiwa hufafanua sheria, mipangilio chaguo-msingi na vikwazo vya Hisa na gawio la taasisi ya fedha. Bidhaa inayoshirikiwa hutoa kiolezo cha akaunti nyingi ambazo zinashikiliwa au zitashikiliwa na wateja wa taasisi ya fedha.",
       "Shares": "Hisa",
+      "Shares Account Details": "Maelezo ya Akaunti ya Hisa",
       "Shares Account Actions": "Vitendo vya Akaunti ya Hisa",
       "Shares Account Charges": "Inashiriki Malipo ya Akaunti",
       "Shares Account Dividends": "Gawio la Akaunti ya Hisa",


### PR DESCRIPTION
**Changes Made :-** 

-Updated the Share Account general routing configuration to use 'Shares Account Details' for consistency with other account types and added the missing translation key across all 13 localization files. 

[WEB-904](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-904)

[WEB-904]: https://mifosforge.jira.com/browse/WEB-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Shares Account page title to "Shares Account Details".
  * Added translations for "Shares Account Details" in 13 locales: en, es (CL/MX), fr, de, pt, it, cs, ko, lt, lv, ne, sw.

* **Bug Fixes**
  * No functional or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->