### PR TITLE
[WEB-820] Display the userMessageGlobalisationCode error in the modal/popup that is displayed on the top right corner

### DIFF
--- a/src/app/core/http/error-handler.interceptor.ts
+++ b/src/app/core/http/error-handler.interceptor.ts
@@ -37,14 +37,34 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
     return next.handle(request).pipe(catchError((error) => this.handleError(error, request)));
   }
 
+  /**
+   * Parses the error body from an HttpErrorResponse.
+   * When a request uses responseType 'arraybuffer' or 'blob', Angular stores the
+   * raw binary data in response.error instead of a parsed JSON object. This method
+   * decodes it so the rest of the error handler can read structured fields like
+   * userMessageGlobalisationCode.
+   */
+  private parseErrorBody(error: any): any {
+    if (error instanceof ArrayBuffer) {
+      try {
+        return JSON.parse(new TextDecoder().decode(error));
+      } catch {
+        return null;
+      }
+    }
+    return error;
+  }
+
   private handleError(response: HttpErrorResponse, request: HttpRequest<any>): Observable<HttpEvent<any>> {
     const status = response.status;
+    const errorBody = this.parseErrorBody(response.error);
 
     // Translate top-level globalisation code if present
-    let topLevelMessage = response.error?.defaultUserMessage || response.error?.developerMessage || response.message;
-    if (response.error?.userMessageGlobalisationCode) {
-      const topCode = response.error.userMessageGlobalisationCode;
-      const translated = this.translate.instant(topCode, response.error || {});
+    const rawTopLevelMessage = errorBody?.defaultUserMessage || errorBody?.developerMessage;
+    let topLevelMessage = rawTopLevelMessage || response.message;
+    if (errorBody?.userMessageGlobalisationCode) {
+      const topCode = errorBody.userMessageGlobalisationCode;
+      const translated = this.translate.instant(topCode, errorBody || {});
       if (translated !== topCode) {
         topLevelMessage = translated;
       }
@@ -52,23 +72,31 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
 
     // Translate nested globalisation code if present
     let nestedMessage: string | null = null;
-    if (response.error?.errors?.[0]?.userMessageGlobalisationCode) {
-      const nestedCode = response.error.errors[0].userMessageGlobalisationCode;
-      const translated = this.translate.instant(nestedCode, response.error.errors[0] || {});
-      nestedMessage = translated !== nestedCode ? translated : response.error.errors[0].defaultUserMessage || null;
+    if (errorBody?.errors?.[0]?.userMessageGlobalisationCode) {
+      const nestedCode = errorBody.errors[0].userMessageGlobalisationCode;
+      const translated = this.translate.instant(nestedCode, errorBody.errors[0] || {});
+      nestedMessage = translated !== nestedCode ? translated : errorBody.errors[0].defaultUserMessage || null;
     }
 
-    // Combine both messages if both exist
-    let errorMessage = nestedMessage ? `${topLevelMessage} ${nestedMessage}` : topLevelMessage;
+    // Combine both messages if both exist and are distinct.
+    // Prefer translated messages; only fall back to raw defaultUserMessage when no translation was resolved.
+    const hasTopLevelPayload = Boolean(rawTopLevelMessage || errorBody?.userMessageGlobalisationCode);
+
+    let errorMessage = nestedMessage
+      ? hasTopLevelPayload && nestedMessage !== topLevelMessage
+        ? `${topLevelMessage} ${nestedMessage}`
+        : nestedMessage
+      : topLevelMessage;
     let parameterName: string | null = null;
-    if (response.error.errors) {
-      if (response.error.errors[0]) {
+    if (errorBody?.errors?.[0]) {
+      if (!nestedMessage) {
         errorMessage =
-          response.error.errors[0].defaultUserMessage.replace(/\\./g, ' ') ||
-          response.error.errors[0].developerMessage.replace(/\\./g, ' ');
+          errorBody.errors[0].defaultUserMessage?.replace(/\\./g, ' ') ||
+          errorBody.errors[0].developerMessage?.replace(/\\./g, ' ') ||
+          errorMessage;
       }
-      if ('parameterName' in response.error.errors[0]) {
-        parameterName = response.error.errors[0].parameterName;
+      if ('parameterName' in errorBody.errors[0]) {
+        parameterName = errorBody.errors[0].parameterName;
       }
     }
     const isClientImage404 = status === 404 && request.url.includes('/clients/') && request.url.includes('/images');
@@ -84,7 +112,7 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
       });
     } else if (
       status === 403 &&
-      response.error?.errors?.[0]?.defaultUserMessage === 'The provided one time token is invalid'
+      errorBody?.errors?.[0]?.defaultUserMessage === 'The provided one time token is invalid'
     ) {
       this.alertService.alert({
         type: this.translate.instant('errors.error.token.invalid.type'),
@@ -114,7 +142,7 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
     } else if (status === 500) {
       this.alertService.alert({
         type: this.translate.instant('errors.error.server.internal.type'),
-        message: this.translate.instant('errors.error.server.internal.message')
+        message: errorMessage || this.translate.instant('errors.error.server.internal.message')
       });
     } else if (status === 501) {
       this.alertService.alert({

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "Úsporný produkt s názvem `{{params[0].value}}` již existuje.",
     "error.msg.product.savings.duplicate.short.name": "Spořicí produkt s krátkým názvem {{params[0].value}} již existuje.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "Při vytváření/aktualizaci spořicího produktu došlo k neočekávanému problému. Chyba přihlášení na serveru.",
+    "error.msg.reporting.error": "Při generování sestavy došlo k chybě.",
     "validation.msg.charge.amount.cannot.be.blank": "Částka nemůže být prázdná.",
     "validation.msg.charge.amount.not.greater.than.zero": "Částka poplatku musí být větší než nula.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "Poplatek se vztahuje na nemůže být prázdný.",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "Das Sparprodukt mit dem Namen „{{params[0].value}}“ existiert bereits.",
     "error.msg.product.savings.duplicate.short.name": "Das Sparprodukt mit dem Kurznamen {{params[0].value}} existiert bereits.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "Beim Erstellen/Aktualisieren des Sparprodukts ist ein unerwartetes Problem aufgetreten. Auf dem Server wurde ein Fehler angemeldet.",
+    "error.msg.reporting.error": "Beim Erstellen des Berichts ist ein Fehler aufgetreten.",
     "validation.msg.charge.amount.cannot.be.blank": "Der Betrag darf nicht leer sein.",
     "validation.msg.charge.amount.not.greater.than.zero": "Der Gebührenbetrag muss größer als Null sein.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "Es wird eine Gebühr erhoben, die nicht leer sein darf.",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "Savings product with name `{{params[0].value}}` already exists.",
     "error.msg.product.savings.duplicate.short.name": "Savings product with short name {{params[0].value}} already exists.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "An unexpected problem occurred when creating/updating the savings product. Error logged on server.",
+    "error.msg.reporting.error": "An error occurred while generating the report.",
     "validation.msg.charge.amount.cannot.be.blank": "Amount cannot be blank.",
     "validation.msg.charge.amount.not.greater.than.zero": "Charge amount must be greater than zero.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "Charge applies to cannot be blank.",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "El producto de ahorro con nombre `{{params[0].value}}` ya existe.",
     "error.msg.product.savings.duplicate.short.name": "El producto de ahorro con nombre corto {{params[0].value}} ya existe.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "Ocurrió un problema inesperado al crear/actualizar el producto de ahorro. Error al iniciar sesión en el servidor.",
+    "error.msg.reporting.error": "Se produjo un error al generar el informe.",
     "validation.msg.charge.amount.cannot.be.blank": "El monto no puede estar en blanco.",
     "validation.msg.charge.amount.not.greater.than.zero": "El monto del cargo debe ser mayor que cero.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "El cargo se aplica a no puede estar en blanco.",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "El producto de ahorro con nombre `{{params[0].value}}` ya existe.",
     "error.msg.product.savings.duplicate.short.name": "El producto de ahorro con nombre corto {{params[0].value}} ya existe.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "Ocurrió un problema inesperado al crear/actualizar el producto de ahorro. Error al iniciar sesión en el servidor.",
+    "error.msg.reporting.error": "Se produjo un error al generar el informe.",
     "validation.msg.charge.amount.cannot.be.blank": "El monto no puede estar en blanco.",
     "validation.msg.charge.amount.not.greater.than.zero": "El monto del cargo debe ser mayor que cero.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "El cargo se aplica a no puede estar en blanco.",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "Le produit d'épargne portant le nom `{{params[0].value}}` existe déjà.",
     "error.msg.product.savings.duplicate.short.name": "Le produit d'épargne portant le nom court {{params[0].value}} existe déjà.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "Un problème inattendu est survenu lors de la création/mise à jour du produit d'épargne. Erreur enregistrée sur le serveur.",
+    "error.msg.reporting.error": "Une erreur s'est produite lors de la génération du rapport.",
     "validation.msg.charge.amount.cannot.be.blank": "Le montant ne peut pas être vide.",
     "validation.msg.charge.amount.not.greater.than.zero": "Le montant des frais doit être supérieur à zéro.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "Les frais s'appliquent à ne peuvent pas être vides.",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "Il prodotto di risparmio con il nome `{{params[0].value}}` esiste già.",
     "error.msg.product.savings.duplicate.short.name": "Il prodotto di risparmio con il nome breve {{params[0].value}} esiste già.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "Si è verificato un problema imprevisto durante la creazione/aggiornamento del prodotto di risparmio. Errore registrato sul server.",
+    "error.msg.reporting.error": "Si è verificato un errore durante la generazione del report.",
     "validation.msg.charge.amount.cannot.be.blank": "L'importo non può essere vuoto.",
     "validation.msg.charge.amount.not.greater.than.zero": "L'importo dell'addebito deve essere maggiore di zero.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "L'addebito si applica a non può essere vuoto.",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "이름이 `{{params[0].value}}`인 저축 상품이 이미 존재합니다.",
     "error.msg.product.savings.duplicate.short.name": "닉네임이 {{params[0].value}}인 저축 상품이 이미 존재합니다.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "적금 상품 생성/업데이트 시 예상치 못한 문제가 발생했습니다. 서버에 오류가 기록되었습니다.",
+    "error.msg.reporting.error": "보고서를 생성하는 동안 오류가 발생했습니다.",
     "validation.msg.charge.amount.cannot.be.blank": "금액은 비워둘 수 없습니다.",
     "validation.msg.charge.amount.not.greater.than.zero": "청구 금액은 0보다 커야 합니다.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "요금이 적용되는 항목은 비워둘 수 없습니다.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "Taupymo produktas pavadinimu `{{params[0].value}}` jau yra.",
     "error.msg.product.savings.duplicate.short.name": "Taupymo produktas trumpuoju pavadinimu {{params[0].value}} jau yra.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "Kuriant/atnaujinant taupymo produktą iškilo netikėta problema. Klaida prisijungta prie serverio.",
+    "error.msg.reporting.error": "Generuojant ataskaitą įvyko klaida.",
     "validation.msg.charge.amount.cannot.be.blank": "Sumos laukas negali būti tuščias.",
     "validation.msg.charge.amount.not.greater.than.zero": "Mokesčio suma turi būti didesnė už nulį.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "Mokestis taikomas negali būti tuščias.",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "Uzkrājuma produkts ar nosaukumu `{{params[0].value}}` jau pastāv.",
     "error.msg.product.savings.duplicate.short.name": "Krājprodukts ar īso nosaukumu {{params[0].value}} jau pastāv.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "Veidojot/atjauninot uzkrājumu produktu, radās neparedzēta problēma. Serverī reģistrēta kļūda.",
+    "error.msg.reporting.error": "Ģenerējot pārskatu, radās kļūda.",
     "validation.msg.charge.amount.cannot.be.blank": "Summas lauks nedrīkst būt tukšs.",
     "validation.msg.charge.amount.not.greater.than.zero": "Maksas summai ir jābūt lielākai par nulli.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "Maksa tiek piemērota, nevar būt tukša.",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "`{{params[0].value}}` नामको बचत उत्पादन पहिले नै अवस्थित छ।",
     "error.msg.product.savings.duplicate.short.name": "छोटो नाम {{params[0].value}} भएको बचत उत्पादन पहिले नै अवस्थित छ।",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "बचत उत्पादन सिर्जना / अद्यावधिक गर्दा एक अप्रत्याशित समस्या भयो। सर्भरमा लगइन त्रुटि भयो।",
+    "error.msg.reporting.error": "रिपोर्ट उत्पन्न गर्दा त्रुटि भयो।",
     "validation.msg.charge.amount.cannot.be.blank": "रकम खाली हुन सक्दैन।",
     "validation.msg.charge.amount.not.greater.than.zero": "शुल्क रकम शून्य भन्दा बढी हुनुपर्छ।",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "शुल्क खाली हुन सक्दैन मा लागू हुन्छ।",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "O produto de poupança com o nome `{{params[0].value}}` já existe.",
     "error.msg.product.savings.duplicate.short.name": "O produto de poupança com nome abreviado {{params[0].value}} já existe.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "Ocorreu um problema inesperado ao criar/atualizar o produto de poupança. Erro logado no servidor.",
+    "error.msg.reporting.error": "Ocorreu um erro ao gerar o relatório.",
     "validation.msg.charge.amount.cannot.be.blank": "O valor não pode ficar em branco.",
     "validation.msg.charge.amount.not.greater.than.zero": "O valor da cobrança deve ser maior que zero.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "A cobrança se aplica a não pode ficar em branco.",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -35,6 +35,7 @@
     "error.msg.product.savings.duplicate.name": "Bidhaa ya akiba yenye jina `{{params[0].value}}` tayari ipo.",
     "error.msg.product.savings.duplicate.short.name": "Bidhaa ya akiba yenye jina fupi {{params[0].value}} tayari ipo.",
     "error.msg.savingsproduct.unknown.data.integrity.issue": "Tatizo lisilotarajiwa limetokea wakati wa kuunda/kusasisha bidhaa ya akiba. Hitilafu imeingia kwenye seva.",
+    "error.msg.reporting.error": "Hitilafu ilitokea wakati wa kuzalisha ripoti.",
     "validation.msg.charge.amount.cannot.be.blank": "Kiasi hakiwezi kuwa tupu.",
     "validation.msg.charge.amount.not.greater.than.zero": "Kiasi cha malipo lazima kiwe kikubwa kuliko sifuri.",
     "validation.msg.charge.chargeAppliesTo.cannot.be.blank": "Ada inatumika kwa haiwezi kuwa tupu.",


### PR DESCRIPTION
JIRA TICKET : [WEB-820](https://mifosforge.jira.com/browse/WEB-820?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)

BIRT report failures return error responses as ArrayBuffer due to the use of responseType: 'arraybuffer'. As a result, the frontend was unable to parse the error payload and displayed a generic HTTP error message instead of a meaningful, user-friendly message.

This change ensures that error responses are properly decoded and that the relevant userMessageGlobalisationCode is extracted and displayed as a translated message in the notification popup.

Additionally, it improves error message handling by preventing duplication and ensuring that translated messages are not unintentionally overwritten. Missing translation keys required for proper localization have also been added.


[WEB-820]: https://mifosforge.jira.com/browse/WEB-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to correctly decode varied error payloads, produce clearer user/developer messages, and refine special-case logic for specific HTTP errors.

* **Localization**
  * Added a new localized error message for "An error occurred while generating the report" across all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->