### PR TITLE
WEB-922 Breach configuration title displaying raw translation key labels text breach configuration

### DIFF
--- a/src/app/products/products-routing.module.ts
+++ b/src/app/products/products-routing.module.ts
@@ -899,7 +899,7 @@ const routes: Routes = [
         },
         {
           path: 'breach-configurations',
-          data: { title: 'Breach Configurations', breadcrumb: 'Breach Configurations' },
+          data: { title: 'Breach Configuration', breadcrumb: 'Breach Configuration' },
           children: [
             {
               path: '',

--- a/src/app/products/products.component.html
+++ b/src/app/products/products.component.html
@@ -207,7 +207,7 @@
                   <fa-icon icon="not-equal" size="sm"></fa-icon>
                 </mat-icon>
                 <div matLine>
-                  {{ 'labels.heading.Breach Configuration' | translate }}
+                  {{ 'labels.text.Breach Configuration' | translate }}
                   @if (arrowBooleans[5]) {
                     <p matLine [routerLink]="['breach-configurations']" class="menu-explanation">
                       {{ 'labels.text.Define breaches for working capital products' | translate }}

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3193,6 +3193,7 @@
       "the Transaction Type": "typ transakce"
     },
     "text": {
+      "Breach Configuration": "Konfigurace porušení",
       "Loading data": "Načítání dat",
       "withoutCategory": "Bez kategorie",
       "No repayment schedule available": "Není nalezeny žádný splátkový kalendář",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3195,6 +3195,7 @@
       "the Transaction Type": "der Transaktionstyp"
     },
     "text": {
+      "Breach Configuration": "Verstoßkonfiguration",
       "Loading data": "Daten werden geladen",
       "withoutCategory": "Ohne Kategorie",
       "No repayment schedule available": "Kein Rückzahlungsplan gefunden",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3229,6 +3229,7 @@
     },
     "text": {
       "About Us": "About Us",
+      "Breach Configuration": "Breach Configuration",
       "withoutCategory": "Without Category",
       "A": "A",
       "Account Transfers": "Account Transfers",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3192,6 +3192,7 @@
       "the Transaction Type": "el tipo de transacción"
     },
     "text": {
+      "Breach Configuration": "Configuración de Incumplimiento",
       "Loading data": "Cargando datos",
       "withoutCategory": "Sin categoría",
       "No repayment schedule available": "No hay cronograma de pagos encontrado",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3206,6 +3206,7 @@
       "the Transaction Type": "el tipo de transacción"
     },
     "text": {
+      "Breach Configuration": "Configuración de Incumplimiento",
       "Unable to load vendors. Please check your connection and try again.": "No se pudieron cargar los proveedores. Verifique su conexión e intente de nuevo.",
       "This remittance has a terminal status and cannot be processed further.": "Esta remesa tiene un estado terminal y no puede ser procesada.",
       "This remittance has already been paid successfully.": "Esta remesa ya ha sido pagada exitosamente.",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3194,6 +3194,7 @@
       "the Transaction Type": "le type de transaction"
     },
     "text": {
+      "Breach Configuration": "Configuration de violation",
       "Loading data": "Chargement des données",
       "No repayment schedule available": "Aucun calendrier de remboursement trouvé",
       "About Us": "À Propos de Nous",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3189,6 +3189,7 @@
       "the Transaction Type": "il tipo di transazione"
     },
     "text": {
+      "Breach Configuration": "Configurazione della violazione",
       "Loading data": "Caricamento dati",
       "No repayment schedule available": "Nessun piano di rimborso trovato",
       "About Us": "Chi Siamo",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3190,6 +3190,7 @@
       "the Transaction Type": "거래 유형"
     },
     "text": {
+      "Breach Configuration": "위반 구성",
       "Loading data": "데이터 로딩 중",
       "No repayment schedule available": "상환 일정을 사용할 수 없습니다",
       "About Us": "회사 소개",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3191,6 +3191,7 @@
       "the Transaction Type": "operacijos tipas"
     },
     "text": {
+      "Breach Configuration": "Pažeidimo konfigūracija",
       "Loading data": "Duomenų įkėlimas",
       "No repayment schedule available": "Nėra galimo grąžinimo grafiko",
       "About Us": "Apie Mus",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3190,6 +3190,7 @@
       "the Transaction Type": "Darījuma veids"
     },
     "text": {
+      "Breach Configuration": "Pārkāpuma konfigurācija",
       "Loading data": "Ielādē datus",
       "No repayment schedule available": "Nav pieejams atmaksas grafiks",
       "About Us": "Par Mums",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3188,6 +3188,7 @@
       "the Transaction Type": "लेनदेन प्रकार"
     },
     "text": {
+      "Breach Configuration": "उल्लंघन कन्फिगरेसन",
       "Loading data": "डाटा लोड गर्दै",
       "No repayment schedule available": "कुनै पुनर्भुक्तानी तालिका उपलब्ध छैन",
       "About Us": "हाम्रो बारेमा",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3190,6 +3190,7 @@
       "the Transaction Type": "o tipo de transação"
     },
     "text": {
+      "Breach Configuration": "Configuração de violação",
       "Loading data": "Carregando dados",
       "No repayment schedule available": "Nenhum cronograma de reembolso encontrada",
       "About Us": "Sobre Nós",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3186,6 +3186,7 @@
       "the Transaction Type": "Aina ya Muamala"
     },
     "text": {
+      "Breach Configuration": "Usanidi wa Ukiukaji",
       "Loading data": "Inapakia data",
       "No repayment schedule available": "Hakuna ratiba ya malipo inayopatikana",
       "About Us": "Kuhusu Sisi",


### PR DESCRIPTION
**Changes Made :-**

-Synchronized "Breach Configuration" translation keys across 13 JSON files and updated the Products routing module and template to use standardized labels.text.Breach Configuration .

[WEB-922](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-922)

Before :- 
<img width="1365" height="594" alt="image" src="https://github.com/user-attachments/assets/1e61a073-51d0-4862-93de-4600ee924966" />

After :-
<img width="1365" height="413" alt="image" src="https://github.com/user-attachments/assets/ce997683-f14c-44ef-b2c4-200970f80454" />

<img width="1365" height="416" alt="image" src="https://github.com/user-attachments/assets/4c2514ce-8ad9-470c-87a2-9d90e29a1618" />


[WEB-922]: https://mifosforge.jira.com/browse/WEB-922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Breach Configuration" translations across 12 languages (Czech, German, English, Spanish, French, Italian, Korean, Lithuanian, Latvian, Nepali, Portuguese, and Swahili).

* **Bug Fixes**
  * Corrected menu label from plural to singular form and updated the associated label key reference for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->