### PR TITLE
WEB-932: Fix null dereference in HasPermissionDirective on unauthenticated session

### DIFF
--- a/src/app/directives/has-permission/has-permission.directive.ts
+++ b/src/app/directives/has-permission/has-permission.directive.ts
@@ -38,7 +38,7 @@ export class HasPermissionDirective {
    */
   constructor() {
     const savedCredentials = this.authenticationService.getCredentials();
-    this.userPermissions = savedCredentials.permissions;
+    this.userPermissions = savedCredentials?.permissions ?? [];
   }
 
   /**


### PR DESCRIPTION
## Description

Guards against a null dereference crash in `HasPermissionDirective`. `AuthenticationService.getCredentials()` returns `Credentials | null` -- when no credentials exist in storage (unauthenticated session), it returns `null` via
`JSON.parse(null)`. The directive constructor accessed `.permissions` directly on this null value, throwing a `TypeError` before any RBAC logic could run.

Changed `savedCredentials.permissions` to `savedCredentials?.permissions ?? []` so the directive initialises safely with an empty array when no credentials are present.

Jira: https://mifosforge.jira.com/browse/WEB-932

## Related issues and discussion

#3527

## Screenshots, if any

<img width="1919" height="976" alt="Screenshot 2026-04-26 105136" src="https://github.com/user-attachments/assets/7030ce74-3c78-4906-b6a4-be68af3be13f" />


<!-- Attach the DevTools console screenshot showing:
     - getCredentials() returns: null
     - BEFORE fix crash: Cannot read properties of null (reading 'permissions')
     - AFTER fix result: []
     - Is empty array: true -->

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of permission handling to gracefully handle missing credentials and prevent potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->