### PR TITLE
[WEB-930] Fix correct clientStatusType.approved typo in StatusLookupPipe

### DIFF
--- a/src/app/pipes/status-lookup.pipe.ts
+++ b/src/app/pipes/status-lookup.pipe.ts
@@ -42,7 +42,7 @@ export class StatusLookupPipe implements PipeTransform {
       'clientStatusType.withdraw': 'status-withdraw', // write
       'clientStatusType.active': 'status-active',
       'clientStatusType.submitted.and.pending.approval': 'status-pending',
-      'clientStatusTYpe.approved': 'status-approved',
+      'clientStatusType.approved': 'status-approved',
       'clientStatusType.transfer.in.progress': 'status-transfer-progress', // write
       'clientStatusType.transfer.on.hold': 'status-transfer-hold', // write
       'groupingStatusType.active': 'status-active',


### PR DESCRIPTION
## Description

The key `clientStatusTYpe.approved` (capital `Y`) in `StatusLookupPipe` never matched the API response value `clientStatusType.approved`, causing approved clients to always fall through to the `status-unknown` CSS class. This fixes the typo so approved clients render with the correct `status-approved` styling across all client list and detail views.

## Related issues and discussion

N/A

## Screenshots, if any

N/A

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a misspelling in the client approval status mapping to ensure proper CSS styling is applied when displaying client approval statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

JIRA ISSUE: https://mifosforge.jira.com/browse/WEB-930