### PR TITLE
WEB-924 View loan originator and edit loan originator page titles displaying raw translation key instead of localized text

### DIFF
--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3331,6 +3331,8 @@
       "Create Journal Entry": "Vytvořit položku deníku",
       "Create Loan Product": "Vytvořte produkt půjčky",
       "Create Loan Originator": "Vytvořit poskytovatele úvěrů",
+      "View Loan Originator": "Zobrazit poskytovatele úvěrů",
+      "Edit Loan Originator": "Upravit poskytovatele úvěrů",
       "Create Loans Account": "Vytvořit úvěrový účet",
       "Create New GL Account": "Tato možnost umožňuje vytvářet nové účty hlavní knihy.",
       "Create Office": "Vytvořit Office",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3332,6 +3332,8 @@
       "Create Journal Entry": "Journaleintrag erstellen",
       "Create Loan Product": "Darlehensprodukt erstellen",
       "Create Loan Originator": "Kreditvermittler erstellen",
+      "View Loan Originator": "Kreditvermittler anzeigen",
+      "Edit Loan Originator": "Kreditvermittler bearbeiten",
       "Create Loans Account": "Erstellen Sie ein Kreditkonto",
       "Create New GL Account": "Mit dieser Option können Sie neue Hauptbuchkonten erstellen.",
       "Create Office": "Büro erstellen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3366,6 +3366,8 @@
       "Create Journal Entry": "Create Journal Entry",
       "Create Loan Product": "Create Loan Product",
       "Create Loan Originator": "Create Loan Originator",
+      "View Loan Originator": "View Loan Originator",
+      "Edit Loan Originator": "Edit Loan Originator",
       "Create Loans Account": "Create Loans Account",
       "Create New GL Account": "This option allows you to create new GL accounts.",
       "Create Office": "Create Office",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3330,6 +3330,8 @@
       "Create Journal Entry": "Crear entrada de diario",
       "Create Loan Product": "Crear producto de Crédito",
       "Create Loan Originator": "Crear Originador de Créditos",
+      "View Loan Originator": "Ver Originador de Créditos",
+      "Edit Loan Originator": "Editar Originador de Créditos",
       "Create Loans Account": "Crear cuenta de Créditos",
       "Create New GL Account": "Esta opción le permite crear nuevas cuentas GL.",
       "Create Office": "Crear oficina",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3361,6 +3361,8 @@
       "Create Journal Entry": "Crear entrada de diario",
       "Create Loan Product": "Crear producto de Crédito",
       "Create Loan Originator": "Crear Originador de Créditos",
+      "View Loan Originator": "Ver Originador de Créditos",
+      "Edit Loan Originator": "Editar Originador de Créditos",
       "Create Loans Account": "Crear cuenta de Créditos",
       "Create New GL Account": "Esta opción le permite crear nuevas cuentas GL.",
       "Create Office": "Crear sucursal",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3332,6 +3332,8 @@
       "Create Journal Entry": "Créer une entrée de journal",
       "Create Loan Product": "Créer un produit de prêt",
       "Create Loan Originator": "Créer un courtier en prêts",
+      "View Loan Originator": "Voir le courtier en prêts",
+      "Edit Loan Originator": "Modifier le courtier en prêts",
       "Create Loans Account": "Créer un compte de prêts",
       "Create New GL Account": "Cette option vous permet de créer de nouveaux comptes GL.",
       "Create Office": "Créer un bureau",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3327,6 +3327,8 @@
       "Create Journal Entry": "Crea voce di diario",
       "Create Loan Product": "Crea prodotto di prestito",
       "Create Loan Originator": "Crea originatore di prestiti",
+      "View Loan Originator": "Visualizza originatore di prestiti",
+      "Edit Loan Originator": "Modifica originatore di prestiti",
       "Create Loans Account": "Crea un conto prestiti",
       "Create New GL Account": "Questa opzione ti consente di creare nuovi account GL.",
       "Create Office": "Crea ufficio",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3328,6 +3328,8 @@
       "Create Journal Entry": "분개 항목 만들기",
       "Create Loan Product": "대출상품 생성",
       "Create Loan Originator": "대출 담당자 생성",
+      "View Loan Originator": "대출 담당자 보기",
+      "Edit Loan Originator": "대출 담당자 수정",
       "Create Loans Account": "대출 계좌 만들기",
       "Create New GL Account": "이 옵션을 사용하면 새 GL 계정을 만들 수 있습니다.",
       "Create Office": "사무실 만들기",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3329,6 +3329,8 @@
       "Create Journal Entry": "Sukurti žurnalo įrašą",
       "Create Loan Product": "Sukurti paskolos produktą",
       "Create Loan Originator": "Sukurti paskolos teikėją",
+      "View Loan Originator": "Peržiūrėti paskolos teikėją",
+      "Edit Loan Originator": "Redaguoti paskolos teikėją",
       "Create Loans Account": "Sukurti paskolų sąskaitą",
       "Create New GL Account": "Ši parinktis leidžia kurti naujas GL paskyras.",
       "Create Office": "Sukurkite biurą",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3327,6 +3327,8 @@
       "Create Journal Entry": "Izveidojiet žurnāla ierakstu",
       "Create Loan Product": "Izveidojiet aizdevuma produktu",
       "Create Loan Originator": "Izveidot aizdevuma izsniedzēju",
+      "View Loan Originator": "Skatīt aizdevuma izsniedzēju",
+      "Edit Loan Originator": "Rediģēt aizdevuma izsniedzēju",
       "Create Loans Account": "Izveidojiet aizdevuma kontu",
       "Create New GL Account": "Šī opcija ļauj izveidot jaunus GL kontus.",
       "Create Office": "Izveidojiet biroju",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3326,6 +3326,8 @@
       "Create Journal Entry": "जर्नल प्रविष्टि सिर्जना गर्नुहोस्",
       "Create Loan Product": "ऋण उत्पादन सिर्जना गर्नुहोस्",
       "Create Loan Originator": "ऋण सुरुवातकर्ता सिर्जना गर्नुहोस्",
+      "View Loan Originator": "ऋण सुरुवातकर्ता हेर्नुहोस्",
+      "Edit Loan Originator": "ऋण सुरुवातकर्ता सम्पादन गर्नुहोस्",
       "Create Loans Account": "ऋण खाता सिर्जना गर्नुहोस्",
       "Create New GL Account": "यो विकल्पले तपाईंलाई नयाँ GL खाताहरू सिर्जना गर्न अनुमति दिन्छ।",
       "Create Office": "कार्यालय सिर्जना गर्नुहोस्",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3328,6 +3328,8 @@
       "Create Journal Entry": "Criar lançamento contábil manual",
       "Create Loan Product": "Criar produto de empréstimo",
       "Create Loan Originator": "Criar Agente de Crédito",
+      "View Loan Originator": "Ver Originador de Empréstimo",
+      "Edit Loan Originator": "Editar Originador de Empréstimo",
       "Create Loans Account": "Criar conta de empréstimos",
       "Create New GL Account": "Esta opção permite criar novas contas contábeis.",
       "Create Office": "Criar escritório",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3324,6 +3324,8 @@
       "Create Journal Entry": "Unda Ingizo la Jarida",
       "Create Loan Product": "Tengeneza Bidhaa ya Mkopo",
       "Create Loan Originator": "Unda Mwanzilishi wa Mkopo",
+      "View Loan Originator": "Angalia Mwanzilishi wa Mkopo",
+      "Edit Loan Originator": "Hariri Mwanzilishi wa Mkopo",
       "Create Loans Account": "Unda Akaunti ya Mikopo",
       "Create New GL Account": "Chaguo hili hukuruhusu kuunda akaunti mpya za GL.",
       "Create Office": "Unda Ofisi",


### PR DESCRIPTION
Changes Made :-

-Added missing "View Loan Originator" and "Edit Loan Originator" translation keys to the labels.text section of all 13 language files .

[WEB-924](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-924)

Before :-
<img width="1365" height="667" alt="image" src="https://github.com/user-attachments/assets/4da8cc64-5bff-4d42-8e9a-2c9d833027d4" />

<img width="1365" height="675" alt="image" src="https://github.com/user-attachments/assets/0ad31db6-8064-4ce9-af50-19638895e59f" />



After :-
<img width="1365" height="653" alt="image" src="https://github.com/user-attachments/assets/486439f2-5a0f-484e-ae91-fc0250d7f849" />

<img width="1364" height="653" alt="image" src="https://github.com/user-attachments/assets/8a55e0b6-d6e6-419b-8bab-a1665b16bac3" />

<img width="1365" height="657" alt="image" src="https://github.com/user-attachments/assets/8074c7e6-3d87-41af-9efc-5fc9f8dbd623" />

<img width="1365" height="652" alt="image" src="https://github.com/user-attachments/assets/b0d0e2ac-9953-49bb-87f5-24a748c21294" />





[WEB-924]: https://mifosforge.jira.com/browse/WEB-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Extended multilingual support with new translated UI labels for loan originator management operations (view and edit actions) across 13 supported languages: English, German, French, Spanish (Chile and Mexico), Italian, Portuguese, Czech, Lithuanian, Latvian, Nepali, Korean, and Swahili. Ensures improved user experience for global audiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->