### PR TITLE
WEB-918: Fix savings application edit flow

### DIFF
--- a/src/app/savings/savings-account-view/savings-account-view.component.ts
+++ b/src/app/savings/savings-account-view/savings-account-view.component.ts
@@ -220,7 +220,14 @@ export class SavingsAccountViewComponent implements OnInit {
         this.router.navigate([`actions/Withdrawal`], { relativeTo: this.route });
         break;
       case 'Modify Application':
-        this.router.navigate(['edit'], { relativeTo: this.route });
+        this.router.navigate(
+          [
+            '../',
+            this.route.snapshot.paramMap.get('savingAccountId') || this.savingsAccountData.id,
+            'edit'
+          ],
+          { relativeTo: this.route }
+        );
         break;
       case 'Delete':
         this.deleteSavingsAccount();

--- a/src/app/savings/savings.service.ts
+++ b/src/app/savings/savings.service.ts
@@ -11,7 +11,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 
 /** rxjs Imports */
-import { Observable } from 'rxjs';
+import { Observable, map, switchMap } from 'rxjs';
 
 /**
  * Savings Service.
@@ -69,8 +69,23 @@ export class SavingsService {
    * @returns {Observable<any>} Savings account and template.
    */
   getSavingsAccountAndTemplate(accountId: string, template: boolean): Observable<any> {
-    const httpParams = new HttpParams().set('template', template.toString()).set('associations', 'charges');
-    return this.http.get(`/savingsaccounts/${accountId}`, { params: httpParams });
+    if (!template) {
+      return this.getSavingsAccountData(accountId);
+    }
+
+    return this.getSavingsAccountData(accountId).pipe(
+      switchMap((savingsAccountData: any) => {
+        const entityId = savingsAccountData.groupId || savingsAccountData.clientId;
+        const isGroup = !!savingsAccountData.groupId;
+
+        return this.getSavingsAccountTemplate(entityId, savingsAccountData.savingsProductId, isGroup).pipe(
+          map((savingsAccountTemplate: any) => ({
+            ...savingsAccountData,
+            productOptions: savingsAccountTemplate.productOptions
+          }))
+        );
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
## Description
This change fixes the savings account Modify Application flow so users are taken to the edit savings application page instead of getting an HTTP 400 error. The savings edit data is now loaded through supported account and template requests, which avoids the failing savings account template call that was breaking the page.

Dependencies: none beyond the existing savings account APIs.

## Related issues and discussion
#WEB-918

## After Video:
https://github.com/user-attachments/assets/e62dbfd7-0559-42a2-99b7-8cf0ced2fa1c

## Checklist
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines at web-app/.github/CONTRIBUTING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation when accessing savings account modifications to ensure proper account references.
  * Enhanced the efficiency of loading savings account template information through optimized data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->