### PR TITLE
WEB-919 fix: add null guards and safe array access to prevent runtimecrashes

### DIFF
--- a/src/app/clients/client-stepper/client-address-step/client-address-step.component.ts
+++ b/src/app/clients/client-stepper/client-address-step/client-address-step.component.ts
@@ -171,7 +171,7 @@ export class ClientAddressStepComponent {
    * @param {any} address Address
    */
   getSelectedValue(fieldName: any, fieldId: any) {
-    return this.clientTemplate.address[0][fieldName].find((fieldObj: any) => fieldObj.id === fieldId);
+    return this.clientTemplate?.address?.[0]?.[fieldName]?.find((fieldObj: any) => fieldObj.id === fieldId);
   }
 
   /**
@@ -181,9 +181,14 @@ export class ClientAddressStepComponent {
   getAddressFormFields(address?: any) {
     let formfields: FormfieldBase[] = [];
 
-    for (let index = 0; index < this.clientTemplate.address[0].addressTypeIdOptions.length; index++) {
-      this.clientTemplate.address[0].addressTypeIdOptions[index].name = this.translateService.instant(
-        `labels.catalogs.${this.clientTemplate.address[0].addressTypeIdOptions[index].name}`
+    const addressTemplate = this.clientTemplate?.address?.[0];
+    if (!addressTemplate) {
+      return formfields;
+    }
+
+    for (let index = 0; index < (addressTemplate.addressTypeIdOptions?.length ?? 0); index++) {
+      addressTemplate.addressTypeIdOptions[index].name = this.translateService.instant(
+        `labels.catalogs.${addressTemplate.addressTypeIdOptions[index].name}`
       );
     }
 
@@ -193,7 +198,7 @@ export class ClientAddressStepComponent {
             controlName: 'addressTypeId',
             label: this.translateService.instant('labels.inputs.Address Type'),
             value: address ? address.addressTypeId : '',
-            options: { label: 'name', value: 'id', data: this.clientTemplate.address[0].addressTypeIdOptions },
+            options: { label: 'name', value: 'id', data: addressTemplate.addressTypeIdOptions ?? [] },
             order: 1,
             required: true
           })
@@ -283,7 +288,7 @@ export class ClientAddressStepComponent {
             controlName: 'stateProvinceId',
             label: this.translateService.instant('labels.inputs.State / Province'),
             value: address ? address.stateProvinceId : '',
-            options: { label: 'name', value: 'id', data: this.clientTemplate.address[0].stateProvinceIdOptions },
+            options: { label: 'name', value: 'id', data: addressTemplate.stateProvinceIdOptions ?? [] },
             order: 8
           })
         : null
@@ -305,7 +310,7 @@ export class ClientAddressStepComponent {
             controlName: 'countryId',
             label: this.translateService.instant('labels.inputs.Country'),
             value: address ? address.countryId : '',
-            options: { label: 'name', value: 'id', data: this.clientTemplate.address[0].countryIdOptions },
+            options: { label: 'name', value: 'id', data: addressTemplate.countryIdOptions ?? [] },
             order: 10
           })
         : null

--- a/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.ts
+++ b/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.ts
@@ -71,7 +71,7 @@ export class ClientPreviewStepComponent {
    * @param {any} fieldId Field Id
    */
   getSelectedValue(fieldName: any, fieldId: any) {
-    return this.clientTemplate.address[0][fieldName].find((fieldObj: any) => fieldObj.id === fieldId);
+    return this.clientTemplate?.address?.[0]?.[fieldName]?.find((fieldObj: any) => fieldObj.id === fieldId);
   }
 
   /**

--- a/src/app/collections/collection-sheet/collection-sheet.component.ts
+++ b/src/app/collections/collection-sheet/collection-sheet.component.ts
@@ -133,17 +133,19 @@ export class CollectionSheetComponent implements OnInit {
       .subscribe((response: CollectionSheetData[]) => {
         if (response.length > 0) {
           this.meetingFallCenters = response[0].meetingFallCenters;
-          const payload = {
-            calendarId: this.meetingFallCenters[0].collectionMeetingCalendar.calendarInstanceId,
-            transactionDate: meetingDate,
-            locale,
-            dateFormat
-          };
-          this.collectionsService
-            .generateCollectionSheetData(this.meetingFallCenters[0].id, payload)
-            .subscribe((jlgGroupData: JLGGroupData) => {
-              this.log.debug('JLG Group Data:', jlgGroupData);
-            });
+          if (this.meetingFallCenters?.length > 0) {
+            const payload = {
+              calendarId: this.meetingFallCenters[0].collectionMeetingCalendar?.calendarInstanceId,
+              transactionDate: meetingDate,
+              locale,
+              dateFormat
+            };
+            this.collectionsService
+              .generateCollectionSheetData(this.meetingFallCenters[0].id, payload)
+              .subscribe((jlgGroupData: JLGGroupData) => {
+                this.log.debug('JLG Group Data:', jlgGroupData);
+              });
+          }
         }
       });
   }

--- a/src/app/directives/format-amount.directive.ts
+++ b/src/app/directives/format-amount.directive.ts
@@ -48,7 +48,7 @@ export class FormatAmountDirective implements OnInit {
   }
 
   parse(value: any) {
-    if (value == '') {
+    if (value === '' || value == null) {
       return '' + this.sufix;
     }
     return formatCurrency(value, this.locale, this.displaySymbol, this.currencyCode, this.digitsInfo) + this.sufix;

--- a/src/app/pipes/datetime-format.pipe.ts
+++ b/src/app/pipes/datetime-format.pipe.ts
@@ -40,6 +40,9 @@ export class DatetimeFormatPipe implements PipeTransform, OnDestroy {
 
     let dateVal: Moment;
     if (Array.isArray(value)) {
+      if (value.length < 3) {
+        return '';
+      }
       const [
         y,
         m,

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-currency-step/saving-product-currency-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-currency-step/saving-product-currency-step.component.ts
@@ -46,7 +46,7 @@ export class SavingProductCurrencyStepComponent implements OnInit {
     this.currencyData = this.savingProductsTemplate.currencyOptions;
 
     this.savingProductCurrencyForm.patchValue({
-      currencyCode: this.savingProductsTemplate.currency.code || this.currencyData[0].code,
+      currencyCode: this.savingProductsTemplate?.currency?.code || this.currencyData?.[0]?.code || '',
       digitsAfterDecimal: this.savingProductsTemplate.digitsAfterDecimal ?? '',
       setMultiples: !!this.savingProductsTemplate.inMultiplesOf,
       inMultiplesOf: this.savingProductsTemplate.inMultiplesOf ?? ''


### PR DESCRIPTION
In this PR, we add defensive null checks and array bounds guards across multiple components to prevent runtime crashes when data arrays are empty or     null. This includes safe access for meetingFallCenters in CollectionSheetComponent, clientTemplate.address[0] in ClientAddressStepComponent and ClientPreviewStepComponent, and currency/currencyData fallback in SavingProductCurrencyStepComponent. We also fix a loose equality (==) bug in FormatAmountDirective that was silently treating zero amounts as empty strings instead of displaying $0.00, and add a minimum array length check in DatetimeFormatPipe to avoid silently producing incorrect dates from malformed arrays.


[WEB-919](https://mifosforge.jira.com/browse/WEB-919)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-919]: https://mifosforge.jira.com/browse/WEB-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented runtime errors in client address and preview steps when address data is missing or incomplete.
  * Guarded collection sheet preview to run only when meeting data exists.
  * Ensured currency field initializes safely when template or currency lists are absent.
  * Improved handling of empty/null inputs for amount formatting and short-array date inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->