### PR TITLE
WEB-657: Working Capital product with GL Account mappings

### DIFF
--- a/src/app/core/utils/accounting.ts
+++ b/src/app/core/utils/accounting.ts
@@ -29,13 +29,20 @@ export class Accounting {
     ];
   }
 
-  public getAccountingRulesForLoans(): string[] {
-    return [
-      'NONE',
-      'Cash',
-      'Accrual (periodic)',
-      'Accrual (upfront)'
-    ];
+  public getAccountingRulesForLoans(isLoanProduct: boolean): string[] {
+    if (isLoanProduct) {
+      return [
+        'NONE',
+        'Cash',
+        'Accrual (periodic)',
+        'Accrual (upfront)'
+      ];
+    } else {
+      return [
+        'NONE',
+        'CASH_BASED'
+      ];
+    }
   }
 
   public getAccountRuleName(value: string): string {

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.html
@@ -1072,80 +1072,84 @@
         }
       </div>
     }
-    @if (loanProductService.isLoanProduct) {
-      <h3 class="mat-h3 flex-100">{{ 'labels.heading.Accounting' | translate }}</h3>
-      <mat-divider [inset]="true"></mat-divider>
-      <div class="flex-100 layout-row">
-        <span class="flex-40">{{ 'labels.inputs.Type' | translate }}:</span>
+    <h3 class="mat-h3 flex-100">{{ 'labels.heading.Accounting' | translate }}</h3>
+    <mat-divider [inset]="true"></mat-divider>
+    <div class="flex-100 layout-row">
+      <span class="flex-40">{{ 'labels.inputs.Type' | translate }}:</span>
+      @if (loanProductService.isLoanProduct) {
         <span class="flex-60">{{
           'labels.accounting.' + getAccountingRuleName(accountingRuleData[accountingRule() - 1]) | translate
         }}</span>
-      </div>
-      @if (isAccountingAccrualBased) {
-        <div class="flex-100 layout-row">
-          <span class="flex-40"
-            >{{ 'labels.inputs.Enable Accrual Activity Posting on Installment Due Date' | translate }}:</span
-          >
-          <span class="flex-60">{{ loanProduct.enableAccrualActivityPosting | yesNo }}</span>
-        </div>
+      } @else if (loanProductService.isWorkingCapital) {
+        <span class="flex-60">{{ 'labels.accounting.' + getAccountingRuleName(accountingRule()) | translate }}</span>
       }
-      @if (isAccountingEnabled()) {
+    </div>
+    @if (loanProductService.isLoanProduct && isAccountingAccrualBased) {
+      <div class="flex-100 layout-row">
+        <span class="flex-40"
+          >{{ 'labels.inputs.Enable Accrual Activity Posting on Installment Due Date' | translate }}:</span
+        >
+        <span class="flex-60">{{ loanProduct.enableAccrualActivityPosting | yesNo }}</span>
+      </div>
+    }
+    @if (isAccountingEnabled()) {
+      <div class="flex-100 layout-row-wrap responsive-column">
+        <h4 class="mat-h4 flex-100">
+          {{ 'labels.heading.Assets' | translate }} / {{ 'labels.heading.Liabilities' | translate }}
+        </h4>
         <div class="flex-100 layout-row-wrap responsive-column">
-          <h4 class="mat-h4 flex-100">
-            {{ 'labels.heading.Assets' | translate }} / {{ 'labels.heading.Liabilities' | translate }}
-          </h4>
-          <div class="flex-100 layout-row-wrap responsive-column">
-            <mifosx-gl-account-display
-              class="flex-100"
-              [accountTitle]="'Fund source'"
-              [glAccount]="accountingMappings.fundSourceAccount"
-              [withTitle]="'47%'"
-            >
-            </mifosx-gl-account-display>
-          </div>
-          <h4 class="mat-h4 flex-100">{{ 'labels.heading.Assets' | translate }}</h4>
-          <div class="flex-100 layout-row-wrap responsive-column">
-            <mifosx-gl-account-display
-              class="flex-100"
-              [accountTitle]="'Loan portfolio'"
-              [glAccount]="accountingMappings.loanPortfolioAccount"
-              [withTitle]="'47%'"
-            >
-            </mifosx-gl-account-display>
-            @if (loanProduct.accountingRule.id === 3 || loanProduct.accountingRule.id === 4) {
-              <div class="flex-fill layout-row-wrap responsive-column">
-                <mifosx-gl-account-display
-                  class="flex-100"
-                  [accountTitle]="'Interest Receivable'"
-                  [glAccount]="accountingMappings.receivableInterestAccount"
-                  [withTitle]="'47%'"
-                >
-                </mifosx-gl-account-display>
-                <mifosx-gl-account-display
-                  class="flex-100"
-                  [accountTitle]="'Fees Receivable'"
-                  [glAccount]="accountingMappings.receivableFeeAccount"
-                  [withTitle]="'47%'"
-                >
-                </mifosx-gl-account-display>
-                <mifosx-gl-account-display
-                  class="flex-100"
-                  [accountTitle]="'Penalties Receivable'"
-                  [glAccount]="accountingMappings.receivablePenaltyAccount"
-                  [withTitle]="'47%'"
-                >
-                </mifosx-gl-account-display>
-              </div>
-            }
-            <mifosx-gl-account-display
-              class="flex-100"
-              [accountTitle]="'Transfer in suspense'"
-              [glAccount]="accountingMappings.transfersInSuspenseAccount"
-              [withTitle]="'47%'"
-            >
-            </mifosx-gl-account-display>
-          </div>
-          <h4 class="mat-h4 flex-100">{{ 'labels.heading.Income' | translate }}</h4>
+          <mifosx-gl-account-display
+            class="flex-100"
+            [accountTitle]="'Fund source'"
+            [glAccount]="accountingMappings.fundSourceAccount"
+            [withTitle]="'47%'"
+          >
+          </mifosx-gl-account-display>
+        </div>
+        <h4 class="mat-h4 flex-100">{{ 'labels.heading.Assets' | translate }}</h4>
+        <div class="flex-100 layout-row-wrap responsive-column">
+          <mifosx-gl-account-display
+            class="flex-100"
+            [accountTitle]="'Loan portfolio'"
+            [glAccount]="accountingMappings.loanPortfolioAccount"
+            [withTitle]="'47%'"
+          >
+          </mifosx-gl-account-display>
+          @if (loanProduct.accountingRule.id === 3 || loanProduct.accountingRule.id === 4) {
+            <div class="flex-fill layout-row-wrap responsive-column">
+              <mifosx-gl-account-display
+                class="flex-100"
+                [accountTitle]="'Interest Receivable'"
+                [glAccount]="accountingMappings.receivableInterestAccount"
+                [withTitle]="'47%'"
+              >
+              </mifosx-gl-account-display>
+              <mifosx-gl-account-display
+                class="flex-100"
+                [accountTitle]="'Fees Receivable'"
+                [glAccount]="accountingMappings.receivableFeeAccount"
+                [withTitle]="'47%'"
+              >
+              </mifosx-gl-account-display>
+              <mifosx-gl-account-display
+                class="flex-100"
+                [accountTitle]="'Penalties Receivable'"
+                [glAccount]="accountingMappings.receivablePenaltyAccount"
+                [withTitle]="'47%'"
+              >
+              </mifosx-gl-account-display>
+            </div>
+          }
+          <mifosx-gl-account-display
+            class="flex-100"
+            [accountTitle]="'Transfer in suspense'"
+            [glAccount]="accountingMappings.transfersInSuspenseAccount"
+            [withTitle]="'47%'"
+          >
+          </mifosx-gl-account-display>
+        </div>
+        <h4 class="mat-h4 flex-100">{{ 'labels.heading.Income' | translate }}</h4>
+        @if (loanProductService.isLoanProduct) {
           <mifosx-gl-account-display
             class="flex-100"
             [accountTitle]="'Income from Interest'"
@@ -1153,81 +1157,91 @@
             [withTitle]="'47%'"
           >
           </mifosx-gl-account-display>
+        } @else if (loanProductService.isWorkingCapital) {
           <mifosx-gl-account-display
             class="flex-100"
-            [accountTitle]="'Income from fees'"
-            [glAccount]="accountingMappings.incomeFromFeeAccount"
+            [accountTitle]="'Income From Discount Fee'"
+            [glAccount]="accountingMappings.incomeFromDiscountFeeAccount"
             [withTitle]="'47%'"
           >
           </mifosx-gl-account-display>
+        }
+        <mifosx-gl-account-display
+          class="flex-100"
+          [accountTitle]="'Income from fees'"
+          [glAccount]="accountingMappings.incomeFromFeeAccount"
+          [withTitle]="'47%'"
+        >
+        </mifosx-gl-account-display>
+        <mifosx-gl-account-display
+          class="flex-100"
+          [accountTitle]="'Income from penalties'"
+          [glAccount]="accountingMappings.incomeFromPenaltyAccount"
+          [withTitle]="'47%'"
+        >
+        </mifosx-gl-account-display>
+        <mifosx-gl-account-display
+          class="flex-100"
+          [accountTitle]="'Income from Recovery Repayments'"
+          [glAccount]="accountingMappings.incomeFromRecoveryAccount"
+          [withTitle]="'47%'"
+        >
+        </mifosx-gl-account-display>
+        @if (accountingMappings.incomeFromChargeOffInterestAccount) {
           <mifosx-gl-account-display
             class="flex-100"
-            [accountTitle]="'Income from penalties'"
-            [glAccount]="accountingMappings.incomeFromPenaltyAccount"
+            [accountTitle]="'Income from ChargeOff Interest'"
+            [glAccount]="accountingMappings.incomeFromChargeOffInterestAccount"
             [withTitle]="'47%'"
           >
           </mifosx-gl-account-display>
+        }
+        @if (accountingMappings.incomeFromChargeOffFeesAccount) {
           <mifosx-gl-account-display
             class="flex-100"
-            [accountTitle]="'Income from Recovery Repayments'"
-            [glAccount]="accountingMappings.incomeFromRecoveryAccount"
+            [accountTitle]="'Income from ChargeOff Fees'"
+            [glAccount]="accountingMappings.incomeFromChargeOffFeesAccount"
             [withTitle]="'47%'"
           >
           </mifosx-gl-account-display>
-          @if (accountingMappings.incomeFromChargeOffInterestAccount) {
-            <mifosx-gl-account-display
-              class="flex-100"
-              [accountTitle]="'Income from ChargeOff Interest'"
-              [glAccount]="accountingMappings.incomeFromChargeOffInterestAccount"
-              [withTitle]="'47%'"
-            >
-            </mifosx-gl-account-display>
-          }
-          @if (accountingMappings.incomeFromChargeOffFeesAccount) {
-            <mifosx-gl-account-display
-              class="flex-100"
-              [accountTitle]="'Income from ChargeOff Fees'"
-              [glAccount]="accountingMappings.incomeFromChargeOffFeesAccount"
-              [withTitle]="'47%'"
-            >
-            </mifosx-gl-account-display>
-          }
-          @if (accountingMappings.incomeFromChargeOffPenaltyAccount) {
-            <mifosx-gl-account-display
-              class="flex-100"
-              [accountTitle]="'Income from ChargeOff Penalty'"
-              [glAccount]="accountingMappings.incomeFromChargeOffPenaltyAccount"
-              [withTitle]="'47%'"
-            >
-            </mifosx-gl-account-display>
-          }
-          @if (accountingMappings.incomeFromCapitalizationAccount) {
-            <mifosx-gl-account-display
-              class="flex-100"
-              [accountTitle]="'Income capitalization'"
-              [glAccount]="accountingMappings.incomeFromCapitalizationAccount"
-              [withTitle]="'47%'"
-            >
-            </mifosx-gl-account-display>
-          }
-          @if (accountingMappings.incomeFromBuyDownAccount) {
-            <mifosx-gl-account-display
-              class="flex-100"
-              [accountTitle]="'Income from Buy down fees'"
-              [glAccount]="accountingMappings.incomeFromBuyDownAccount"
-              [withTitle]="'47%'"
-            >
-            </mifosx-gl-account-display>
-          }
-          <h4 class="mat-h4 flex-100">{{ 'labels.heading.Expenses' | translate }}</h4>
-          <div class="flex-fill layout-row-wrap responsive-column">
-            <mifosx-gl-account-display
-              class="flex-100"
-              [accountTitle]="'Losses written off'"
-              [glAccount]="accountingMappings.writeOffAccount"
-              [withTitle]="'47%'"
-            >
-            </mifosx-gl-account-display>
+        }
+        @if (accountingMappings.incomeFromChargeOffPenaltyAccount) {
+          <mifosx-gl-account-display
+            class="flex-100"
+            [accountTitle]="'Income from ChargeOff Penalty'"
+            [glAccount]="accountingMappings.incomeFromChargeOffPenaltyAccount"
+            [withTitle]="'47%'"
+          >
+          </mifosx-gl-account-display>
+        }
+        @if (accountingMappings.incomeFromCapitalizationAccount) {
+          <mifosx-gl-account-display
+            class="flex-100"
+            [accountTitle]="'Income capitalization'"
+            [glAccount]="accountingMappings.incomeFromCapitalizationAccount"
+            [withTitle]="'47%'"
+          >
+          </mifosx-gl-account-display>
+        }
+        @if (accountingMappings.incomeFromBuyDownAccount) {
+          <mifosx-gl-account-display
+            class="flex-100"
+            [accountTitle]="'Income from Buy down fees'"
+            [glAccount]="accountingMappings.incomeFromBuyDownAccount"
+            [withTitle]="'47%'"
+          >
+          </mifosx-gl-account-display>
+        }
+        <h4 class="mat-h4 flex-100">{{ 'labels.heading.Expenses' | translate }}</h4>
+        <div class="flex-fill layout-row-wrap responsive-column">
+          <mifosx-gl-account-display
+            class="flex-100"
+            [accountTitle]="'Losses written off'"
+            [glAccount]="accountingMappings.writeOffAccount"
+            [withTitle]="'47%'"
+          >
+          </mifosx-gl-account-display>
+          @if (accountingMappings.goodwillCreditAccount) {
             <mifosx-gl-account-display
               class="flex-100"
               [accountTitle]="'Expenses from Goodwill Credit'"
@@ -1235,159 +1249,157 @@
               [withTitle]="'47%'"
             >
             </mifosx-gl-account-display>
-            @if (accountingMappings.chargeOffExpenseAccount) {
-              <mifosx-gl-account-display
-                class="flex-100"
-                [accountTitle]="'ChargeOff Expense'"
-                [glAccount]="accountingMappings.chargeOffExpenseAccount"
-                [withTitle]="'47%'"
-              >
-              </mifosx-gl-account-display>
-            }
-            @if (accountingMappings.chargeOffFraudExpenseAccount) {
-              <mifosx-gl-account-display
-                class="flex-100"
-                [accountTitle]="'ChargeOff Fraud Expense'"
-                [glAccount]="accountingMappings.chargeOffFraudExpenseAccount"
-                [withTitle]="'47%'"
-              >
-              </mifosx-gl-account-display>
-            }
-            @if (accountingMappings.buyDownExpenseAccount) {
-              <mifosx-gl-account-display
-                class="flex-100"
-                [accountTitle]="'Buy down fee Expense'"
-                [glAccount]="accountingMappings.buyDownExpenseAccount"
-                [withTitle]="'47%'"
-              >
-              </mifosx-gl-account-display>
-            }
-            <h4 class="mat-h4 flex-fill">{{ 'labels.heading.Liabilities' | translate }}</h4>
+          }
+          @if (accountingMappings.chargeOffExpenseAccount) {
             <mifosx-gl-account-display
               class="flex-100"
-              [accountTitle]="'Over payment liability'"
-              [glAccount]="accountingMappings.overpaymentLiabilityAccount"
+              [accountTitle]="'ChargeOff Expense'"
+              [glAccount]="accountingMappings.chargeOffExpenseAccount"
               [withTitle]="'47%'"
             >
             </mifosx-gl-account-display>
-            @if (accountingMappings.deferredIncomeLiabilityAccount) {
-              <mifosx-gl-account-display
-                class="flex-100"
-                [accountTitle]="'Deferred income'"
-                [glAccount]="accountingMappings.deferredIncomeLiabilityAccount"
-                [withTitle]="'47%'"
-              >
-              </mifosx-gl-account-display>
-            }
-            @if (isAdvancedAccountingEnabled()) {
-              <div class="flex-fill layout-row-wrap responsive-column">
-                <h3 class="mat-h3 flex-100">{{ 'labels.heading.Advanced Accounting Rules' | translate }}</h3>
-                <mat-divider [inset]="true"></mat-divider>
-                @if (paymentChannelToFundSourceMappings?.length > 0) {
-                  <div class="flex-100 layout-row-wrap responsive-column">
-                    <h4 class="mat-h4 flex-100">
-                      {{ 'labels.heading.Configure Fund Sources for Payment Channels' | translate }}
-                    </h4>
-                    <table
-                      class="mat-elevation-z1 flex-100"
-                      mat-table
-                      [dataSource]="paymentChannelToFundSourceMappings"
-                    >
-                      <ng-container matColumnDef="paymentTypeId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.heading.Payment Type' | translate }}</th>
-                        <td mat-cell *matCellDef="let paymentFundSource">
-                          {{ paymentFundSource.paymentType.name }}
-                        </td>
-                      </ng-container>
-                      <ng-container matColumnDef="fundSourceAccountId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fund Source' | translate }}</th>
-                        <td mat-cell *matCellDef="let paymentFundSource">
-                          {{ paymentFundSource.fundSourceAccount.name }}
-                        </td>
-                      </ng-container>
-                      <tr mat-header-row *matHeaderRowDef="paymentFundSourceDisplayedColumns"></tr>
-                      <tr mat-row *matRowDef="let row; columns: paymentFundSourceDisplayedColumns"></tr>
-                    </table>
-                  </div>
-                }
-                @if (feeToIncomeAccountMappings?.length > 0) {
-                  <div class="flex-100 layout-row-wrap responsive-column">
-                    <h4 class="mat-h4 flex-100">
-                      {{ 'labels.heading.Map Fees to Specific Income Accounts' | translate }}
-                    </h4>
-                    <table class="mat-elevation-z1 flex-100" mat-table [dataSource]="feeToIncomeAccountMappings">
-                      <ng-container matColumnDef="chargeId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.catalogs.Fees' | translate }}</th>
-                        <td mat-cell *matCellDef="let feesIncome">
-                          {{ feesIncome.charge.name }}
-                        </td>
-                      </ng-container>
-                      <ng-container matColumnDef="incomeAccountId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
-                        <td mat-cell *matCellDef="let feesIncome">
-                          @if (feesIncome.incomeAccount) {
-                            <span>
-                              {{ feesIncome.incomeAccount.name }}
-                            </span>
-                          }
-                        </td>
-                      </ng-container>
-                      <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
-                      <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns"></tr>
-                    </table>
-                  </div>
-                }
-                @if (penaltyToIncomeAccountMappings?.length > 0) {
-                  <div class="flex-100 layout-row-wrap responsive-column">
-                    <h4 class="mat-h4 flex-100">
-                      {{ 'labels.heading.Map Penalties to Specific Income Accounts' | translate }}
-                    </h4>
-                    <table class="mat-elevation-z1 flex-100" mat-table [dataSource]="penaltyToIncomeAccountMappings">
-                      <ng-container matColumnDef="chargeId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Penalty' | translate }}</th>
-                        <td mat-cell *matCellDef="let penaltyIncome">
-                          {{ penaltyIncome.charge.name }}
-                        </td>
-                      </ng-container>
-                      <ng-container matColumnDef="incomeAccountId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
-                        <td mat-cell *matCellDef="let penaltyIncome">
-                          {{ penaltyIncome.incomeAccount.name }}
-                        </td>
-                      </ng-container>
-                      <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
-                      <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns"></tr>
-                    </table>
-                  </div>
-                }
-                @if (chargeOffReasonToExpenseAccountMappings?.length > 0) {
-                  <div class="flex-100 layout-row-wrap responsive-column">
-                    <h4 class="mat-h4 flex-100">
-                      {{ 'labels.heading.Map Charge-off reasons to Expense accounts' | translate }}
-                    </h4>
-                    <table
-                      class="mat-elevation-z1 flex-100"
-                      mat-table
-                      [dataSource]="chargeOffReasonToExpenseAccountMappings"
-                    >
-                      <ng-container matColumnDef="chargeOffReasonCodeValueId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Charge-off reason' | translate }}</th>
-                        <td mat-cell *matCellDef="let chargeOffReasonToExpenseAccountMapping">
-                          {{ chargeOffReasonToExpenseAccountMapping.reasonCodeValue.name }}
-                        </td>
-                      </ng-container>
-                      <ng-container matColumnDef="expenseAccountId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Expense Account' | translate }}</th>
-                        <td mat-cell *matCellDef="let chargeOffReasonToExpenseAccountMapping">
-                          ({{ chargeOffReasonToExpenseAccountMapping.expenseAccount.glCode }})
-                          {{ chargeOffReasonToExpenseAccountMapping.expenseAccount.name }}
-                        </td>
-                      </ng-container>
-                      <tr mat-header-row *matHeaderRowDef="chargeOffReasonExpenseDisplayedColumns"></tr>
-                      <tr mat-row *matRowDef="let row; columns: chargeOffReasonExpenseDisplayedColumns"></tr>
-                    </table>
-                  </div>
-                }
+          }
+          @if (accountingMappings.chargeOffFraudExpenseAccount) {
+            <mifosx-gl-account-display
+              class="flex-100"
+              [accountTitle]="'ChargeOff Fraud Expense'"
+              [glAccount]="accountingMappings.chargeOffFraudExpenseAccount"
+              [withTitle]="'47%'"
+            >
+            </mifosx-gl-account-display>
+          }
+          @if (accountingMappings.buyDownExpenseAccount) {
+            <mifosx-gl-account-display
+              class="flex-100"
+              [accountTitle]="'Buy down fee Expense'"
+              [glAccount]="accountingMappings.buyDownExpenseAccount"
+              [withTitle]="'47%'"
+            >
+            </mifosx-gl-account-display>
+          }
+          <h4 class="mat-h4 flex-fill">{{ 'labels.heading.Liabilities' | translate }}</h4>
+          <mifosx-gl-account-display
+            class="flex-100"
+            [accountTitle]="'Over payment liability'"
+            [glAccount]="accountingMappings.overpaymentLiabilityAccount"
+            [withTitle]="'47%'"
+          >
+          </mifosx-gl-account-display>
+          @if (accountingMappings.deferredIncomeLiabilityAccount) {
+            <mifosx-gl-account-display
+              class="flex-100"
+              [accountTitle]="'Deferred income'"
+              [glAccount]="accountingMappings.deferredIncomeLiabilityAccount"
+              [withTitle]="'47%'"
+            >
+            </mifosx-gl-account-display>
+          }
+          @if (isAdvancedAccountingEnabled()) {
+            <div class="flex-fill layout-row-wrap responsive-column">
+              <h3 class="mat-h3 flex-100">{{ 'labels.heading.Advanced Accounting Rules' | translate }}</h3>
+              <mat-divider [inset]="true"></mat-divider>
+              @if (paymentChannelToFundSourceMappings?.length > 0) {
+                <div class="flex-100 layout-row-wrap responsive-column">
+                  <h4 class="mat-h4 flex-100">
+                    {{ 'labels.heading.Configure Fund Sources for Payment Channels' | translate }}
+                  </h4>
+                  <table class="mat-elevation-z1 flex-100" mat-table [dataSource]="paymentChannelToFundSourceMappings">
+                    <ng-container matColumnDef="paymentTypeId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.heading.Payment Type' | translate }}</th>
+                      <td mat-cell *matCellDef="let paymentFundSource">
+                        {{ paymentFundSource.paymentType.name }}
+                      </td>
+                    </ng-container>
+                    <ng-container matColumnDef="fundSourceAccountId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fund Source' | translate }}</th>
+                      <td mat-cell *matCellDef="let paymentFundSource">
+                        {{ paymentFundSource.fundSourceAccount.name }}
+                      </td>
+                    </ng-container>
+                    <tr mat-header-row *matHeaderRowDef="paymentFundSourceDisplayedColumns"></tr>
+                    <tr mat-row *matRowDef="let row; columns: paymentFundSourceDisplayedColumns"></tr>
+                  </table>
+                </div>
+              }
+              @if (feeToIncomeAccountMappings?.length > 0) {
+                <div class="flex-100 layout-row-wrap responsive-column">
+                  <h4 class="mat-h4 flex-100">
+                    {{ 'labels.heading.Map Fees to Specific Income Accounts' | translate }}
+                  </h4>
+                  <table class="mat-elevation-z1 flex-100" mat-table [dataSource]="feeToIncomeAccountMappings">
+                    <ng-container matColumnDef="chargeId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.catalogs.Fees' | translate }}</th>
+                      <td mat-cell *matCellDef="let feesIncome">
+                        {{ feesIncome.charge.name }}
+                      </td>
+                    </ng-container>
+                    <ng-container matColumnDef="incomeAccountId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
+                      <td mat-cell *matCellDef="let feesIncome">
+                        @if (feesIncome.incomeAccount) {
+                          <span>
+                            {{ feesIncome.incomeAccount.name }}
+                          </span>
+                        }
+                      </td>
+                    </ng-container>
+                    <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
+                    <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns"></tr>
+                  </table>
+                </div>
+              }
+              @if (penaltyToIncomeAccountMappings?.length > 0) {
+                <div class="flex-100 layout-row-wrap responsive-column">
+                  <h4 class="mat-h4 flex-100">
+                    {{ 'labels.heading.Map Penalties to Specific Income Accounts' | translate }}
+                  </h4>
+                  <table class="mat-elevation-z1 flex-100" mat-table [dataSource]="penaltyToIncomeAccountMappings">
+                    <ng-container matColumnDef="chargeId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Penalty' | translate }}</th>
+                      <td mat-cell *matCellDef="let penaltyIncome">
+                        {{ penaltyIncome.charge.name }}
+                      </td>
+                    </ng-container>
+                    <ng-container matColumnDef="incomeAccountId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
+                      <td mat-cell *matCellDef="let penaltyIncome">
+                        {{ penaltyIncome.incomeAccount.name }}
+                      </td>
+                    </ng-container>
+                    <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
+                    <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns"></tr>
+                  </table>
+                </div>
+              }
+              @if (chargeOffReasonToExpenseAccountMappings?.length > 0) {
+                <div class="flex-100 layout-row-wrap responsive-column">
+                  <h4 class="mat-h4 flex-100">
+                    {{ 'labels.heading.Map Charge-off reasons to Expense accounts' | translate }}
+                  </h4>
+                  <table
+                    class="mat-elevation-z1 flex-100"
+                    mat-table
+                    [dataSource]="chargeOffReasonToExpenseAccountMappings"
+                  >
+                    <ng-container matColumnDef="chargeOffReasonCodeValueId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Charge-off reason' | translate }}</th>
+                      <td mat-cell *matCellDef="let chargeOffReasonToExpenseAccountMapping">
+                        {{ chargeOffReasonToExpenseAccountMapping.reasonCodeValue.name }}
+                      </td>
+                    </ng-container>
+                    <ng-container matColumnDef="expenseAccountId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Expense Account' | translate }}</th>
+                      <td mat-cell *matCellDef="let chargeOffReasonToExpenseAccountMapping">
+                        ({{ chargeOffReasonToExpenseAccountMapping.expenseAccount.glCode }})
+                        {{ chargeOffReasonToExpenseAccountMapping.expenseAccount.name }}
+                      </td>
+                    </ng-container>
+                    <tr mat-header-row *matHeaderRowDef="chargeOffReasonExpenseDisplayedColumns"></tr>
+                    <tr mat-row *matRowDef="let row; columns: chargeOffReasonExpenseDisplayedColumns"></tr>
+                  </table>
+                </div>
+              }
+              @if (buydownFeeClassificationToIncomeAccountMappings?.length > 0) {
                 <div class="flex-100 layout-row-wrap responsive-column">
                   <h4 class="mat-h4 flex-100">
                     {{ 'labels.heading.Buydown Fee classifications to Income accounts' | translate }}
@@ -1414,63 +1426,63 @@
                     <tr mat-row *matRowDef="let row; columns: chargeOffReasonExpenseDisplayedColumns"></tr>
                   </table>
                 </div>
-                @if (capitalizedIncomeClassificationToIncomeAccountMappings?.length > 0) {
-                  <div class="flex-100 layout-row-wrap responsive-column">
-                    <h4 class="mat-h4 flex-100">
-                      {{ 'labels.heading.Capitalized Income classifications to Income accounts' | translate }}
-                    </h4>
-                    <table
-                      class="mat-elevation-z1 flex-100"
-                      mat-table
-                      [dataSource]="capitalizedIncomeClassificationToIncomeAccountMappings"
-                    >
-                      <ng-container matColumnDef="chargeOffReasonCodeValueId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Classification' | translate }}</th>
-                        <td mat-cell *matCellDef="let capitalizedIncomeClassificationToIncomeAccountMapping">
-                          {{ capitalizedIncomeClassificationToIncomeAccountMapping.classificationCodeValue.name }}
-                        </td>
-                      </ng-container>
-                      <ng-container matColumnDef="expenseAccountId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
-                        <td mat-cell *matCellDef="let capitalizedIncomeClassificationToIncomeAccountMapping">
-                          ({{ capitalizedIncomeClassificationToIncomeAccountMapping.incomeAccount.glCode }})
-                          {{ capitalizedIncomeClassificationToIncomeAccountMapping.incomeAccount.name }}
-                        </td>
-                      </ng-container>
-                      <tr mat-header-row *matHeaderRowDef="chargeOffReasonExpenseDisplayedColumns"></tr>
-                      <tr mat-row *matRowDef="let row; columns: chargeOffReasonExpenseDisplayedColumns"></tr>
-                    </table>
-                  </div>
-                }
-                @if (writeOffReasonsToExpenseMappings?.length > 0) {
-                  <div class="flex-100 layout-row-wrap responsive-column">
-                    <h4 class="mat-h4 flex-100">
-                      {{ 'labels.heading.WriteOff reasons to Expense accounts' | translate }}
-                    </h4>
-                    <table class="mat-elevation-z1 flex-100" mat-table [dataSource]="writeOffReasonsToExpenseMappings">
-                      <ng-container matColumnDef="chargeOffReasonCodeValueId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.WriteOff Reason' | translate }}</th>
-                        <td mat-cell *matCellDef="let writeOffReasonsToExpenseMapping">
-                          {{ writeOffReasonsToExpenseMapping.reasonCodeValue.name }}
-                        </td>
-                      </ng-container>
-                      <ng-container matColumnDef="expenseAccountId">
-                        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Expense Account' | translate }}</th>
-                        <td mat-cell *matCellDef="let writeOffReasonsToExpenseMapping">
-                          ({{ writeOffReasonsToExpenseMapping.expenseAccount.glCode }})
-                          {{ writeOffReasonsToExpenseMapping.expenseAccount.name }}
-                        </td>
-                      </ng-container>
-                      <tr mat-header-row *matHeaderRowDef="chargeOffReasonExpenseDisplayedColumns"></tr>
-                      <tr mat-row *matRowDef="let row; columns: chargeOffReasonExpenseDisplayedColumns"></tr>
-                    </table>
-                  </div>
-                }
-              </div>
-            }
-          </div>
+              }
+              @if (capitalizedIncomeClassificationToIncomeAccountMappings?.length > 0) {
+                <div class="flex-100 layout-row-wrap responsive-column">
+                  <h4 class="mat-h4 flex-100">
+                    {{ 'labels.heading.Capitalized Income classifications to Income accounts' | translate }}
+                  </h4>
+                  <table
+                    class="mat-elevation-z1 flex-100"
+                    mat-table
+                    [dataSource]="capitalizedIncomeClassificationToIncomeAccountMappings"
+                  >
+                    <ng-container matColumnDef="chargeOffReasonCodeValueId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Classification' | translate }}</th>
+                      <td mat-cell *matCellDef="let capitalizedIncomeClassificationToIncomeAccountMapping">
+                        {{ capitalizedIncomeClassificationToIncomeAccountMapping.classificationCodeValue.name }}
+                      </td>
+                    </ng-container>
+                    <ng-container matColumnDef="expenseAccountId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
+                      <td mat-cell *matCellDef="let capitalizedIncomeClassificationToIncomeAccountMapping">
+                        ({{ capitalizedIncomeClassificationToIncomeAccountMapping.incomeAccount.glCode }})
+                        {{ capitalizedIncomeClassificationToIncomeAccountMapping.incomeAccount.name }}
+                      </td>
+                    </ng-container>
+                    <tr mat-header-row *matHeaderRowDef="chargeOffReasonExpenseDisplayedColumns"></tr>
+                    <tr mat-row *matRowDef="let row; columns: chargeOffReasonExpenseDisplayedColumns"></tr>
+                  </table>
+                </div>
+              }
+              @if (writeOffReasonsToExpenseMappings?.length > 0) {
+                <div class="flex-100 layout-row-wrap responsive-column">
+                  <h4 class="mat-h4 flex-100">
+                    {{ 'labels.heading.WriteOff reasons to Expense accounts' | translate }}
+                  </h4>
+                  <table class="mat-elevation-z1 flex-100" mat-table [dataSource]="writeOffReasonsToExpenseMappings">
+                    <ng-container matColumnDef="chargeOffReasonCodeValueId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.WriteOff Reason' | translate }}</th>
+                      <td mat-cell *matCellDef="let writeOffReasonsToExpenseMapping">
+                        {{ writeOffReasonsToExpenseMapping.reasonCodeValue.name }}
+                      </td>
+                    </ng-container>
+                    <ng-container matColumnDef="expenseAccountId">
+                      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Expense Account' | translate }}</th>
+                      <td mat-cell *matCellDef="let writeOffReasonsToExpenseMapping">
+                        ({{ writeOffReasonsToExpenseMapping.expenseAccount.glCode }})
+                        {{ writeOffReasonsToExpenseMapping.expenseAccount.name }}
+                      </td>
+                    </ng-container>
+                    <tr mat-header-row *matHeaderRowDef="chargeOffReasonExpenseDisplayedColumns"></tr>
+                    <tr mat-row *matRowDef="let row; columns: chargeOffReasonExpenseDisplayedColumns"></tr>
+                  </table>
+                </div>
+              }
+            </div>
+          }
         </div>
-      }
+      </div>
     }
   </div>
 }

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
@@ -135,7 +135,7 @@ export class LoanProductSummaryComponent extends LoanProductBaseComponent implem
   writeOffReasonsToExpenseMappings: ChargeOffReasonToExpenseAccountMapping[] = [];
 
   ngOnInit() {
-    this.accountingRuleData = this.accounting.getAccountingRulesForLoans();
+    this.accountingRuleData = this.accounting.getAccountingRulesForLoans(this.loanProductService.isLoanProduct);
     this.setCurrentValues();
   }
 
@@ -180,86 +180,81 @@ export class LoanProductSummaryComponent extends LoanProductBaseComponent implem
         }
       }
 
+      const assetAccountData = this.loanProductsTemplate.accountingMappingOptions.assetAccountOptions || [];
+      const incomeAccountData = this.loanProductsTemplate.accountingMappingOptions.incomeAccountOptions || [];
+      const expenseAccountData = this.loanProductsTemplate.accountingMappingOptions.expenseAccountOptions || [];
+      const liabilityAccountData = this.loanProductsTemplate.accountingMappingOptions.liabilityAccountOptions || [];
+      const assetAndLiabilityAccountData = assetAccountData.concat(liabilityAccountData);
+      const chargeOffReasonOptions: any = this.loanProductsTemplate.chargeOffReasonOptions || [];
+      const writeOffReasonOptions: any = this.loanProductsTemplate.writeOffReasonOptions || [];
+
+      this.accountingMappings = {
+        fundSourceAccount: this.glAccountLookUp(this.loanProduct.fundSourceAccountId, assetAndLiabilityAccountData),
+        loanPortfolioAccount: this.glAccountLookUp(this.loanProduct.loanPortfolioAccountId, assetAccountData),
+        receivableInterestAccount: this.glAccountLookUp(this.loanProduct.receivableInterestAccountId, assetAccountData),
+        receivableFeeAccount: this.glAccountLookUp(this.loanProduct.receivableFeeAccountId, assetAccountData),
+        receivablePenaltyAccount: this.glAccountLookUp(this.loanProduct.receivablePenaltyAccountId, assetAccountData),
+        transfersInSuspenseAccount: this.glAccountLookUp(
+          this.loanProduct.transfersInSuspenseAccountId,
+          assetAccountData
+        ),
+
+        interestOnLoanAccount: this.glAccountLookUp(this.loanProduct.interestOnLoanAccountId, incomeAccountData),
+        incomeFromDiscountFeeAccount: this.glAccountLookUp(
+          this.loanProduct.incomeFromDiscountFeeAccountId,
+          incomeAccountData
+        ),
+        incomeFromFeeAccount: this.glAccountLookUp(this.loanProduct.incomeFromFeeAccountId, incomeAccountData),
+        incomeFromPenaltyAccount: this.glAccountLookUp(this.loanProduct.incomeFromPenaltyAccountId, incomeAccountData),
+        incomeFromRecoveryAccount: this.glAccountLookUp(
+          this.loanProduct.incomeFromRecoveryAccountId,
+          incomeAccountData
+        ),
+        incomeFromChargeOffInterestAccount: this.glAccountLookUp(
+          this.loanProduct.incomeFromChargeOffInterestAccountId,
+          incomeAccountData
+        ),
+        incomeFromChargeOffFeesAccount: this.glAccountLookUp(
+          this.loanProduct.incomeFromChargeOffFeesAccountId,
+          incomeAccountData
+        ),
+        incomeFromChargeOffPenaltyAccount: this.glAccountLookUp(
+          this.loanProduct.incomeFromChargeOffPenaltyAccountId,
+          incomeAccountData
+        ),
+        incomeFromCapitalizationAccount: this.glAccountLookUp(
+          this.loanProduct.incomeFromCapitalizationAccountId,
+          incomeAccountData
+        ),
+        incomeFromBuyDownAccount: this.glAccountLookUp(this.loanProduct.incomeFromBuyDownAccountId, incomeAccountData),
+
+        writeOffAccount: this.glAccountLookUp(this.loanProduct.writeOffAccountId, expenseAccountData),
+        goodwillCreditAccount: this.glAccountLookUp(this.loanProduct.goodwillCreditAccountId, expenseAccountData),
+        chargeOffExpenseAccount: this.glAccountLookUp(this.loanProduct.chargeOffExpenseAccountId, expenseAccountData),
+        chargeOffFraudExpenseAccount: this.glAccountLookUp(
+          this.loanProduct.chargeOffFraudExpenseAccountId,
+          expenseAccountData
+        ),
+        buyDownExpenseAccount: this.glAccountLookUp(this.loanProduct.buyDownExpenseAccountId, expenseAccountData),
+
+        overpaymentLiabilityAccount: this.glAccountLookUp(
+          this.loanProduct.overpaymentLiabilityAccountId,
+          liabilityAccountData
+        ),
+        deferredIncomeLiabilityAccount: this.glAccountLookUp(
+          this.loanProduct.deferredIncomeLiabilityAccountId,
+          liabilityAccountData
+        )
+      };
+
       if (this.loanProductService.isLoanProduct) {
         if (
           (this.loanProduct.accountingRule && this.loanProduct.accountingRule > 1) ||
           this.loanProductsTemplate.accountingRule.value !== 'NONE'
         ) {
-          const assetAccountData = this.loanProductsTemplate.accountingMappingOptions.assetAccountOptions || [];
-          const incomeAccountData = this.loanProductsTemplate.accountingMappingOptions.incomeAccountOptions || [];
-          const expenseAccountData = this.loanProductsTemplate.accountingMappingOptions.expenseAccountOptions || [];
-          const liabilityAccountData = this.loanProductsTemplate.accountingMappingOptions.liabilityAccountOptions || [];
-          const assetAndLiabilityAccountData =
-            this.loanProductsTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions || [];
-          const chargeOffReasonOptions: any = this.loanProductsTemplate.chargeOffReasonOptions || [];
-          const writeOffReasonOptions: any = this.loanProductsTemplate.writeOffReasonOptions || [];
           const buydownFeeClassificationOptions: any = this.loanProductsTemplate.buydownFeeClassificationOptions || [];
           const capitalizedIncomeClassificationOptions: any =
             this.loanProductsTemplate.capitalizedIncomeClassificationOptions || [];
-
-          this.accountingMappings = {
-            fundSourceAccount: this.glAccountLookUp(this.loanProduct.fundSourceAccountId, assetAndLiabilityAccountData),
-            loanPortfolioAccount: this.glAccountLookUp(this.loanProduct.loanPortfolioAccountId, assetAccountData),
-            receivableInterestAccount: this.glAccountLookUp(
-              this.loanProduct.receivableInterestAccountId,
-              assetAccountData
-            ),
-            receivableFeeAccount: this.glAccountLookUp(this.loanProduct.receivableFeeAccountId, assetAccountData),
-            receivablePenaltyAccount: this.glAccountLookUp(
-              this.loanProduct.receivablePenaltyAccountId,
-              assetAccountData
-            ),
-            transfersInSuspenseAccount: this.glAccountLookUp(
-              this.loanProduct.transfersInSuspenseAccountId,
-              assetAccountData
-            ),
-
-            interestOnLoanAccount: this.glAccountLookUp(this.loanProduct.interestOnLoanAccountId, incomeAccountData),
-            incomeFromFeeAccount: this.glAccountLookUp(this.loanProduct.incomeFromFeeAccountId, incomeAccountData),
-            incomeFromPenaltyAccount: this.glAccountLookUp(
-              this.loanProduct.incomeFromPenaltyAccountId,
-              incomeAccountData
-            ),
-            incomeFromRecoveryAccount: this.glAccountLookUp(
-              this.loanProduct.incomeFromRecoveryAccountId,
-              incomeAccountData
-            ),
-            incomeFromChargeOffInterestAccount: this.glAccountLookUp(
-              this.loanProduct.incomeFromChargeOffInterestAccountId,
-              incomeAccountData
-            ),
-            incomeFromChargeOffFeesAccount: this.glAccountLookUp(
-              this.loanProduct.incomeFromChargeOffFeesAccountId,
-              incomeAccountData
-            ),
-            incomeFromChargeOffPenaltyAccount: this.glAccountLookUp(
-              this.loanProduct.incomeFromChargeOffPenaltyAccountId,
-              incomeAccountData
-            ),
-            incomeFromCapitalizationAccount: this.glAccountLookUp(
-              this.loanProduct.incomeFromCapitalizationAccountId,
-              incomeAccountData
-            ),
-            incomeFromBuyDownAccount: this.glAccountLookUp(
-              this.loanProduct.incomeFromBuyDownAccountId,
-              incomeAccountData
-            ),
-
-            writeOffAccount: this.glAccountLookUp(this.loanProduct.writeOffAccountId, expenseAccountData),
-            goodwillCreditAccount: this.glAccountLookUp(this.loanProduct.goodwillCreditAccountId, expenseAccountData),
-            chargeOffExpenseAccount: this.glAccountLookUp(this.loanProduct.writeOffAccountId, expenseAccountData),
-            chargeOffFraudExpenseAccount: this.glAccountLookUp(this.loanProduct.writeOffAccountId, expenseAccountData),
-            buyDownExpenseAccount: this.glAccountLookUp(this.loanProduct.buyDownExpenseAccountId, expenseAccountData),
-
-            overpaymentLiabilityAccount: this.glAccountLookUp(
-              this.loanProduct.overpaymentLiabilityAccountId,
-              liabilityAccountData
-            ),
-            deferredIncomeLiabilityAccount: this.glAccountLookUp(
-              this.loanProduct.deferredIncomeLiabilityAccountId,
-              liabilityAccountData
-            )
-          };
 
           this.paymentChannelToFundSourceMappings = [];
           if (this.loanProduct.paymentChannelToFundSourceMappings?.length > 0) {
@@ -658,10 +653,7 @@ export class LoanProductSummaryComponent extends LoanProductBaseComponent implem
     return delinquencyBucketData;
   }
 
-  accountingRule(): number {
-    if (this.loanProductService.isWorkingCapital) {
-      return 0;
-    }
+  accountingRule(): any {
     return this.loanProduct.accountingRule.id ? this.loanProduct.accountingRule.id : this.loanProduct.accountingRule;
   }
 
@@ -670,7 +662,7 @@ export class LoanProductSummaryComponent extends LoanProductBaseComponent implem
   }
 
   isAccountingEnabled(): boolean {
-    return this.accountingRule() >= 2;
+    return this.loanProductService.isLoanProduct ? this.accountingRule() >= 2 : this.accountingRule() !== 'NONE';
   }
 
   isAdvancedAccountingEnabled(): boolean {
@@ -690,7 +682,7 @@ export class LoanProductSummaryComponent extends LoanProductBaseComponent implem
   }
 
   getAccountingRuleName(value: string): string {
-    return this.loanProductService.isWorkingCapital ? '' : this.accounting.getAccountRuleName(value.toUpperCase());
+    return this.accounting.getAccountRuleName(value.toUpperCase());
   }
 
   mapHumanReadableValueStringEnumOptionDataList(incomingParameter: StringEnumOptionData[]): string[] {

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
@@ -151,21 +151,19 @@
       </mat-step>
     }
 
-    @if (loanProductService.isLoanProduct) {
-      <mat-step [stepControl]="loanProductAccountingForm">
-        <ng-template matStepLabel
-          ><strong>{{ getProductTypeLabel(true) }} : </strong>{{ 'labels.inputs.ACCOUNTING' | translate }}</ng-template
-        >
+    <mat-step>
+      <ng-template matStepLabel
+        ><strong>{{ getProductTypeLabel(true) }} : </strong>{{ 'labels.inputs.ACCOUNTING' | translate }}</ng-template
+      >
 
-        <mifosx-loan-product-accounting-step
-          [loanProductsTemplate]="loanProductsTemplate"
-          [accountingRuleData]="accountingRuleData"
-          [loanProductFormValid]="loanProductFormValid"
-          [deferredIncomeRecognition]="deferredIncomeRecognition"
-        >
-        </mifosx-loan-product-accounting-step>
-      </mat-step>
-    }
+      <mifosx-loan-product-accounting-step
+        [loanProductsTemplate]="loanProductsTemplate"
+        [accountingRuleData]="accountingRuleData"
+        [loanProductFormValid]="loanProductFormValid"
+        [deferredIncomeRecognition]="deferredIncomeRecognition"
+      >
+      </mifosx-loan-product-accounting-step>
+    </mat-step>
 
     @if (loanProductFormValid) {
       <mat-step state="preview" completed>

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
@@ -86,7 +86,7 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
   loanProductSettingsStep: LoanProductSettingsStepComponent;
   @ViewChild(LoanProductChargesStepComponent, { static: false })
   loanProductChargesStep: LoanProductChargesStepComponent;
-  @ViewChild(LoanProductAccountingStepComponent, { static: false })
+  @ViewChild(LoanProductAccountingStepComponent, { static: true })
   loanProductAccountingStep: LoanProductAccountingStepComponent;
 
   loanProductsTemplate: any;
@@ -127,10 +127,9 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
   }
 
   ngOnInit() {
-    this.accountingRuleData = this.accounting.getAccountingRulesForLoans();
+    this.accountingRuleData = this.accounting.getAccountingRulesForLoans(this.loanProductService.isLoanProduct);
     this.buildAdvancedPaymentAllocation();
     if (this.loanProductService.isWorkingCapital) {
-      this.accountingRuleData = ['NONE'];
       this.loanProductsTemplate['creditAllocationTransactionTypes'] = [];
     }
   }
@@ -249,9 +248,7 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
   }
 
   get loanProductAccountingForm() {
-    if (this.loanProductService.isLoanProduct) {
-      return this.loanProductAccountingStep?.loanProductAccountingForm;
-    }
+    return this.loanProductAccountingStep?.loanProductAccountingForm;
   }
 
   get loanProductFormValid() {
@@ -280,7 +277,8 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
         this.loanProductDetailsForm.valid &&
         this.loanProductCurrencyForm.valid &&
         this.loanProductTermsForm.valid &&
-        this.loanProductSettingsForm.valid
+        this.loanProductSettingsForm.valid &&
+        this.loanProductAccountingForm?.valid
       );
     }
   }
@@ -328,7 +326,8 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
         ...this.loanProductDetailsStep.loanProductDetails,
         ...this.loanProductCurrencyStep.loanProductCurrency,
         ...this.loanProductTermsStep.loanProductTerms,
-        ...this.loanProductSettingsStep.loanProductSettings
+        ...this.loanProductSettingsStep.loanProductSettings,
+        ...this.loanProductAccountingStep.loanProductAccounting
       };
       loanProduct['paymentAllocation'] = this.paymentAllocation;
       return loanProduct;
@@ -376,7 +375,14 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
   submitWCProduct(): void {
     const loanProduct = this.loanProducts.buildPayload(this.loanProduct, this.itemsByDefault);
 
-    loanProduct['accountingRule'] = 'NONE';
+    // No Empty values to be sent
+    [
+      'nearBreachId'
+    ].forEach((attr: string) => {
+      if (loanProduct[attr] === null || loanProduct[attr] === '') {
+        delete loanProduct[attr];
+      }
+    });
 
     this.productsService
       .createLoanProduct(this.loanProductService.loanProductPath, loanProduct)

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.html
@@ -151,21 +151,19 @@
       </mat-step>
     }
 
-    @if (loanProductService.isLoanProduct) {
-      <mat-step [stepControl]="loanProductAccountingForm" completed>
-        <ng-template matStepLabel
-          ><strong>{{ getProductTypeLabel(true) }} : </strong>{{ 'labels.inputs.ACCOUNTING' | translate }}</ng-template
-        >
+    <mat-step completed>
+      <ng-template matStepLabel
+        ><strong>{{ getProductTypeLabel(true) }} : </strong>{{ 'labels.inputs.ACCOUNTING' | translate }}</ng-template
+      >
 
-        <mifosx-loan-product-accounting-step
-          [loanProductsTemplate]="loanProductAndTemplate"
-          [accountingRuleData]="accountingRuleData"
-          [loanProductFormValid]="loanProductFormValidAndNotPristine"
-          [deferredIncomeRecognition]="deferredIncomeRecognition"
-        >
-        </mifosx-loan-product-accounting-step>
-      </mat-step>
-    }
+      <mifosx-loan-product-accounting-step
+        [loanProductsTemplate]="loanProductAndTemplate"
+        [accountingRuleData]="accountingRuleData"
+        [loanProductFormValid]="loanProductFormValidAndNotPristine"
+        [deferredIncomeRecognition]="deferredIncomeRecognition"
+      >
+      </mifosx-loan-product-accounting-step>
+    </mat-step>
 
     @if (loanProductFormValidAndNotPristine) {
       <mat-step state="preview" completed>

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
@@ -89,7 +89,7 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
   loanProductSettingsStep: LoanProductSettingsStepComponent;
   @ViewChild(LoanProductChargesStepComponent, { static: false })
   loanProductChargesStep: LoanProductChargesStepComponent;
-  @ViewChild(LoanProductAccountingStepComponent, { static: false })
+  @ViewChild(LoanProductAccountingStepComponent, { static: true })
   loanProductAccountingStep: LoanProductAccountingStepComponent;
 
   loanProductAndTemplate: any;
@@ -129,7 +129,7 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
   }
 
   ngOnInit() {
-    this.accountingRuleData = this.accounting.getAccountingRulesForLoans();
+    this.accountingRuleData = this.accounting.getAccountingRulesForLoans(this.loanProductService.isLoanProduct);
     this.buildAdvancedPaymentAllocation();
     if (this.loanProductService.isLoanProduct) {
       this.advancePaymentStrategy(this.loanProductAndTemplate.transactionProcessingStrategyCode);
@@ -166,8 +166,6 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
           };
         }
       }
-    } else {
-      this.accountingRuleData = ['NONE'];
     }
   }
 
@@ -264,9 +262,7 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
   }
 
   get loanProductAccountingForm() {
-    if (this.loanProductService.isLoanProduct) {
-      return this.loanProductAccountingStep?.loanProductAccountingForm;
-    }
+    return this.loanProductAccountingStep?.loanProductAccountingForm;
   }
 
   get loanProductFormValid(): boolean {
@@ -295,7 +291,8 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
         this.loanProductDetailsForm.valid &&
         this.loanProductCurrencyForm.valid &&
         this.loanProductTermsForm.valid &&
-        this.loanProductSettingsForm.valid
+        this.loanProductSettingsForm.valid &&
+        this.loanProductAccountingForm?.valid
       );
     }
   }
@@ -330,6 +327,7 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
         !this.loanProductCurrencyForm.pristine ||
         !this.loanProductTermsForm.pristine ||
         !this.loanProductSettingsForm.pristine ||
+        !(this.loanProductAccountingForm?.pristine ?? true) ||
         this.wasPaymentAllocationChanged
       );
     }
@@ -389,7 +387,8 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
         ...this.loanProductDetailsStep.loanProductDetails,
         ...this.loanProductCurrencyStep.loanProductCurrency,
         ...this.loanProductTermsStep.loanProductTerms,
-        ...this.loanProductSettingsStep.loanProductSettings
+        ...this.loanProductSettingsStep.loanProductSettings,
+        ...this.loanProductAccountingStep.loanProductAccounting
       };
       loanProduct['paymentAllocation'] = this.paymentAllocation;
       return loanProduct;
@@ -415,9 +414,14 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
       delete loanProduct['useDueForRepaymentsConfigurations'];
     }
 
-    if (this.loanProductService.isWorkingCapital) {
-      loanProduct['accountingRule'] = 'NONE';
-    }
+    // No Empty values to be sent
+    [
+      'nearBreachId'
+    ].forEach((attr: string) => {
+      if (loanProduct[attr] === null || loanProduct[attr] === '') {
+        delete loanProduct[attr];
+      }
+    });
 
     this.productsService
       .updateLoanProduct(this.loanProductService.loanProductPath, this.loanProductAndTemplate.id, loanProduct)

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
@@ -7,27 +7,529 @@
 -->
 
 <form [formGroup]="loanProductAccountingForm">
-  <div class="layout-row-wrap gap-2px responsive-column">
-    <mat-radio-group
-      class="flex-98 layout-row gap-5percent layout-lt-md-column radio-group-spacing"
-      formControlName="accountingRule"
-    >
-      @for (accountingRule of accountingRuleData; track accountingRule; let i = $index) {
-        <mat-radio-button [value]="i + 1">
-          {{ 'labels.accounting.' + accountingRule | translate }}
-        </mat-radio-button>
-      }
-    </mat-radio-group>
-
-    <mat-divider class="flex-98"></mat-divider>
-
-    @if (loanProductAccountingForm.value.accountingRule >= 2 && loanProductAccountingForm.value.accountingRule <= 4) {
-      <div class="flex-100 layout-row-wrap responsive-column">
-        @if (isAccountingAccrualBased) {
-          <mat-checkbox class="flex-73" formControlName="enableAccrualActivityPosting">{{
-            'labels.inputs.Enable Accrual Activity Posting on Installment Due Date' | translate
-          }}</mat-checkbox>
+  @if (loanProductService.isLoanProduct) {
+    <div class="layout-row-wrap gap-2px responsive-column">
+      <mat-radio-group
+        class="flex-98 layout-row gap-5percent layout-lt-md-column radio-group-spacing"
+        formControlName="accountingRule"
+      >
+        @for (accountingRule of accountingRuleData; track accountingRule; let i = $index) {
+          <mat-radio-button [value]="i + 1">
+            {{ 'labels.accounting.' + accountingRule | translate }}
+          </mat-radio-button>
         }
+      </mat-radio-group>
+
+      <mat-divider class="flex-98"></mat-divider>
+
+      @if (loanProductAccountingForm.value.accountingRule >= 2 && loanProductAccountingForm.value.accountingRule <= 4) {
+        <div class="flex-100 layout-row-wrap responsive-column">
+          @if (isAccountingAccrualBased) {
+            <mat-checkbox class="flex-73" formControlName="enableAccrualActivityPosting">{{
+              'labels.inputs.Enable Accrual Activity Posting on Installment Due Date' | translate
+            }}</mat-checkbox>
+          }
+          <h4 class="mat-h4 flex-98">
+            {{ 'labels.heading.Assets' | translate }} / {{ 'labels.heading.Liabilities' | translate }}
+          </h4>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.fundSourceAccountId"
+            [glAccountList]="assetAndLiabilityAccountData"
+            [required]="true"
+            [inputLabel]="'Fund source'"
+          >
+          </mifosx-gl-account-selector>
+          <h4 class="mat-h4 flex-98">{{ 'labels.heading.Assets' | translate }}</h4>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.loanPortfolioAccountId"
+            [glAccountList]="assetAccountData"
+            [required]="true"
+            [inputLabel]="'Loan portfolio'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.transfersInSuspenseAccountId"
+            [glAccountList]="assetAccountData"
+            [required]="true"
+            [inputLabel]="'Transfer in suspense'"
+          >
+          </mifosx-gl-account-selector>
+          @if (
+            loanProductAccountingForm.value.accountingRule === 3 || loanProductAccountingForm.value.accountingRule === 4
+          ) {
+            <div class="flex-100 layout-row-wrap responsive-column">
+              <mifosx-gl-account-selector
+                class="flex-48"
+                [inputFormControl]="loanProductAccountingForm.controls.receivableInterestAccountId"
+                [glAccountList]="assetAccountData"
+                [required]="true"
+                [inputLabel]="'Interest Receivable'"
+              >
+              </mifosx-gl-account-selector>
+              <mifosx-gl-account-selector
+                class="flex-48"
+                [inputFormControl]="loanProductAccountingForm.controls.receivableFeeAccountId"
+                [glAccountList]="assetAccountData"
+                [required]="true"
+                [inputLabel]="'Fees Receivable'"
+              >
+              </mifosx-gl-account-selector>
+              <mifosx-gl-account-selector
+                class="flex-48"
+                [inputFormControl]="loanProductAccountingForm.controls.receivablePenaltyAccountId"
+                [glAccountList]="assetAccountData"
+                [required]="true"
+                [inputLabel]="'Penalties Receivable'"
+              >
+              </mifosx-gl-account-selector>
+            </div>
+          }
+          <mat-divider class="flex-98"></mat-divider>
+          <h4 class="mat-h4 flex-98">{{ 'labels.heading.Income' | translate }}</h4>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.interestOnLoanAccountId"
+            [glAccountList]="incomeAccountData"
+            [required]="true"
+            [inputLabel]="'Income from Interest'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.incomeFromFeeAccountId"
+            [glAccountList]="incomeAccountData"
+            [required]="true"
+            [inputLabel]="'Income from fees'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.incomeFromPenaltyAccountId"
+            [glAccountList]="incomeAccountData"
+            [required]="true"
+            [inputLabel]="'Income from penalties'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.incomeFromRecoveryAccountId"
+            [glAccountList]="incomeAccountData"
+            [required]="true"
+            [inputLabel]="'Income from Recovery Repayments'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.incomeFromChargeOffInterestAccountId"
+            [glAccountList]="incomeAccountData"
+            [required]="true"
+            [inputLabel]="'Income from ChargeOff Interest'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.incomeFromChargeOffFeesAccountId"
+            [glAccountList]="incomeAccountData"
+            [required]="true"
+            [inputLabel]="'Income from ChargeOff Fees'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.incomeFromChargeOffPenaltyAccountId"
+            [glAccountList]="incomeAccountData"
+            [required]="true"
+            [inputLabel]="'Income from ChargeOff Penalty'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.incomeFromGoodwillCreditInterestAccountId"
+            [glAccountList]="incomeAccountData"
+            [required]="true"
+            [inputLabel]="'Income from Goodwill Credit Interest'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.incomeFromGoodwillCreditFeesAccountId"
+            [glAccountList]="incomeAccountData"
+            [required]="true"
+            [inputLabel]="'Income from Goodwill Credit Fees'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.incomeFromGoodwillCreditPenaltyAccountId"
+            [glAccountList]="incomeAccountData"
+            [required]="true"
+            [inputLabel]="'Income from Goodwill Credit Penalty'"
+          >
+          </mifosx-gl-account-selector>
+          @if (deferredIncomeRecognition?.capitalizedIncome?.enableIncomeCapitalization) {
+            <mifosx-gl-account-selector
+              class="flex-48"
+              [inputFormControl]="loanProductAccountingForm.controls.incomeFromCapitalizationAccountId"
+              [glAccountList]="incomeAccountData"
+              [required]="true"
+              [inputLabel]="'Income capitalization'"
+            >
+            </mifosx-gl-account-selector>
+          }
+          @if (deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee) {
+            <mifosx-gl-account-selector
+              class="flex-48"
+              [inputFormControl]="loanProductAccountingForm.controls.incomeFromBuyDownAccountId"
+              [glAccountList]="incomeAccountData"
+              [required]="true"
+              [inputLabel]="'Income from Buy down fees'"
+            >
+            </mifosx-gl-account-selector>
+          }
+          <mat-divider class="flex-98"></mat-divider>
+          <h4 class="mat-h4 flex-98">{{ 'labels.heading.Expenses' | translate }}</h4>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.writeOffAccountId"
+            [glAccountList]="expenseAccountData"
+            [required]="true"
+            [inputLabel]="'Losses written off'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.goodwillCreditAccountId"
+            [glAccountList]="expenseAccountData"
+            [required]="true"
+            [inputLabel]="'Expenses from Goodwill Credit'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.chargeOffExpenseAccountId"
+            [glAccountList]="expenseAccountData"
+            [required]="true"
+            [inputLabel]="'ChargeOff Expense'"
+          >
+          </mifosx-gl-account-selector>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.chargeOffFraudExpenseAccountId"
+            [glAccountList]="expenseAccountData"
+            [required]="true"
+            [inputLabel]="'ChargeOff Fraud Expense'"
+          >
+          </mifosx-gl-account-selector>
+          @if (
+            deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee &&
+            deferredIncomeRecognition?.buyDownFee?.merchantBuyDownFee
+          ) {
+            <mifosx-gl-account-selector
+              class="flex-48"
+              [inputFormControl]="loanProductAccountingForm.controls.buyDownExpenseAccountId"
+              [glAccountList]="expenseAccountData"
+              [required]="true"
+              [inputLabel]="'Buy down fee Expense'"
+            >
+            </mifosx-gl-account-selector>
+          }
+          <mat-divider class="flex-98"></mat-divider>
+          <h4 class="mat-h4 flex-98">{{ 'labels.heading.Liabilities' | translate }}</h4>
+          <mifosx-gl-account-selector
+            class="flex-48"
+            [inputFormControl]="loanProductAccountingForm.controls.overpaymentLiabilityAccountId"
+            [glAccountList]="liabilityAccountData"
+            [required]="true"
+            [inputLabel]="'Over payment liability'"
+          >
+          </mifosx-gl-account-selector>
+          @if (
+            deferredIncomeRecognition?.capitalizedIncome?.enableIncomeCapitalization ||
+            deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee
+          ) {
+            <mifosx-gl-account-selector
+              class="flex-48"
+              [inputFormControl]="loanProductAccountingForm.controls.deferredIncomeLiabilityAccountId"
+              [glAccountList]="liabilityAccountData"
+              [required]="true"
+              [inputLabel]="'Deferred income'"
+            >
+            </mifosx-gl-account-selector>
+          }
+          <mat-divider fxFlex="flex-98"></mat-divider>
+          <mat-checkbox class="flex-73" formControlName="advancedAccountingRules">{{
+            'labels.heading.Advanced Accounting Rules' | translate
+          }}</mat-checkbox>
+
+          @if (loanProductAccountingForm.value.advancedAccountingRules) {
+            <div class="flex-100 layout-row-wrap responsive-column">
+              <h4 class="mat-h4 flex-33">
+                {{ 'labels.heading.Configure Fund Sources for Payment Channels' | translate }}
+              </h4>
+              <div class="flex-63">
+                <button
+                  type="button"
+                  mat-raised-button
+                  color="primary"
+                  (click)="add('PaymentFundSource', paymentChannelToFundSourceMappings)"
+                >
+                  <fa-icon icon="plus" class="m-r-10"></fa-icon>
+                  {{ 'labels.buttons.Add' | translate }}
+                </button>
+              </div>
+              @if (paymentChannelToFundSourceMappings.value.length !== 0) {
+                <table
+                  class="flex-98 mat-elevation-z1"
+                  mat-table
+                  [dataSource]="paymentChannelToFundSourceMappings.value"
+                >
+                  <ng-container matColumnDef="paymentTypeId">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Payment Type' | translate }}</th>
+                    <td mat-cell *matCellDef="let paymentFundSource">
+                      {{ paymentFundSource.paymentTypeId | find: paymentTypeData : 'id' : 'name' }}
+                    </td>
+                  </ng-container>
+                  <ng-container matColumnDef="fundSourceAccountId">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fund Source' | translate }}</th>
+                    <td mat-cell *matCellDef="let paymentFundSource">
+                      {{ paymentFundSource.fundSourceAccountId | find: assetAccountData : 'id' : 'name' }}
+                    </td>
+                  </ng-container>
+                  <ng-container matColumnDef="actions">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+                    <td mat-cell *matCellDef="let paymentFundSource; let i = index">
+                      <button
+                        mat-icon-button
+                        color="primary"
+                        (click)="edit('PaymentFundSource', paymentChannelToFundSourceMappings, i)"
+                      >
+                        <fa-icon icon="edit"></fa-icon>
+                      </button>
+                      <button
+                        mat-icon-button
+                        color="warn"
+                        (click)="delete('PaymentFundSource', paymentChannelToFundSourceMappings, i)"
+                      >
+                        <fa-icon icon="trash"></fa-icon>
+                      </button>
+                    </td>
+                  </ng-container>
+                  <tr mat-header-row *matHeaderRowDef="paymentFundSourceDisplayedColumns"></tr>
+                  <tr mat-row *matRowDef="let row; columns: paymentFundSourceDisplayedColumns"></tr>
+                </table>
+              }
+              <h4 class="mat-h4 flex-33">{{ 'labels.heading.Map Fees to Specific Income Accounts' | translate }}</h4>
+              <div class="flex-63">
+                <button
+                  type="button"
+                  mat-raised-button
+                  color="primary"
+                  (click)="add('FeesIncome', feeToIncomeAccountMappings)"
+                >
+                  <fa-icon icon="plus" class="m-r-10"></fa-icon>
+                  {{ 'labels.buttons.Add' | translate }}
+                </button>
+              </div>
+              @if (feeToIncomeAccountMappings.value.length !== 0) {
+                <table class="flex-98 mat-elevation-z1" mat-table [dataSource]="feeToIncomeAccountMappings.value">
+                  <ng-container matColumnDef="chargeId">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fees' | translate }}</th>
+                    <td mat-cell *matCellDef="let feesIncome">
+                      {{ feesIncome.chargeId | find: chargeData : 'id' : 'name' }}
+                    </td>
+                  </ng-container>
+                  <ng-container matColumnDef="incomeAccountId">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
+                    <td mat-cell *matCellDef="let feesIncome">
+                      {{ feesIncome.incomeAccountId | find: incomeAndLiabilityAccountData : 'id' : 'name' }}
+                    </td>
+                  </ng-container>
+                  <ng-container matColumnDef="actions">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+                    <td mat-cell *matCellDef="let feesIncome; let i = index">
+                      <button
+                        mat-icon-button
+                        color="primary"
+                        (click)="edit('FeesIncome', feeToIncomeAccountMappings, i)"
+                      >
+                        <fa-icon icon="edit"></fa-icon>
+                      </button>
+                      <button
+                        mat-icon-button
+                        color="warn"
+                        (click)="delete('FeesIncome', feeToIncomeAccountMappings, i)"
+                      >
+                        <fa-icon icon="trash"></fa-icon>
+                      </button>
+                    </td>
+                  </ng-container>
+                  <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
+                  <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns"></tr>
+                </table>
+              }
+              <h4 class="mat-h4 flex-33">
+                {{ 'labels.heading.Map Penalties to Specific Income Accounts' | translate }}
+              </h4>
+              <div class="flex-63">
+                <button
+                  type="button"
+                  mat-raised-button
+                  color="primary"
+                  (click)="add('PenaltyIncome', penaltyToIncomeAccountMappings)"
+                >
+                  <fa-icon icon="plus" class="m-r-10"></fa-icon>
+                  {{ 'labels.buttons.Add' | translate }}
+                </button>
+              </div>
+              @if (penaltyToIncomeAccountMappings.value.length !== 0) {
+                <table class="flex-98 mat-elevation-z1" mat-table [dataSource]="penaltyToIncomeAccountMappings.value">
+                  <ng-container matColumnDef="chargeId">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Penalty' | translate }}</th>
+                    <td mat-cell *matCellDef="let penaltyIncome">
+                      {{ penaltyIncome.chargeId | find: penaltyData : 'id' : 'name' }}
+                    </td>
+                  </ng-container>
+                  <ng-container matColumnDef="incomeAccountId">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
+                    <td mat-cell *matCellDef="let penaltyIncome">
+                      {{ penaltyIncome.incomeAccountId | find: incomeAccountData : 'id' : 'name' }}
+                    </td>
+                  </ng-container>
+                  <ng-container matColumnDef="actions">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+                    <td mat-cell *matCellDef="let penaltyIncome; let i = index">
+                      <button
+                        mat-icon-button
+                        color="primary"
+                        (click)="edit('PenaltyIncome', penaltyToIncomeAccountMappings, i)"
+                      >
+                        <fa-icon icon="edit"></fa-icon>
+                      </button>
+                      <button
+                        mat-icon-button
+                        color="warn"
+                        (click)="delete('PenaltyIncome', penaltyToIncomeAccountMappings, i)"
+                      >
+                        <fa-icon icon="trash"></fa-icon>
+                      </button>
+                    </td>
+                  </ng-container>
+                  <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
+                  <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns"></tr>
+                </table>
+              }
+              <h4 class="mat-h4 flex-33">
+                {{ 'labels.heading.Map Charge-off reasons to Expense accounts' | translate }}
+              </h4>
+              <div class="flex-63">
+                <button
+                  type="button"
+                  mat-raised-button
+                  color="primary"
+                  [disabled]="!allowAddChargeOffReasonExpense"
+                  (click)="add('ChargeOffReasonExpense', chargeOffReasonToExpenseAccountMappings)"
+                >
+                  <fa-icon icon="plus" class="m-r-10"></fa-icon>
+                  {{ 'labels.buttons.Add' | translate }}
+                </button>
+              </div>
+              @if (chargeOffReasonToExpenseAccountMappings.value.length !== 0) {
+                <table
+                  class="flex-98 mat-elevation-z1"
+                  mat-table
+                  [dataSource]="chargeOffReasonToExpenseAccountMappings.value"
+                >
+                  <ng-container matColumnDef="chargeOffReasonCodeValueId">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Charge-off reason' | translate }}</th>
+                    <td mat-cell *matCellDef="let chargeOffReasonExpense">
+                      {{
+                        chargeOffReasonExpense.chargeOffReasonCodeValueId | find: chargeOffReasonOptions : 'id' : 'name'
+                      }}
+                    </td>
+                  </ng-container>
+                  <ng-container matColumnDef="expenseAccountId">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Expense Account' | translate }}</th>
+                    <td mat-cell *matCellDef="let chargeOffReasonExpense">
+                      {{ chargeOffReasonExpense.expenseAccountId | find: expenseAccountData : 'id' : 'name' }}
+                    </td>
+                  </ng-container>
+                  <ng-container matColumnDef="actions">
+                    <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+                    <td mat-cell *matCellDef="let chargeOffReasonExpense; let i = index">
+                      <button
+                        mat-icon-button
+                        color="primary"
+                        (click)="edit('ChargeOffReasonExpense', chargeOffReasonToExpenseAccountMappings, i)"
+                      >
+                        <fa-icon icon="edit"></fa-icon>
+                      </button>
+                      <button
+                        mat-icon-button
+                        color="warn"
+                        (click)="delete('ChargeOffReasonExpense', chargeOffReasonToExpenseAccountMappings, i)"
+                      >
+                        <fa-icon icon="trash"></fa-icon>
+                      </button>
+                    </td>
+                  </ng-container>
+                  <tr mat-header-row *matHeaderRowDef="chargeOffReasonExpenseDisplayedColumns"></tr>
+                  <tr mat-row *matRowDef="let row; columns: chargeOffReasonExpenseDisplayedColumns"></tr>
+                </table>
+              }
+              <mifosx-advanced-accounting-mapping-rule
+                class="flex-100 m-t-10"
+                [textField]="'Classification'"
+                [formType]="'BuydownFeeClassificationToIncome'"
+                [formArray]="buydownfeeClassificationToIncomeAccountMappings"
+                [textHeading]="'Buydown Fee classifications to Income accounts'"
+                [incomeAccountData]="incomeAccountData"
+                [accountingMappingOptions]="buydownFeeClassificationOptions"
+                (formChangeEvent)="formChangeEvent($event)"
+              ></mifosx-advanced-accounting-mapping-rule>
+              <mifosx-advanced-accounting-mapping-rule
+                class="flex-100 m-t-10"
+                [textField]="'Classification'"
+                [formType]="'CapitalizedIncomeClassificationToIncome'"
+                [formArray]="capitalizedIncomeClassificationToIncomeAccountMappings"
+                [textHeading]="'Capitalized Income classifications to Income accounts'"
+                [incomeAccountData]="incomeAccountData"
+                [accountingMappingOptions]="capitalizedIncomeClassificationOptions"
+                (formChangeEvent)="formChangeEvent($event)"
+              ></mifosx-advanced-accounting-mapping-rule>
+              <mifosx-advanced-accounting-mapping-rule
+                class="flex-100 m-t-10"
+                [textField]="'WriteOff Reason'"
+                [formType]="'WriteOffReasonToExpense'"
+                [formArray]="writeOffReasonsToExpenseMappings"
+                [textHeading]="'WriteOff reasons to Expense accounts'"
+                [expenseAccountData]="expenseAccountData"
+                [accountingMappingOptions]="writeOffReasonOptions"
+                (formChangeEvent)="formChangeEvent($event)"
+              ></mifosx-advanced-accounting-mapping-rule>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  } @else if (loanProductService.isWorkingCapital) {
+    <div class="flex-100 layout-row-wrap responsive-column">
+      <mat-radio-group
+        class="flex-98 layout-row gap-5percent layout-lt-md-column radio-group-spacing"
+        formControlName="accountingRule"
+      >
+        @for (accountingRule of accountingRuleData; track accountingRule; let i = $index) {
+          <mat-radio-button [value]="accountingRule">
+            {{ 'labels.accounting.' + accountingRule | translate }}
+          </mat-radio-button>
+        }
+      </mat-radio-group>
+
+      <mat-divider class="flex-98"></mat-divider>
+
+      @if (loanProductAccountingForm.value.accountingRule !== 'NONE') {
         <h4 class="mat-h4 flex-98">
           {{ 'labels.heading.Assets' | translate }} / {{ 'labels.heading.Liabilities' | translate }}
         </h4>
@@ -39,6 +541,7 @@
           [inputLabel]="'Fund source'"
         >
         </mifosx-gl-account-selector>
+
         <h4 class="mat-h4 flex-98">{{ 'labels.heading.Assets' | translate }}</h4>
         <mifosx-gl-account-selector
           class="flex-48"
@@ -56,44 +559,14 @@
           [inputLabel]="'Transfer in suspense'"
         >
         </mifosx-gl-account-selector>
-        @if (
-          loanProductAccountingForm.value.accountingRule === 3 || loanProductAccountingForm.value.accountingRule === 4
-        ) {
-          <div class="flex-100 layout-row-wrap responsive-column">
-            <mifosx-gl-account-selector
-              class="flex-48"
-              [inputFormControl]="loanProductAccountingForm.controls.receivableInterestAccountId"
-              [glAccountList]="assetAccountData"
-              [required]="true"
-              [inputLabel]="'Interest Receivable'"
-            >
-            </mifosx-gl-account-selector>
-            <mifosx-gl-account-selector
-              class="flex-48"
-              [inputFormControl]="loanProductAccountingForm.controls.receivableFeeAccountId"
-              [glAccountList]="assetAccountData"
-              [required]="true"
-              [inputLabel]="'Fees Receivable'"
-            >
-            </mifosx-gl-account-selector>
-            <mifosx-gl-account-selector
-              class="flex-48"
-              [inputFormControl]="loanProductAccountingForm.controls.receivablePenaltyAccountId"
-              [glAccountList]="assetAccountData"
-              [required]="true"
-              [inputLabel]="'Penalties Receivable'"
-            >
-            </mifosx-gl-account-selector>
-          </div>
-        }
-        <mat-divider class="flex-98"></mat-divider>
+
         <h4 class="mat-h4 flex-98">{{ 'labels.heading.Income' | translate }}</h4>
         <mifosx-gl-account-selector
           class="flex-48"
-          [inputFormControl]="loanProductAccountingForm.controls.interestOnLoanAccountId"
+          [inputFormControl]="loanProductAccountingForm.controls.incomeFromDiscountFeeAccountId"
           [glAccountList]="incomeAccountData"
           [required]="true"
-          [inputLabel]="'Income from Interest'"
+          [inputLabel]="'Income From Discount Fee'"
         >
         </mifosx-gl-account-selector>
         <mifosx-gl-account-selector
@@ -124,7 +597,7 @@
           class="flex-48"
           [inputFormControl]="loanProductAccountingForm.controls.incomeFromChargeOffInterestAccountId"
           [glAccountList]="incomeAccountData"
-          [required]="true"
+          [required]="false"
           [inputLabel]="'Income from ChargeOff Interest'"
         >
         </mifosx-gl-account-selector>
@@ -132,7 +605,7 @@
           class="flex-48"
           [inputFormControl]="loanProductAccountingForm.controls.incomeFromChargeOffFeesAccountId"
           [glAccountList]="incomeAccountData"
-          [required]="true"
+          [required]="false"
           [inputLabel]="'Income from ChargeOff Fees'"
         >
         </mifosx-gl-account-selector>
@@ -140,7 +613,7 @@
           class="flex-48"
           [inputFormControl]="loanProductAccountingForm.controls.incomeFromChargeOffPenaltyAccountId"
           [glAccountList]="incomeAccountData"
-          [required]="true"
+          [required]="false"
           [inputLabel]="'Income from ChargeOff Penalty'"
         >
         </mifosx-gl-account-selector>
@@ -148,7 +621,7 @@
           class="flex-48"
           [inputFormControl]="loanProductAccountingForm.controls.incomeFromGoodwillCreditInterestAccountId"
           [glAccountList]="incomeAccountData"
-          [required]="true"
+          [required]="false"
           [inputLabel]="'Income from Goodwill Credit Interest'"
         >
         </mifosx-gl-account-selector>
@@ -156,7 +629,7 @@
           class="flex-48"
           [inputFormControl]="loanProductAccountingForm.controls.incomeFromGoodwillCreditFeesAccountId"
           [glAccountList]="incomeAccountData"
-          [required]="true"
+          [required]="false"
           [inputLabel]="'Income from Goodwill Credit Fees'"
         >
         </mifosx-gl-account-selector>
@@ -164,31 +637,11 @@
           class="flex-48"
           [inputFormControl]="loanProductAccountingForm.controls.incomeFromGoodwillCreditPenaltyAccountId"
           [glAccountList]="incomeAccountData"
-          [required]="true"
+          [required]="false"
           [inputLabel]="'Income from Goodwill Credit Penalty'"
         >
         </mifosx-gl-account-selector>
-        @if (deferredIncomeRecognition?.capitalizedIncome?.enableIncomeCapitalization) {
-          <mifosx-gl-account-selector
-            class="flex-48"
-            [inputFormControl]="loanProductAccountingForm.controls.incomeFromCapitalizationAccountId"
-            [glAccountList]="incomeAccountData"
-            [required]="true"
-            [inputLabel]="'Income capitalization'"
-          >
-          </mifosx-gl-account-selector>
-        }
-        @if (deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee) {
-          <mifosx-gl-account-selector
-            class="flex-48"
-            [inputFormControl]="loanProductAccountingForm.controls.incomeFromBuyDownAccountId"
-            [glAccountList]="incomeAccountData"
-            [required]="true"
-            [inputLabel]="'Income from Buy down fees'"
-          >
-          </mifosx-gl-account-selector>
-        }
-        <mat-divider class="flex-98"></mat-divider>
+
         <h4 class="mat-h4 flex-98">{{ 'labels.heading.Expenses' | translate }}</h4>
         <mifosx-gl-account-selector
           class="flex-48"
@@ -202,7 +655,7 @@
           class="flex-48"
           [inputFormControl]="loanProductAccountingForm.controls.goodwillCreditAccountId"
           [glAccountList]="expenseAccountData"
-          [required]="true"
+          [required]="false"
           [inputLabel]="'Expenses from Goodwill Credit'"
         >
         </mifosx-gl-account-selector>
@@ -210,7 +663,7 @@
           class="flex-48"
           [inputFormControl]="loanProductAccountingForm.controls.chargeOffExpenseAccountId"
           [glAccountList]="expenseAccountData"
-          [required]="true"
+          [required]="false"
           [inputLabel]="'ChargeOff Expense'"
         >
         </mifosx-gl-account-selector>
@@ -218,24 +671,11 @@
           class="flex-48"
           [inputFormControl]="loanProductAccountingForm.controls.chargeOffFraudExpenseAccountId"
           [glAccountList]="expenseAccountData"
-          [required]="true"
+          [required]="false"
           [inputLabel]="'ChargeOff Fraud Expense'"
         >
         </mifosx-gl-account-selector>
-        @if (
-          deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee &&
-          deferredIncomeRecognition?.buyDownFee?.merchantBuyDownFee
-        ) {
-          <mifosx-gl-account-selector
-            class="flex-48"
-            [inputFormControl]="loanProductAccountingForm.controls.buyDownExpenseAccountId"
-            [glAccountList]="expenseAccountData"
-            [required]="true"
-            [inputLabel]="'Buy down fee Expense'"
-          >
-          </mifosx-gl-account-selector>
-        }
-        <mat-divider class="flex-98"></mat-divider>
+
         <h4 class="mat-h4 flex-98">{{ 'labels.heading.Liabilities' | translate }}</h4>
         <mifosx-gl-account-selector
           class="flex-48"
@@ -245,261 +685,17 @@
           [inputLabel]="'Over payment liability'"
         >
         </mifosx-gl-account-selector>
-        @if (
-          deferredIncomeRecognition?.capitalizedIncome?.enableIncomeCapitalization ||
-          deferredIncomeRecognition?.buyDownFee?.enableBuyDownFee
-        ) {
-          <mifosx-gl-account-selector
-            class="flex-48"
-            [inputFormControl]="loanProductAccountingForm.controls.deferredIncomeLiabilityAccountId"
-            [glAccountList]="liabilityAccountData"
-            [required]="true"
-            [inputLabel]="'Deferred income'"
-          >
-          </mifosx-gl-account-selector>
-        }
-        <mat-divider fxFlex="flex-98"></mat-divider>
-        <mat-checkbox class="flex-73" formControlName="advancedAccountingRules">{{
-          'labels.heading.Advanced Accounting Rules' | translate
-        }}</mat-checkbox>
-        @if (loanProductAccountingForm.value.advancedAccountingRules) {
-          <div class="flex-100 layout-row-wrap responsive-column">
-            <h4 class="mat-h4 flex-33">
-              {{ 'labels.heading.Configure Fund Sources for Payment Channels' | translate }}
-            </h4>
-            <div class="flex-63">
-              <button
-                type="button"
-                mat-raised-button
-                color="primary"
-                (click)="add('PaymentFundSource', paymentChannelToFundSourceMappings)"
-              >
-                <fa-icon icon="plus" class="m-r-10"></fa-icon>
-                {{ 'labels.buttons.Add' | translate }}
-              </button>
-            </div>
-            @if (paymentChannelToFundSourceMappings.value.length !== 0) {
-              <table class="flex-98 mat-elevation-z1" mat-table [dataSource]="paymentChannelToFundSourceMappings.value">
-                <ng-container matColumnDef="paymentTypeId">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Payment Type' | translate }}</th>
-                  <td mat-cell *matCellDef="let paymentFundSource">
-                    {{ paymentFundSource.paymentTypeId | find: paymentTypeData : 'id' : 'name' }}
-                  </td>
-                </ng-container>
-                <ng-container matColumnDef="fundSourceAccountId">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fund Source' | translate }}</th>
-                  <td mat-cell *matCellDef="let paymentFundSource">
-                    {{ paymentFundSource.fundSourceAccountId | find: assetAccountData : 'id' : 'name' }}
-                  </td>
-                </ng-container>
-                <ng-container matColumnDef="actions">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-                  <td mat-cell *matCellDef="let paymentFundSource; let i = index">
-                    <button
-                      mat-icon-button
-                      color="primary"
-                      (click)="edit('PaymentFundSource', paymentChannelToFundSourceMappings, i)"
-                    >
-                      <fa-icon icon="edit"></fa-icon>
-                    </button>
-                    <button
-                      mat-icon-button
-                      color="warn"
-                      (click)="delete('PaymentFundSource', paymentChannelToFundSourceMappings, i)"
-                    >
-                      <fa-icon icon="trash"></fa-icon>
-                    </button>
-                  </td>
-                </ng-container>
-                <tr mat-header-row *matHeaderRowDef="paymentFundSourceDisplayedColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: paymentFundSourceDisplayedColumns"></tr>
-              </table>
-            }
-            <h4 class="mat-h4 flex-33">{{ 'labels.heading.Map Fees to Specific Income Accounts' | translate }}</h4>
-            <div class="flex-63">
-              <button
-                type="button"
-                mat-raised-button
-                color="primary"
-                (click)="add('FeesIncome', feeToIncomeAccountMappings)"
-              >
-                <fa-icon icon="plus" class="m-r-10"></fa-icon>
-                {{ 'labels.buttons.Add' | translate }}
-              </button>
-            </div>
-            @if (feeToIncomeAccountMappings.value.length !== 0) {
-              <table class="flex-98 mat-elevation-z1" mat-table [dataSource]="feeToIncomeAccountMappings.value">
-                <ng-container matColumnDef="chargeId">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fees' | translate }}</th>
-                  <td mat-cell *matCellDef="let feesIncome">
-                    {{ feesIncome.chargeId | find: chargeData : 'id' : 'name' }}
-                  </td>
-                </ng-container>
-                <ng-container matColumnDef="incomeAccountId">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
-                  <td mat-cell *matCellDef="let feesIncome">
-                    {{ feesIncome.incomeAccountId | find: incomeAndLiabilityAccountData : 'id' : 'name' }}
-                  </td>
-                </ng-container>
-                <ng-container matColumnDef="actions">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-                  <td mat-cell *matCellDef="let feesIncome; let i = index">
-                    <button mat-icon-button color="primary" (click)="edit('FeesIncome', feeToIncomeAccountMappings, i)">
-                      <fa-icon icon="edit"></fa-icon>
-                    </button>
-                    <button mat-icon-button color="warn" (click)="delete('FeesIncome', feeToIncomeAccountMappings, i)">
-                      <fa-icon icon="trash"></fa-icon>
-                    </button>
-                  </td>
-                </ng-container>
-                <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns"></tr>
-              </table>
-            }
-            <h4 class="mat-h4 flex-33">
-              {{ 'labels.heading.Map Penalties to Specific Income Accounts' | translate }}
-            </h4>
-            <div class="flex-63">
-              <button
-                type="button"
-                mat-raised-button
-                color="primary"
-                (click)="add('PenaltyIncome', penaltyToIncomeAccountMappings)"
-              >
-                <fa-icon icon="plus" class="m-r-10"></fa-icon>
-                {{ 'labels.buttons.Add' | translate }}
-              </button>
-            </div>
-            @if (penaltyToIncomeAccountMappings.value.length !== 0) {
-              <table class="flex-98 mat-elevation-z1" mat-table [dataSource]="penaltyToIncomeAccountMappings.value">
-                <ng-container matColumnDef="chargeId">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Penalty' | translate }}</th>
-                  <td mat-cell *matCellDef="let penaltyIncome">
-                    {{ penaltyIncome.chargeId | find: penaltyData : 'id' : 'name' }}
-                  </td>
-                </ng-container>
-                <ng-container matColumnDef="incomeAccountId">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
-                  <td mat-cell *matCellDef="let penaltyIncome">
-                    {{ penaltyIncome.incomeAccountId | find: incomeAccountData : 'id' : 'name' }}
-                  </td>
-                </ng-container>
-                <ng-container matColumnDef="actions">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-                  <td mat-cell *matCellDef="let penaltyIncome; let i = index">
-                    <button
-                      mat-icon-button
-                      color="primary"
-                      (click)="edit('PenaltyIncome', penaltyToIncomeAccountMappings, i)"
-                    >
-                      <fa-icon icon="edit"></fa-icon>
-                    </button>
-                    <button
-                      mat-icon-button
-                      color="warn"
-                      (click)="delete('PenaltyIncome', penaltyToIncomeAccountMappings, i)"
-                    >
-                      <fa-icon icon="trash"></fa-icon>
-                    </button>
-                  </td>
-                </ng-container>
-                <tr mat-header-row *matHeaderRowDef="feesPenaltyIncomeDisplayedColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: feesPenaltyIncomeDisplayedColumns"></tr>
-              </table>
-            }
-            <h4 class="mat-h4 flex-33">
-              {{ 'labels.heading.Map Charge-off reasons to Expense accounts' | translate }}
-            </h4>
-            <div class="flex-63">
-              <button
-                type="button"
-                mat-raised-button
-                color="primary"
-                [disabled]="!allowAddChargeOffReasonExpense"
-                (click)="add('ChargeOffReasonExpense', chargeOffReasonToExpenseAccountMappings)"
-              >
-                <fa-icon icon="plus" class="m-r-10"></fa-icon>
-                {{ 'labels.buttons.Add' | translate }}
-              </button>
-            </div>
-            @if (chargeOffReasonToExpenseAccountMappings.value.length !== 0) {
-              <table
-                class="flex-98 mat-elevation-z1"
-                mat-table
-                [dataSource]="chargeOffReasonToExpenseAccountMappings.value"
-              >
-                <ng-container matColumnDef="chargeOffReasonCodeValueId">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Charge-off reason' | translate }}</th>
-                  <td mat-cell *matCellDef="let chargeOffReasonExpense">
-                    {{
-                      chargeOffReasonExpense.chargeOffReasonCodeValueId | find: chargeOffReasonOptions : 'id' : 'name'
-                    }}
-                  </td>
-                </ng-container>
-                <ng-container matColumnDef="expenseAccountId">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Expense Account' | translate }}</th>
-                  <td mat-cell *matCellDef="let chargeOffReasonExpense">
-                    {{ chargeOffReasonExpense.expenseAccountId | find: expenseAccountData : 'id' : 'name' }}
-                  </td>
-                </ng-container>
-                <ng-container matColumnDef="actions">
-                  <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-                  <td mat-cell *matCellDef="let chargeOffReasonExpense; let i = index">
-                    <button
-                      mat-icon-button
-                      color="primary"
-                      (click)="edit('ChargeOffReasonExpense', chargeOffReasonToExpenseAccountMappings, i)"
-                    >
-                      <fa-icon icon="edit"></fa-icon>
-                    </button>
-                    <button
-                      mat-icon-button
-                      color="warn"
-                      (click)="delete('ChargeOffReasonExpense', chargeOffReasonToExpenseAccountMappings, i)"
-                    >
-                      <fa-icon icon="trash"></fa-icon>
-                    </button>
-                  </td>
-                </ng-container>
-                <tr mat-header-row *matHeaderRowDef="chargeOffReasonExpenseDisplayedColumns"></tr>
-                <tr mat-row *matRowDef="let row; columns: chargeOffReasonExpenseDisplayedColumns"></tr>
-              </table>
-            }
-            <mifosx-advanced-accounting-mapping-rule
-              class="flex-100 m-t-10"
-              [textField]="'Classification'"
-              [formType]="'BuydownFeeClassificationToIncome'"
-              [formArray]="buydownfeeClassificationToIncomeAccountMappings"
-              [textHeading]="'Buydown Fee classifications to Income accounts'"
-              [incomeAccountData]="incomeAccountData"
-              [accountingMappingOptions]="buydownFeeClassificationOptions"
-              (formChangeEvent)="formChangeEvent($event)"
-            ></mifosx-advanced-accounting-mapping-rule>
-            <mifosx-advanced-accounting-mapping-rule
-              class="flex-100 m-t-10"
-              [textField]="'Classification'"
-              [formType]="'CapitalizedIncomeClassificationToIncome'"
-              [formArray]="capitalizedIncomeClassificationToIncomeAccountMappings"
-              [textHeading]="'Capitalized Income classifications to Income accounts'"
-              [incomeAccountData]="incomeAccountData"
-              [accountingMappingOptions]="capitalizedIncomeClassificationOptions"
-              (formChangeEvent)="formChangeEvent($event)"
-            ></mifosx-advanced-accounting-mapping-rule>
-            <mifosx-advanced-accounting-mapping-rule
-              class="flex-100 m-t-10"
-              [textField]="'WriteOff Reason'"
-              [formType]="'WriteOffReasonToExpense'"
-              [formArray]="writeOffReasonsToExpenseMappings"
-              [textHeading]="'WriteOff reasons to Expense accounts'"
-              [expenseAccountData]="expenseAccountData"
-              [accountingMappingOptions]="writeOffReasonOptions"
-              (formChangeEvent)="formChangeEvent($event)"
-            ></mifosx-advanced-accounting-mapping-rule>
-          </div>
-        }
-      </div>
-    }
-  </div>
+        <mifosx-gl-account-selector
+          class="flex-48"
+          [inputFormControl]="loanProductAccountingForm.controls.deferredIncomeLiabilityAccountId"
+          [glAccountList]="liabilityAccountData"
+          [required]="true"
+          [inputLabel]="'Deferred income'"
+        >
+        </mifosx-gl-account-selector>
+      }
+    </div>
+  }
 
   <div class="layout-row align-center margin-t responsive-column gap-2percent">
     <button mat-raised-button matStepperPrevious>

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -44,6 +44,7 @@ import { FindPipe } from '../../../../pipes/find.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { AdvancedAccountingMappingRuleComponent } from './advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component';
 import { AccountingMappingDTO, AdvancedMappingDTO } from '../../models/loan-product.model';
+import { LoanProductBaseComponent } from '../../common/loan-product-base.component';
 
 @Component({
   selector: 'mifosx-loan-product-accounting-step',
@@ -74,7 +75,7 @@ import { AccountingMappingDTO, AdvancedMappingDTO } from '../../models/loan-prod
     AdvancedAccountingMappingRuleComponent
   ]
 })
-export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
+export class LoanProductAccountingStepComponent extends LoanProductBaseComponent implements OnInit, OnChanges {
   private formBuilder = inject(UntypedFormBuilder);
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
@@ -120,6 +121,7 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
   ];
 
   constructor() {
+    super();
     this.createLoanProductAccountingForm();
     this.setConditionalControls();
   }
@@ -132,346 +134,515 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
     this.chargeData = this.loanProductsTemplate.chargeOptions || [];
     this.penaltyData = this.loanProductsTemplate.penaltyOptions || [];
     this.paymentTypeData = this.loanProductsTemplate.paymentTypeOptions || [];
+
     this.assetAccountData = this.loanProductsTemplate.accountingMappingOptions.assetAccountOptions || [];
     this.incomeAccountData = this.loanProductsTemplate.accountingMappingOptions.incomeAccountOptions || [];
     this.expenseAccountData = this.loanProductsTemplate.accountingMappingOptions.expenseAccountOptions || [];
     this.liabilityAccountData = this.loanProductsTemplate.accountingMappingOptions.liabilityAccountOptions || [];
     this.incomeAndLiabilityAccountData = this.incomeAccountData.concat(this.liabilityAccountData);
     this.assetAndLiabilityAccountData =
-      this.loanProductsTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions || [];
+      this.loanProductsTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions ||
+      this.assetAccountData.concat(this.liabilityAccountData);
+
     this.chargeOffReasonOptions = this.loanProductsTemplate.chargeOffReasonOptions || [];
-    this.capitalizedIncomeClassificationOptions =
-      this.loanProductsTemplate.capitalizedIncomeClassificationOptions || [];
-    this.buydownFeeClassificationOptions = this.loanProductsTemplate.buydownFeeClassificationOptions || [];
     this.writeOffReasonOptions = this.loanProductsTemplate.writeOffReasonOptions || [];
 
+    if (this.loanProductService.isLoanProduct) {
+      this.capitalizedIncomeClassificationOptions =
+        this.loanProductsTemplate.capitalizedIncomeClassificationOptions || [];
+      this.buydownFeeClassificationOptions = this.loanProductsTemplate.buydownFeeClassificationOptions || [];
+    }
+
+    const accountingRuleId = this.loanProductService.isLoanProduct
+      ? this.loanProductsTemplate.accountingRule?.id
+      : (this.loanProductsTemplate.accountingRule?.id ??
+        this.loanProductsTemplate.accountingRule ??
+        this.loanProductsTemplate.accountingRuleOptions?.[0]?.id ??
+        'NONE');
+
     this.loanProductAccountingForm.patchValue({
-      accountingRule: this.loanProductsTemplate.accountingRule.id
+      accountingRule: accountingRuleId
     });
 
-    const accountingMappings = this.loanProductsTemplate.accountingMappings;
+    const accountingMappings = this.loanProductService.isLoanProduct
+      ? this.loanProductsTemplate.accountingMappings
+      : this.loanProductsTemplate.accountingMappings || this.loanProductsTemplate.accountingMappingOptions;
+
     this.setDeferredIncomeRecognitionControls();
-    switch (this.loanProductsTemplate.accountingRule.id) {
-      case 3:
-      case 4:
-        this.loanProductAccountingForm.patchValue({
-          receivableInterestAccountId: accountingMappings.receivableInterestAccount.id,
-          receivableFeeAccountId: accountingMappings.receivableFeeAccount.id,
-          receivablePenaltyAccountId: accountingMappings.receivablePenaltyAccount.id
-        });
-        this.loanProductAccountingForm.patchValue({
-          enableAccrualActivityPosting: this.loanProductsTemplate.enableAccrualActivityPosting
-        });
-        if (this.deferredIncomeRecognition) {
-          if (this.deferredIncomeRecognition.capitalizedIncome?.enableIncomeCapitalization) {
-            this.loanProductAccountingForm.patchValue({
-              deferredIncomeLiabilityAccountId: accountingMappings.deferredIncomeLiabilityAccount.id,
-              incomeFromCapitalizationAccountId: accountingMappings.incomeFromCapitalizationAccount.id
-            });
-          }
-          if (this.deferredIncomeRecognition.buyDownFee?.enableBuyDownFee) {
-            this.loanProductAccountingForm.patchValue({
-              deferredIncomeLiabilityAccountId: accountingMappings.deferredIncomeLiabilityAccount.id,
-              incomeFromBuyDownAccountId: accountingMappings.incomeFromBuyDownAccount.id
-            });
-            if (this.deferredIncomeRecognition.buyDownFee?.merchantBuyDownFee) {
+    if (this.loanProductService.isLoanProduct) {
+      switch (accountingRuleId) {
+        case 3:
+        case 4:
+          this.loanProductAccountingForm.patchValue({
+            receivableInterestAccountId: accountingMappings.receivableInterestAccount.id,
+            receivableFeeAccountId: accountingMappings.receivableFeeAccount.id,
+            receivablePenaltyAccountId: accountingMappings.receivablePenaltyAccount.id
+          });
+          this.loanProductAccountingForm.patchValue({
+            enableAccrualActivityPosting: this.loanProductsTemplate.enableAccrualActivityPosting
+          });
+          if (this.deferredIncomeRecognition) {
+            if (this.deferredIncomeRecognition.capitalizedIncome?.enableIncomeCapitalization) {
               this.loanProductAccountingForm.patchValue({
-                buyDownExpenseAccountId: accountingMappings.buyDownExpenseAccount?.id
+                deferredIncomeLiabilityAccountId: accountingMappings.deferredIncomeLiabilityAccount.id,
+                incomeFromCapitalizationAccountId: accountingMappings.incomeFromCapitalizationAccount.id
               });
             }
+            if (this.deferredIncomeRecognition.buyDownFee?.enableBuyDownFee) {
+              this.loanProductAccountingForm.patchValue({
+                deferredIncomeLiabilityAccountId: accountingMappings.deferredIncomeLiabilityAccount.id,
+                incomeFromBuyDownAccountId: accountingMappings.incomeFromBuyDownAccount.id
+              });
+              if (this.deferredIncomeRecognition.buyDownFee?.merchantBuyDownFee) {
+                this.loanProductAccountingForm.patchValue({
+                  buyDownExpenseAccountId: accountingMappings.buyDownExpenseAccount?.id
+                });
+              }
+            }
           }
-        }
-      /* falls through */
-      case 2:
-        this.loanProductAccountingForm.patchValue({
-          fundSourceAccountId: accountingMappings.fundSourceAccount.id,
-          loanPortfolioAccountId: accountingMappings.loanPortfolioAccount.id,
-          transfersInSuspenseAccountId: accountingMappings.transfersInSuspenseAccount.id,
-          interestOnLoanAccountId: accountingMappings.interestOnLoanAccount.id,
-          incomeFromFeeAccountId: accountingMappings.incomeFromFeeAccount.id,
-          incomeFromPenaltyAccountId: accountingMappings.incomeFromPenaltyAccount.id,
-          incomeFromRecoveryAccountId: accountingMappings.incomeFromRecoveryAccount.id,
-          writeOffAccountId: accountingMappings.writeOffAccount.id,
-          goodwillCreditAccountId: accountingMappings.goodwillCreditAccount?.id || null,
-          overpaymentLiabilityAccountId: accountingMappings.overpaymentLiabilityAccount.id,
-          chargeOffFraudExpenseAccountId: accountingMappings.chargeOffFraudExpenseAccount
-            ? accountingMappings.chargeOffFraudExpenseAccount.id
-            : '',
-          chargeOffExpenseAccountId: accountingMappings.chargeOffExpenseAccount
-            ? accountingMappings.chargeOffExpenseAccount.id
-            : '',
-          incomeFromChargeOffPenaltyAccountId: accountingMappings.incomeFromChargeOffPenaltyAccount
-            ? accountingMappings.incomeFromChargeOffPenaltyAccount.id
-            : '',
-          incomeFromChargeOffFeesAccountId: accountingMappings.incomeFromChargeOffFeesAccount
-            ? accountingMappings.incomeFromChargeOffFeesAccount.id
-            : '',
-          incomeFromChargeOffInterestAccountId: accountingMappings.incomeFromChargeOffInterestAccount
-            ? accountingMappings.incomeFromChargeOffInterestAccount.id
-            : '',
-          incomeFromGoodwillCreditInterestAccountId: accountingMappings.incomeFromGoodwillCreditInterestAccount
-            ? accountingMappings.incomeFromGoodwillCreditInterestAccount.id
-            : '',
-          incomeFromGoodwillCreditFeesAccountId: accountingMappings.incomeFromGoodwillCreditFeesAccount
-            ? accountingMappings.incomeFromGoodwillCreditFeesAccount.id
-            : '',
-          incomeFromGoodwillCreditPenaltyAccountId: accountingMappings.incomeFromGoodwillCreditPenaltyAccount
-            ? accountingMappings.incomeFromGoodwillCreditPenaltyAccount.id
-            : '',
-          advancedAccountingRules:
-            this.loanProductsTemplate.paymentChannelToFundSourceMappings ||
-            this.loanProductsTemplate.feeToIncomeAccountMappings ||
-            this.loanProductsTemplate.penaltyToIncomeAccountMappings ||
-            this.loanProductsTemplate.chargeOffReasonToExpenseAccountMappings ||
-            this.loanProductsTemplate.buydownFeeClassificationToIncomeAccountMappings ||
-            this.loanProductsTemplate.capitalizedIncomeClassificationToIncomeAccountMappings ||
-            this.loanProductsTemplate.writeOffReasonsToExpenseMappings
-              ? true
-              : false
-        });
+        /* falls through */
+        case 2:
+          this.loanProductAccountingForm.patchValue({
+            fundSourceAccountId: accountingMappings.fundSourceAccount.id,
+            loanPortfolioAccountId: accountingMappings.loanPortfolioAccount.id,
+            transfersInSuspenseAccountId: accountingMappings.transfersInSuspenseAccount.id,
+            interestOnLoanAccountId: accountingMappings.interestOnLoanAccount.id,
+            incomeFromFeeAccountId: accountingMappings.incomeFromFeeAccount.id,
+            incomeFromPenaltyAccountId: accountingMappings.incomeFromPenaltyAccount.id,
+            incomeFromRecoveryAccountId: accountingMappings.incomeFromRecoveryAccount.id,
+            writeOffAccountId: accountingMappings.writeOffAccount.id,
+            goodwillCreditAccountId: accountingMappings.goodwillCreditAccount?.id || null,
+            overpaymentLiabilityAccountId: accountingMappings.overpaymentLiabilityAccount.id,
+            chargeOffFraudExpenseAccountId: accountingMappings.chargeOffFraudExpenseAccount
+              ? accountingMappings.chargeOffFraudExpenseAccount.id
+              : '',
+            chargeOffExpenseAccountId: accountingMappings.chargeOffExpenseAccount
+              ? accountingMappings.chargeOffExpenseAccount.id
+              : '',
+            incomeFromChargeOffPenaltyAccountId: accountingMappings.incomeFromChargeOffPenaltyAccount
+              ? accountingMappings.incomeFromChargeOffPenaltyAccount.id
+              : '',
+            incomeFromChargeOffFeesAccountId: accountingMappings.incomeFromChargeOffFeesAccount
+              ? accountingMappings.incomeFromChargeOffFeesAccount.id
+              : '',
+            incomeFromChargeOffInterestAccountId: accountingMappings.incomeFromChargeOffInterestAccount
+              ? accountingMappings.incomeFromChargeOffInterestAccount.id
+              : '',
+            incomeFromGoodwillCreditInterestAccountId: accountingMappings.incomeFromGoodwillCreditInterestAccount
+              ? accountingMappings.incomeFromGoodwillCreditInterestAccount.id
+              : '',
+            incomeFromGoodwillCreditFeesAccountId: accountingMappings.incomeFromGoodwillCreditFeesAccount
+              ? accountingMappings.incomeFromGoodwillCreditFeesAccount.id
+              : '',
+            incomeFromGoodwillCreditPenaltyAccountId: accountingMappings.incomeFromGoodwillCreditPenaltyAccount
+              ? accountingMappings.incomeFromGoodwillCreditPenaltyAccount.id
+              : '',
+            advancedAccountingRules:
+              (this.loanProductsTemplate.paymentChannelToFundSourceMappings?.length ?? 0) > 0 ||
+              (this.loanProductsTemplate.feeToIncomeAccountMappings?.length ?? 0) > 0 ||
+              (this.loanProductsTemplate.penaltyToIncomeAccountMappings?.length ?? 0) > 0 ||
+              (this.loanProductsTemplate.chargeOffReasonToExpenseAccountMappings?.length ?? 0) > 0 ||
+              (this.loanProductsTemplate.buydownFeeClassificationToIncomeAccountMappings?.length ?? 0) > 0 ||
+              (this.loanProductsTemplate.capitalizedIncomeClassificationToIncomeAccountMappings?.length ?? 0) > 0 ||
+              (this.loanProductsTemplate.writeOffReasonsToExpenseMappings?.length ?? 0) > 0
+                ? true
+                : false
+          });
 
-        this.loanProductAccountingForm.setControl(
-          'paymentChannelToFundSourceMappings',
-          this.formBuilder.array(
-            (this.loanProductsTemplate.paymentChannelToFundSourceMappings || []).map((paymentFundSource: any) => ({
-              paymentTypeId: paymentFundSource.paymentType.id,
-              fundSourceAccountId: paymentFundSource.fundSourceAccount.id
-            }))
-          )
-        );
-        this.loanProductAccountingForm.setControl(
-          'feeToIncomeAccountMappings',
-          this.formBuilder.array(
-            (this.loanProductsTemplate.feeToIncomeAccountMappings || []).map((feesIncome: any) => ({
-              chargeId: feesIncome.charge.id,
-              incomeAccountId: feesIncome.incomeAccount.id
-            }))
-          )
-        );
-        this.loanProductAccountingForm.setControl(
-          'penaltyToIncomeAccountMappings',
-          this.formBuilder.array(
-            (this.loanProductsTemplate.penaltyToIncomeAccountMappings || []).map((penaltyIncome: any) => ({
-              chargeId: penaltyIncome.charge.id,
-              incomeAccountId: penaltyIncome.incomeAccount.id
-            }))
-          )
-        );
-        this.loanProductAccountingForm.setControl(
-          'chargeOffReasonToExpenseAccountMappings',
-          this.formBuilder.array(
-            (this.loanProductsTemplate.chargeOffReasonToExpenseAccountMappings || []).map(
-              (m: ChargeOffReasonToExpenseAccountMapping) => ({
-                chargeOffReasonCodeValueId: m.reasonCodeValue.id,
-                expenseAccountId: m.expenseAccount.id
-              })
+          this.loanProductAccountingForm.setControl(
+            'paymentChannelToFundSourceMappings',
+            this.formBuilder.array(
+              (this.loanProductsTemplate.paymentChannelToFundSourceMappings || []).map((paymentFundSource: any) => ({
+                paymentTypeId: paymentFundSource.paymentType.id,
+                fundSourceAccountId: paymentFundSource.fundSourceAccount.id
+              }))
             )
-          )
-        );
-        this.loanProductAccountingForm.setControl(
-          'buydownfeeClassificationToIncomeAccountMappings',
-          this.formBuilder.array(
-            (this.loanProductsTemplate.buydownFeeClassificationToIncomeAccountMappings || []).map(
-              (m: ClassificationToIncomeAccountMapping) => ({
-                value: m.classificationCodeValue,
-                glAccount: m.incomeAccount
-              })
+          );
+          this.loanProductAccountingForm.setControl(
+            'feeToIncomeAccountMappings',
+            this.formBuilder.array(
+              (this.loanProductsTemplate.feeToIncomeAccountMappings || []).map((feesIncome: any) => ({
+                chargeId: feesIncome.charge.id,
+                incomeAccountId: feesIncome.incomeAccount.id
+              }))
             )
-          )
-        );
-        this.loanProductAccountingForm.setControl(
-          'capitalizedIncomeClassificationToIncomeAccountMappings',
-          this.formBuilder.array(
-            (this.loanProductsTemplate.capitalizedIncomeClassificationToIncomeAccountMappings || []).map(
-              (m: ClassificationToIncomeAccountMapping) => ({
-                value: m.classificationCodeValue,
-                glAccount: m.incomeAccount
-              })
+          );
+          this.loanProductAccountingForm.setControl(
+            'penaltyToIncomeAccountMappings',
+            this.formBuilder.array(
+              (this.loanProductsTemplate.penaltyToIncomeAccountMappings || []).map((penaltyIncome: any) => ({
+                chargeId: penaltyIncome.charge.id,
+                incomeAccountId: penaltyIncome.incomeAccount.id
+              }))
             )
-          )
-        );
-        this.loanProductAccountingForm.setControl(
-          'writeOffReasonsToExpenseMappings',
-          this.formBuilder.array(
-            (this.loanProductsTemplate.writeOffReasonsToExpenseMappings || []).map(
-              (m: ChargeOffReasonToExpenseAccountMapping) => ({
-                value: m.reasonCodeValue,
-                glAccount: m.expenseAccount
-              })
+          );
+          this.loanProductAccountingForm.setControl(
+            'chargeOffReasonToExpenseAccountMappings',
+            this.formBuilder.array(
+              (this.loanProductsTemplate.chargeOffReasonToExpenseAccountMappings || []).map(
+                (m: ChargeOffReasonToExpenseAccountMapping) => ({
+                  chargeOffReasonCodeValueId: m.reasonCodeValue.id,
+                  expenseAccountId: m.expenseAccount.id
+                })
+              )
             )
-          )
-        );
+          );
+          this.loanProductAccountingForm.setControl(
+            'buydownfeeClassificationToIncomeAccountMappings',
+            this.formBuilder.array(
+              (this.loanProductsTemplate.buydownFeeClassificationToIncomeAccountMappings || []).map(
+                (m: ClassificationToIncomeAccountMapping) => ({
+                  value: m.classificationCodeValue,
+                  glAccount: m.incomeAccount
+                })
+              )
+            )
+          );
+          this.loanProductAccountingForm.setControl(
+            'capitalizedIncomeClassificationToIncomeAccountMappings',
+            this.formBuilder.array(
+              (this.loanProductsTemplate.capitalizedIncomeClassificationToIncomeAccountMappings || []).map(
+                (m: ClassificationToIncomeAccountMapping) => ({
+                  value: m.classificationCodeValue,
+                  glAccount: m.incomeAccount
+                })
+              )
+            )
+          );
+          this.loanProductAccountingForm.setControl(
+            'writeOffReasonsToExpenseMappings',
+            this.formBuilder.array(
+              (this.loanProductsTemplate.writeOffReasonsToExpenseMappings || []).map(
+                (m: ChargeOffReasonToExpenseAccountMapping) => ({
+                  value: m.reasonCodeValue,
+                  glAccount: m.expenseAccount
+                })
+              )
+            )
+          );
+      }
+    } else if (this.loanProductService.isWorkingCapital) {
+      switch (accountingRuleId) {
+        case 'CASH_BASED':
+          this.loanProductAccountingForm.patchValue({
+            fundSourceAccountId: accountingMappings.fundSourceAccount.id,
+            loanPortfolioAccountId: accountingMappings.loanPortfolioAccount.id,
+            transfersInSuspenseAccountId: accountingMappings.transfersInSuspenseAccount.id,
+            incomeFromDiscountFeeAccountId: accountingMappings.incomeFromDiscountFeeAccount.id,
+            incomeFromFeeAccountId: accountingMappings.incomeFromFeeAccount.id,
+            incomeFromPenaltyAccountId: accountingMappings.incomeFromPenaltyAccount.id,
+            incomeFromRecoveryAccountId: accountingMappings.incomeFromRecoveryAccount.id,
+            incomeFromChargeOffPenaltyAccountId: accountingMappings.incomeFromChargeOffPenaltyAccount
+              ? accountingMappings.incomeFromChargeOffPenaltyAccount.id
+              : '',
+            incomeFromChargeOffFeesAccountId: accountingMappings.incomeFromChargeOffFeesAccount
+              ? accountingMappings.incomeFromChargeOffFeesAccount.id
+              : '',
+            incomeFromChargeOffInterestAccountId: accountingMappings.incomeFromChargeOffInterestAccount
+              ? accountingMappings.incomeFromChargeOffInterestAccount.id
+              : '',
+            incomeFromGoodwillCreditInterestAccountId: accountingMappings.incomeFromGoodwillCreditInterestAccount
+              ? accountingMappings.incomeFromGoodwillCreditInterestAccount.id
+              : '',
+            incomeFromGoodwillCreditFeesAccountId: accountingMappings.incomeFromGoodwillCreditFeesAccount
+              ? accountingMappings.incomeFromGoodwillCreditFeesAccount.id
+              : '',
+            incomeFromGoodwillCreditPenaltyAccountId: accountingMappings.incomeFromGoodwillCreditPenaltyAccount
+              ? accountingMappings.incomeFromGoodwillCreditPenaltyAccount.id
+              : '',
+            writeOffAccountId: accountingMappings.writeOffAccount.id,
+            goodwillCreditAccountId: accountingMappings.goodwillCreditAccount?.id || null,
+            chargeOffFraudExpenseAccountId: accountingMappings.chargeOffFraudExpenseAccount
+              ? accountingMappings.chargeOffFraudExpenseAccount.id
+              : '',
+            chargeOffExpenseAccountId: accountingMappings.chargeOffExpenseAccount
+              ? accountingMappings.chargeOffExpenseAccount.id
+              : '',
+            overpaymentLiabilityAccountId: accountingMappings.overpaymentLiabilityAccount.id,
+            deferredIncomeLiabilityAccountId: accountingMappings.deferredIncomeLiabilityAccount.id
+          });
+          break;
+      }
     }
   }
 
   createLoanProductAccountingForm() {
-    this.loanProductAccountingForm = this.formBuilder.group({
-      accountingRule: [1]
-    });
+    if (this.loanProductService.isLoanProduct) {
+      this.loanProductAccountingForm = this.formBuilder.group({
+        accountingRule: [1]
+      });
+    } else if (this.loanProductService.isWorkingCapital) {
+      this.loanProductAccountingForm = this.formBuilder.group({
+        accountingRule: 'NONE'
+      });
+    }
   }
 
   setConditionalControls() {
-    this.loanProductAccountingForm.get('accountingRule').valueChanges.subscribe((accountingRule: any) => {
-      if (accountingRule >= 2 && accountingRule <= 4) {
-        this.loanProductAccountingForm.addControl(
-          'fundSourceAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'loanPortfolioAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'transfersInSuspenseAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'interestOnLoanAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'incomeFromFeeAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'incomeFromPenaltyAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'incomeFromRecoveryAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl('writeOffAccountId', new UntypedFormControl('', Validators.required));
-        this.loanProductAccountingForm.addControl(
-          'goodwillCreditAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'overpaymentLiabilityAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl('advancedAccountingRules', new UntypedFormControl(false));
-        this.loanProductAccountingForm.addControl(
-          'chargeOffFraudExpenseAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'chargeOffExpenseAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'incomeFromChargeOffPenaltyAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'incomeFromChargeOffFeesAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'incomeFromChargeOffInterestAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'incomeFromGoodwillCreditInterestAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'incomeFromGoodwillCreditFeesAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'incomeFromGoodwillCreditPenaltyAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
+    if (this.loanProductService.isLoanProduct) {
+      this.loanProductAccountingForm.get('accountingRule').valueChanges.subscribe((accountingRule: any) => {
+        if (accountingRule >= 2 && accountingRule <= 4) {
+          this.loanProductAccountingForm.addControl(
+            'fundSourceAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'loanPortfolioAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'transfersInSuspenseAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'interestOnLoanAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromFeeAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromPenaltyAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromRecoveryAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'writeOffAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'goodwillCreditAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'overpaymentLiabilityAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl('advancedAccountingRules', new UntypedFormControl(false));
+          this.loanProductAccountingForm.addControl(
+            'chargeOffFraudExpenseAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'chargeOffExpenseAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromChargeOffPenaltyAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromChargeOffFeesAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromChargeOffInterestAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromGoodwillCreditInterestAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromGoodwillCreditFeesAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromGoodwillCreditPenaltyAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
 
-        this.loanProductAccountingForm
-          .get('advancedAccountingRules')
-          .valueChanges.subscribe((advancedAccountingRules: boolean) => {
-            if (advancedAccountingRules) {
-              this.loanProductAccountingForm.addControl(
-                'paymentChannelToFundSourceMappings',
-                this.formBuilder.array([])
-              );
-              this.loanProductAccountingForm.addControl('feeToIncomeAccountMappings', this.formBuilder.array([]));
-              this.loanProductAccountingForm.addControl('penaltyToIncomeAccountMappings', this.formBuilder.array([]));
-              this.loanProductAccountingForm.addControl(
-                'chargeOffReasonToExpenseAccountMappings',
-                this.formBuilder.array([])
-              );
-              this.loanProductAccountingForm.addControl(
-                'buydownfeeClassificationToIncomeAccountMappings',
-                this.formBuilder.array([])
-              );
-              this.loanProductAccountingForm.addControl(
-                'capitalizedIncomeClassificationToIncomeAccountMappings',
-                this.formBuilder.array([])
-              );
-              this.loanProductAccountingForm.addControl('writeOffReasonsToExpenseMappings', this.formBuilder.array([]));
-            } else {
-              this.loanProductAccountingForm.setControl(
-                'paymentChannelToFundSourceMappings',
-                this.formBuilder.array([])
-              );
-              this.loanProductAccountingForm.setControl('feeToIncomeAccountMappings', this.formBuilder.array([]));
-              this.loanProductAccountingForm.setControl('penaltyToIncomeAccountMappings', this.formBuilder.array([]));
-              this.loanProductAccountingForm.setControl(
-                'chargeOffReasonToExpenseAccountMappings',
-                this.formBuilder.array([])
-              );
-              this.loanProductAccountingForm.setControl(
-                'buydownfeeClassificationToIncomeAccountMappings',
-                this.formBuilder.array([])
-              );
-              this.loanProductAccountingForm.setControl(
-                'capitalizedIncomeClassificationToIncomeAccountMappings',
-                this.formBuilder.array([])
-              );
-              this.loanProductAccountingForm.setControl('writeOffReasonsToExpenseMappings', this.formBuilder.array([]));
-            }
-          });
-      } else {
-        this.loanProductAccountingForm.removeControl('fundSourceAccountId');
-        this.loanProductAccountingForm.removeControl('loanPortfolioAccountId');
-        this.loanProductAccountingForm.removeControl('transfersInSuspenseAccountId');
-        this.loanProductAccountingForm.removeControl('interestOnLoanAccountId');
-        this.loanProductAccountingForm.removeControl('incomeFromFeeAccountId');
-        this.loanProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
-        this.loanProductAccountingForm.removeControl('incomeFromRecoveryAccountId');
-        this.loanProductAccountingForm.removeControl('writeOffAccountId');
-        this.loanProductAccountingForm.removeControl('goodwillCreditAccountId');
-        this.loanProductAccountingForm.removeControl('overpaymentLiabilityAccountId');
-        this.loanProductAccountingForm.removeControl('advancedAccountingRules');
-        this.loanProductAccountingForm.removeControl('chargeOffExpenseAccountId');
-        this.loanProductAccountingForm.removeControl('chargeOffFraudExpenseAccountId');
-        this.loanProductAccountingForm.removeControl('incomeFromChargeOffPenaltyAccountId');
-        this.loanProductAccountingForm.removeControl('incomeFromChargeOffFeesAccountId');
-        this.loanProductAccountingForm.removeControl('incomeFromChargeOffInterestAccountId');
-        this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditInterestAccountId');
-        this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditFeesAccountId');
-        this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditPenaltyAccountId');
-      }
+          this.loanProductAccountingForm
+            .get('advancedAccountingRules')
+            .valueChanges.subscribe((advancedAccountingRules: boolean) => {
+              if (advancedAccountingRules) {
+                this.loanProductAccountingForm.addControl(
+                  'paymentChannelToFundSourceMappings',
+                  this.formBuilder.array([])
+                );
+                this.loanProductAccountingForm.addControl('feeToIncomeAccountMappings', this.formBuilder.array([]));
+                this.loanProductAccountingForm.addControl('penaltyToIncomeAccountMappings', this.formBuilder.array([]));
+                this.loanProductAccountingForm.addControl(
+                  'chargeOffReasonToExpenseAccountMappings',
+                  this.formBuilder.array([])
+                );
+                this.loanProductAccountingForm.addControl(
+                  'buydownfeeClassificationToIncomeAccountMappings',
+                  this.formBuilder.array([])
+                );
+                this.loanProductAccountingForm.addControl(
+                  'capitalizedIncomeClassificationToIncomeAccountMappings',
+                  this.formBuilder.array([])
+                );
+                this.loanProductAccountingForm.addControl(
+                  'writeOffReasonsToExpenseMappings',
+                  this.formBuilder.array([])
+                );
+              } else {
+                this.loanProductAccountingForm.setControl(
+                  'paymentChannelToFundSourceMappings',
+                  this.formBuilder.array([])
+                );
+                this.loanProductAccountingForm.setControl('feeToIncomeAccountMappings', this.formBuilder.array([]));
+                this.loanProductAccountingForm.setControl('penaltyToIncomeAccountMappings', this.formBuilder.array([]));
+                this.loanProductAccountingForm.setControl(
+                  'chargeOffReasonToExpenseAccountMappings',
+                  this.formBuilder.array([])
+                );
+                this.loanProductAccountingForm.setControl(
+                  'buydownfeeClassificationToIncomeAccountMappings',
+                  this.formBuilder.array([])
+                );
+                this.loanProductAccountingForm.setControl(
+                  'capitalizedIncomeClassificationToIncomeAccountMappings',
+                  this.formBuilder.array([])
+                );
+                this.loanProductAccountingForm.setControl(
+                  'writeOffReasonsToExpenseMappings',
+                  this.formBuilder.array([])
+                );
+              }
+            });
+        } else {
+          this.loanProductAccountingForm.removeControl('fundSourceAccountId');
+          this.loanProductAccountingForm.removeControl('loanPortfolioAccountId');
+          this.loanProductAccountingForm.removeControl('transfersInSuspenseAccountId');
+          this.loanProductAccountingForm.removeControl('interestOnLoanAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromFeeAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromRecoveryAccountId');
+          this.loanProductAccountingForm.removeControl('writeOffAccountId');
+          this.loanProductAccountingForm.removeControl('goodwillCreditAccountId');
+          this.loanProductAccountingForm.removeControl('overpaymentLiabilityAccountId');
+          this.loanProductAccountingForm.removeControl('advancedAccountingRules');
+          this.loanProductAccountingForm.removeControl('chargeOffExpenseAccountId');
+          this.loanProductAccountingForm.removeControl('chargeOffFraudExpenseAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromChargeOffPenaltyAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromChargeOffFeesAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromChargeOffInterestAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditInterestAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditFeesAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditPenaltyAccountId');
+        }
 
-      if (accountingRule === 3 || accountingRule === 4) {
-        this.loanProductAccountingForm.addControl(
-          'receivableInterestAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'receivableFeeAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl(
-          'receivablePenaltyAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.loanProductAccountingForm.addControl('enableAccrualActivityPosting', new UntypedFormControl(false));
-      } else {
-        this.loanProductAccountingForm.removeControl('receivableInterestAccountId');
-        this.loanProductAccountingForm.removeControl('receivableFeeAccountId');
-        this.loanProductAccountingForm.removeControl('receivablePenaltyAccountId');
-        this.loanProductAccountingForm.removeControl('enableAccrualActivityPosting');
-      }
-    });
+        if (accountingRule === 3 || accountingRule === 4) {
+          this.loanProductAccountingForm.addControl(
+            'receivableInterestAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'receivableFeeAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'receivablePenaltyAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl('enableAccrualActivityPosting', new UntypedFormControl(false));
+        } else {
+          this.loanProductAccountingForm.removeControl('receivableInterestAccountId');
+          this.loanProductAccountingForm.removeControl('receivableFeeAccountId');
+          this.loanProductAccountingForm.removeControl('receivablePenaltyAccountId');
+          this.loanProductAccountingForm.removeControl('enableAccrualActivityPosting');
+        }
+      });
+    } else if (this.loanProductService.isWorkingCapital) {
+      this.loanProductAccountingForm.get('accountingRule').valueChanges.subscribe((accountingRule: any) => {
+        if (accountingRule === 'NONE') {
+          this.loanProductAccountingForm.removeControl('fundSourceAccountId');
+          this.loanProductAccountingForm.removeControl('loanPortfolioAccountId');
+          this.loanProductAccountingForm.removeControl('transfersInSuspenseAccountId');
+
+          this.loanProductAccountingForm.removeControl('incomeFromDiscountFeeAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromFeeAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromRecoveryAccountId');
+
+          this.loanProductAccountingForm.removeControl('incomeFromChargeOffInterestAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromChargeOffFeesAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromChargeOffPenaltyAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditInterestAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditFeesAccountId');
+          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditPenaltyAccountId');
+
+          this.loanProductAccountingForm.removeControl('writeOffAccountId');
+          this.loanProductAccountingForm.removeControl('goodwillCreditAccountId');
+          this.loanProductAccountingForm.removeControl('chargeOffExpenseAccountId');
+          this.loanProductAccountingForm.removeControl('chargeOffFraudExpenseAccountId');
+
+          this.loanProductAccountingForm.removeControl('overpaymentLiabilityAccountId');
+          this.loanProductAccountingForm.removeControl('deferredIncomeLiabilityAccountId');
+
+          // this.loanProductAccountingForm.removeControl('advancedAccountingRules');
+        } else if (accountingRule === 'CASH_BASED') {
+          this.loanProductAccountingForm.addControl(
+            'fundSourceAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'loanPortfolioAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'transfersInSuspenseAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromDiscountFeeAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromFeeAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromPenaltyAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromRecoveryAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl('incomeFromChargeOffInterestAccountId', new UntypedFormControl(''));
+          this.loanProductAccountingForm.addControl('incomeFromChargeOffFeesAccountId', new UntypedFormControl(''));
+          this.loanProductAccountingForm.addControl('incomeFromChargeOffPenaltyAccountId', new UntypedFormControl(''));
+          this.loanProductAccountingForm.addControl(
+            'incomeFromGoodwillCreditInterestAccountId',
+            new UntypedFormControl('')
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromGoodwillCreditFeesAccountId',
+            new UntypedFormControl('')
+          );
+          this.loanProductAccountingForm.addControl(
+            'incomeFromGoodwillCreditPenaltyAccountId',
+            new UntypedFormControl('')
+          );
+
+          this.loanProductAccountingForm.addControl(
+            'writeOffAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl('goodwillCreditAccountId', new UntypedFormControl(''));
+          this.loanProductAccountingForm.addControl('chargeOffFraudExpenseAccountId', new UntypedFormControl(''));
+          this.loanProductAccountingForm.addControl('chargeOffExpenseAccountId', new UntypedFormControl(''));
+
+          this.loanProductAccountingForm.addControl(
+            'overpaymentLiabilityAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          this.loanProductAccountingForm.addControl(
+            'deferredIncomeLiabilityAccountId',
+            new UntypedFormControl('', Validators.required)
+          );
+          // this.loanProductAccountingForm.addControl('advancedAccountingRules', new UntypedFormControl(false));
+        }
+      });
+    }
   }
 
   get paymentChannelToFundSourceMappings(): UntypedFormArray {
@@ -671,13 +842,16 @@ export class LoanProductAccountingStepComponent implements OnInit, OnChanges {
     return formfields;
   }
 
-  get isAccountingAccrualBased() {
+  get isAccountingAccrualBased(): boolean {
     const accountingRule = this.loanProductAccountingForm.value.accountingRule;
-    return accountingRule === 3 || accountingRule === 4;
+    if (this.loanProductService.isLoanProduct) {
+      return accountingRule === 3 || accountingRule === 4;
+    }
+    return false;
   }
 
   get loanProductAccounting() {
-    return this.loanProductAccountingForm.value;
+    return this.loanProductAccountingForm.getRawValue();
   }
 
   setDeferredIncomeRecognitionControls() {

--- a/src/app/products/loan-products/models/loan-product.model.ts
+++ b/src/app/products/loan-products/models/loan-product.model.ts
@@ -172,8 +172,11 @@ export interface LoanProduct {
   receivableFeeAccountId?: number;
   receivablePenaltyAccountId?: number;
   transfersInSuspenseAccountId?: number;
+  incomeFromDiscountFeeAccountId?: number;
   writeOffAccountId?: number;
   deferredIncomeLiabilityAccountId?: number;
+  chargeOffExpenseAccountId?: number;
+  chargeOffFraudExpenseAccountId?: number;
   // Advanced Accounting
   paymentChannelToFundSourceMappings?: PaymentChannelToFundSourceMapping[];
   feeToIncomeAccountMappings?: ChargeToIncomeAccountMapping[];

--- a/src/app/shared/accounting/gl-account-selector/gl-account-selector.component.html
+++ b/src/app/shared/accounting/gl-account-selector/gl-account-selector.component.html
@@ -30,6 +30,15 @@
           <strong>{{ 'labels.commons.required' | translate }}</strong>
         </mat-error>
       }
+      <button
+        type="button"
+        matSuffix
+        mat-icon-button
+        [attr.aria-label]="'labels.buttons.Clear' | translate"
+        (click)="resetValue($event)"
+      >
+        <fa-icon icon="close" size="md"></fa-icon>
+      </button>
     </mat-form-field>
   }
 
@@ -51,6 +60,15 @@
           </mat-option>
         }
       </mat-select>
+      <button
+        type="button"
+        matSuffix
+        mat-icon-button
+        [attr.aria-label]="'labels.buttons.Clear' | translate"
+        (click)="resetValue($event)"
+      >
+        <fa-icon icon="close" size="md"></fa-icon>
+      </button>
     </mat-form-field>
   }
 </div>

--- a/src/app/shared/accounting/gl-account-selector/gl-account-selector.component.ts
+++ b/src/app/shared/accounting/gl-account-selector/gl-account-selector.component.ts
@@ -15,6 +15,8 @@ import { takeUntil } from 'rxjs/operators';
 import { AsyncPipe } from '@angular/common';
 import { NgxMatSelectSearchModule } from 'ngx-mat-select-search';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { MatIconButton } from '@angular/material/button';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
 @Component({
   selector: 'mifosx-gl-account-selector',
@@ -23,6 +25,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
     NgxMatSelectSearchModule,
+    MatIconButton,
+    FaIconComponent,
     AsyncPipe
   ]
 })
@@ -81,5 +85,13 @@ export class GlAccountSelectorComponent implements OnInit, OnChanges, OnDestroy 
         );
       }
     }
+  }
+
+  resetValue($event: Event): void {
+    $event.stopPropagation();
+    this.inputFormControl.setValue(null);
+    this.inputFormControl.markAsDirty();
+    this.inputFormControl.markAsTouched();
+    this.inputFormControl.updateValueAndValidity();
   }
 }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -471,6 +471,7 @@
     "accounting": {
       "Accrual (periodic)": "Akruální (periodické)",
       "Accrual (upfront)": "Akruální (předem)",
+      "CASH_BASED": "Hotovost",
       "Cash": "Hotovost",
       "NONE": "Žádný",
       "financialActivity": {
@@ -2133,6 +2134,7 @@
       "Incentive Type": "Typ pobídky",
       "Include in Customer Loan Counter": "Zahrnout do přepážky zákaznických půjček",
       "Income Account": "Příjmový účet",
+      "Income From Discount Fee": "Výnosy z diskontního poplatku",
       "Income capitalization": "Kapitalizace příjmu",
       "INCOME CAPITALIZATION": "KAPITALIZACE PŘÍJMU",
       "Income from Charge": "Příjem z poplatku",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -472,6 +472,7 @@
     "accounting": {
       "Accrual (periodic)": "Abgrenzung (periodisch)",
       "Accrual (upfront)": "Rückstellung (im Voraus)",
+      "CASH_BASED": "Kasse",
       "Cash": "Kasse",
       "NONE": "Keiner",
       "financialActivity": {
@@ -2135,6 +2136,7 @@
       "Incentive Type": "Anreiztyp",
       "Include in Customer Loan Counter": "In Kundenkreditzähler einbeziehen",
       "Income Account": "Einkommenskonto",
+      "Income From Discount Fee": "Einnahmen aus Diskontgebühr",
       "Income capitalization": "Einkommenskapitalisierung",
       "INCOME CAPITALIZATION": "EINKOMMENSKAPITALISIERUNG",
       "Income from Charge": "Einnahmen aus Gebühr",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -473,6 +473,7 @@
     "accounting": {
       "Accrual (periodic)": "Accrual (periodic)",
       "Accrual (upfront)": "Accrual (upfront)",
+      "CASH_BASED": "Cash",
       "Cash": "Cash",
       "NONE": "None",
       "financialActivity": {
@@ -2150,6 +2151,7 @@
       "Incentive Type": "Incentive Type",
       "Include in Customer Loan Counter": "Include in Customer Loan Counter",
       "Income Account": "Income Account",
+      "Income From Discount Fee": "Income From Discount Fee",
       "Income capitalization": "Income capitalization",
       "INCOME CAPITALIZATION": "INCOME CAPITALIZATION",
       "Income from Charge": "Income from Charge",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -470,6 +470,7 @@
     "accounting": {
       "Accrual (periodic)": "Devengo (periódico)",
       "Accrual (upfront)": "Devengo (adelantado)",
+      "CASH_BASED": "Efectivo",
       "Cash": "Efectivo",
       "NONE": "Ninguno",
       "financialActivity": {
@@ -2133,6 +2134,7 @@
       "Incentive Type": "Tipo de incentivo",
       "Include in Customer Loan Counter": "Incluir en el contador de Créditos al cliente",
       "Income Account": "Cuenta de Ingresos",
+      "Income From Discount Fee": "Ingresos por tarifa de descuento",
       "Income capitalization": "Capitalización de ingresos",
       "INCOME CAPITALIZATION": "CAPITALIZACIÓN DE INGRESOS",
       "Income from Charge": "Ingresos por cargo",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -470,6 +470,7 @@
     "accounting": {
       "Accrual (periodic)": "Devengo (periódico)",
       "Accrual (upfront)": "Devengo (adelantado)",
+      "CASH_BASED": "Efectivo",
       "Cash": "Efectivo",
       "NONE": "Ninguno",
       "financialActivity": {
@@ -2136,6 +2137,7 @@
       "Incentive Type": "Tipo de incentivo",
       "Include in Customer Loan Counter": "Incluir en el contador de Créditos al cliente",
       "Income Account": "Cuenta de Ingresos",
+      "Income From Discount Fee": "Ingresos por tarifa de descuento",
       "Income capitalization": "Capitalización de ingresos",
       "INCOME CAPITALIZATION": "CAPITALIZACIÓN DE INGRESOS",
       "Income from Charge": "Ingresos por cargo",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -470,6 +470,7 @@
     "accounting": {
       "Accrual (periodic)": "Accumulation (périodique)",
       "Accrual (upfront)": "Accumulation (d'avance)",
+      "CASH_BASED": "Espèces",
       "Cash": "Espèces",
       "NONE": "Aucun",
       "financialActivity": {
@@ -2136,6 +2137,7 @@
       "Incentive Type": "Type d'incitation",
       "Include in Customer Loan Counter": "Inclure dans le compteur de prêts clients",
       "Income Account": "Compte de revenu",
+      "Income From Discount Fee": "Revenus de frais d'escompte",
       "Income capitalization": "Capitalisation des revenus",
       "INCOME CAPITALIZATION": "CAPITALISATION DES REVENUS",
       "Income from Charge": "Revenu de Charge",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -470,6 +470,7 @@
     "accounting": {
       "Accrual (periodic)": "Accantonamento (periodico)",
       "Accrual (upfront)": "Accantonamento (in anticipo)",
+      "CASH_BASED": "Contanti",
       "Cash": "Contanti",
       "NONE": "Nessuno",
       "financialActivity": {
@@ -2133,6 +2134,7 @@
       "Incentive Type": "Tipo di incentivo",
       "Include in Customer Loan Counter": "Includi nel contatore dei prestiti al cliente",
       "Income Account": "Conto dei redditi",
+      "Income From Discount Fee": "Proventi da commissione di sconto",
       "Income capitalization": "Capitalizzazione del reddito",
       "INCOME CAPITALIZATION": "CAPITALIZZAZIONE DEL REDDITO",
       "Income from Charge": "Proventi da carica",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -470,6 +470,7 @@
     "accounting": {
       "Accrual (periodic)": "발생(정기적)",
       "Accrual (upfront)": "발생(선불)",
+      "CASH_BASED": "현금",
       "Cash": "현금",
       "NONE": "없음",
       "financialActivity": {
@@ -2134,6 +2135,7 @@
       "Incentive Type": "인센티브 유형",
       "Include in Customer Loan Counter": "고객 대출 카운터에 포함",
       "Income Account": "소득 계정",
+      "Income From Discount Fee": "할인 수수료 수입",
       "Income capitalization": "소득 자본화",
       "INCOME CAPITALIZATION": "소득 자본화",
       "Income from Charge": "수수료 수입",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -470,6 +470,7 @@
     "accounting": {
       "Accrual (periodic)": "Kaupiamasis (periodinis)",
       "Accrual (upfront)": "Sukaupimas (išankstinis)",
+      "CASH_BASED": "Grynieji pinigai",
       "Cash": "Grynieji pinigai",
       "NONE": "Nė vienas",
       "financialActivity": {
@@ -2132,6 +2133,7 @@
       "Incentive Type": "Paskatinimo tipas",
       "Include in Customer Loan Counter": "Įtraukti į klientų paskolų skaitiklį",
       "Income Account": "Pajamų sąskaita",
+      "Income From Discount Fee": "Pajamos iš nuolaidų mokesčio",
       "Income capitalization": "Pajamų kapitalizacija",
       "INCOME CAPITALIZATION": "PAJAMŲ KAPITALIZAVIMAS",
       "Income from Charge": "Pajamos iš mokesčių",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -470,6 +470,7 @@
     "accounting": {
       "Accrual (periodic)": "Uzkrāšana (periodiski)",
       "Accrual (upfront)": "Uzkrāšana (iepriekšēja)",
+      "CASH_BASED": "Skaidra nauda",
       "Cash": "Skaidra nauda",
       "NONE": "Nav",
       "financialActivity": {
@@ -2133,6 +2134,7 @@
       "Incentive Type": "Stimulēšanas veids",
       "Include in Customer Loan Counter": "Iekļaut klientu aizdevumu skaitītājā",
       "Income Account": "Ienākumu konts",
+      "Income From Discount Fee": "Ienākumi no atlaides maksas",
       "Income capitalization": "Ienākumu kapitalizācija",
       "INCOME CAPITALIZATION": "IENĀKUMU KAPITALIZĀCIJA",
       "Income from Charge": "Ienākumi no maksas",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -470,6 +470,7 @@
     "accounting": {
       "Accrual (periodic)": "उपार्जन (आवधिक)",
       "Accrual (upfront)": "उपार्जन (अगाडि)",
+      "CASH_BASED": "नगद",
       "Cash": "नगद",
       "NONE": "कुनै पनि छैन",
       "financialActivity": {
@@ -2132,6 +2133,7 @@
       "Incentive Type": "प्रोत्साहन प्रकार",
       "Include in Customer Loan Counter": "ग्राहक ऋण काउन्टरमा समावेश गर्नुहोस्",
       "Income Account": "आय खाता",
+      "Income From Discount Fee": "छुट शुल्कबाट आय",
       "Income capitalization": "आय पूंजीकरण",
       "INCOME CAPITALIZATION": "आय पूंजीकरण",
       "Income from Charge": "शुल्कबाट आम्दानी",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -470,6 +470,7 @@
     "accounting": {
       "Accrual (periodic)": "Acumulação (periódica)",
       "Accrual (upfront)": "Acumulação (antecipada)",
+      "CASH_BASED": "Dinheiro",
       "Cash": "Dinheiro",
       "NONE": "Nenhum",
       "financialActivity": {
@@ -2132,6 +2133,7 @@
       "Incentive Type": "Tipo de incentivo",
       "Include in Customer Loan Counter": "Incluir no contador de empréstimos do cliente",
       "Income Account": "Conta de Renda",
+      "Income From Discount Fee": "Receita de taxa de desconto",
       "Income capitalization": "Capitalização de renda",
       "INCOME CAPITALIZATION": "CAPITALIZAÇÃO DE RENDA",
       "Income from Charge": "Renda de cobrança",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -470,6 +470,7 @@
     "accounting": {
       "Accrual (periodic)": "Accrual (mara kwa mara)",
       "Accrual (upfront)": "Accrual (mbele)",
+      "CASH_BASED": "Fedha taslimu",
       "Cash": "Fedha taslimu",
       "NONE": "Hakuna",
       "financialActivity": {
@@ -2130,6 +2131,7 @@
       "Incentive Type": "Aina ya motisha",
       "Include in Customer Loan Counter": "Jumuisha katika Kaunta ya Mkopo kwa Wateja",
       "Income Account": "Akaunti ya Mapato",
+      "Income From Discount Fee": "Mapato kutoka ada ya punguzo",
       "Income capitalization": "Mtaji wa mapato",
       "INCOME CAPITALIZATION": "MTAJI WA KIPATO",
       "Income from Charge": "Mapato kutoka kwa Malipo",


### PR DESCRIPTION
## Description

Backend GL and loan product mapping works now for Working Capital product,  so the user should be able to configure the mapping from the UI as well.

[WEB-657](WEB-657)

## Screenshots

- Input GL Account mappings
<img width="1470" height="954" alt="Screenshot 2026-04-17 at 10 59 34 PM" src="https://github.com/user-attachments/assets/a7bfa6cf-2c67-460f-a520-2c3b48324881" />

- Working Capital product details
<img width="1491" height="883" alt="Screenshot 2026-04-17 at 9 02 10 PM" src="https://github.com/user-attachments/assets/e9b70e69-1af9-4e08-a200-e2a0e3a92f00" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Working-capital products now support a Cash-based accounting option; new account mappings for discount-fee income and charge-off expenses added
  * Clear button added to GL account selectors for easier clearing

* **UI Improvements**
  * Accounting step is always shown in create/edit flows; accounting UI adapts per product type
  * Advanced accounting mappings simplified and are now shown only for loan products

* **Localization**
  * Added translations for the new accounting option and "Income From Discount Fee" across languages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->