### PR TITLE
WEB-931-loan-account-application-must-allow-rate-0-the-nominal-interest-rate-field-fix

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
@@ -318,7 +318,7 @@
       @if (!loansAccountTermsData?.isLoanProductLinkedToFloatingRate) {
         <mat-form-field class="flex-fill flex-23">
           <mat-label>{{ 'labels.inputs.Nominal interest rate' | translate }} %</mat-label>
-          <input type="number" matInput formControlName="interestRatePerPeriod" min="0.01" step="0.01" />
+          <input type="number" matInput formControlName="interestRatePerPeriod" min="0" step="0.01" />
         </mat-form-field>
         <mat-form-field class="flex-fill flex-23">
           <mat-label>{{ 'labels.inputs.Frequency' | translate }}</mat-label>

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -576,7 +576,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
           'interestRatePerPeriod',
           new UntypedFormControl({ value: 0, disabled: true }, [
             Validators.required,
-            Validators.min(0.01)
+            Validators.min(0)
           ])
         );
         this.loansAccountTermsForm.addControl(
@@ -588,7 +588,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
           'interestRatePerPeriod',
           new UntypedFormControl(this.loansAccountTermsData.interestRatePerPeriod, [
             Validators.required,
-            Validators.min(0.01)
+            Validators.min(0)
           ])
         );
       }
@@ -649,7 +649,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         interestChargedFromDate: [''],
         interestRatePerPeriod: [
           '',
-          Validators.min(0.01)
+          Validators.min(0)
         ],
         interestType: [''],
         isFloatingInterestRate: [null],

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.html
@@ -113,16 +113,16 @@
 
       <mat-form-field class="flex-31">
         <mat-label>{{ 'labels.inputs.Minimum' | translate }}</mat-label>
-        <input type="number" matInput formControlName="minPeriodPaymentRate" [min]="0.01" step="0.01" />
+        <input type="number" matInput formControlName="minPeriodPaymentRate" [min]="0" step="0.01" />
         <mat-error *ngIf="loanProductTermsForm.get('minPeriodPaymentRate')?.hasError('min')">
           {{ 'labels.commons.Minimum Value must be' | translate }}
-          <strong>{{ loanProductTermsForm.get('minPeriodPaymentRate')?.errors?.['min']?.min || 0.01 }}</strong>
+          <strong>{{ loanProductTermsForm.get('minPeriodPaymentRate')?.errors?.['min']?.min || 0 }}</strong>
         </mat-error>
       </mat-form-field>
 
       <mat-form-field class="flex-31">
         <mat-label>{{ 'labels.inputs.Default' | translate }}</mat-label>
-        <input type="number" matInput formControlName="periodPaymentRate" required [min]="0.01" step="0.01" />
+        <input type="number" matInput formControlName="periodPaymentRate" required [min]="0" step="0.01" />
         <mat-error
           *ngIf="
             loanProductTermsForm.get('periodPaymentRate')?.hasError('required') &&
@@ -136,16 +136,16 @@
         <mat-error *ngIf="loanProductTermsForm.get('periodPaymentRate')?.hasError('min')">
           {{ 'labels.catalogs.Default' | translate }} {{ 'labels.inputs.Period Payment Rate' | translate }}
           {{ 'labels.commons.is' | translate }}
-          <strong>{{ loanProductTermsForm.get('periodPaymentRate')?.errors?.['min']?.min || 0.01 }}</strong>
+          <strong>{{ loanProductTermsForm.get('periodPaymentRate')?.errors?.['min']?.min || 0 }}</strong>
         </mat-error>
       </mat-form-field>
 
       <mat-form-field class="flex-31">
         <mat-label>{{ 'labels.inputs.Maximum' | translate }}</mat-label>
-        <input type="number" matInput formControlName="maxPeriodPaymentRate" [min]="0.01" step="0.01" />
+        <input type="number" matInput formControlName="maxPeriodPaymentRate" [min]="0" step="0.01" />
         <mat-error *ngIf="loanProductTermsForm.get('maxPeriodPaymentRate')?.hasError('min')">
           {{ 'labels.commons.Minimum Value must be' | translate }}
-          <strong>{{ loanProductTermsForm.get('maxPeriodPaymentRate')?.errors?.['min']?.min || 0.01 }}</strong>
+          <strong>{{ loanProductTermsForm.get('maxPeriodPaymentRate')?.errors?.['min']?.min || 0 }}</strong>
         </mat-error>
       </mat-form-field>
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -75,7 +75,7 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
 
   @Input() loanProductsTemplate: any;
 
-  loanProductTermsForm: UntypedFormGroup;
+  loanProductTermsForm!: UntypedFormGroup;
 
   /** Zero Interest control. */
   zeroInterest = new UntypedFormControl(false);
@@ -324,20 +324,20 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
         minPeriodPaymentRate: [
           '',
           [
-            Validators.min(0.01)
+            Validators.min(0)
           ]
         ],
         periodPaymentRate: [
           '',
           [
             Validators.required,
-            Validators.min(0.01)
+            Validators.min(0)
           ]
         ],
         maxPeriodPaymentRate: [
           '',
           [
-            Validators.min(0.01)
+            Validators.min(0)
           ]
         ],
         repaymentEvery: [
@@ -370,19 +370,19 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
   setConditionalControls() {
     if (this.loanProductService.isLoanProduct) {
       this.loanProductTermsForm
-        .get('allowApprovedDisbursedAmountsOverApplied')
+        .get('allowApprovedDisbursedAmountsOverApplied')!
         .valueChanges.subscribe((allowApprovedDisbursedAmountsOverApplied) => {
           if (allowApprovedDisbursedAmountsOverApplied) {
-            this.loanProductTermsForm.get('overAppliedCalculationType').enable();
-            this.loanProductTermsForm.get('overAppliedNumber').enable();
+            this.loanProductTermsForm.get('overAppliedCalculationType')!.enable();
+            this.loanProductTermsForm.get('overAppliedNumber')!.enable();
             if (this.loanProductService.isLoanProduct) {
               this.loanProductTermsForm.addControl('disallowExpectedDisbursements', new UntypedFormControl(true));
             }
           } else {
-            this.loanProductTermsForm.get('overAppliedCalculationType').disable();
-            this.loanProductTermsForm.get('overAppliedCalculationType').patchValue(null);
-            this.loanProductTermsForm.get('overAppliedNumber').disable();
-            this.loanProductTermsForm.get('overAppliedNumber').patchValue(null);
+            this.loanProductTermsForm.get('overAppliedCalculationType')!.disable();
+            this.loanProductTermsForm.get('overAppliedCalculationType')!.patchValue(null);
+            this.loanProductTermsForm.get('overAppliedNumber')!.disable();
+            this.loanProductTermsForm.get('overAppliedNumber')!.patchValue(null);
             if (this.loanProductService.isLoanProduct) {
               this.loanProductTermsForm.removeControl('disallowExpectedDisbursements');
             }
@@ -390,7 +390,7 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
         });
 
       this.loanProductTermsForm
-        .get('isLinkedToFloatingInterestRates')
+        .get('isLinkedToFloatingInterestRates')!
         .valueChanges.subscribe((isLinkedToFloatingInterestRates) => {
           if (isLinkedToFloatingInterestRates) {
             this.loanProductTermsForm.removeControl('minInterestRatePerPeriod');
@@ -457,7 +457,7 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
           }
         });
 
-      this.loanProductTermsForm.get('useBorrowerCycle').valueChanges.subscribe((useBorrowerCycle) => {
+      this.loanProductTermsForm.get('useBorrowerCycle')!.valueChanges.subscribe((useBorrowerCycle) => {
         if (useBorrowerCycle) {
           this.loanProductTermsForm.addControl('principalVariationsForBorrowerCycle', this.formBuilder.array([]));
           this.loanProductTermsForm.addControl(
@@ -474,25 +474,25 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
 
       this.zeroInterest.valueChanges.subscribe((zeroInterest) => {
         if (zeroInterest) {
-          this.loanProductTermsForm.get('minInterestRatePerPeriod').patchValue(0);
-          this.loanProductTermsForm.get('minInterestRatePerPeriod').disable();
-          this.loanProductTermsForm.get('interestRatePerPeriod').patchValue(0);
-          this.loanProductTermsForm.get('interestRatePerPeriod').disable();
-          this.loanProductTermsForm.get('maxInterestRatePerPeriod').patchValue(0);
-          this.loanProductTermsForm.get('maxInterestRatePerPeriod').disable();
+          this.loanProductTermsForm.get('minInterestRatePerPeriod')!.patchValue(0);
+          this.loanProductTermsForm.get('minInterestRatePerPeriod')!.disable();
+          this.loanProductTermsForm.get('interestRatePerPeriod')!.patchValue(0);
+          this.loanProductTermsForm.get('interestRatePerPeriod')!.disable();
+          this.loanProductTermsForm.get('maxInterestRatePerPeriod')!.patchValue(0);
+          this.loanProductTermsForm.get('maxInterestRatePerPeriod')!.disable();
         } else {
           this.loanProductTermsForm
-            .get('minInterestRatePerPeriod')
+            .get('minInterestRatePerPeriod')!
             .patchValue(this.loanProductsTemplate.minInterestRatePerPeriod);
-          this.loanProductTermsForm.get('minInterestRatePerPeriod').enable();
+          this.loanProductTermsForm.get('minInterestRatePerPeriod')!.enable();
           this.loanProductTermsForm
-            .get('interestRatePerPeriod')
+            .get('interestRatePerPeriod')!
             .patchValue(this.loanProductsTemplate.interestRatePerPeriod);
-          this.loanProductTermsForm.get('interestRatePerPeriod').enable();
+          this.loanProductTermsForm.get('interestRatePerPeriod')!.enable();
           this.loanProductTermsForm
-            .get('maxInterestRatePerPeriod')
+            .get('maxInterestRatePerPeriod')!
             .patchValue(this.loanProductsTemplate.maxInterestRatePerPeriod);
-          this.loanProductTermsForm.get('maxInterestRatePerPeriod').enable();
+          this.loanProductTermsForm.get('maxInterestRatePerPeriod')!.enable();
         }
         this.validateAdvancedPaymentStrategyControls();
       });
@@ -500,15 +500,15 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
   }
 
   get principalVariationsForBorrowerCycle(): UntypedFormArray {
-    return this.loanProductTermsForm.get('principalVariationsForBorrowerCycle') as UntypedFormArray;
+    return this.loanProductTermsForm.get('principalVariationsForBorrowerCycle')! as UntypedFormArray;
   }
 
   get numberOfRepaymentVariationsForBorrowerCycle(): UntypedFormArray {
-    return this.loanProductTermsForm.get('numberOfRepaymentVariationsForBorrowerCycle') as UntypedFormArray;
+    return this.loanProductTermsForm.get('numberOfRepaymentVariationsForBorrowerCycle')! as UntypedFormArray;
   }
 
   get interestRateVariationsForBorrowerCycle(): UntypedFormArray {
-    return this.loanProductTermsForm.get('interestRateVariationsForBorrowerCycle') as UntypedFormArray;
+    return this.loanProductTermsForm.get('interestRateVariationsForBorrowerCycle')! as UntypedFormArray;
   }
 
   setLoanProductTermsFormDirty() {
@@ -654,9 +654,9 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
 
   private validateAdvancedPaymentStrategyControls(): void {
     if (this.allowFixedLength()) {
-      this.loanProductTermsForm.get('fixedLength').patchValue(this.loanProductsTemplate.fixedLength || null);
+      this.loanProductTermsForm.get('fixedLength')!.patchValue(this.loanProductsTemplate.fixedLength || null);
     } else {
-      this.loanProductTermsForm.get('fixedLength').patchValue(null);
+      this.loanProductTermsForm.get('fixedLength')!.patchValue(null);
     }
   }
 }


### PR DESCRIPTION
**Changes Made :-** 

-Update HTML min attributes to allow 0 interest rates in loan forms

[WEB-931](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-931)

[WEB-931]: https://mifosforge.jira.com/browse/WEB-931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loan account nominal interest rate input field now permits zero as a valid value. Previously, the minimum accepted value was 0.01.
  * Period payment rate input fields (minimum, standard, and maximum) now accept zero as valid values. Previously, these fields had a minimum constraint of 0.01.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->