### PR TITLE
WEB-905 fix: replace className with class in Angular template

### DIFF
--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -35,7 +35,7 @@
   <!-- Upcoming Charges -->
   <div class="heading-content">
     <div class="layout-column flex-50">
-      <div className="heading-name">
+      <div class="heading-name">
         <h3>{{ 'labels.heading.Upcoming Charges' | translate }}</h3>
       </div>
     </div>


### PR DESCRIPTION
This PR fixes the incorrect usage of the className attribute in an Angular template.className is specific to React and is not valid in Angular templates. Replacing it with the standard HTML class attribute ensures that styles are applied correctly and prevents potential rendering inconsistencies.



[WEB-905](https://mifosforge.jira.com/browse/WEB-905)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-905]: https://mifosforge.jira.com/browse/WEB-905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Corrected HTML attribute naming conventions for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->