### PR TITLE
WEB-879 Handle API response where report category returns '(NULL)' string

### DIFF
--- a/src/app/system/manage-reports/manage-reports.component.html
+++ b/src/app/system/manage-reports/manage-reports.component.html
@@ -42,7 +42,15 @@
 
       <ng-container matColumnDef="reportCategory">
         <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'labels.inputs.Report Category' | translate }}</th>
-        <td mat-cell *matCellDef="let report">{{ report.reportCategory | translateKey: 'catalogs' }}</td>
+        <td mat-cell *matCellDef="let report">
+          {{
+            report.reportCategory &&
+            report.reportCategory.trim() &&
+            report.reportCategory.trim().toUpperCase() !== '(NULL)'
+              ? (report.reportCategory.trim() | translateKey: 'catalogs')
+              : ''
+          }}
+        </td>
       </ng-container>
 
       <ng-container matColumnDef="coreReport">


### PR DESCRIPTION
## Description
Handle API response where report category returns '(NULL)' string, displaying empty cell instead of null text in table.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

before 
<img width="1215" height="176" alt="before" src="https://github.com/user-attachments/assets/4dd8a25b-7647-4825-b77b-b4199449e341" />

after
<img width="1228" height="219" alt="after" src="https://github.com/user-attachments/assets/d4e4d325-bf55-4915-9ffc-9f01e255cc12" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed report category display in the reports table to handle missing, empty, or literal "(NULL)" values. Invalid entries now render as blank; valid categories are trimmed, uppercased, and shown with the proper translated label for clearer, more consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->