### PR TITLE
WEB-913 Add export to pdf translation support for repayment schedule export button

### DIFF
--- a/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.html
+++ b/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.html
@@ -10,7 +10,7 @@
   @if (!forEditing) {
     <div class="layout-row m-t-20 align-end align-items-center">
       <button mat-raised-button color="primary" (click)="exportToPDF()">
-        <fa-icon icon="download" class="m-r-10"></fa-icon>Export to PDF
+        <fa-icon icon="download" class="m-r-10"></fa-icon>{{ 'labels.buttons.Export to PDF' | translate }}
       </button>
     </div>
   }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -478,6 +478,7 @@
       "Export to File": "Export do FILE",
       "Export CSV": "Vývozní CSV",
       "Export XLS": "Vývozní XLS",
+      "Export to PDF": "Export do PDF",
       "Export KYC": "Vývozní KYC",
       "Validate Documentation": "Ověřit dokumentaci",
       "INCOMPLETE": "NEÚPLNÉ",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -479,6 +479,7 @@
       "Export to File": "In eine Datei exportieren",
       "Export CSV": "CSV exportieren",
       "Export XLS": "XLS exportieren",
+      "Export to PDF": "Als PDF exportieren",
       "Export KYC": "KYC exportieren",
       "Validate Documentation": "Dokumentation validieren",
       "INCOMPLETE": "UNVOLLSTÄNDIG",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -483,6 +483,7 @@
       "Export to File": "Export to File",
       "Export CSV": "Export CSV",
       "Export XLS": "Export XLS",
+      "Export to PDF": "Export to PDF",
       "Export KYC": "Export KYC",
       "Validate Documentation": "Validate Documentation",
       "INCOMPLETE": "INCOMPLETE",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -479,6 +479,7 @@
       "Export to File": "Exportar Archivo",
       "Export CSV": "Exportar CSV",
       "Export XLS": "Exportar XLS",
+      "Export to PDF": "Exportar a PDF",
       "Export KYC": "Exportar KYC",
       "Validate Documentation": "Validar Documentación",
       "INCOMPLETE": "INCOMPLETO",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -479,6 +479,7 @@
       "Export to File": "Exportar Archivo",
       "Export CSV": "Exportar CSV",
       "Export XLS": "Exportar XLS",
+      "Export to PDF": "Exportar a PDF",
       "Export KYC": "Exportar KYC",
       "Validate Documentation": "Validar Documentación",
       "INCOMPLETE": "INCOMPLETO",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -479,6 +479,7 @@
       "Export to File": "Exporter vers un fichier",
       "Export CSV": "Exporter au format CSV",
       "Export XLS": "Exporter au format XLS",
+      "Export to PDF": "Exporter en PDF",
       "Export KYC": "Exporter KYC",
       "Validate Documentation": "Valider la documentation",
       "INCOMPLETE": "INCOMPLET",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -479,6 +479,7 @@
       "Export to File": "Esporta su file",
       "Export CSV": "Esporta CSV",
       "Export XLS": "Esporta XLS",
+      "Export to PDF": "Esporta come PDF",
       "Export KYC": "Esporta KYC",
       "Validate Documentation": "Convalida Documentazione",
       "INCOMPLETE": "INCOMPLETO",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -479,6 +479,7 @@
       "Export to File": "파일로 내보내기",
       "Export CSV": "CSV 내보내기",
       "Export XLS": "XLS 내보내기",
+      "Export to PDF": "PDF로 내보내기",
       "Export KYC": "KYC 내보내기",
       "Validate Documentation": "문서 검증",
       "INCOMPLETE": "미완료",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -479,6 +479,7 @@
       "Export to File": "Eksportuoti į failą",
       "Export CSV": "Eksportuoti CSV",
       "Export XLS": "Eksportuoti XLS",
+      "Export to PDF": "Eksportuoti kaip PDF",
       "Export KYC": "Eksportuoti KYC",
       "Validate Documentation": "Patvirtinti dokumentaciją",
       "INCOMPLETE": "NEBAIGTA",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -479,6 +479,7 @@
       "Export to File": "Eksportēt uz failu",
       "Export CSV": "Eksportēt CSV",
       "Export XLS": "Eksportēt XLS",
+      "Export to PDF": "Eksportēt kā PDF",
       "Export KYC": "Eksportēt KYC",
       "Validate Documentation": "Validēt dokumentāciju",
       "INCOMPLETE": "NEPABEIGTS",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -479,6 +479,7 @@
       "Export to File": "फाइलमा निर्यात गर्नुहोस्",
       "Export CSV": "CSV निर्यात गर्नुहोस्",
       "Export XLS": "XLS निर्यात गर्नुहोस्",
+      "Export to PDF": "PDF को रूपमा निर्यात गर्नुहोस्",
       "Export KYC": "KYC निर्यात गर्नुहोस्",
       "Validate Documentation": "कागजात प्रमाणित गर्नुहोस्",
       "INCOMPLETE": "अपूर्ण",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -479,6 +479,7 @@
       "Export to File": "Exportar arquivo",
       "Export CSV": "Exportar CSV",
       "Export XLS": "Exportar XLS",
+      "Export to PDF": "Exportar para PDF",
       "Export KYC": "Exportar KYC",
       "Validate Documentation": "Validar Documentação",
       "INCOMPLETE": "INCOMPLETO",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -479,6 +479,7 @@
       "Export to File": "Hamisha kwa FILE",
       "Export CSV": "Hamisha CSV",
       "Export XLS": "Hamisha XLS",
+      "Export to PDF": "Hamisha kwa PDF",
       "Export KYC": "Hamisha KYC",
       "Validate Documentation": "Thibitisha Nyaraka",
       "INCOMPLETE": "HAIJAKAMILIKA",


### PR DESCRIPTION
**Changes Made :-** 

-Update repayment-schedule-tab component to use {{ 'labels.buttons.Export to PDF' | translate }} instead of hardcoded text for multi-language support. .
-Add "Export to PDF" translation key and translations to all 13 language files.

[WEB-913](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-913)

[WEB-913]: https://mifosforge.jira.com/browse/WEB-913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The “Export to PDF” button label now uses the app’s translation system so it appears in the user’s selected language.
  * Added localized strings for the Export to PDF label across supported locales (including Czech, German, English, Spanish (CL/MX), French, Italian, Korean, Lithuanian, Latvian, Nepali, Portuguese, and Swahili).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->