### PR TITLE
WEB-933: Fix null dereference in ErrorHandlerInterceptor when default…

### DIFF
--- a/src/app/core/http/error-handler.interceptor.ts
+++ b/src/app/core/http/error-handler.interceptor.ts
@@ -92,21 +92,19 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
         : nestedMessage
       : topLevelMessage;
     let parameterName: string | null = null;
-    if (response.error.errors) {
-      if (response.error.errors[0]) {
-        if (
-          response.error.errors[0].userMessageGlobalisationCode &&
-          this.databaseErrorCodes.indexOf(response.error.errors[0].userMessageGlobalisationCode) > -1
-        ) {
-          errorMessage = this.translate.instant('errors.error.msg.data.integrity.issue');
-        } else {
-          errorMessage =
-            response.error.errors[0].defaultUserMessage.replace(/\\./g, ' ') ||
-            response.error.errors[0].developerMessage.replace(/\\./g, ' ');
-        }
+    if (errorBody?.errors?.[0]) {
+      const firstError = errorBody.errors[0];
+      if (
+        firstError.userMessageGlobalisationCode &&
+        this.databaseErrorCodes.indexOf(firstError.userMessageGlobalisationCode) > -1
+      ) {
+        errorMessage = this.translate.instant('errors.error.msg.data.integrity.issue');
+      } else {
+        errorMessage =
+          firstError.defaultUserMessage?.replace(/\\./g, ' ') || firstError.developerMessage?.replace(/\\./g, ' ');
       }
-      if ('parameterName' in errorBody.errors[0]) {
-        parameterName = errorBody.errors[0].parameterName;
+      if ('parameterName' in firstError) {
+        parameterName = firstError.parameterName;
       }
     }
     const isClientImage404 = status === 404 && request.url.includes('/clients/') && request.url.includes('/images');


### PR DESCRIPTION
## Description

Guards against a null dereference crash in `ErrorHandlerInterceptor`. Fineract APIs can return `defaultUserMessage` as `null` on constraint violations. The error handler accessed `.replace()` directly on that null value, crashing before the `developerMessage` fallback could run.
This silently broke error reporting across the entire app for any API response where `defaultUserMessage` is null.

Also switches from `response.error.errors` to the already-decoded `errorBody` (which `parseErrorBody` produces) for consistent binary response handling, and extracts `firstError` to eliminate repeated deep-chain access.

Jira: https://mifosforge.jira.com/browse/WEB-933

## Related issues and discussion

No existing issue. Ticket created: WEB-933.

## Screenshots, if any

#### Before: Cannot read properties of null (reading 'replace')
<img width="1919" height="969" alt="Screenshot 2026-04-26 115239" src="https://github.com/user-attachments/assets/a57f1940-f64c-41d8-8d76-ae2f0c4f08c1" />

#### After: Result: Some dev message
<img width="1919" height="979" alt="Screenshot 2026-04-26 121847" src="https://github.com/user-attachments/assets/22e8cef7-9531-4acd-a0d1-1a4531f6dc27" />



<!-- Attach the DevTools console screenshot showing:
     BEFORE fix: Cannot read properties of null (reading 'replace')
     AFTER fix:  Result: Some dev message  -->

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of nested error parsing to reliably extract and display the most relevant error message.
  * Enhanced fallback selection for user-facing messages when database error codes don't match.
  * Corrected extraction of parameter names for clearer error context and ensured consistent formatting of message punctuation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->