### PR TITLE
WEB-920 Add missing validation error messages and prevent negative values in recurring deposits form

### DIFF
--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-stepper/recurring-deposits-account-settings-step/recurring-deposits-account-settings-step.component.html
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-stepper/recurring-deposits-account-settings-step/recurring-deposits-account-settings-step.component.html
@@ -24,7 +24,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="lockinPeriodFrequency" />
+      <input type="number" matInput formControlName="lockinPeriodFrequency" mifosxPositiveInteger />
     </mat-form-field>
 
     <mat-form-field class="flex-48">
@@ -54,7 +54,11 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Deposit Period' | translate }}</mat-label>
-      <input type="number" matInput formControlName="depositPeriod" required />
+      <input type="number" matInput formControlName="depositPeriod" mifosxPositiveInteger required />
+      <mat-error>
+        {{ 'labels.inputs.Deposit Period' | translate }} {{ 'labels.commons.is' | translate }}
+        <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field class="flex-48">
@@ -66,6 +70,10 @@
           </mat-option>
         }
       </mat-select>
+      <mat-error>
+        {{ 'labels.inputs.Deposit Period Type' | translate }} {{ 'labels.commons.is' | translate }}
+        <strong>{{ 'labels.commons.required' | translate }}</strong>
+      </mat-error>
     </mat-form-field>
 
     <mat-checkbox labelPosition="before" formControlName="isCalendarInherited" class="margin-v flex-48">
@@ -85,11 +93,15 @@
         />
         <mat-datepicker-toggle matSuffix [for]="expectedFirstDepositOnDatePicker"></mat-datepicker-toggle>
         <mat-datepicker #expectedFirstDepositOnDatePicker></mat-datepicker>
+        <mat-error>
+          {{ 'labels.inputs.Deposit Start Date' | translate }} {{ 'labels.commons.is' | translate }}
+          <strong>{{ 'labels.commons.required' | translate }}</strong>
+        </mat-error>
       </mat-form-field>
       <h4 class="mat-h4 flex-98">{{ 'labels.heading.Deposit Frequency' | translate }}</h4>
       <mat-form-field class="flex-48">
         <mat-label>{{ 'labels.inputs.Deposit Frequency' | translate }}</mat-label>
-        <input type="number" matInput formControlName="recurringFrequency" required />
+        <input type="number" matInput formControlName="recurringFrequency" min="0" required />
         <mat-error>
           {{ 'labels.inputs.Deposit Frequency' | translate }} {{ 'labels.commons.is' | translate }}
           <strong>{{ 'labels.commons.required' | translate }}</strong>

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-stepper/recurring-deposits-account-settings-step/recurring-deposits-account-settings-step.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-stepper/recurring-deposits-account-settings-step/recurring-deposits-account-settings-step.component.ts
@@ -23,6 +23,7 @@ import { MatDivider } from '@angular/material/divider';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { PositiveIntegerDirective } from 'app/directives/positive-integer.directive';
 
 /** Custom Services */
 
@@ -40,7 +41,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatDivider,
     MatStepperPrevious,
     FaIconComponent,
-    MatStepperNext
+    MatStepperNext,
+    PositiveIntegerDirective
   ]
 })
 export class RecurringDepositsAccountSettingsStepComponent implements OnInit, OnChanges {
@@ -52,7 +54,7 @@ export class RecurringDepositsAccountSettingsStepComponent implements OnInit, On
   @Input() recurringDepositsAccountProductTemplate: any;
 
   /** Recurring Deposits Account Settings Form */
-  recurringDepositAccountSettingsForm: UntypedFormGroup;
+  recurringDepositAccountSettingsForm!: UntypedFormGroup;
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
@@ -120,21 +122,21 @@ export class RecurringDepositsAccountSettingsStepComponent implements OnInit, On
       });
       if (recurringDepositsAccount.withHoldTax) {
         this.recurringDepositAccountSettingsForm.addControl('withHoldTax', new UntypedFormControl(false));
-        this.recurringDepositAccountSettingsForm.get('withHoldTax').valueChanges.subscribe((value: boolean) => {
+        this.recurringDepositAccountSettingsForm.get('withHoldTax')!.valueChanges.subscribe((value: boolean) => {
           if (value) {
             this.recurringDepositAccountSettingsForm.addControl(
               'taxGroupId',
               new UntypedFormControl({ value: '', disabled: true })
             );
             this.recurringDepositAccountSettingsForm
-              .get('taxGroupId')
+              .get('taxGroupId')!
               .patchValue(recurringDepositsAccount.taxGroup && recurringDepositsAccount.taxGroup.name);
           } else {
             this.recurringDepositAccountSettingsForm.removeControl('taxGroupId');
           }
         });
         this.recurringDepositAccountSettingsForm
-          .get('withHoldTax')
+          .get('withHoldTax')!
           .patchValue(this.recurringDepositsAccountTemplate.withHoldTax);
       } else {
         this.recurringDepositAccountSettingsForm.removeControl('withHoldTax');
@@ -216,7 +218,7 @@ export class RecurringDepositsAccountSettingsStepComponent implements OnInit, On
    */
   buildDependencies() {
     this.recurringDepositAccountSettingsForm
-      .get('isCalendarInherited')
+      .get('isCalendarInherited')!
       .valueChanges.subscribe((isCalendarInherited: any) => {
         if (isCalendarInherited) {
           this.recurringDepositAccountSettingsForm.removeControl('expectedFirstDepositOnDate');


### PR DESCRIPTION
**Changes Made :-** 

-Add validation error messages to required fields and restrict numeric inputs to non-negative values in recurring deposits account settings form when creating recurring deposit applications for client .

[WEB-920](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-920)

Before :- 
<img width="884" height="536" alt="image" src="https://github.com/user-attachments/assets/3a40abaa-3503-4923-8e66-cb2c7b030580" />

<img width="888" height="528" alt="image" src="https://github.com/user-attachments/assets/4db3a043-5059-4fd4-81c3-7d47801a820a" />


After :- 
<img width="895" height="412" alt="image" src="https://github.com/user-attachments/assets/e7bf48e6-7671-4d71-ad20-43e91108b9e8" />

<img width="952" height="535" alt="image" src="https://github.com/user-attachments/assets/929556bc-372f-42fe-97d5-a9cf65b1671d" />



[WEB-920]: https://mifosforge.jira.com/browse/WEB-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation in the recurring deposits account settings form to prevent negative values and enforce positive integer inputs.
  * Added clearer required-field error messages for deposit period, deposit period frequency, and conditional deposit start date.
  * Constrained recurring frequency input to disallow negative entries and ensure consistent error feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->