### PR TITLE
WEB-657: Working Capital loan near breach config

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
@@ -106,14 +106,14 @@
             </mat-option>
           }
         </mat-select>
-        @if (loansAccountTermsForm.controls.breachId) {
+        @if (loansAccountTermsForm.controls.breachId && allowAttributeOverridesBreach) {
           <button matSuffix mat-icon-button aria-label="Clear" (click)="clearProperty($event, 'breachId')">
             <fa-icon icon="close" size="md"></fa-icon>
           </button>
         }
       </mat-form-field>
 
-      @if (loansAccountTermsForm.value.breachId) {
+      @if (selectedBreach) {
         <mat-form-field class="flex-48">
           <mat-label>{{ 'labels.inputs.Near Breach' | translate }}</mat-label>
           <mat-select formControlName="nearBreachId" class="breach-id-select" panelClass="breach-select-panel">
@@ -128,7 +128,7 @@
               </mat-option>
             }
           </mat-select>
-          @if (loansAccountTermsForm.controls.nearBreachId) {
+          @if (loansAccountTermsForm.controls.nearBreachId && allowAttributeOverridesBreach) {
             <button matSuffix mat-icon-button aria-label="Clear" (click)="clearProperty($event, 'nearBreachId')">
               <fa-icon icon="close" size="md"></fa-icon>
             </button>

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -179,6 +179,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
   delinquencyStartTypeOptions: StringEnumOptionData[] = [];
   breachOptions: Breach[] = [];
   nearBreachOptions: NearBreach[] = [];
+  allowAttributeOverridesBreach: boolean = true;
 
   constructor() {
     super();
@@ -372,6 +373,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         this.loansAccountTermsForm.controls.discount.disable();
       }
       if (!this.allowAttributeOverrides.breach || this.allowAttributeOverrides.breach === false) {
+        this.allowAttributeOverridesBreach = false;
         this.loansAccountTermsForm.controls.breachId.disable();
         this.loansAccountTermsForm.controls.nearBreachId.disable();
       }

--- a/src/app/shared/loan/breach-display/breach-display.component.html
+++ b/src/app/shared/loan/breach-display/breach-display.component.html
@@ -28,22 +28,22 @@
     <div class="breach-display-column">
       <div class="flex-fill layout-row">
         <span class="flex-30 attribute-name">{{ 'labels.inputs.Breach' | translate }}:</span>
-        <span class="flex-30">{{ breach.name }}</span>
+        <span class="flex-60">{{ breach.name }}</span>
       </div>
       <div class="flex-fill layout-row">
         <span class="flex-30 attribute-name">{{ 'labels.inputs.Frequency' | translate }}:</span>
-        <span class="flex-30"
+        <span class="flex-60"
           >{{ breach.breachFrequency | formatNumber: '' : 0 }}
           {{ breach.breachFrequencyType.code | translateKey: 'catalogs' }}</span
         >
       </div>
       <div class="flex-fill layout-row">
         <span class="flex-30 attribute-name">{{ 'labels.inputs.Calculation Type' | translate }}:</span>
-        <span class="flex-30">{{ camalize(breach.breachAmountCalculationType.code) | translateKey: 'catalogs' }}</span>
+        <span class="flex-60">{{ camalize(breach.breachAmountCalculationType.code) | translateKey: 'catalogs' }}</span>
       </div>
       <div class="flex-fill layout-row">
         <span class="flex-30 attribute-name">{{ 'labels.inputs.Amount' | translate }}:</span>
-        <span class="flex-30">{{ breach.breachAmount | formatNumber }}</span>
+        <span class="flex-60">{{ breach.breachAmount | formatNumber }}</span>
       </div>
     </div>
   }
@@ -66,18 +66,18 @@
     <div class="breach-display-column">
       <div class="flex-fill layout-row">
         <span class="flex-30 attribute-name">{{ 'labels.inputs.Near Breach' | translate }}:</span>
-        <span class="flex-30">{{ nearBreach.name }}</span>
+        <span class="flex-60">{{ nearBreach.name }}</span>
       </div>
       <div class="flex-fill layout-row">
         <span class="flex-30 attribute-name">{{ 'labels.inputs.Frequency' | translate }}:</span>
-        <span class="flex-30"
+        <span class="flex-60"
           >{{ nearBreach.frequency | formatNumber: '' : 0 }}
           {{ nearBreach.frequencyType.code | translateKey: 'catalogs' }}</span
         >
       </div>
       <div class="flex-fill layout-row">
         <span class="flex-30 attribute-name">{{ 'labels.inputs.Threshold' | translate }}:</span>
-        <span class="flex-30">{{ nearBreach.threshold | formatNumber }} %</span>
+        <span class="flex-60">{{ nearBreach.threshold | formatNumber }} %</span>
       </div>
     </div>
   }


### PR DESCRIPTION
## Description

There was an issue when the WC Loan creation and modification and the WC Product does not allow to override the Breach settings. the Near Breach in the WC Loan view was not being displayed

[WEB-657](WEB-657)

## Related issues and discussion

## Screenshots
<img width="1319" height="747" alt="Screenshot 2026-04-22 at 11 43 46 PM" src="https://github.com/user-attachments/assets/77c9eba7-9736-4a66-b83f-3f6363074a3f" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation logic for breach and near-breach clear buttons to require additional conditions before allowing overrides
  * Enhanced near-breach form visibility to align with selected breach state
  * Adjusted breach display layout spacing for better readability and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->