### PR TITLE
WEB-915 Prevent negative values in Re-Age and Sell Loan forms

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/asset-transfer-loan/asset-transfer-loan.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/asset-transfer-loan/asset-transfer-loan.component.html
@@ -34,7 +34,16 @@
           @if (!isBuyBack()) {
             <mat-form-field>
               <mat-label>{{ 'labels.inputs.Purchase Price Ratio' | translate }}</mat-label>
-              <input type="number" matInput required formControlName="purchasePriceRatio" />
+              <input
+                type="number"
+                matInput
+                required
+                formControlName="purchasePriceRatio"
+                min="0"
+                max="100"
+                step="0.01"
+                mifosxPositiveNumber
+              />
               @if (saleLoanForm.controls.purchasePriceRatio.hasError('required')) {
                 <mat-error>
                   {{ 'labels.inputs.Purchase Price Ratio' | translate }} {{ 'labels.commons.is' | translate }}

--- a/src/app/loans/loans-view/loan-account-actions/asset-transfer-loan/asset-transfer-loan.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/asset-transfer-loan/asset-transfer-loan.component.ts
@@ -12,6 +12,7 @@ import { Dates } from 'app/core/utils/dates';
 import { ExternalAssetOwnerService } from 'app/loans/services/external-asset-owner.service';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { LoanAccountActionsBaseComponent } from '../loan-account-actions-base.component';
+import { rangeValidator } from 'app/shared/validators/percentage.validator';
 
 @Component({
   selector: 'mifosx-asset-transfer-loan',
@@ -35,7 +36,7 @@ export class AssetTransferLoanComponent extends LoanAccountActionsBaseComponent 
   /** Maximum Date allowed. */
   maxDate = new Date();
   /** Sell Loan Form */
-  saleLoanForm: UntypedFormGroup;
+  saleLoanForm!: UntypedFormGroup;
 
   constructor() {
     super();
@@ -68,7 +69,10 @@ export class AssetTransferLoanComponent extends LoanAccountActionsBaseComponent 
       ],
       purchasePriceRatio: [
         '',
-        Validators.required
+        [
+          Validators.required,
+          rangeValidator(0, 100)
+        ]
       ],
       transferExternalId: '',
       ownerExternalId: [

--- a/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.html
@@ -12,14 +12,16 @@
       <form [formGroup]="reagingLoanForm" (ngSubmit)="submit()">
         <mat-card-content>
           <div class="layout-column">
-            <mat-form-field>
-              <mat-label>{{ 'labels.inputs.Number of Installments' | translate }}</mat-label>
-              <input type="number" matInput required formControlName="numberOfInstallments" />
-            </mat-form-field>
-            <mat-form-field>
-              <mat-label>{{ 'labels.inputs.Frequency Number' | translate }}</mat-label>
-              <input type="number" matInput required formControlName="frequencyNumber" />
-            </mat-form-field>
+            <mifosx-input-positive-integer
+              [inputFormControl]="reagingLoanForm.controls.numberOfInstallments"
+              [inputLabel]="'Number of Installments'"
+              [isRequired]="true"
+            ></mifosx-input-positive-integer>
+            <mifosx-input-positive-integer
+              [inputFormControl]="reagingLoanForm.controls.frequencyNumber"
+              [inputLabel]="'Frequency Number'"
+              [isRequired]="true"
+            ></mifosx-input-positive-integer>
             <mat-form-field>
               <mat-label>{{ 'labels.inputs.Frequency Type' | translate }}</mat-label>
               <mat-select formControlName="frequencyType" required>

--- a/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/loan-reaging/loan-reaging.component.ts
@@ -18,6 +18,8 @@ import { InputAmountComponent } from 'app/shared/input-amount/input-amount.compo
 import { LoanTransactionTemplate } from 'app/loans/models/loan-transaction-type.model';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { LoanAccountActionsBaseComponent } from '../loan-account-actions-base.component';
+import { InputPositiveIntegerComponent } from 'app/shared/input-positive-integer/input-positive-integer.component';
+import { positiveIntegerValidator } from 'app/shared/validators/positive-integer.validator';
 
 @Component({
   selector: 'mifosx-loan-reaging',
@@ -26,7 +28,8 @@ import { LoanAccountActionsBaseComponent } from '../loan-account-actions-base.co
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
     InputAmountComponent,
-    MatSlideToggle
+    MatSlideToggle,
+    InputPositiveIntegerComponent
   ]
 })
 export class LoanReagingComponent extends LoanAccountActionsBaseComponent implements OnInit {
@@ -35,7 +38,7 @@ export class LoanReagingComponent extends LoanAccountActionsBaseComponent implem
   private dialog = inject(MatDialog);
 
   /** Repayment Loan Form */
-  reagingLoanForm: UntypedFormGroup;
+  reagingLoanForm!: UntypedFormGroup;
 
   reAgeReasonOptions: any[] = [];
   periodFrequencyOptions: OptionData[] = [];
@@ -68,7 +71,10 @@ export class LoanReagingComponent extends LoanAccountActionsBaseComponent implem
     this.reagingLoanForm = this.formBuilder.group({
       numberOfInstallments: [
         1,
-        Validators.required
+        [
+          Validators.required,
+          positiveIntegerValidator()
+        ]
       ],
       startDate: [
         this.settingsService.businessDate,
@@ -76,7 +82,10 @@ export class LoanReagingComponent extends LoanAccountActionsBaseComponent implem
       ],
       frequencyNumber: [
         1,
-        Validators.required
+        [
+          Validators.required,
+          positiveIntegerValidator()
+        ]
       ],
       frequencyType: [
         ,
@@ -123,7 +132,7 @@ export class LoanReagingComponent extends LoanAccountActionsBaseComponent implem
 
     this.loanService.getReAgePreview(this.loanId, data).subscribe({
       next: (response: RepaymentSchedule) => {
-        const currencyCode = response.currency?.code || this.loanTransactionData.currency.code;
+        const currencyCode = response.currency?.code || this.loanTransactionData?.currency?.code;
 
         if (!currencyCode) {
           console.error('Currency code is not available in API response or loan details');


### PR DESCRIPTION
**Changes Made :-**

-Add min="0" HTML attribute and Validators.min(0) validation to prevent negative values from being entered in Re-Age (numberOfInstallments, frequencyNumber) and Sell Loan (purchasePriceRatio) form fields.

[WEB-915](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-915)

Before :-
<img width="915" height="573" alt="image" src="https://github.com/user-attachments/assets/7c24c2f9-807e-4586-b502-559ada9d2836" />

<img width="823" height="363" alt="image" src="https://github.com/user-attachments/assets/d8388e75-8076-4fa4-ace4-6dca7cab84ad" />

After :-
<img width="838" height="553" alt="image" src="https://github.com/user-attachments/assets/b1b404e7-7c83-44dc-ac41-2bf44b229b2c" />

<img width="837" height="373" alt="image" src="https://github.com/user-attachments/assets/5e57a1f4-a55c-448b-ad4a-908340ba5229" />


[WEB-915]: https://mifosforge.jira.com/browse/WEB-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Loan asset-transfer form now enforces a bounded percentage and positive numeric input, improving validation and preventing invalid entries.
  * Loan reaging form uses positive-integer inputs for installments/frequency, with required validation and clearer labels.
  * Improved null-safety when resolving currency for loan reaging previews to prevent runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->