### PR TITLE
Fix guard against null credentials in HasPermissionDirective

### DIFF
--- a/src/app/directives/has-permission/has-permission.directive.ts
+++ b/src/app/directives/has-permission/has-permission.directive.ts
@@ -38,7 +38,7 @@ export class HasPermissionDirective {
    */
   constructor() {
     const savedCredentials = this.authenticationService.getCredentials();
-    this.userPermissions = savedCredentials.permissions;
+    this.userPermissions = savedCredentials?.permissions ?? [];
   }
 
   /**


### PR DESCRIPTION
## Description

Guards against a null dereference crash in `HasPermissionDirective`. `AuthenticationService.getCredentials()` returns `Credentials | null`, when no credentials exist in storage (unauthenticated session), it returns `null` via `JSON.parse(null)`. The directive constructor accessed `.permissions` directly on this null value, throwing a `TypeError` before any RBAC guard could run.

Changed `savedCredentials.permissions` -> `savedCredentials?.permissions ?? []` so the directive initialises safely with an empty array when no credentials are present.

## Screenshots, if any

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

---

## Reproduction Logs

### Before: crash on unauthenticated route

```
> getCredentials() returns: null         // JSON.parse(null) === null
> BEFORE fix crash: Cannot read properties of null (reading 'permissions')
```

Constructor throws before `hasPermission()` is ever called, the `rbacEnabled` guard is unreachable.

### After: safe initialisation

```
> getCredentials() returns: null
> AFTER fix result: []                   // savedCredentials?.permissions ?? []
> Is empty array: true

> rbacEnabled=false, hasPermission('CREATE_TEMPLATE'): true   // backward compat preserved
> rbacEnabled=true,  hasPermission('CREATE_TEMPLATE'): false  // hidden, not crashed

> Authenticated userPermissions: [ 'CREATE_TEMPLATE', 'READ_LOAN', 'ALL_FUNCTIONS_READ' ]
> No regression on authenticated path: PASS
```