### PR TITLE
WEB-914 Validation error message not displayed for required Note fiel…

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/undo-disbursal/undo-disbursal.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/undo-disbursal/undo-disbursal.component.html
@@ -13,6 +13,12 @@
         <mat-form-field class="flex-fill">
           <mat-label>{{ 'labels.inputs.Note' | translate }}</mat-label>
           <textarea matInput required [formControl]="note" cdkTextareaAutosize cdkAutosizeMinRows="2"></textarea>
+          @if (note.hasError('required')) {
+            <mat-error>
+              {{ 'labels.inputs.Note' | translate }} {{ 'labels.commons.is' | translate }}
+              <strong>{{ 'labels.commons.required' | translate }}</strong>
+            </mat-error>
+          }
         </mat-form-field>
       </div>
 


### PR DESCRIPTION
**Changes Made :-**

-Add validation error message display to the Undo Disbursal form's Note field. 

[WEB-914](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-914)

Before :- 
<img width="1189" height="479" alt="image" src="https://github.com/user-attachments/assets/e0394980-1f61-4fc3-9c85-92b3d6c15535" />

After :- 
<img width="1344" height="609" alt="image" src="https://github.com/user-attachments/assets/3c0ae54a-5ec8-4bfb-b12d-946198a07632" />



[WEB-914]: https://mifosforge.jira.com/browse/WEB-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form validation with error messages now displayed for required fields when left empty, providing clearer user feedback during form submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->