### PR TITLE
WEB-937 Display the checker inbox and task icon on the left menu for the users with the grant approve loan

### DIFF
--- a/src/app/core/shell/sidenav/sidenav.component.html
+++ b/src/app/core/shell/sidenav/sidenav.component.html
@@ -99,7 +99,7 @@
           matTooltip="{{ 'tooltips.Checker Inbox and Tasks' | translate }}"
           routerLinkActive="active-menu"
           [routerLinkActiveOptions]="{ exact: false }"
-          *mifosxHasPermission="'READ_MAKERCHECKER'"
+          *mifosxHasPermission="['READ_MAKERCHECKER', 'APPROVE_LOAN']"
         >
           <mat-icon matListIcon>
             <i class="fa fa-check"></i>

--- a/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
@@ -18,7 +18,7 @@
           routerLinkActive
           #checkerInbox="routerLinkActive"
           [active]="checkerInbox.isActive"
-          *mifosxHasPermission="'ALL_FUNCTIONS_READ'"
+          *mifosxHasPermission="['ALL_FUNCTIONS_READ', 'READ_MAKERCHECKER', 'APPROVE_LOAN']"
         >
           {{ 'labels.inputs.Checker Inbox' | translate }}
         </a>


### PR DESCRIPTION
**Changes Made :-** 

-Display the Checker Inbox menu icon and tab for users with the APPROVE_LOAN grant .

[WEB-937](https://mifosforge.jira.com/browse/WEB-937)

[WEB-937]: https://mifosforge.jira.com/browse/WEB-937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded user access to Checker Inbox and Tasks features for additional permission roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->