### PR TITLE
fix: add null-guards to dialog close callbacks in savings, clients etc

### DIFF
--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -276,6 +276,9 @@ export class ClientsViewComponent implements OnInit {
       data: { deleteContext: `client with id: ${this.clientViewData.id}` }
     });
     deleteClientDialogRef.afterClosed().subscribe((response: any) => {
+      if (!response) {
+        return;
+      }
       if (response.delete) {
         this.clientsService.deleteClient(this.clientViewData.id).subscribe(() => {
           this.router.navigate(['/clients'], { relativeTo: this.route });
@@ -290,6 +293,9 @@ export class ClientsViewComponent implements OnInit {
   private unassignStaff() {
     const unAssignStaffDialogRef = this.dialog.open(UnassignStaffDialogComponent);
     unAssignStaffDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
+      if (!response) {
+        return;
+      }
       if (response.confirm) {
         this.clientsService
           .executeClientCommand(this.clientViewData.id, 'unassignStaff', { staffId: this.clientViewData.staffId })
@@ -312,6 +318,9 @@ export class ClientsViewComponent implements OnInit {
         }
       });
       viewSignatureDialogRef.afterClosed().subscribe((response: any) => {
+        if (!response) {
+          return;
+        }
         if (response.upload) {
           this.uploadSignature();
         } else if (response.draw) {
@@ -360,6 +369,9 @@ export class ClientsViewComponent implements OnInit {
         data: documents
       });
       deleteSignatureDialogRef.afterClosed().subscribe((response: any) => {
+        if (!response) {
+          return;
+        }
         if (response.delete) {
           this.clientsService.deleteClientDocument(this.clientViewData.id, response.id).subscribe(() => {
             this.reload();

--- a/src/app/loans/loans-view/loans-view.component.ts
+++ b/src/app/loans/loans-view/loans-view.component.ts
@@ -469,6 +469,9 @@ export class LoansViewComponent extends LoanProductBaseComponent implements OnIn
       }
     });
     recoverFromGuarantorDialogRef.afterClosed().subscribe((response: any) => {
+      if (!response) {
+        return;
+      }
       if (response.confirm) {
         this.loansService.loanActionButtons(this.loanId, 'recoverGuarantees').subscribe(() => {
           this.reload();
@@ -500,6 +503,9 @@ export class LoansViewComponent extends LoanProductBaseComponent implements OnIn
       }
     });
     undoTransactionAccountDialogRef.afterClosed().subscribe((response: any) => {
+      if (!response) {
+        return;
+      }
       if (response.confirm) {
         let undoCommand: string = '';
         switch (actionName) {
@@ -564,6 +570,9 @@ export class LoansViewComponent extends LoanProductBaseComponent implements OnIn
       data: { deleteContext: `with loan id: ${this.loanId}` }
     });
     deleteGuarantorDialogRef.afterClosed().subscribe((response: any) => {
+      if (!response) {
+        return;
+      }
       if (response.delete) {
         this.loansService.deleteLoanAccount(this.loanId).subscribe(() => {
           this.router.navigate(['../../'], { relativeTo: this.route });

--- a/src/app/savings/savings-account-view/savings-account-view.component.ts
+++ b/src/app/savings/savings-account-view/savings-account-view.component.ts
@@ -281,6 +281,9 @@ export class SavingsAccountViewComponent implements OnInit {
       data: { deleteContext: `savings account with id: ${this.savingsAccountData.id}` }
     });
     deleteSavingsAccountDialogRef.afterClosed().subscribe((response: any) => {
+      if (!response) {
+        return;
+      }
       if (response.delete) {
         this.savingsService.deleteSavingsAccount(this.savingsAccountData.id).subscribe(() => {
           this.router.navigate(['../../'], { relativeTo: this.route });
@@ -295,6 +298,9 @@ export class SavingsAccountViewComponent implements OnInit {
   private calculateInterest() {
     const calculateInterestAccountDialogRef = this.dialog.open(CalculateInterestDialogComponent);
     calculateInterestAccountDialogRef.afterClosed().subscribe((response: any) => {
+      if (!response) {
+        return;
+      }
       if (response.confirm) {
         this.savingsService
           .executeSavingsAccountCommand(this.savingsAccountData.id, 'calculateInterest', {})
@@ -311,6 +317,9 @@ export class SavingsAccountViewComponent implements OnInit {
   private postInterest() {
     const postInterestAccountDialogRef = this.dialog.open(PostInterestDialogComponent);
     postInterestAccountDialogRef.afterClosed().subscribe((response: any) => {
+      if (!response) {
+        return;
+      }
       if (response.confirm) {
         this.savingsService
           .executeSavingsAccountCommand(this.savingsAccountData.id, 'postInterest', {})
@@ -329,6 +338,9 @@ export class SavingsAccountViewComponent implements OnInit {
       data: { isEnable: true }
     });
     deleteSavingsAccountDialogRef.afterClosed().subscribe((response: any) => {
+      if (!response) {
+        return;
+      }
       if (response.confirm) {
         this.savingsService
           .executeSavingsAccountUpdateCommand(this.savingsAccountData.id, 'updateWithHoldTax', { withHoldTax: true })
@@ -347,6 +359,9 @@ export class SavingsAccountViewComponent implements OnInit {
       data: { isEnable: false }
     });
     disableWithHoldTaxDialogRef.afterClosed().subscribe((response: any) => {
+      if (!response) {
+        return;
+      }
       if (response.confirm) {
         this.savingsService
           .executeSavingsAccountUpdateCommand(this.savingsAccountData.id, 'updateWithHoldTax', { withHoldTax: false })
@@ -378,6 +393,9 @@ export class SavingsAccountViewComponent implements OnInit {
       command = 'unblockDebit';
     }
     unblockSavingsAccountDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
+      if (!response) {
+        return;
+      }
       if (response.confirm) {
         this.savingsService.executeSavingsAccountCommand(this.savingsAccountData.id, command, {}).subscribe(() => {
           this.reload();


### PR DESCRIPTION
## Description

This PR resolves a silent crash (`TypeError: Cannot read properties of undefined`) that occurred when users dismissed confirmation dialogs across the Savings, Clients, and Loans modules by pressing `Escape` or clicking the backdrop. 

When Angular Material's `MatDialog` is dismissed without a direct action button, `afterClosed()` emits `undefined`. Several components previously accessed `.confirm` or `.delete` on this undefined response without checking it first, breaking the action cascade flow.

Fix: Added a defensive `if (!response) { return; }` guard at the top of 13 `afterClosed()` callbacks across `savings-account-view.component.ts`, `clients-view.component.ts`, and `loans-view.component.ts`.

No external dependencies are required for this change.

## Screenshots, if any

*(Not applicable, silent console crash fixed)*

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.