### PR TITLE
fix(loans): replace hardcoded Total label with i18n translate key in repayment schedule

### DIFF
--- a/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.html
+++ b/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.html
@@ -27,7 +27,9 @@
         <td mat-cell class="center" *matCellDef="let item" [ngClass]="installmentStyle(item)">
           {{ item.daysInPeriod }}
         </td>
-        <td mat-footer-cell class="center" *matFooterCellDef><b> Total</b></td>
+        <td mat-footer-cell class="center" *matFooterCellDef>
+          <b>{{ 'labels.inputs.Total' | translate }}</b>
+        </td>
       </ng-container>
       <ng-container matColumnDef="date">
         <th mat-header-cell class="center mat-header-cell" *matHeaderCellDef>{{ 'labels.inputs.Date' | translate }}</th>


### PR DESCRIPTION
## Description
The repayment schedule table footer had a hardcoded "Total" label in English. Every other label in this file correctly uses the `| translate` pipe for internationalization, but this one was missed.

This means users running Mifos in non-English languages (Hindi, Spanish, French, etc.) would see "Total" in English while everything else is translated — breaking the i18n consistency of the loan repayment view.

Fixed by replacing the hardcoded string with the existing translation key `labels.inputs.Total` which is already present in all locale files.

I am exploring this codebase as part of my DMP 2026 application for the Dynamic Pricing of Micro-loans Using Reinforcement Learning project. The repayment schedule component is directly relevant as it displays the installment-level data my RL environment will model.

## Related issues and discussion
openMF/mifos-x-ai-sentiment-analysis-module#2

## Screenshots, if any
N/A - Single label text fix, no visual change for English users.

## Checklist
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed localization of the total label in the repayment schedule so it uses the translated "Total" string and supports multiple languages.

* **Style**
  * Preserved and enhanced the formatting of the total label in the repayment schedule (bold styling) for improved visual clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->