### PR TITLE
WEB-884 feat: auto-fill address fields from postal code using Zippopotam API

### DIFF
--- a/src/app/clients/clients-view/address-tab/address-tab.component.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.ts
@@ -8,7 +8,8 @@
 
 /** Angular Imports */
 import { Component, inject } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-base';
 import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
@@ -19,6 +20,12 @@ import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.componen
 
 /** Custom Services */
 import { TranslateService } from '@ngx-translate/core';
+import { PostalCodeLookupService } from 'app/shared/services/postal-code-lookup.service';
+import { ResolvedAddress } from 'app/shared/models/postal-code-lookup.model';
+
+/** rxjs Imports */
+import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+import { of, Subscription } from 'rxjs';
 import { ClientsService } from '../../clients.service';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import {
@@ -56,6 +63,7 @@ export class AddressTabComponent {
   private clientService = inject(ClientsService);
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private postalCodeLookup = inject(PostalCodeLookupService);
 
   /** Client Address Data */
   clientAddressData: any;
@@ -97,6 +105,7 @@ export class AddressTabComponent {
       formfields: this.getAddressFormFields('add')
     };
     const addAddressDialogRef = this.dialog.open(FormDialogComponent, { data });
+    this.setupPostalCodeLookup(addAddressDialogRef);
     addAddressDialogRef.afterClosed().subscribe((response: any) => {
       if (response.data) {
         this.clientService
@@ -129,6 +138,7 @@ export class AddressTabComponent {
       layout: { addButtonText: 'Edit' }
     };
     const editAddressDialogRef = this.dialog.open(FormDialogComponent, { data });
+    this.setupPostalCodeLookup(editAddressDialogRef);
     editAddressDialogRef.afterClosed().subscribe((response: any) => {
       if (response.data) {
         const addressData = response.data.value;
@@ -143,6 +153,139 @@ export class AddressTabComponent {
           });
       }
     });
+  }
+
+  /** Tracks which fields were auto-filled by the postal code lookup. */
+  private autoFilledFields = new Set<string>();
+
+  /**
+   * Sets up postal code auto-lookup on the dialog form.
+   * Subscribes to postalCode valueChanges, queries the lookup API,
+   * and auto-fills City, State/Province, and Country fields.
+   */
+  private setupPostalCodeLookup(dialogRef: MatDialogRef<FormDialogComponent>) {
+    if (!this.postalCodeLookup.enabled) return;
+
+    let postalSub: Subscription;
+
+    dialogRef.afterOpened().subscribe(() => {
+      const form: UntypedFormGroup = dialogRef.componentInstance.form;
+      const postalCodeControl = form.get('postalCode');
+      if (!postalCodeControl) return;
+
+      // Capture the initial country value so we can distinguish
+      // user-selected countries from auto-filled ones.
+      const initialCountryId = form.get('countryId')?.value || null;
+
+      postalSub = postalCodeControl.valueChanges
+        .pipe(
+          debounceTime(600),
+          distinctUntilChanged(),
+          switchMap((value: string) => {
+            if (!value || value.trim().length < 3) {
+              return of(null);
+            }
+            const postalCode = value.trim();
+            // Only use the country for lookup if the user explicitly selected it
+            // (i.e. it was set initially or the user changed it manually).
+            const currentCountryId = form.get('countryId')?.value;
+            const isUserSelectedCountry =
+              currentCountryId && (currentCountryId === initialCountryId || !this.autoFilledFields.has('countryId'));
+
+            if (isUserSelectedCountry) {
+              const countryCode = this.getSelectedCountryCode(form);
+              if (countryCode) {
+                return this.postalCodeLookup.lookup(countryCode, postalCode);
+              }
+            }
+            return this.postalCodeLookup.lookupWithFallback(postalCode);
+          })
+        )
+        .subscribe((response) => {
+          if (!response) {
+            this.clearAutoFilledFields(form);
+            return;
+          }
+          const resolved = this.postalCodeLookup.toResolvedAddress(response);
+          if (resolved) {
+            this.clearAutoFilledFields(form);
+            this.applyResolvedAddress(form, resolved);
+          } else {
+            this.clearAutoFilledFields(form);
+          }
+        });
+    });
+
+    dialogRef.afterClosed().subscribe(() => {
+      postalSub?.unsubscribe();
+      this.autoFilledFields.clear();
+    });
+  }
+
+  /**
+   * Gets the ISO country code for the currently selected country in the form.
+   */
+  private getSelectedCountryCode(form: UntypedFormGroup): string | null {
+    const countryIdValue = form.get('countryId')?.value;
+    if (!countryIdValue) return null;
+
+    const selectedCountry = this.clientAddressTemplate.countryIdOptions?.find((c: any) => c.id === countryIdValue);
+    if (!selectedCountry) return null;
+
+    return this.postalCodeLookup.resolveCountryCode(selectedCountry.name);
+  }
+
+  /**
+   * Applies the resolved address to the form fields.
+   * Passes both full name and abbreviation to maximize match chances
+   * against Fineract's configured code values.
+   */
+  /**
+   * Clears form fields that were previously set by auto-fill,
+   * so stale data doesn't persist when a new lookup fails or returns different results.
+   */
+  private clearAutoFilledFields(form: UntypedFormGroup) {
+    for (const fieldName of this.autoFilledFields) {
+      const control = form.get(fieldName);
+      if (control) {
+        control.setValue(fieldName === 'city' ? '' : '');
+        control.markAsDirty();
+      }
+    }
+    this.autoFilledFields.clear();
+  }
+
+  private applyResolvedAddress(form: UntypedFormGroup, address: ResolvedAddress) {
+    const cityControl = form.get('city');
+    if (cityControl && address.city) {
+      cityControl.setValue(address.city);
+      cityControl.markAsDirty();
+      this.autoFilledFields.add('city');
+    }
+
+    const stateControl = form.get('stateProvinceId');
+    if (stateControl && (address.state || address.stateAbbreviation)) {
+      const stateOptions = this.clientAddressTemplate.stateProvinceIdOptions ?? [];
+      const matched = this.postalCodeLookup.findBestMatch(stateOptions, address.state, address.stateAbbreviation);
+      if (matched) {
+        stateControl.setValue(matched.id);
+        stateControl.markAsDirty();
+        this.autoFilledFields.add('stateProvinceId');
+      }
+    }
+
+    const countryControl = form.get('countryId');
+    if (countryControl && (address.country || address.countryAbbreviation)) {
+      const countryOptions = this.clientAddressTemplate.countryIdOptions ?? [];
+      const matched = this.postalCodeLookup.findBestMatch(countryOptions, address.country, address.countryAbbreviation);
+      if (matched) {
+        countryControl.setValue(matched.id);
+        countryControl.markAsDirty();
+        this.autoFilledFields.add('countryId');
+      }
+    }
+
+    form.markAsDirty();
   }
 
   /**

--- a/src/app/shared/constants/country-codes.ts
+++ b/src/app/shared/constants/country-codes.ts
@@ -1,0 +1,190 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Mapping of common country names (lowercase) to ISO 3166-1 alpha-2 codes.
+ * Used by PostalCodeLookupService to resolve country names from Fineract
+ * code values into API-compatible country codes.
+ *
+ * Covers countries commonly served by microfinance institutions.
+ */
+export const COUNTRY_NAME_TO_ISO_CODE: Record<string, string> = {
+  // Americas
+  'united states': 'us',
+  usa: 'us',
+  us: 'us',
+  canada: 'ca',
+  ca: 'ca',
+  mexico: 'mx',
+  méxico: 'mx',
+  mx: 'mx',
+  brazil: 'br',
+  brasil: 'br',
+  br: 'br',
+  argentina: 'ar',
+  ar: 'ar',
+  colombia: 'co',
+  co: 'co',
+  peru: 'pe',
+  perú: 'pe',
+  pe: 'pe',
+  chile: 'cl',
+  cl: 'cl',
+  ecuador: 'ec',
+  ec: 'ec',
+  guatemala: 'gt',
+  gt: 'gt',
+  'dominican republic': 'do',
+  do: 'do',
+  honduras: 'hn',
+  hn: 'hn',
+  'el salvador': 'sv',
+  sv: 'sv',
+  bolivia: 'bo',
+  bo: 'bo',
+  paraguay: 'py',
+  py: 'py',
+
+  // Europe
+  'united kingdom': 'gb',
+  'great britain': 'gb',
+  uk: 'gb',
+  gb: 'gb',
+  germany: 'de',
+  deutschland: 'de',
+  de: 'de',
+  france: 'fr',
+  fr: 'fr',
+  spain: 'es',
+  españa: 'es',
+  es: 'es',
+  italy: 'it',
+  italia: 'it',
+  it: 'it',
+  poland: 'pl',
+  pl: 'pl',
+  netherlands: 'nl',
+  nl: 'nl',
+  portugal: 'pt',
+  pt: 'pt',
+  belgium: 'be',
+  be: 'be',
+  switzerland: 'ch',
+  ch: 'ch',
+  austria: 'at',
+  at: 'at',
+  romania: 'ro',
+  ro: 'ro',
+
+  // Africa
+  'south africa': 'za',
+  za: 'za',
+  nigeria: 'ng',
+  ng: 'ng',
+  kenya: 'ke',
+  ke: 'ke',
+  tanzania: 'tz',
+  tz: 'tz',
+  uganda: 'ug',
+  ug: 'ug',
+  ghana: 'gh',
+  gh: 'gh',
+  ethiopia: 'et',
+  et: 'et',
+  mozambique: 'mz',
+  mz: 'mz',
+  rwanda: 'rw',
+  rw: 'rw',
+  senegal: 'sn',
+  sn: 'sn',
+  mali: 'ml',
+  ml: 'ml',
+  cameroon: 'cm',
+  cm: 'cm',
+  madagascar: 'mg',
+  mg: 'mg',
+  zambia: 'zm',
+  zm: 'zm',
+  zimbabwe: 'zw',
+  zw: 'zw',
+
+  // Asia & Pacific
+  india: 'in',
+  in: 'in',
+  pakistan: 'pk',
+  pk: 'pk',
+  bangladesh: 'bd',
+  bd: 'bd',
+  indonesia: 'id',
+  id: 'id',
+  philippines: 'ph',
+  ph: 'ph',
+  thailand: 'th',
+  th: 'th',
+  japan: 'jp',
+  jp: 'jp',
+  australia: 'au',
+  au: 'au',
+  myanmar: 'mm',
+  mm: 'mm',
+  cambodia: 'kh',
+  kh: 'kh',
+  nepal: 'np',
+  np: 'np',
+  'sri lanka': 'lk',
+  lk: 'lk'
+};
+
+/**
+ * Default ISO country codes to try when no country is selected in the form.
+ * Ordered by prevalence in typical Mifos deployments (microfinance hotspots).
+ */
+export const DEFAULT_LOOKUP_COUNTRY_CODES = [
+  'us',
+  'mx',
+  'in',
+  'ke',
+  'ph',
+  'br',
+  'gb'
+];
+
+/**
+ * Aliases for country names that differ between the Zippopotam API
+ * and common Fineract code value configurations.
+ * Key: API-returned name (lowercase) → Value: array of alternative names to try matching.
+ */
+export const COUNTRY_NAME_ALIASES: Record<string, string[]> = {
+  'great britain': [
+    'united kingdom',
+    'uk',
+    'england',
+    'britain'
+  ],
+  'united kingdom': [
+    'great britain',
+    'uk',
+    'england',
+    'britain'
+  ],
+  'united states': [
+    'usa',
+    'us',
+    'united states of america'
+  ],
+  brasil: ['brazil'],
+  brazil: ['brasil'],
+  méxico: ['mexico'],
+  mexico: ['méxico'],
+  deutschland: ['germany'],
+  germany: ['deutschland'],
+  españa: ['spain'],
+  spain: ['españa'],
+  italia: ['italy'],
+  italy: ['italia']
+};

--- a/src/app/shared/models/postal-code-lookup.model.ts
+++ b/src/app/shared/models/postal-code-lookup.model.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Represents a single place returned by the postal code lookup API */
+export interface PostalCodePlace {
+  'place name': string;
+  longitude: string;
+  latitude: string;
+  state: string;
+  'state abbreviation': string;
+}
+
+/** Response from the postal code lookup API (Zippopotam.us) */
+export interface PostalCodeLookupResponse {
+  country: string;
+  'country abbreviation': string;
+  'post code': string;
+  places: PostalCodePlace[];
+}
+
+/** Resolved address fields from a postal code lookup */
+export interface ResolvedAddress {
+  city: string;
+  state: string;
+  stateAbbreviation: string;
+  country: string;
+  countryAbbreviation: string;
+}

--- a/src/app/shared/services/postal-code-lookup.service.ts
+++ b/src/app/shared/services/postal-code-lookup.service.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpBackend } from '@angular/common/http';
+import { Observable, of, concat } from 'rxjs';
+import { catchError, first, filter } from 'rxjs/operators';
+import { PostalCodeLookupResponse, ResolvedAddress } from '../models/postal-code-lookup.model';
+import {
+  COUNTRY_NAME_TO_ISO_CODE,
+  COUNTRY_NAME_ALIASES,
+  DEFAULT_LOOKUP_COUNTRY_CODES
+} from '../constants/country-codes';
+import { environment } from 'environments/environment';
+
+/**
+ * Service for looking up address details from postal codes.
+ *
+ * Uses the free Zippopotam.us API (no API key required).
+ * Bypasses Angular HTTP interceptors to avoid adding Fineract auth headers.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class PostalCodeLookupService {
+  private httpBackend = inject(HttpBackend);
+  private externalHttp = new HttpClient(this.httpBackend);
+
+  private readonly API_BASE = 'https://api.zippopotam.us';
+
+  /** Whether the postal code lookup feature is enabled via environment config. */
+  get enabled(): boolean {
+    return environment.enablePostalCodeLookup;
+  }
+
+  /**
+   * Looks up address details for a postal code in a specific country.
+   * @param countryCode ISO 3166-1 alpha-2 country code
+   * @param postalCode Postal code to look up
+   * @returns Observable of the API response, or null if not found/disabled
+   */
+  lookup(countryCode: string, postalCode: string): Observable<PostalCodeLookupResponse | null> {
+    if (!this.enabled) return of(null);
+    return this.externalHttp
+      .get<PostalCodeLookupResponse>(`${this.API_BASE}/${countryCode}/${postalCode}`)
+      .pipe(catchError(() => of(null)));
+  }
+
+  /**
+   * Tries to resolve a postal code by testing multiple country codes.
+   * Emits the first successful result and completes.
+   * @param postalCode Postal code to look up
+   * @param countryCodes Country codes to try (defaults to common MFI countries)
+   */
+  lookupWithFallback(
+    postalCode: string,
+    countryCodes: string[] = DEFAULT_LOOKUP_COUNTRY_CODES
+  ): Observable<PostalCodeLookupResponse | null> {
+    if (!this.enabled || !countryCodes.length) return of(null);
+
+    const lookups$ = countryCodes.map((code) => this.lookup(code, postalCode));
+
+    return concat(...lookups$).pipe(
+      filter((result): result is PostalCodeLookupResponse => result !== null && result.places?.length > 0),
+      first(undefined, null)
+    );
+  }
+
+  /**
+   * Resolves a country name (from Fineract code values) to an ISO country code.
+   * Performs case-insensitive matching.
+   */
+  resolveCountryCode(countryName: string): string | null {
+    const lower = countryName.toLowerCase();
+    const direct = COUNTRY_NAME_TO_ISO_CODE[lower];
+    if (direct) return direct;
+
+    // Check aliases — e.g. "United States of America" → "united states" → "us"
+    const aliases = COUNTRY_NAME_ALIASES[lower];
+    if (aliases) {
+      for (const alias of aliases) {
+        const code = COUNTRY_NAME_TO_ISO_CODE[alias];
+        if (code) return code;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Extracts a clean ResolvedAddress from the raw API response.
+   */
+  toResolvedAddress(response: PostalCodeLookupResponse): ResolvedAddress | null {
+    if (!response?.places?.length) return null;
+    const place = response.places[0];
+    return {
+      city: place['place name'],
+      state: place.state,
+      stateAbbreviation: place['state abbreviation'],
+      country: response.country,
+      countryAbbreviation: response['country abbreviation']
+    };
+  }
+
+  /** Minimum character length for partial (contains) matching to avoid false positives */
+  private readonly MIN_PARTIAL_MATCH_LENGTH = 4;
+
+  /**
+   * Finds the best match for a name in a list of dropdown options.
+   * Matching strategy (stops at first hit):
+   *   1. Exact match (case-insensitive) on all candidates
+   *   2. Starts-with match (option starts with candidate or vice-versa)
+   *   3. Contains match — only for candidates with 4+ characters to avoid
+   *      false positives like "MA" matching "Za-ma-bia"
+   *
+   * @param options   Dropdown options from Fineract code values
+   * @param names     One or more names to try (e.g. full name + abbreviation)
+   */
+  findBestMatch<T extends { id: number; name: string }>(options: T[], ...names: string[]): T | null {
+    if (!options?.length || !names.length) return null;
+
+    const candidates = this.expandWithAliases(names);
+
+    // 1. Exact match (case-insensitive)
+    for (const candidate of candidates) {
+      const exact = options.find((o) => o.name.toLowerCase() === candidate);
+      if (exact) return exact;
+    }
+
+    // 2. Starts-with match (safe for short strings)
+    for (const candidate of candidates) {
+      const startsWith = options.find((o) => {
+        const optName = o.name.toLowerCase();
+        return optName.startsWith(candidate) || candidate.startsWith(optName);
+      });
+      if (startsWith) return startsWith;
+    }
+
+    // 3. Contains match — only for longer candidates to prevent false positives
+    for (const candidate of candidates) {
+      if (candidate.length < this.MIN_PARTIAL_MATCH_LENGTH) continue;
+      const contains = options.find((o) => {
+        const optName = o.name.toLowerCase();
+        return optName.includes(candidate) || candidate.includes(optName);
+      });
+      if (contains) return contains;
+    }
+
+    return null;
+  }
+
+  /**
+   * Expands a list of names with known aliases (lowercase, deduplicated).
+   */
+  private expandWithAliases(names: string[]): string[] {
+    const result = new Set<string>();
+    for (const name of names) {
+      if (!name) continue;
+      const lower = name.toLowerCase();
+      result.add(lower);
+      const aliases = COUNTRY_NAME_ALIASES[lower];
+      if (aliases) {
+        aliases.forEach((a) => result.add(a));
+      }
+    }
+    return [...result];
+  }
+}

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -112,6 +112,10 @@
   window['env']['externalNationalIdSystemApiKey'] = '';
   window['env']['externalNationalIdRegex'] = '';
 
+  // Postal Code Lookup (auto-fill address from postal code via external API)
+  // Set to 'true' to enable, 'false' (default) to disable
+  window['env']['enablePostalCodeLookup'] = 'false';
+
   // Password Configuration
   window['env']['minPasswordLength'] = 8;
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -97,6 +97,13 @@ export const environment = {
   mifosRemittanceApiHeader: loadedEnv['mifosRemittanceApiClientHeader'] || '',
   mifosRemittanceApiKey: loadedEnv['mifosRemittanceApiClientKey'] || '',
 
+  /**
+   * Postal Code Lookup — auto-fill city/state/country from postal code.
+   * Uses external Zippopotam.us API. Disable for deployments with strict privacy requirements.
+   */
+  enablePostalCodeLookup:
+    loadedEnv['enablePostalCodeLookup'] === 'true' || loadedEnv['enablePostalCodeLookup'] === true || false,
+
   minPasswordLength: resolvedMinPasswordLength,
   passwordRegex:
     loadedEnv.passwordRegex ||

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -111,6 +111,13 @@ export const environment = {
   externalNationalIdSystemApiKey: loadedEnv.externalNationalIdSystemApiKey || '',
   externalNationalIdRegex: loadedEnv.externalNationalIdRegex || '',
 
+  /**
+   * Postal Code Lookup — auto-fill city/state/country from postal code.
+   * Uses external Zippopotam.us API. Disable for deployments with strict privacy requirements.
+   */
+  enablePostalCodeLookup:
+    loadedEnv.enablePostalCodeLookup === 'true' || loadedEnv.enablePostalCodeLookup === true || false,
+
   minPasswordLength: resolvedMinPasswordLength,
   passwordRegex:
     loadedEnv.passwordRegex ||


### PR DESCRIPTION

 When entering a Postal Code in the client address dialog, the system now automatically queries the https://api.zippopotam.us API and auto-fills the City, State/Province, and Country fields. This reduces manual data entry errors and speeds up address capture for field officers.

  Key design :
  - Created a dedicated PostalCodeLookupService in shared/services/ so any address form in the app can reuse it (not just client addresses)
  - Used HttpBackend to bypass Fineract interceptors for external API calls
  - 3-tier matching strategy (exact → starts-with → contains with 4+ char minimum) to prevent false positives like "MA" matching "Zambia"
  - When no country is pre-selected, the service tries common MFI country codes (us, mx, in, ke, ph, br, gb) until one matches
  - Country name aliases handle API vs Fineract naming differences (e.g., "Great Britain" ↔ "United Kingdom")

  Note: State/Province and Country auto-fill only works when matching code values are configured in Fineract (Admin → System → Manage Codes under STATE  
  and COUNTRY). City always fills since it is a free-text field.


[WEB-884](https://mifosforge.jira.com/browse/WEB-884)

https://github.com/user-attachments/assets/cecd6c9f-9914-4ea6-9a7a-ec4f6b3f6da1

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-884]: https://mifosforge.jira.com/browse/WEB-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic postal-code lookup in address dialogs: entering a postal code now auto-populates city, state/province, and country. Works in both add and edit flows, supports multi-country fallback and fuzzy name matching, and clears auto-filled fields when no match is found.
* **Chores**
  * Runtime feature flag added to enable/disable postal-code lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->