### PR TITLE
WEB-897: Add Playwright E2E test for close client workflow

### DIFF
--- a/playwright/fixtures/fineract-api.ts
+++ b/playwright/fixtures/fineract-api.ts
@@ -9,8 +9,20 @@
 import { APIRequestContext, APIResponse, request } from '@playwright/test';
 
 export class FineractApiClient {
+  private static readonly CLIENT_CLOSURE_REASON_CODE_NAME = 'ClientClosureReason';
+  private static readonly DEFAULT_DATE_FORMAT = 'dd MMMM yyyy';
+  private static readonly DEFAULT_LOCALE = 'en';
+  private static readonly CREATE_RACE_RETRY_DELAY_MS = 250;
+  private static readonly CREATE_RACE_RETRY_COUNT = 2;
   private ctx!: APIRequestContext;
 
+  /**
+   * Creates an authenticated Fineract API client for Playwright tests.
+   * @param baseUrl - The Fineract base URL
+   * @param tenantId - The tenant identifier header value
+   * @param username - The username for basic authentication
+   * @param password - The password for basic authentication
+   */
   constructor(
     private baseUrl: string,
     private tenantId: string,
@@ -18,6 +30,9 @@ export class FineractApiClient {
     private password: string
   ) {}
 
+  /**
+   * Initializes the Playwright request context with Fineract auth headers.
+   */
   async init(): Promise<void> {
     this.ctx = await request.newContext({
       baseURL: this.baseUrl,
@@ -30,26 +45,517 @@ export class FineractApiClient {
     });
   }
 
+  /**
+   * Validates a Fineract API response and returns its parsed JSON payload.
+   * @param res - The API response to validate
+   * @param operation - The operation name for error reporting
+   * @returns The parsed JSON payload for a successful response
+   */
   private async validateResponse(res: APIResponse, operation: string): Promise<any> {
     if (!res.ok()) {
-      throw new Error(`Fineract API error [${operation}]: ${res.status()} ${res.statusText()}`);
+      const errorBody = await res.text();
+      const trimmedBody = errorBody.trim();
+      const errorSuffix = trimmedBody ? ` - ${trimmedBody}` : '';
+      throw new Error(`Fineract API error [${operation}]: ${res.status()} ${res.statusText()}${errorSuffix}`);
     }
     return res.json();
   }
 
+  /**
+   * Determines whether an API error can be treated as a duplicate/create race.
+   * @param error - The thrown error from a create attempt
+   * @returns true when the error represents a recoverable duplicate conflict
+   */
+  private isRecoverableDuplicateError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return /409|duplicate|already exists|resource already exists|unique/i.test(message);
+  }
+
+  /**
+   * Pauses execution briefly before retrying a create race.
+   * @returns A promise that resolves after the retry delay
+   */
+  private async waitForCreateRaceRetry(): Promise<void> {
+    await new Promise((resolve) => {
+      setTimeout(resolve, FineractApiClient.CREATE_RACE_RETRY_DELAY_MS);
+    });
+  }
+
+  /**
+   * Checks whether the Fineract health endpoint responds successfully.
+   * @returns true when the health endpoint returns an OK response
+   */
   async healthCheck(): Promise<boolean> {
     const res = await this.ctx.get('/fineract-provider/actuator/health');
     return res.ok();
   }
 
+  /**
+   * Fetches the list of available offices.
+   * @returns The available office collection
+   */
   async getOffices(): Promise<any[]> {
     const res = await this.ctx.get('/fineract-provider/api/v1/offices');
     return this.validateResponse(res, 'getOffices');
   }
 
+  /**
+   * Creates a client using the supplied request payload.
+   * @param data - The client creation payload
+   * @returns The Fineract create-client response payload
+   */
   async createClient(data: Record<string, unknown>): Promise<any> {
     const res = await this.ctx.post('/fineract-provider/api/v1/clients', { data });
     return this.validateResponse(res, 'createClient');
+  }
+
+  /**
+   * Fetches a client record by id.
+   * @param clientId - The client id to fetch
+   * @returns The requested client payload
+   */
+  async getClient(clientId: number): Promise<any> {
+    const res = await this.ctx.get(`/fineract-provider/api/v1/clients/${clientId}`);
+    return this.validateResponse(res, 'getClient');
+  }
+
+  /**
+   * Fetches all configured Fineract system codes.
+   * @returns The configured system codes
+   */
+  async getCodes(): Promise<any[]> {
+    const res = await this.ctx.get('/fineract-provider/api/v1/codes');
+    return this.validateResponse(res, 'getCodes');
+  }
+
+  /**
+   * Fetches basic loan product details used for deterministic test setup.
+   * @returns The loan product basic-details collection
+   */
+  async getLoanProductsBasicDetails(): Promise<any[]> {
+    const res = await this.ctx.get('/fineract-provider/api/v1/loanproducts/basic-details');
+    return this.validateResponse(res, 'getLoanProductsBasicDetails');
+  }
+
+  /**
+   * Creates a loan product using the supplied request payload.
+   * @param data - The loan product creation payload
+   * @returns The Fineract create-loan-product response payload
+   */
+  async createLoanProduct(data: Record<string, unknown>): Promise<any> {
+    const res = await this.ctx.post('/fineract-provider/api/v1/loanproducts', { data });
+    return this.validateResponse(res, 'createLoanProduct');
+  }
+
+  /**
+   * Fetches a loan with associations by loan id.
+   * @param clientId - The loan id to fetch
+   * @returns The requested loan payload with associations
+   */
+  async getLoan(clientId: number): Promise<any> {
+    const res = await this.ctx.get(`/fineract-provider/api/v1/loans/${clientId}?associations=all`);
+    return this.validateResponse(res, 'getLoan');
+  }
+
+  /**
+   * Fetches the individual loan template for a client and optional product.
+   * @param clientId - The client id used to resolve the loan template
+   * @param productId - Optional loan product id to scope the template
+   * @returns The loan template payload
+   */
+  async getLoanTemplate(clientId: number, productId?: number): Promise<any> {
+    const query = new URLSearchParams({
+      clientId: clientId.toString(),
+      templateType: 'individual',
+      activeOnly: 'true',
+      staffInSelectedOfficeOnly: 'true'
+    });
+
+    if (productId) {
+      query.set('productId', productId.toString());
+    }
+
+    const res = await this.ctx.get(`/fineract-provider/api/v1/loans/template?${query.toString()}`);
+    return this.validateResponse(res, 'getLoanTemplate');
+  }
+
+  /**
+   * Creates a loan using the supplied request payload.
+   * @param data - The loan creation payload
+   * @returns The Fineract create-loan response payload
+   */
+  async createLoan(data: Record<string, unknown>): Promise<any> {
+    const res = await this.ctx.post('/fineract-provider/api/v1/loans', { data });
+    return this.validateResponse(res, 'createLoan');
+  }
+
+  /**
+   * Fetches code values for a specific code id.
+   * @param codeId - The code id whose values should be fetched
+   * @returns The code values for the requested code
+   */
+  async getCodeValues(codeId: number): Promise<any[]> {
+    const res = await this.ctx.get(`/fineract-provider/api/v1/codes/${codeId}/codevalues`);
+    return this.validateResponse(res, 'getCodeValues');
+  }
+
+  /**
+   * Creates a new code value under a specific code id.
+   * @param codeId - The code id that owns the new value
+   * @param data - The code value creation payload
+   * @returns The Fineract create-code-value response payload
+   */
+  async createCodeValue(codeId: number, data: Record<string, unknown>): Promise<any> {
+    const res = await this.ctx.post(`/fineract-provider/api/v1/codes/${codeId}/codevalues`, { data });
+    return this.validateResponse(res, 'createCodeValue');
+  }
+
+  /**
+   * Executes a command against an existing client resource.
+   * @param clientId - The client id to operate on
+   * @param command - The Fineract client command name
+   * @param data - The command payload
+   * @returns The command response payload
+   */
+  async executeClientCommand(clientId: number, command: string, data: Record<string, unknown>): Promise<any> {
+    const res = await this.ctx.post(`/fineract-provider/api/v1/clients/${clientId}?command=${command}`, { data });
+    return this.validateResponse(res, 'executeClientCommand');
+  }
+
+  /**
+   * Executes a command against an existing loan resource.
+   * @param loanId - The loan id to operate on
+   * @param command - The Fineract loan command name
+   * @param data - The command payload
+   * @returns The command response payload
+   */
+  async executeLoanCommand(loanId: number, command: string, data: Record<string, unknown>): Promise<any> {
+    const res = await this.ctx.post(`/fineract-provider/api/v1/loans/${loanId}?command=${command}`, { data });
+    return this.validateResponse(res, 'executeLoanCommand');
+  }
+
+  /**
+   * Resolves a system code by its exact name.
+   * @param codeName - The exact system code name
+   * @returns The matching system code payload
+   */
+  async getCodeByName(codeName: string): Promise<any> {
+    const codes = await this.getCodes();
+    const code = codes.find((candidate) => candidate.name === codeName);
+
+    if (!code) {
+      throw new Error(`Fineract API error [getCodeByName]: code '${codeName}' not found`);
+    }
+
+    return code;
+  }
+
+  /**
+   * Ensures a named code value exists and returns the existing or created value.
+   * @param codeName - The parent system code name
+   * @param valueName - The exact code value name
+   * @param options - Optional code value creation attributes
+   * @returns The existing or created code value
+   */
+  async ensureCodeValue(
+    codeName: string,
+    valueName: string,
+    options: {
+      description?: string;
+      isActive?: boolean;
+    } = {}
+  ): Promise<any> {
+    const code = await this.getCodeByName(codeName);
+    for (let attempt = 0; attempt <= FineractApiClient.CREATE_RACE_RETRY_COUNT; attempt += 1) {
+      const existingValues = await this.getCodeValues(code.id);
+      const existingValue = existingValues.find((value) => value.name === valueName);
+
+      if (existingValue) {
+        return existingValue;
+      }
+
+      try {
+        const createdValue = await this.createCodeValue(code.id, {
+          name: valueName,
+          description: options.description ?? `Seeded for Playwright tests: ${valueName}`,
+          position: existingValues.length + 1,
+          isActive: options.isActive ?? true
+        });
+
+        return {
+          id: createdValue.subResourceId,
+          name: valueName
+        };
+      } catch (error) {
+        if (!this.isRecoverableDuplicateError(error)) {
+          throw error;
+        }
+
+        if (attempt === FineractApiClient.CREATE_RACE_RETRY_COUNT) {
+          const refreshedValues = await this.getCodeValues(code.id);
+          const refreshedValue = refreshedValues.find((value) => value.name === valueName);
+
+          if (refreshedValue) {
+            return refreshedValue;
+          }
+        } else {
+          await this.waitForCreateRaceRetry();
+        }
+      }
+    }
+
+    throw new Error(`Fineract API error [ensureCodeValue]: failed to resolve code value '${valueName}'`);
+  }
+
+  /**
+   * Ensures a closure reason exists for close-client workflow tests.
+   * @param name - The closure reason name to ensure exists
+   * @returns The existing or created closure reason
+   */
+  async ensureClientClosureReason(name = 'E2E Close Client Reason'): Promise<any> {
+    return this.ensureCodeValue(FineractApiClient.CLIENT_CLOSURE_REASON_CODE_NAME, name, {
+      description: 'Seeded for Playwright close-client test'
+    });
+  }
+
+  /**
+   * Ensures a minimal loan product exists for active-loan negative-path tests.
+   * @param options - Optional loan product identifiers to match or create
+   * @returns The existing or created loan product
+   */
+  async ensureMinimalLoanProduct(
+    options: {
+      name?: string;
+      shortName?: string;
+    } = {}
+  ): Promise<any> {
+    const name = options.name ?? 'E2E Loan Product';
+    const shortName = options.shortName ?? 'E2LP';
+    for (let attempt = 0; attempt <= FineractApiClient.CREATE_RACE_RETRY_COUNT; attempt += 1) {
+      const existingProducts = await this.getLoanProductsBasicDetails();
+      const existingProduct = existingProducts.find(
+        (product) => product.name === name && product.shortName === shortName
+      );
+
+      if (existingProduct) {
+        return existingProduct;
+      }
+
+      try {
+        const createdProduct = await this.createLoanProduct({
+          name,
+          shortName,
+          description: 'Seeded for Playwright tests',
+          includeInBorrowerCycle: false,
+          currencyCode: 'USD',
+          digitsAfterDecimal: 2,
+          principal: 1000,
+          numberOfRepayments: 1,
+          repaymentEvery: 1,
+          repaymentFrequencyType: 2,
+          interestRatePerPeriod: 0,
+          interestRateFrequencyType: 2,
+          amortizationType: 1,
+          interestType: 0,
+          interestCalculationPeriodType: 1,
+          transactionProcessingStrategyCode: 'mifos-standard-strategy',
+          daysInMonthType: 1,
+          daysInYearType: 1,
+          accountingRule: 1,
+          loanScheduleType: 'CUMULATIVE',
+          loanScheduleProcessingType: 'HORIZONTAL',
+          isInterestRecalculationEnabled: false,
+          dateFormat: FineractApiClient.DEFAULT_DATE_FORMAT,
+          locale: FineractApiClient.DEFAULT_LOCALE,
+          charges: []
+        });
+
+        return {
+          id: createdProduct.resourceId,
+          name,
+          shortName
+        };
+      } catch (error) {
+        if (!this.isRecoverableDuplicateError(error)) {
+          throw error;
+        }
+
+        if (attempt === FineractApiClient.CREATE_RACE_RETRY_COUNT) {
+          const refreshedProducts = await this.getLoanProductsBasicDetails();
+          const refreshedProduct = refreshedProducts.find(
+            (product) => product.name === name && product.shortName === shortName
+          );
+
+          if (refreshedProduct) {
+            return refreshedProduct;
+          }
+        } else {
+          await this.waitForCreateRaceRetry();
+        }
+      }
+    }
+
+    throw new Error(`Fineract API error [ensureMinimalLoanProduct]: failed to resolve loan product '${name}'`);
+  }
+
+  /**
+   * Closes a client with the provided reason and closure date.
+   * @param clientId - The client id to close
+   * @param closureReasonId - The closure reason code value id
+   * @param closureDate - The closure date in Fineract's expected format
+   * @returns The close-client command response payload
+   */
+  async closeClient(clientId: number, closureReasonId: number, closureDate: string): Promise<any> {
+    return this.executeClientCommand(clientId, 'close', {
+      closureDate,
+      closureReasonId,
+      dateFormat: FineractApiClient.DEFAULT_DATE_FORMAT,
+      locale: FineractApiClient.DEFAULT_LOCALE
+    });
+  }
+
+  /**
+   * Approves a loan on the provided date.
+   * @param loanId - The loan id to approve
+   * @param approvedOnDate - The approval date in Fineract's expected format
+   * @returns The approve-loan command response payload
+   */
+  async approveLoan(loanId: number, approvedOnDate: string): Promise<any> {
+    return this.executeLoanCommand(loanId, 'approve', {
+      approvedOnDate,
+      dateFormat: FineractApiClient.DEFAULT_DATE_FORMAT,
+      locale: FineractApiClient.DEFAULT_LOCALE
+    });
+  }
+
+  /**
+   * Disburses a loan on the provided date for the supplied amount.
+   * @param loanId - The loan id to disburse
+   * @param actualDisbursementDate - The disbursement date in Fineract's expected format
+   * @param transactionAmount - The amount to disburse
+   * @returns The disburse-loan command response payload
+   */
+  async disburseLoan(loanId: number, actualDisbursementDate: string, transactionAmount: number): Promise<any> {
+    return this.executeLoanCommand(loanId, 'disburse', {
+      actualDisbursementDate,
+      transactionAmount,
+      dateFormat: FineractApiClient.DEFAULT_DATE_FORMAT,
+      locale: FineractApiClient.DEFAULT_LOCALE
+    });
+  }
+
+  /**
+   * Creates, approves, and disburses an active loan for a client.
+   * @param clientId - The client id that owns the loan
+   * @param submittedOnDate - The submitted-on date in Fineract's expected format
+   * @param expectedDisbursementDate - The expected disbursement date in Fineract's expected format
+   * @returns The created loan after approval and disbursement
+   */
+  async createActiveLoanForClient(
+    clientId: number,
+    submittedOnDate: string,
+    expectedDisbursementDate: string
+  ): Promise<any> {
+    const loanProduct = await this.ensureMinimalLoanProduct();
+    const loanTemplate = await this.getLoanTemplate(clientId, loanProduct.id);
+    const principal = loanTemplate.principal ?? 1000;
+
+    const createLoanResponse = await this.createLoan({
+      clientId,
+      productId: loanProduct.id,
+      submittedOnDate,
+      expectedDisbursementDate,
+      principal,
+      loanType: 'individual',
+      loanTermFrequency: loanTemplate.termFrequency ?? 1,
+      loanTermFrequencyType: loanTemplate.termPeriodFrequencyType?.id ?? 2,
+      numberOfRepayments: loanTemplate.numberOfRepayments ?? 1,
+      repaymentEvery: loanTemplate.repaymentEvery ?? 1,
+      repaymentFrequencyType: loanTemplate.repaymentFrequencyType?.id ?? 2,
+      interestRatePerPeriod: loanTemplate.interestRatePerPeriod ?? 0,
+      interestRateFrequencyType: loanTemplate.interestRateFrequencyType?.id ?? 2,
+      amortizationType: loanTemplate.amortizationType?.id ?? 1,
+      interestType: loanTemplate.interestType?.id ?? 0,
+      interestCalculationPeriodType: loanTemplate.interestCalculationPeriodType?.id ?? 1,
+      transactionProcessingStrategyCode: loanTemplate.transactionProcessingStrategyCode ?? 'mifos-standard-strategy',
+      dateFormat: FineractApiClient.DEFAULT_DATE_FORMAT,
+      locale: FineractApiClient.DEFAULT_LOCALE
+    });
+
+    const loanId = createLoanResponse.loanId ?? createLoanResponse.resourceId;
+    await this.approveLoan(loanId, submittedOnDate);
+    await this.disburseLoan(loanId, expectedDisbursementDate, principal);
+
+    return this.getLoan(loanId);
+  }
+
+  /**
+   * Creates an active client with deterministic activation details.
+   * @param officeId - The office id that owns the client
+   * @param data - The active client creation details
+   * @returns The Fineract create-client response payload
+   */
+  async createActiveClient(
+    officeId: number,
+    data: {
+      firstname: string;
+      lastname: string;
+      submittedOnDate: string;
+      activationDate: string;
+    }
+  ): Promise<any> {
+    return this.createClient({
+      officeId,
+      legalFormId: 1,
+      firstname: data.firstname,
+      lastname: data.lastname,
+      active: true,
+      submittedOnDate: data.submittedOnDate,
+      activationDate: data.activationDate,
+      dateFormat: FineractApiClient.DEFAULT_DATE_FORMAT,
+      locale: FineractApiClient.DEFAULT_LOCALE
+    });
+  }
+
+  /**
+   * Creates a pending client that has not yet been activated.
+   * @param officeId - The office id that owns the client
+   * @param data - The pending client creation details
+   * @returns The Fineract create-client response payload
+   */
+  async createPendingClient(
+    officeId: number,
+    data: {
+      firstname: string;
+      lastname: string;
+      submittedOnDate: string;
+    }
+  ): Promise<any> {
+    return this.createClient({
+      officeId,
+      legalFormId: 1,
+      firstname: data.firstname,
+      lastname: data.lastname,
+      active: false,
+      submittedOnDate: data.submittedOnDate,
+      dateFormat: FineractApiClient.DEFAULT_DATE_FORMAT,
+      locale: FineractApiClient.DEFAULT_LOCALE
+    });
+  }
+
+  /**
+   * Returns the first available office id for test setup.
+   * @returns The first available office id
+   */
+  async getFirstOfficeId(): Promise<number> {
+    const offices = await this.getOffices();
+    const officeId = offices[0]?.id;
+
+    if (!officeId) {
+      throw new Error('Fineract API error [getFirstOfficeId]: no offices available');
+    }
+
+    return officeId;
   }
 
   /**
@@ -58,6 +564,10 @@ export class FineractApiClient {
    *   submittedOnDate, dateFormat, locale, nominalAnnualInterestRate,
    *   interestCompoundingPeriodType, interestPostingPeriodType,
    *   interestCalculationType, interestCalculationDaysInYearType
+   * @param clientId - The client id that owns the savings account
+   * @param productId - The savings product id to create the account from
+   * @param overrides - Additional savings account creation fields
+   * @returns The Fineract create-savings-account response payload
    */
   async createSavingsAccount(
     clientId: number,
@@ -70,6 +580,9 @@ export class FineractApiClient {
     return this.validateResponse(res, 'createSavingsAccount');
   }
 
+  /**
+   * Disposes the underlying Playwright request context.
+   */
   async dispose(): Promise<void> {
     await this.ctx?.dispose();
   }

--- a/playwright/pages/client-view.page.ts
+++ b/playwright/pages/client-view.page.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from './BasePage';
+
+export class ClientViewPage extends BasePage {
+  readonly url: string;
+
+  /**
+   * Builds the client general-view page object for a specific client id.
+   * @param page - The Playwright Page instance
+   * @param clientId - The client id used to build view URLs and locators
+   */
+  constructor(
+    page: Page,
+    private readonly clientId: number
+  ) {
+    super(page);
+    this.url = `/#/clients/${clientId}/general`;
+  }
+
+  /**
+   * Returns the top-level client actions trigger button.
+   * @returns The locator for the client actions button
+   */
+  get clientActionsButton(): Locator {
+    return this.page.getByRole('button', { name: 'Client actions' });
+  }
+
+  /**
+   * Returns the nested Actions submenu trigger inside the client actions menu.
+   * @returns The locator for the Actions submenu trigger
+   */
+  get actionsMenuItem(): Locator {
+    return this.page.getByRole('menuitem', { name: 'Actions' });
+  }
+
+  /**
+   * Returns a specific item inside the Actions submenu by its visible label.
+   * @param name - The visible menu item label
+   * @returns The locator for the matching action menu item
+   */
+  actionMenuItem(name: string): Locator {
+    return this.page.getByRole('menuitem', { name });
+  }
+
+  /**
+   * Returns the personal data tab used to inspect post-action client fields.
+   * @returns The locator for the personal data tab
+   */
+  get personalDataTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Personal Data' });
+  }
+
+  /**
+   * Returns the snackbar container used for success and error notifications.
+   * @returns The locator for the Material snackbar container
+   */
+  get successSnackbar(): Locator {
+    return this.page.locator('.mat-mdc-snack-bar-container');
+  }
+
+  /**
+   * Returns the active overlay backdrop rendered by Angular Material menus.
+   * @returns The locator for the active overlay backdrop
+   */
+  get overlayBackdrop(): Locator {
+    return this.page.locator('.cdk-overlay-backdrop');
+  }
+
+  /**
+   * Returns the personal-data field that shows the client's closed date.
+   * @returns The locator for the closed date value
+   */
+  closedDateValue(): Locator {
+    return this.page.locator('.data-item', { hasText: 'Closed Date' }).locator('.value');
+  }
+
+  /**
+   * Dismisses an open Material overlay so subsequent clicks are not blocked.
+   */
+  async dismissOverlay(): Promise<void> {
+    if (await this.overlayBackdrop.isVisible()) {
+      await this.overlayBackdrop.click({ force: true });
+      await this.overlayBackdrop.waitFor({ state: 'hidden', timeout: 10000 });
+    }
+  }
+
+  /**
+   * Waits until the client general view is loaded and interactive.
+   */
+  async waitForLoad(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/general$`));
+    await this.waitForVisible(this.clientActionsButton, 30000);
+  }
+
+  /**
+   * Opens the top-level client actions menu.
+   */
+  async openActionsMenu(): Promise<void> {
+    await this.clientActionsButton.click();
+    await this.waitForVisible(this.actionsMenuItem, 10000);
+  }
+
+  /**
+   * Opens the nested Actions submenu within the client actions menu.
+   */
+  async openActionsSubmenu(): Promise<void> {
+    await this.openActionsMenu();
+    await this.actionsMenuItem.hover();
+    await this.actionsMenuItem.click();
+  }
+
+  /**
+   * Opens the requested client action from the nested Actions submenu.
+   */
+  async chooseAction(name: string): Promise<void> {
+    await this.openActionsSubmenu();
+    await this.waitForVisible(this.actionMenuItem(name), 10000);
+    await this.actionMenuItem(name).click();
+  }
+
+  /**
+   * Navigates to the personal data tab for field-level verification.
+   */
+  async gotoPersonalDataTab(): Promise<void> {
+    await this.personalDataTab.click();
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/personal-data$`));
+  }
+}

--- a/playwright/pages/close-client.page.ts
+++ b/playwright/pages/close-client.page.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from './BasePage';
+
+export class CloseClientPage extends BasePage {
+  readonly url: string;
+
+  /**
+   * Builds the close-client action page object for a specific client id.
+   * @param page - The Playwright Page instance
+   * @param clientId - The client id used to build action URLs and locators
+   */
+  constructor(
+    page: Page,
+    private readonly clientId: number
+  ) {
+    super(page);
+    this.url = `/#/clients/${clientId}/actions/Close`;
+  }
+
+  /**
+   * Returns the closure date input used by the close-client form.
+   * @returns The locator for the closure date input
+   */
+  get closureDateInput(): Locator {
+    return this.page.locator('input[formcontrolname="closureDate"]');
+  }
+
+  /**
+   * Returns the closure reason select field.
+   * @returns The locator for the closure reason select
+   */
+  get closureReasonSelect(): Locator {
+    return this.page.locator('mat-select[formcontrolname="closureReasonId"]');
+  }
+
+  /**
+   * Returns the form submission control for closing the client.
+   * @returns The locator for the confirm button
+   */
+  get confirmButton(): Locator {
+    return this.page.getByRole('button', { name: 'Confirm' });
+  }
+
+  /**
+   * Returns the cancel control that navigates back to the client view.
+   * @returns The locator for the cancel button
+   */
+  get cancelButton(): Locator {
+    return this.page.getByRole('button', { name: 'Cancel' });
+  }
+
+  /**
+   * Returns a specific closure reason option by its visible label.
+   * @param name - The visible label of the closure reason
+   * @returns The locator for the matching closure reason option
+   */
+  closureReasonOption(name: string): Locator {
+    return this.page.getByRole('option', { name });
+  }
+
+  /**
+   * Waits for the close-client action form to load.
+   */
+  async waitForLoad(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/actions/Close$`));
+    await this.waitForVisible(this.closureDateInput, 30000);
+  }
+
+  /**
+   * Opens the reason select and chooses the requested closure reason.
+   * @param reasonName - The visible closure reason label to select
+   */
+  async selectClosureReason(reasonName: string): Promise<void> {
+    await this.closureReasonSelect.click();
+    await this.closureReasonOption(reasonName).click();
+  }
+
+  /**
+   * Completes and submits the close-client form.
+   * @param closureDate - The closure date to submit
+   * @param reasonName - The closure reason label to select
+   */
+  async submitClosure({ closureDate, reasonName }: { closureDate: string; reasonName: string }): Promise<void> {
+    await this.closureDateInput.fill(closureDate);
+    await this.closureDateInput.blur();
+
+    await this.selectClosureReason(reasonName);
+
+    await expect(this.confirmButton).toBeEnabled();
+    await this.confirmButton.click();
+  }
+
+  /**
+   * Waits until cancellation returns the browser to the client general view.
+   */
+  async waitForCancelNavigation(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/general$`));
+  }
+}

--- a/playwright/tests/close-client.spec.ts
+++ b/playwright/tests/close-client.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '../fixtures/test-fixtures';
+import { ClientViewPage } from '../pages/client-view.page';
+import { CloseClientPage } from '../pages/close-client.page';
+
+const SUBMITTED_ON_DATE = '01 January 2024';
+const ACTIVATION_DATE = '02 January 2024';
+const CLOSURE_DATE = '03 January 2024';
+const ACTIVE_LOAN_TEST_DATE = '04 January 2024';
+const CLOSURE_REASON_NAME = 'E2E Close Client Reason';
+
+test.describe('Close Client Workflow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      const creds = localStorage.getItem('mifosXCredentials');
+      if (creds) {
+        sessionStorage.setItem('mifosXCredentials', creds);
+      }
+    });
+  });
+
+  test('should close an active client from the client actions flow', async ({ page, fineractApi }) => {
+    await fineractApi.ensureClientClosureReason(CLOSURE_REASON_NAME);
+    const officeId = await fineractApi.getFirstOfficeId();
+
+    const uniqueSuffix = Date.now();
+    const createClientResponse = await fineractApi.createActiveClient(officeId, {
+      firstname: `Close${uniqueSuffix}`,
+      lastname: 'Client',
+      submittedOnDate: SUBMITTED_ON_DATE,
+      activationDate: ACTIVATION_DATE
+    });
+
+    const clientId = createClientResponse.resourceId;
+    const clientViewPage = new ClientViewPage(page, clientId);
+    const closeClientPage = new CloseClientPage(page, clientId);
+
+    await clientViewPage.navigate();
+    await clientViewPage.chooseAction('Close');
+
+    await closeClientPage.waitForLoad();
+    await closeClientPage.submitClosure({
+      closureDate: CLOSURE_DATE,
+      reasonName: CLOSURE_REASON_NAME
+    });
+
+    await clientViewPage.waitForLoad();
+    await expect(clientViewPage.successSnackbar).toContainText('Client closed successfully.');
+
+    await clientViewPage.openActionsSubmenu();
+    await expect(clientViewPage.actionMenuItem('Reactivate')).toBeVisible();
+    await clientViewPage.dismissOverlay();
+
+    await clientViewPage.gotoPersonalDataTab();
+    await expect(clientViewPage.closedDateValue()).toContainText('03 January 2024');
+
+    const clientDetails = await fineractApi.getClient(clientId);
+    expect(clientDetails.status?.value).toBe('Closed');
+    expect(clientDetails.timeline?.closedOnDate).toEqual([
+      2024,
+      1,
+      3
+    ]);
+  });
+
+  test('should keep the close form invalid until both closure date and reason are provided', async ({
+    page,
+    fineractApi
+  }) => {
+    await fineractApi.ensureClientClosureReason(CLOSURE_REASON_NAME);
+    const officeId = await fineractApi.getFirstOfficeId();
+    const uniqueSuffix = Date.now();
+
+    const createClientResponse = await fineractApi.createActiveClient(officeId, {
+      firstname: `Validation${uniqueSuffix}`,
+      lastname: 'Client',
+      submittedOnDate: SUBMITTED_ON_DATE,
+      activationDate: ACTIVATION_DATE
+    });
+
+    const clientId = createClientResponse.resourceId;
+    const clientViewPage = new ClientViewPage(page, clientId);
+    const closeClientPage = new CloseClientPage(page, clientId);
+
+    await clientViewPage.navigate();
+    await clientViewPage.chooseAction('Close');
+
+    await closeClientPage.waitForLoad();
+    await expect(closeClientPage.confirmButton).toBeDisabled();
+
+    await closeClientPage.closureDateInput.fill(CLOSURE_DATE);
+    await closeClientPage.closureDateInput.blur();
+    await expect(closeClientPage.confirmButton).toBeDisabled();
+
+    await closeClientPage.selectClosureReason(CLOSURE_REASON_NAME);
+    await expect(closeClientPage.confirmButton).toBeEnabled();
+  });
+
+  test('should show Reactivate for a client already closed through the API', async ({ page, fineractApi }) => {
+    const closureReason = await fineractApi.ensureClientClosureReason(CLOSURE_REASON_NAME);
+    const officeId = await fineractApi.getFirstOfficeId();
+    const uniqueSuffix = Date.now();
+
+    const createClientResponse = await fineractApi.createActiveClient(officeId, {
+      firstname: `Closed${uniqueSuffix}`,
+      lastname: 'Client',
+      submittedOnDate: SUBMITTED_ON_DATE,
+      activationDate: ACTIVATION_DATE
+    });
+
+    const clientId = createClientResponse.resourceId;
+    await fineractApi.closeClient(clientId, closureReason.id, CLOSURE_DATE);
+
+    const clientViewPage = new ClientViewPage(page, clientId);
+    await clientViewPage.navigate();
+
+    await clientViewPage.openActionsSubmenu();
+    await expect(clientViewPage.actionMenuItem('Reactivate')).toBeVisible();
+  });
+
+  test('should keep the client active when cancel or browser back is used from the close flow', async ({
+    page,
+    fineractApi
+  }) => {
+    await fineractApi.ensureClientClosureReason(CLOSURE_REASON_NAME);
+    const officeId = await fineractApi.getFirstOfficeId();
+    const uniqueSuffix = Date.now();
+
+    const createClientResponse = await fineractApi.createActiveClient(officeId, {
+      firstname: `CancelBack${uniqueSuffix}`,
+      lastname: 'Client',
+      submittedOnDate: SUBMITTED_ON_DATE,
+      activationDate: ACTIVATION_DATE
+    });
+
+    const clientId = createClientResponse.resourceId;
+    const clientViewPage = new ClientViewPage(page, clientId);
+    const closeClientPage = new CloseClientPage(page, clientId);
+
+    await clientViewPage.navigate();
+    await clientViewPage.chooseAction('Close');
+
+    await closeClientPage.waitForLoad();
+    await closeClientPage.cancelButton.click();
+    await closeClientPage.waitForCancelNavigation();
+
+    let clientDetails = await fineractApi.getClient(clientId);
+    expect(clientDetails.status?.value).toBe('Active');
+
+    await clientViewPage.openActionsSubmenu();
+    await expect(clientViewPage.actionMenuItem('Close')).toBeVisible();
+    await clientViewPage.dismissOverlay();
+
+    await clientViewPage.gotoPersonalDataTab();
+    await expect(clientViewPage.closedDateValue()).toHaveCount(0);
+
+    await clientViewPage.navigate();
+    await clientViewPage.chooseAction('Close');
+
+    await closeClientPage.waitForLoad();
+    await closeClientPage.closureDateInput.fill(CLOSURE_DATE);
+    await closeClientPage.closureDateInput.blur();
+    await closeClientPage.selectClosureReason(CLOSURE_REASON_NAME);
+
+    await page.goBack();
+    await closeClientPage.waitForCancelNavigation();
+
+    clientDetails = await fineractApi.getClient(clientId);
+    expect(clientDetails.status?.value).toBe('Active');
+
+    await clientViewPage.openActionsSubmenu();
+    await expect(clientViewPage.actionMenuItem('Close')).toBeVisible();
+    await clientViewPage.dismissOverlay();
+
+    await clientViewPage.gotoPersonalDataTab();
+    await expect(clientViewPage.closedDateValue()).toHaveCount(0);
+  });
+
+  test('should reject closing a client with an active loan', async ({ page, fineractApi }) => {
+    const closureReason = await fineractApi.ensureClientClosureReason(CLOSURE_REASON_NAME);
+    const officeId = await fineractApi.getFirstOfficeId();
+    const uniqueSuffix = Date.now();
+
+    const createClientResponse = await fineractApi.createActiveClient(officeId, {
+      firstname: `LoanBlock${uniqueSuffix}`,
+      lastname: 'Client',
+      submittedOnDate: ACTIVE_LOAN_TEST_DATE,
+      activationDate: ACTIVE_LOAN_TEST_DATE
+    });
+
+    const clientId = createClientResponse.resourceId;
+    const loan = await fineractApi.createActiveLoanForClient(clientId, ACTIVE_LOAN_TEST_DATE, ACTIVE_LOAN_TEST_DATE);
+
+    expect(loan.status?.value).toBe('Active');
+
+    const clientViewPage = new ClientViewPage(page, clientId);
+    const closeClientPage = new CloseClientPage(page, clientId);
+
+    await clientViewPage.navigate();
+    await clientViewPage.chooseAction('Close');
+
+    await closeClientPage.waitForLoad();
+    await closeClientPage.submitClosure({
+      closureDate: ACTIVE_LOAN_TEST_DATE,
+      reasonName: closureReason.name
+    });
+
+    await expect(page).toHaveURL(new RegExp(`/clients/${clientId}/actions/Close$`));
+    await expect(page.getByText('Client cannot be closed because of non-closed loans.')).toBeVisible();
+
+    const clientDetails = await fineractApi.getClient(clientId);
+    expect(clientDetails.status?.value).toBe('Active');
+  });
+});


### PR DESCRIPTION
  ## Description

  This PR adds end-to-end coverage for the client close workflow so the application is validated against real
  user-facing close scenarios and the resulting backend state changes. The goal is to improve confidence in a
  financial workflow where UI navigation alone is not enough and the final client state must be verified after
  submission.

  The added coverage includes successful client closure, required-field validation, cancel and browser-
  navigation safety, status-based action behavior, and rejection when a client still has an active loan. It
  also introduces reusable test helpers for setting up the client and loan states needed by these scenarios.

  Dependencies required for this change:

  - a running Fineract backend accessible to the Playwright test environment
  - Playwright authentication/setup already configured for the test suite

  ## Related issues and discussion

  #897

  ## Screenshots, if any

  ## Checklist

  Please make sure these boxes are checked before submitting your pull request - thanks!

  - [ ] If you have multiple commits please combine them into one commit by squashing them.
  - [ ] Read and understood the contribution guidelines at web-app/.github/CONTRIBUTING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer test-side API helpers and orchestration to create/prepare clients, loan products, and active loans.
  * Added page objects for client view and client-close workflows to simplify UI interactions.

* **Tests**
  * Added end-to-end client-closure test suite covering successful closure, form validation, reactivation visibility, API validation, and handling of clients with active loans.

* **Documentation**
  * Updated JSDoc for savings account creation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->