### PR TITLE
WEB-921 Restrict negative values in fixed deposits frequency and period  fields

### DIFF
--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-settings-step/fixed-deposit-account-settings-step.component.html
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-settings-step/fixed-deposit-account-settings-step.component.html
@@ -12,7 +12,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>
-      <input type="number" matInput formControlName="lockinPeriodFrequency" />
+      <input type="number" matInput formControlName="lockinPeriodFrequency" mifosxPositiveInteger />
     </mat-form-field>
 
     <mat-form-field class="flex-48">

--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-settings-step/fixed-deposit-account-settings-step.component.ts
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-settings-step/fixed-deposit-account-settings-step.component.ts
@@ -22,6 +22,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { PositiveIntegerDirective } from 'app/directives/positive-integer.directive';
 
 /**
  * Fixed Deposits Account Settings Step
@@ -36,7 +37,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatCheckbox,
     MatStepperPrevious,
     FaIconComponent,
-    MatStepperNext
+    MatStepperNext,
+    PositiveIntegerDirective
   ]
 })
 export class FixedDepositAccountSettingsStepComponent implements OnInit, OnChanges {
@@ -53,7 +55,7 @@ export class FixedDepositAccountSettingsStepComponent implements OnInit, OnChang
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Fixed Deposits Account Settings Form */
-  fixedDepositAccountSettingsForm: UntypedFormGroup;
+  fixedDepositAccountSettingsForm!: UntypedFormGroup;
   /** Lockin Period Frequency Type Data */
   lockinPeriodFrequencyTypeData: any;
   /** Period Frequency Type Data */
@@ -63,7 +65,7 @@ export class FixedDepositAccountSettingsStepComponent implements OnInit, OnChang
   /** Savings Accounts Data */
   savingsAccountsData: any;
 
-  maturityInstructionOptions: OptionData[];
+  maturityInstructionOptions!: OptionData[];
 
   /**
    * @param {FormBuilder} formBuilder Form Builder
@@ -98,14 +100,14 @@ export class FixedDepositAccountSettingsStepComponent implements OnInit, OnChang
       });
       if (this.fixedDepositsAccountProductTemplate.withHoldTax) {
         this.fixedDepositAccountSettingsForm.addControl('withHoldTax', new UntypedFormControl(false));
-        this.fixedDepositAccountSettingsForm.get('withHoldTax').valueChanges.subscribe((value: boolean) => {
+        this.fixedDepositAccountSettingsForm.get('withHoldTax')!.valueChanges.subscribe((value: boolean) => {
           if (value) {
             this.fixedDepositAccountSettingsForm.addControl(
               'taxGroupId',
               new UntypedFormControl({ value: '', disabled: true })
             );
             this.fixedDepositAccountSettingsForm
-              .get('taxGroupId')
+              .get('taxGroupId')!
               .patchValue(
                 this.fixedDepositsAccountProductTemplate.taxGroup &&
                   this.fixedDepositsAccountProductTemplate.taxGroup.name
@@ -115,7 +117,7 @@ export class FixedDepositAccountSettingsStepComponent implements OnInit, OnChang
           }
         });
         this.fixedDepositAccountSettingsForm
-          .get('withHoldTax')
+          .get('withHoldTax')!
           .patchValue(this.fixedDepositsAccountTemplate.withHoldTax);
       } else {
         this.fixedDepositAccountSettingsForm.removeControl('withHoldTax');
@@ -162,14 +164,14 @@ export class FixedDepositAccountSettingsStepComponent implements OnInit, OnChang
    * Subscribes to value changes and sets new form controls accordingly.
    */
   buildDependencies() {
-    this.fixedDepositAccountSettingsForm.get('transferInterestToSavings').valueChanges.subscribe((value: boolean) => {
+    this.fixedDepositAccountSettingsForm.get('transferInterestToSavings')!.valueChanges.subscribe((value: boolean) => {
       if (value) {
         this.fixedDepositAccountSettingsForm.addControl(
           'linkAccountId',
           new UntypedFormControl('', Validators.required)
         );
         this.fixedDepositAccountSettingsForm
-          .get('linkAccountId')
+          .get('linkAccountId')!
           .patchValue(
             this.fixedDepositsAccountTemplate.linkedAccount && this.fixedDepositsAccountTemplate.linkedAccount.id
           );
@@ -177,14 +179,14 @@ export class FixedDepositAccountSettingsStepComponent implements OnInit, OnChang
         this.fixedDepositAccountSettingsForm.removeControl('linkAccountId');
       }
     });
-    this.fixedDepositAccountSettingsForm.get('maturityInstructionId').valueChanges.subscribe((value: number) => {
+    this.fixedDepositAccountSettingsForm.get('maturityInstructionId')!.valueChanges.subscribe((value: number) => {
       if (value > 100) {
         this.fixedDepositAccountSettingsForm.addControl(
           'transferToSavingsId',
           new UntypedFormControl('', Validators.required)
         );
         this.fixedDepositAccountSettingsForm
-          .get('transferToSavingsId')
+          .get('transferToSavingsId')!
           .patchValue(
             this.fixedDepositsAccountTemplate.transferToSavingsId &&
               this.fixedDepositsAccountTemplate.transferToSavingsId.id

--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-terms-step/fixed-deposit-account-terms-step.component.html
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-terms-step/fixed-deposit-account-terms-step.component.html
@@ -23,7 +23,7 @@
 
     <mat-form-field class="flex-48">
       <mat-label>{{ 'labels.inputs.Deposit Period' | translate }}</mat-label>
-      <input type="number" matInput formControlName="depositPeriod" required />
+      <input type="number" matInput formControlName="depositPeriod" mifosxPositiveInteger required />
       <mat-error>
         {{ 'labels.inputs.Deposit Period' | translate }} {{ 'labels.commons.is' | translate }}
         <strong>{{ 'labels.commons.required' | translate }}</strong>

--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-terms-step/fixed-deposit-account-terms-step.component.ts
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-terms-step/fixed-deposit-account-terms-step.component.ts
@@ -16,6 +16,7 @@ import { MatDivider } from '@angular/material/divider';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { PositiveIntegerDirective } from 'app/directives/positive-integer.directive';
 
 /**
  * Fixed Deposits Terms Step
@@ -30,7 +31,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatDivider,
     MatStepperPrevious,
     FaIconComponent,
-    MatStepperNext
+    MatStepperNext,
+    PositiveIntegerDirective
   ]
 })
 export class FixedDepositAccountTermsStepComponent implements OnInit, OnChanges {
@@ -47,7 +49,7 @@ export class FixedDepositAccountTermsStepComponent implements OnInit, OnChanges 
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Fixed Deposits Account Terms Form */
-  fixedDepositAccountTermsForm: UntypedFormGroup;
+  fixedDepositAccountTermsForm!: UntypedFormGroup;
   /** Interest Compounding Period Type Data */
   interestCompoundingPeriodTypeData: any;
   /** Interest Posting Period Type Data */


### PR DESCRIPTION
**Chnages Made :-**

-Fixed deposits account creation form allows negative values in Lock-in Period Frequency and Deposit Period fields .

[WEB-921](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-921)



[WEB-921]: https://mifosforge.jira.com/browse/WEB-921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced numeric input validation throughout the fixed deposit account setup process. Deposit period and lock-in period frequency fields now enforce strict positive integer constraints, preventing users from entering invalid or erroneous values. This improvement significantly reduces data entry errors and ensures higher data quality when creating and configuring fixed deposit accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->