### PR TITLE
WEB-925: Fix Generate Report button styling on savings export transactions page

### DIFF
--- a/src/app/savings/savings-account-view/transactions-tab/export-transactions/export-transactions.component.html
+++ b/src/app/savings/savings-account-view/transactions-tab/export-transactions/export-transactions.component.html
@@ -8,7 +8,7 @@
 
 <form class="m-t-20 layout-column" [formGroup]="transactionsReportForm" (ngSubmit)="generate()">
   <div class="layout-row layout-align-center gap-3percent">
-    <mat-form-field class="flex-30" (click)="fromDatePicker.open()">
+    <mat-form-field class="flex-fill" (click)="fromDatePicker.open()">
       <mat-label>{{ 'labels.inputs.From Date' | translate }}</mat-label>
       <input
         matInput
@@ -26,7 +26,7 @@
       </mat-error>
     </mat-form-field>
 
-    <mat-form-field class="flex-30" (click)="toDatePicker.open()">
+    <mat-form-field class="flex-fill" (click)="toDatePicker.open()">
       <mat-label>{{ 'labels.inputs.To Date' | translate }}</mat-label>
       <input
         matInput
@@ -45,10 +45,12 @@
     </mat-form-field>
   </div>
 
-  <div class="generate-button layout-row layout-xs-column layout-align-center gap-5percent">
-    <button type="button" mat-raised-button [routerLink]="['../']">{{ 'labels.buttons.Cancel' | translate }}</button>
+  <div class="button-row layout-row layout-xs-column layout-align-center gap-5px">
+    <button type="button" mat-raised-button [routerLink]="['../']">
+      {{ 'labels.buttons.Cancel' | translate }}
+    </button>
     <button mat-raised-button color="primary" [disabled]="!transactionsReportForm.valid">
-      <fa-icon icon="cogs" class="m-r-10"></fa-icon>{{ 'labels.buttons.Generate Report' | translate }} &nbsp;
+      <fa-icon icon="cogs" size="sm" class="m-r-10"></fa-icon>{{ 'labels.buttons.Generate Report' | translate }}
     </button>
   </div>
 </form>

--- a/src/app/savings/savings-account-view/transactions-tab/export-transactions/export-transactions.component.scss
+++ b/src/app/savings/savings-account-view/transactions-tab/export-transactions/export-transactions.component.scss
@@ -6,8 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-.generate-button {
-  max-height: 2%;
-  padding: 1% 0 2% 6%;
+.button-row {
+  padding: 1rem 0;
   align-self: center;
 }


### PR DESCRIPTION
The "Generate Report" button on the Savings Export Transactions page had styling issues. The cogs icon was oversized due to missing size="sm", the button container used percentage-based CSS (max-height: 2%, padding: 1% 0 2% 6%) causing inconsistent sizing, and the date fields were unnecessarily narrow with flex-30. This update aligns the button and form layout with the same pattern used on Loan Export Transactions and Screen Reports pages.

[WEB-925](https://mifosforge.jira.com/browse/WEB-925)

<img width="1913" height="971" alt="Screenshot 2026-04-17 210333" src="https://github.com/user-attachments/assets/48e16148-85b0-4c73-ae44-3356e1e795c0" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-925]: https://mifosforge.jira.com/browse/WEB-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined date picker field layout (From/To dates) to better distribute available space in the export form
  * Updated action button container styling with improved spacing between Cancel and Generate buttons
  * Optimized Generate button icon sizing for improved visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->