### PR TITLE
WEB-874 Prevent negative values in numeric fields of group 

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
@@ -53,7 +53,7 @@
           matInput
           required
           mifosxPositiveNumber
-          min="0"
+          min="1"
           formControlName="repaymentEvery"
           matTooltip="{{ 'tooltips.Fields are input to calculating the repayment schedule' | translate }}"
         />
@@ -112,7 +112,7 @@
     @if (loanProductService.isLoanProduct) {
       <mat-form-field class="flex-fill flex-23">
         <mat-label>{{ 'labels.inputs.Loan Term' | translate }}</mat-label>
-        <input type="number" matInput required formControlName="loanTermFrequency" />
+        <input type="number" matInput required formControlName="loanTermFrequency" min="0" />
         @if (loansAccountTermsForm.controls.loanTermFrequency.hasError('required')) {
           <mat-error>
             {{ 'labels.inputs.Loan Term' | translate }} {{ 'labels.commons.is' | translate }}
@@ -157,7 +157,9 @@
         <input
           type="number"
           matInput
+          required
           formControlName="numberOfRepayments"
+          min="0"
           matTooltip="{{ 'tooltips.Enter the total count of repayments' | translate }}"
         />
         @if (loansAccountTermsForm.controls.numberOfRepayments.hasError('required')) {
@@ -218,6 +220,7 @@
           matInput
           required
           formControlName="repaymentEvery"
+          min="0"
           matTooltip="{{ 'tooltips.Fields are input to calculating the repayment schedule' | translate }}"
         />
         @if (loansAccountTermsForm.controls.repaymentEvery.hasError('required')) {
@@ -287,7 +290,7 @@
       @if (!loansAccountTermsData?.isLoanProductLinkedToFloatingRate) {
         <mat-form-field class="flex-fill flex-23">
           <mat-label>{{ 'labels.inputs.Nominal interest rate' | translate }} %</mat-label>
-          <input type="number" matInput formControlName="interestRatePerPeriod" />
+          <input type="number" matInput formControlName="interestRatePerPeriod" min="0.01" step="0.01" />
         </mat-form-field>
         <mat-form-field class="flex-fill flex-23">
           <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
@@ -468,6 +471,7 @@
           matInput
           type="number"
           formControlName="inArrearsTolerance"
+          min="0"
           matTooltip="{{ 'tooltips.With Arrears tolerance' | translate }}"
         />
       </mat-form-field>
@@ -476,7 +480,9 @@
         <mat-label>{{ 'labels.inputs.Interest free period' | translate }}</mat-label>
         <input
           matInput
+          type="number"
           formControlName="graceOnInterestCharged"
+          min="0"
           matTooltip="{{ 'tooltips.If the Interest Free Period' | translate }}"
         />
       </mat-form-field>
@@ -488,17 +494,17 @@
 
       <mat-form-field class="flex-fill flex-23">
         <mat-label>{{ 'labels.inputs.Grace on principal payment' | translate }}</mat-label>
-        <input type="number" matInput formControlName="graceOnPrincipalPayment" />
+        <input type="number" matInput formControlName="graceOnPrincipalPayment" min="0" />
       </mat-form-field>
 
       <mat-form-field class="flex-fill flex-23">
         <mat-label>{{ 'labels.inputs.Grace on interest payment' | translate }}</mat-label>
-        <input type="number" matInput formControlName="graceOnInterestPayment" />
+        <input type="number" matInput formControlName="graceOnInterestPayment" min="0" />
       </mat-form-field>
 
       <mat-form-field class="flex-48">
         <mat-label>{{ 'labels.inputs.On arrears ageing' | translate }}</mat-label>
-        <input type="number" matInput formControlName="graceOnArrearsAgeing" />
+        <input type="number" matInput formControlName="graceOnArrearsAgeing" min="0" />
       </mat-form-field>
 
       @if (isDelinquencyEnabled()) {

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -105,7 +105,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
   /** Is Multi Disburse Loan  */
   multiDisburseLoan: any;
   // @Input() loansAccountFormValid: LoansAccountFormValid
-  @Input() loansAccountFormValid: boolean;
+  @Input() loansAccountFormValid: boolean = false;
   // @Input collateralOptions: Collateral Options
   @Input() collateralOptions: any;
   // @Input loanPrincipal: Loan Principle
@@ -116,7 +116,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
   /** Maximum date allowed. */
   maxDate = new Date(2100, 0, 1);
   /** Loans Account Terms Form */
-  loansAccountTermsForm: UntypedFormGroup;
+  loansAccountTermsForm: UntypedFormGroup = new UntypedFormGroup({});
   /** Term Frequency Type Data */
   termFrequencyTypeData: any;
   /** Repayment Frequency Nth Day Type Data */
@@ -259,7 +259,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
             'enableInstallmentLevelDelinquency',
             new UntypedFormControl(
               this.loansAccountTermsData.enableInstallmentLevelDelinquency ||
-                this.loanProduct.enableInstallmentLevelDelinquency
+                this.loanProduct?.enableInstallmentLevelDelinquency
             )
           );
         }
@@ -397,7 +397,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
             'enableInstallmentLevelDelinquency',
             new UntypedFormControl(
               this.loansAccountTermsData.enableInstallmentLevelDelinquency ||
-                this.loanProduct.enableInstallmentLevelDelinquency
+                this.loanProduct?.enableInstallmentLevelDelinquency
             )
           );
         }
@@ -437,6 +437,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
       this.setAdvancedPaymentStrategyControls();
       this.setCustomValidators();
       this.setLoanTermListener();
+      this.setNumericFieldListeners();
 
       if (this.allowAddDisbursementDetails()) {
         this.loansAccountTermsForm.removeControl('maxOutstandingLoanBalance');
@@ -487,34 +488,34 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
     const repaymentFrequencyNthDayType = this.loansAccountTermsForm.get('repaymentFrequencyNthDayType');
     const repaymentFrequencyDayOfWeekType = this.loansAccountTermsForm.get('repaymentFrequencyDayOfWeekType');
 
-    this.loansAccountTermsForm.get('repaymentFrequencyType').valueChanges.subscribe((repaymentFrequencyType) => {
-      repaymentFrequencyNthDayType.setValidators(null);
-      repaymentFrequencyDayOfWeekType.setValidators(null);
+    this.loansAccountTermsForm.get('repaymentFrequencyType')?.valueChanges.subscribe((repaymentFrequencyType) => {
+      repaymentFrequencyNthDayType?.setValidators(null);
+      repaymentFrequencyDayOfWeekType?.setValidators(null);
 
       setTimeout(() => {
-        repaymentFrequencyNthDayType.updateValueAndValidity();
-        repaymentFrequencyDayOfWeekType.updateValueAndValidity();
+        repaymentFrequencyNthDayType?.updateValueAndValidity();
+        repaymentFrequencyDayOfWeekType?.updateValueAndValidity();
       });
     });
   }
 
   /** Custom Listeners for the form to calculate Loan Term */
   setLoanTermListener() {
-    this.loansAccountTermsForm.get('numberOfRepayments').valueChanges.subscribe((numberOfRepayments) => {
+    this.loansAccountTermsForm.get('numberOfRepayments')?.valueChanges.subscribe((numberOfRepayments) => {
       const repaymentEvery: number = this.loansAccountTermsForm.value.repaymentEvery;
       this.calculateLoanTerm(numberOfRepayments, repaymentEvery);
     });
 
-    this.loansAccountTermsForm.get('repaymentEvery').valueChanges.subscribe((repaymentEvery) => {
+    this.loansAccountTermsForm.get('repaymentEvery')?.valueChanges.subscribe((repaymentEvery) => {
       const numberOfRepayments: number = this.loansAccountTermsForm.value.numberOfRepayments;
       this.calculateLoanTerm(numberOfRepayments, repaymentEvery);
     });
 
-    this.loansAccountTermsForm.get('loanTermFrequencyType').valueChanges.subscribe((loanTermFrequencyType) => {
+    this.loansAccountTermsForm.get('loanTermFrequencyType')?.valueChanges.subscribe((loanTermFrequencyType) => {
       this.loansAccountTermsForm.patchValue({ repaymentFrequencyType: loanTermFrequencyType });
     });
 
-    this.loansAccountTermsForm.get('amortizationType').valueChanges.subscribe((amortizationType) => {
+    this.loansAccountTermsForm.get('amortizationType')?.valueChanges.subscribe((amortizationType) => {
       if (amortizationType === 0) {
         // Equal Principal Payments
         this.loansAccountTermsForm.addControl('fixedPrincipalPercentagePerInstallment', new UntypedFormControl(''));
@@ -525,6 +526,38 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
     });
   }
 
+  /** Prevent negative values in numeric fields */
+  setNumericFieldListeners() {
+    const numericFieldsWithMinZero = [
+      'graceOnPrincipalPayment',
+      'graceOnInterestPayment',
+      'graceOnArrearsAgeing',
+      'inArrearsTolerance',
+      'graceOnInterestCharged',
+      'loanTermFrequency',
+      'numberOfRepayments',
+      'repaymentEvery'
+    ];
+    numericFieldsWithMinZero.forEach((fieldName) => {
+      const control = this.loansAccountTermsForm.get(fieldName);
+      if (control) {
+        control.valueChanges.subscribe((value) => {
+          if (typeof value === 'number' && value < 0) {
+            control.setValue(0, { emitEvent: false });
+          }
+        });
+      }
+    });
+    const interestRateControl = this.loansAccountTermsForm.get('interestRatePerPeriod');
+    if (interestRateControl) {
+      interestRateControl.valueChanges.subscribe((value) => {
+        if (typeof value === 'number' && value < 0.01) {
+          interestRateControl.setValue(0.01, { emitEvent: false });
+        }
+      });
+    }
+  }
+
   setAdvancedPaymentStrategyControls(): void {
     // Fixed Length validation
     if (this.loansAccountTermsData) {
@@ -533,7 +566,10 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
       if (this.loansAccountTermsData.product.fixedLength) {
         this.loansAccountTermsForm.addControl(
           'interestRatePerPeriod',
-          new UntypedFormControl({ value: 0, disabled: true }, Validators.required)
+          new UntypedFormControl({ value: 0, disabled: true }, [
+            Validators.required,
+            Validators.min(0.01)
+          ])
         );
         this.loansAccountTermsForm.addControl(
           'fixedLength',
@@ -542,7 +578,10 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
       } else {
         this.loansAccountTermsForm.addControl(
           'interestRatePerPeriod',
-          new UntypedFormControl(this.loansAccountTermsData.interestRatePerPeriod, Validators.required)
+          new UntypedFormControl(this.loansAccountTermsData.interestRatePerPeriod, [
+            Validators.required,
+            Validators.min(0.01)
+          ])
         );
       }
     }
@@ -569,7 +608,10 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         ],
         loanTermFrequency: [
           { value: '', disabled: true },
-          Validators.required
+          [
+            Validators.required,
+            Validators.min(0)
+          ]
         ],
         loanTermFrequencyType: [
           '',
@@ -577,11 +619,17 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         ],
         numberOfRepayments: [
           '',
-          Validators.required
+          [
+            Validators.required,
+            Validators.min(0)
+          ]
         ],
         repaymentEvery: [
           '',
-          Validators.required
+          [
+            Validators.required,
+            Validators.min(0)
+          ]
         ],
         repaymentFrequencyType: [
           { value: '', disabled: true },
@@ -591,7 +639,10 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         repaymentFrequencyDayOfWeekType: [''],
         repaymentsStartingFromDate: [''],
         interestChargedFromDate: [''],
-        interestRatePerPeriod: [''],
+        interestRatePerPeriod: [
+          '',
+          Validators.min(0.01)
+        ],
         interestType: [''],
         isFloatingInterestRate: [null],
         isEqualAmortization: [''],
@@ -601,11 +652,26 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         ],
         interestCalculationPeriodType: [''],
         allowPartialPeriodInterestCalculation: [''],
-        inArrearsTolerance: [''],
-        graceOnInterestCharged: [''],
-        graceOnPrincipalPayment: [''],
-        graceOnInterestPayment: [''],
-        graceOnArrearsAgeing: [''],
+        inArrearsTolerance: [
+          '',
+          Validators.min(0)
+        ],
+        graceOnInterestCharged: [
+          '',
+          Validators.min(0)
+        ],
+        graceOnPrincipalPayment: [
+          '',
+          Validators.min(0)
+        ],
+        graceOnInterestPayment: [
+          '',
+          Validators.min(0)
+        ],
+        graceOnArrearsAgeing: [
+          '',
+          Validators.min(0)
+        ],
         loanIdToClose: [''],
         fixedEmiAmount: [''],
         isTopup: [''],
@@ -689,7 +755,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
    * Adds the Disbursement Data entry form to given Disbursement Data entry.
    */
   addDisbursementDataEntry() {
-    const currentPrincipalAmount = this.loansAccountTermsForm.get('principalAmount').value;
+    const currentPrincipalAmount = this.loansAccountTermsForm.get('principalAmount')?.value;
     const formfields: FormfieldBase[] = [
       new DatepickerBase({
         controlName: 'expectedDisbursementDate',
@@ -734,7 +800,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
    * @param {number} index Array index from where Disbursement Data entry form needs to be removed.
    */
   removeDisbursementDataEntry(index: number) {
-    const currentPrincipalAmount = this.loansAccountTermsForm.get('principalAmount').value;
+    const currentPrincipalAmount = this.loansAccountTermsForm.get('principalAmount')?.value;
     const dialogRef = this.dialog.open(DeleteDialogComponent, {
       data: { deleteContext: `this` }
     });
@@ -814,7 +880,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
     this.clientActiveLoanData = this.loansAccountProductTemplate.clientActiveLoanOptions;
     this.loanScheduleType = this.loansAccountProductTemplate.loanScheduleType;
     this.transactionProcessingStrategyOptions = [];
-    if (this.loanScheduleType.code === LoanProducts.LOAN_SCHEDULE_TYPE_CUMULATIVE) {
+    if (this.loanScheduleType?.code === LoanProducts.LOAN_SCHEDULE_TYPE_CUMULATIVE) {
       // Filter Advanced Payment Allocation Strategy
       this.transactionProcessingStrategyOptions =
         this.loansAccountProductTemplate.transactionProcessingStrategyOptions.filter(

--- a/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.html
+++ b/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.html
@@ -20,11 +20,13 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Nominal Annual Interest' | translate }}</mat-label>
-      <input type="number" matInput formControlName="nominalAnnualInterestRate" required />
-      <mat-error>
-        {{ 'labels.inputs.Nominal Annual Interest' | translate }} {{ 'labels.commons.is' | translate }}
-        <strong>{{ 'labels.commons.required' | translate }}</strong>
-      </mat-error>
+      <input type="number" matInput formControlName="nominalAnnualInterestRate" required min="0" step="0.01" />
+      @if (savingsAccountTermsForm.controls.nominalAnnualInterestRate.hasError('required')) {
+        <mat-error>
+          {{ 'labels.inputs.Nominal Annual Interest' | translate }} {{ 'labels.commons.is' | translate }}
+          <strong>{{ 'labels.commons.required' | translate }}</strong>
+        </mat-error>
+      }
     </mat-form-field>
 
     <mat-form-field class="flex-48">
@@ -92,7 +94,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Minimum Opening Balance' | translate }}</mat-label>
-      <input type="number" matInput formControlName="minRequiredOpeningBalance" />
+      <input type="number" matInput formControlName="minRequiredOpeningBalance" min="0" />
     </mat-form-field>
 
     <mat-checkbox labelPosition="before" formControlName="withdrawalFeeForTransfers" class="margin-v flex-48">
@@ -103,7 +105,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="lockinPeriodFrequency" />
+      <input type="number" matInput formControlName="lockinPeriodFrequency" min="0" />
     </mat-form-field>
 
     <mat-form-field class="flex-48">
@@ -129,15 +131,15 @@
       <div class="flex-fill layout-row-wrap gap-2percent responsive-column">
         <mat-form-field class="flex-31">
           <mat-label>{{ 'labels.inputs.Minimum Overdraft Required for Interest Calculation' | translate }}</mat-label>
-          <input type="number" matInput formControlName="minOverdraftForInterestCalculation" />
+          <input type="number" matInput formControlName="minOverdraftForInterestCalculation" min="0" />
         </mat-form-field>
         <mat-form-field class="flex-31">
           <mat-label>{{ 'labels.inputs.Nominal Annual Interest for Overdraft' | translate }}</mat-label>
-          <input type="number" matInput formControlName="nominalAnnualInterestRateOverdraft" />
+          <input type="number" matInput formControlName="nominalAnnualInterestRateOverdraft" min="0" />
         </mat-form-field>
         <mat-form-field class="flex-31">
           <mat-label>{{ 'labels.inputs.Maximum Overdraft Amount Limit' | translate }}</mat-label>
-          <input type="number" matInput formControlName="overdraftLimit" />
+          <input type="number" matInput formControlName="overdraftLimit" min="0" />
         </mat-form-field>
       </div>
     }
@@ -150,13 +152,13 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Minimum Balance' | translate }}</mat-label>
-      <input type="number" matInput formControlName="minRequiredBalance" />
+      <input type="number" matInput formControlName="minRequiredBalance" min="0" />
     </mat-form-field>
 
     @if (savingsAccountTermsForm.controls.minBalanceForInterestCalculation.value) {
       <mat-form-field class="flex-48">
         <mat-label>{{ 'labels.inputs.Balance Required for Interest Calculation' | translate }}</mat-label>
-        <input type="number" matInput formControlName="minBalanceForInterestCalculation" />
+        <input type="number" matInput formControlName="minBalanceForInterestCalculation" min="0" />
       </mat-form-field>
     }
   </div>

--- a/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.ts
@@ -128,7 +128,10 @@ export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
       decimal: [{ value: '', disabled: true }],
       nominalAnnualInterestRate: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          Validators.min(0)
+        ]
       ],
       interestCompoundingPeriodType: [
         '',
@@ -146,13 +149,22 @@ export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
         '',
         Validators.required
       ],
-      minRequiredOpeningBalance: [''],
+      minRequiredOpeningBalance: [
+        '',
+        Validators.min(0)
+      ],
       withdrawalFeeForTransfers: [false],
-      lockinPeriodFrequency: [''],
+      lockinPeriodFrequency: [
+        '',
+        Validators.min(0)
+      ],
       lockinPeriodFrequencyType: [''],
       allowOverdraft: [false],
       enforceMinRequiredBalance: [false],
-      minRequiredBalance: [''],
+      minRequiredBalance: [
+        '',
+        Validators.min(0)
+      ],
       minBalanceForInterestCalculation: [{ value: '', disabled: true }]
     });
   }
@@ -173,11 +185,25 @@ export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
    * Subscribes to value changes and sets new form controls accordingly.
    */
   buildDependencies() {
+    const nominalInterestControl = this.savingsAccountTermsForm.get('nominalAnnualInterestRate');
+    if (nominalInterestControl) {
+      nominalInterestControl.valueChanges.subscribe((value) => {
+        if (typeof value === 'number' && value < 0) {
+          nominalInterestControl.setValue(0, { emitEvent: false });
+        }
+      });
+    }
     this.savingsAccountTermsForm.get('allowOverdraft').valueChanges.subscribe((allowOverdraft: any) => {
       if (allowOverdraft) {
-        this.savingsAccountTermsForm.addControl('minOverdraftForInterestCalculation', new UntypedFormControl(''));
-        this.savingsAccountTermsForm.addControl('nominalAnnualInterestRateOverdraft', new UntypedFormControl(''));
-        this.savingsAccountTermsForm.addControl('overdraftLimit', new UntypedFormControl(''));
+        this.savingsAccountTermsForm.addControl(
+          'minOverdraftForInterestCalculation',
+          new UntypedFormControl('', Validators.min(0))
+        );
+        this.savingsAccountTermsForm.addControl(
+          'nominalAnnualInterestRateOverdraft',
+          new UntypedFormControl('', Validators.min(0))
+        );
+        this.savingsAccountTermsForm.addControl('overdraftLimit', new UntypedFormControl('', Validators.min(0)));
       } else {
         this.savingsAccountTermsForm.removeControl('minOverdraftForInterestCalculation');
         this.savingsAccountTermsForm.removeControl('nominalAnnualInterestRateOverdraft');


### PR DESCRIPTION
**Changes Made :-**

-Changes Made :-

-Add min(0) validation to numeric fields in Savings Account Terms, Loans Account Terms, and GLIM account in GROUP .

[WEB-874](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-874)

[WEB-874]: https://mifosforge.jira.com/browse/WEB-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced non-negative constraints on loan and savings numeric fields and minimum 0.01 for interest rate inputs.
  * Form inputs now auto-correct negative values to valid minimums.
  * Validation messages improved to display only when relevant errors occur, reducing confusing/errorneous prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->