### PR TITLE
WEB-940 Fix missing translation for mandatory guarantee error message in loan product settings form

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.html
@@ -879,7 +879,7 @@
             <mat-label>{{ 'labels.inputs.Mandatory Guarantee(%)' | translate }}</mat-label>
             <input type="number" matInput formControlName="mandatoryGuarantee" required min="0" />
             <mat-error>
-              {{ 'labels.inputs.Mandatory Guarantee' | translate }} {{ 'labels.commons.is' | translate }}
+              {{ 'labels.inputs.Mandatory Guarantee(%)' | translate }} {{ 'labels.commons.is' | translate }}
               <strong>{{ 'labels.commons.required' | translate }}</strong>
             </mat-error>
           </mat-form-field>


### PR DESCRIPTION
**Changes Made :-** 

-Changed the error message translation key in the loan product settings form from labels.inputs.Mandatory Guarantee to labels.inputs.Mandatory Guarantee(%) to use the existing translation key that's already defined in all language files. 

[WEB-940](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-940)

Before :- 
<img width="1365" height="718" alt="image" src="https://github.com/user-attachments/assets/b83a6a84-6bf0-488a-a6c9-b72fbc9282ad" />

After :- 
<img width="1362" height="718" alt="image" src="https://github.com/user-attachments/assets/86fcbb30-3c20-4c4d-86be-dd126e7965fe" />


[WEB-940]: https://mifosforge.jira.com/browse/WEB-940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation error message for the mandatory guarantee field to display the correct percentage format label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->