### PR TITLE
WEB-923  Fix incorrect Create Template page title

### DIFF
--- a/src/app/templates/templates-routing.module.ts
+++ b/src/app/templates/templates-routing.module.ts
@@ -41,7 +41,7 @@ const routes: Routes = [
         {
           path: 'create',
           component: CreateEditComponent,
-          data: { mode: 'create', breadcrumb: 'Create Template' },
+          data: { title: 'Create Template', mode: 'create', breadcrumb: 'Create Template' },
           resolve: { templateData: CreateTemplateResolver }
         },
         {


### PR DESCRIPTION
**Changes Made :-**

-Corrected the route title data and standardized translation keys to ensure "Create Template" is displayed instead of the parent "Templates" title. 

[WEB-923](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-923)

Before :- 
<img width="1350" height="651" alt="image" src="https://github.com/user-attachments/assets/e58c3f41-d327-4b85-9fc3-3125ed6df6cf" />


After :- 
<img width="1365" height="654" alt="image" src="https://github.com/user-attachments/assets/c57ef8dd-4083-4658-95e8-c54201b77280" />

<img width="1355" height="649" alt="image" src="https://github.com/user-attachments/assets/d70f227b-bc00-41f5-910e-172b70f32f0a" />


[WEB-923]: https://mifosforge.jira.com/browse/WEB-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ