### PR TITLE
Removed other accounts

### DIFF
--- a/src/app/centers/centers-view/centers-view.component.html
+++ b/src/app/centers/centers-view/centers-view.component.html
@@ -126,21 +126,6 @@
           </mat-icon>
           <span>{{ 'labels.buttons.Manage Groups' | translate }}</span>
         </button>
-        @if (centerViewData.active) {
-          <span>
-            <button
-              [disabled]="true"
-              mat-menu-item
-              *mifosxHasPermission="'CREATE_SAVINGSACCOUNT'"
-              [routerLink]="['savings-accounts', 'create']"
-            >
-              <mat-icon matListIcon>
-                <fa-icon icon="file" size="sm"></fa-icon>
-              </mat-icon>
-              <span>{{ 'labels.buttons.Centers Saving Application' | translate }}</span>
-            </button>
-          </span>
-        }
         <button mat-menu-item [matMenuTriggerFor]="More">{{ 'labels.buttons.More' | translate }}</button>
         <mat-menu #More="matMenu">
           @if (centerViewData.collectionMeetingCalendar) {

--- a/src/app/centers/centers-view/general-tab/general-tab.component.html
+++ b/src/app/centers/centers-view/general-tab/general-tab.component.html
@@ -59,119 +59,121 @@
     </table>
   }
 
-  <!-- savings overview table -->
-  @if (!(savingsAccountData === undefined)) {
-    @if (savingsAccountData.length > 0) {
-      <h3>{{ 'labels.heading.Savings Account Overview' | translate }}</h3>
-      <table mat-table [dataSource]="savingsAccountData" matSort>
-        <ng-container matColumnDef="Account No">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-          <td mat-cell *matCellDef="let element">
-            <i
-              class="fa fa-stop"
-              matTooltip="{{ element.status.value }}"
-              [ngClass]="element.status.code | statusLookup"
-            ></i>
-            {{ element.accountNo }}
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="Products">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Products' | translate }}</th>
-          <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
-        </ng-container>
-        <ng-container matColumnDef="Balance">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
-          <td mat-cell *matCellDef="let element">{{ element.accountBalance }}</td>
-        </ng-container>
-        <ng-container matColumnDef="Actions">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-          <td mat-cell *matCellDef="let element">
-            @if (element.status.active) {
-              @if (element.depositType.id === 100) {
+  @if (showNonLoanAccounts) {
+    <!-- savings overview table -->
+    @if (!(savingsAccountData === undefined)) {
+      @if (savingsAccountData.length > 0) {
+        <h3>{{ 'labels.heading.Savings Account Overview' | translate }}</h3>
+        <table mat-table [dataSource]="savingsAccountData" matSort>
+          <ng-container matColumnDef="Account No">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+            <td mat-cell *matCellDef="let element">
+              <i
+                class="fa fa-stop"
+                matTooltip="{{ element.status.value }}"
+                [ngClass]="element.status.code | statusLookup"
+              ></i>
+              {{ element.accountNo }}
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="Products">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Products' | translate }}</th>
+            <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
+          </ng-container>
+          <ng-container matColumnDef="Balance">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
+            <td mat-cell *matCellDef="let element">{{ element.accountBalance }}</td>
+          </ng-container>
+          <ng-container matColumnDef="Actions">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+            <td mat-cell *matCellDef="let element">
+              @if (element.status.active) {
+                @if (element.depositType.id === 100) {
+                  <button
+                    class="account-action-button"
+                    mat-raised-button
+                    color="primary"
+                    (click)="routeEdit($event)"
+                    [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Deposit']"
+                  >
+                    <i class="fa fa-arrow-right" matTooltip="{{ 'tooltips.Deposit' | translate }}"></i>
+                  </button>
+                }
+                @if (element.depositType.id === 300) {
+                  <button
+                    class="account-action-button"
+                    mat-raised-button
+                    color="primary"
+                    (click)="routeEdit($event)"
+                    [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Deposit']"
+                  >
+                    <i class="fa fa-arrow-right" matTooltip="{{ 'tooltips.Deposit' | translate }}"></i>
+                  </button>
+                }
+                @if (element.depositType.id === 100) {
+                  <button
+                    class="account-action-button"
+                    mat-raised-button
+                    color="primary"
+                    (click)="routeEdit($event)"
+                    [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Withdrawal']"
+                  >
+                    <i class="fa fa-arrow-left" matTooltip="{{ 'tooltips.Withdraw' | translate }}"></i>
+                  </button>
+                }
+                @if (element.depositType.id === 300) {
+                  <button
+                    class="account-action-button"
+                    mat-raised-button
+                    color="primary"
+                    (click)="routeEdit($event)"
+                    [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Withdrawal']"
+                  >
+                    <i class="fa fa-arrow-left" matTooltip="{{ 'tooltips.Withdraw' | translate }}"></i>
+                  </button>
+                }
+              }
+              @if (element.status.submittedAndPendingApproval) {
                 <button
                   class="account-action-button"
                   mat-raised-button
                   color="primary"
                   (click)="routeEdit($event)"
-                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Deposit']"
+                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Approve']"
                 >
-                  <i class="fa fa-arrow-right" matTooltip="{{ 'tooltips.Deposit' | translate }}"></i>
+                  <i class="fa fa-check" matTooltip="{{ 'tooltips.Approve' | translate }}"></i>
                 </button>
               }
-              @if (element.depositType.id === 300) {
+              @if (!element.status.submittedAndPendingApproval && !element.status.active) {
                 <button
                   class="account-action-button"
                   mat-raised-button
                   color="primary"
                   (click)="routeEdit($event)"
-                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Deposit']"
+                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Undo Approval']"
                 >
-                  <i class="fa fa-arrow-right" matTooltip="{{ 'tooltips.Deposit' | translate }}"></i>
+                  <i class="fa fa-undo" matTooltip="{{ 'tooltips.Undo Approve' | translate }}"></i>
                 </button>
-              }
-              @if (element.depositType.id === 100) {
                 <button
                   class="account-action-button"
                   mat-raised-button
                   color="primary"
                   (click)="routeEdit($event)"
-                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Withdrawal']"
+                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Activate']"
                 >
-                  <i class="fa fa-arrow-left" matTooltip="{{ 'tooltips.Withdraw' | translate }}"></i>
+                  <i class="fa fa-power-off" matTooltip="{{ 'tooltips.Activate' | translate }}"></i>
                 </button>
               }
-              @if (element.depositType.id === 300) {
-                <button
-                  class="account-action-button"
-                  mat-raised-button
-                  color="primary"
-                  (click)="routeEdit($event)"
-                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Withdrawal']"
-                >
-                  <i class="fa fa-arrow-left" matTooltip="{{ 'tooltips.Withdraw' | translate }}"></i>
-                </button>
-              }
-            }
-            @if (element.status.submittedAndPendingApproval) {
-              <button
-                class="account-action-button"
-                mat-raised-button
-                color="primary"
-                (click)="routeEdit($event)"
-                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Approve']"
-              >
-                <i class="fa fa-check" matTooltip="{{ 'tooltips.Approve' | translate }}"></i>
-              </button>
-            }
-            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-              <button
-                class="account-action-button"
-                mat-raised-button
-                color="primary"
-                (click)="routeEdit($event)"
-                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Undo Approval']"
-              >
-                <i class="fa fa-undo" matTooltip="{{ 'tooltips.Undo Approve' | translate }}"></i>
-              </button>
-              <button
-                class="account-action-button"
-                mat-raised-button
-                color="primary"
-                (click)="routeEdit($event)"
-                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Activate']"
-              >
-                <i class="fa fa-power-off" matTooltip="{{ 'tooltips.Activate' | translate }}"></i>
-              </button>
-            }
-          </td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="savingsAccountColumns"></tr>
-        <tr
-          mat-row
-          *matRowDef="let row; columns: savingsAccountColumns"
-          [routerLink]="['../', 'savings-accounts', row.id, 'transactions']"
-        ></tr>
-      </table>
+            </td>
+          </ng-container>
+          <tr mat-header-row *matHeaderRowDef="savingsAccountColumns"></tr>
+          <tr
+            mat-row
+            *matRowDef="let row; columns: savingsAccountColumns"
+            [routerLink]="['../', 'savings-accounts', row.id, 'transactions']"
+          ></tr>
+        </table>
+      }
     }
   }
 </div>

--- a/src/app/centers/centers-view/general-tab/general-tab.component.ts
+++ b/src/app/centers/centers-view/general-tab/general-tab.component.ts
@@ -57,6 +57,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class GeneralTabComponent {
   private route = inject(ActivatedRoute);
 
+  /** Show hidden savings account section when the full account interface is needed again. */
+  showNonLoanAccounts = false;
+
   /** Savings Account Table Columns */
   savingsAccountColumns: string[] = [
     'Account No',

--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
@@ -300,29 +300,6 @@
         }
       </mat-form-field>
     }
-
-    <mat-checkbox labelPosition="before" formControlName="addSavings" class="margin-v flex-48">
-      {{ 'labels.inputs.Open Savings Account' | translate }}?
-    </mat-checkbox>
-
-    @if (createClientForm.contains('savingsProductId')) {
-      <mat-form-field class="flex-48">
-        <mat-label>{{ 'labels.inputs.Savings Product' | translate }}</mat-label>
-        <mat-select required formControlName="savingsProductId">
-          @for (product of savingProductOptions; track product) {
-            <mat-option [value]="product.id">
-              {{ product.name }}
-            </mat-option>
-          }
-        </mat-select>
-        @if (createClientForm.controls.savingsProductId.hasError('required')) {
-          <mat-error>
-            {{ 'labels.inputs.Savings Product' | translate }} {{ 'labels.commons.is' | translate }}
-            <strong>{{ 'labels.commons.required' | translate }}</strong>
-          </mat-error>
-        }
-      </mat-form-field>
-    }
   </div>
 
   <div class="layout-row align-center gap-2percent margin-t responsive-column">

--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
@@ -90,9 +90,6 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
   constitutionOptions: any;
   /** Gender Options */
   genderOptions: any;
-  /** Saving Product Options */
-  savingProductOptions: any;
-
   /**
    * @param {FormBuilder} formBuilder Form Builder
    * @param {Dates} dateUtils Date Utils
@@ -126,7 +123,6 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
       ],
       isStaff: [false],
       active: [false],
-      addSavings: [false],
       accountNo: [''],
       externalId: [''],
       genderId: [''],
@@ -157,7 +153,6 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
     this.businessLineOptions = this.clientTemplate.clientNonPersonMainBusinessLineOptions;
     this.constitutionOptions = this.clientTemplate.clientNonPersonConstitutionOptions;
     this.genderOptions = this.clientTemplate.genderOptions;
-    this.savingProductOptions = this.clientTemplate.savingProductOptions;
   }
 
   /**
@@ -225,16 +220,6 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
         }
       });
     this.createClientForm
-      .get('addSavings')
-      .valueChanges.pipe(takeUntil(this.destroy$))
-      .subscribe((active: boolean) => {
-        if (active) {
-          this.createClientForm.addControl('savingsProductId', new UntypedFormControl('', Validators.required));
-        } else {
-          this.createClientForm.removeControl('savingsProductId');
-        }
-      });
-    this.createClientForm
       .get('officeId')
       .valueChanges.pipe(
         filter((officeId: number) => !!officeId),
@@ -263,7 +248,7 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
     const dateFormat = this.settingsService.dateFormat;
     const locale = this.settingsService.language.code;
     for (const key in generalDetails) {
-      if (generalDetails[key] === '' || key === 'addSavings') {
+      if (generalDetails[key] === '') {
         delete generalDetails[key];
       }
     }

--- a/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.html
+++ b/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.html
@@ -89,15 +89,6 @@
     </div>
   }
 
-  @if (client.savingsProductId) {
-    <div class="flex-fill">
-      <span class="flex-40">{{ 'labels.inputs.Savings Product' | translate }}</span>
-      <span class="flex-60">{{
-        client.savingsProductId | find: clientTemplate.savingProductOptions : 'id' : 'name'
-      }}</span>
-    </div>
-  }
-
   @if (client.submittedOnDate) {
     <div class="flex-fill">
       <span class="flex-40">{{ 'labels.inputs.Submitted On Date' | translate }}</span>

--- a/src/app/clients/clients-view/client-actions/client-actions.component.html
+++ b/src/app/clients/clients-view/client-actions/client-actions.component.html
@@ -24,9 +24,6 @@
 @if (actions['Withdraw']) {
   <mifosx-withdraw-client></mifosx-withdraw-client>
 }
-@if (actions['Update Default Savings']) {
-  <mifosx-update-client-savings-account></mifosx-update-client-savings-account>
-}
 @if (actions['Transfer Client']) {
   <mifosx-transfer-client></mifosx-transfer-client>
 }

--- a/src/app/clients/clients-view/client-actions/client-actions.component.ts
+++ b/src/app/clients/clients-view/client-actions/client-actions.component.ts
@@ -15,7 +15,6 @@ import { ViewSurveyComponent } from './view-survey/view-survey.component';
 import { RejectClientComponent } from './reject-client/reject-client.component';
 import { ActivateClientComponent } from './activate-client/activate-client.component';
 import { WithdrawClientComponent } from './withdraw-client/withdraw-client.component';
-import { UpdateClientSavingsAccountComponent } from './update-client-savings-account/update-client-savings-account.component';
 import { TransferClientComponent } from './transfer-client/transfer-client.component';
 import { UndoClientTransferComponent } from './undo-client-transfer/undo-client-transfer.component';
 import { RejectClientTransferComponent } from './reject-client-transfer/reject-client-transfer.component';
@@ -43,7 +42,6 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     RejectClientComponent,
     ActivateClientComponent,
     WithdrawClientComponent,
-    UpdateClientSavingsAccountComponent,
     TransferClientComponent,
     UndoClientTransferComponent,
     RejectClientTransferComponent,
@@ -67,7 +65,6 @@ export class ClientActionsComponent {
     Reject: boolean;
     Survey: boolean;
     Withdraw: boolean;
-    'Update Default Savings': boolean;
     'Transfer Client': boolean;
     'Undo Transfer': boolean;
     'Accept Transfer': boolean;
@@ -85,7 +82,6 @@ export class ClientActionsComponent {
     Reject: false,
     Survey: false,
     Withdraw: false,
-    'Update Default Savings': false,
     'Transfer Client': false,
     'Undo Transfer': false,
     'Accept Transfer': false,

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -93,20 +93,14 @@
                     </td>
                     <td><mifosx-account-number accountNo="{{ clientViewData.accountNo }}"></mifosx-account-number></td>
                   </tr>
-                  <tr>
-                    <td>
-                      <b>{{ 'labels.inputs.External Id' | translate }}</b>
-                    </td>
-                    <td>
-                      <mifosx-external-identifier
-                        [externalId]="
-                          complianceHideClientData ? maskValue(clientViewData.externalId) : clientViewData.externalId
-                        "
-                        [completed]="true"
-                        [hideCopy]="complianceHideClientData"
-                      ></mifosx-external-identifier>
-                    </td>
-                  </tr>
+                  @if (headerEntityId !== null) {
+                    <tr>
+                      <td>
+                        <b>{{ 'labels.inputs.EntityID' | translate }}</b>
+                      </td>
+                      <td>{{ headerEntityId }}</td>
+                    </tr>
+                  }
                   @if (clientViewData.activationDate) {
                     <tr>
                       <td>
@@ -208,17 +202,7 @@
         </button>
 
         @if (isActive()) {
-          <button
-            mat-menu-item
-            [matMenuTriggerFor]="accountApplications"
-            *mifosxHasPermission="[
-              'CREATE_LOAN',
-              'CREATE_SAVINGSACCOUNT',
-              'CREATE_SHAREACCOUNT',
-              'CREATE_RECURRINGDEPOSITACCOUNT',
-              'CREATE_FIXEDDEPOSITACCOUNT'
-            ]"
-          >
+          <button mat-menu-item [matMenuTriggerFor]="accountApplications" *mifosxHasPermission="'CREATE_LOAN'">
             <mat-icon matListIcon>
               <fa-icon icon="money-bill-alt" size="sm"></fa-icon>
             </mat-icon>
@@ -259,30 +243,6 @@
       <mat-menu #accountApplications="matMenu">
         <button mat-menu-item *mifosxHasPermission="'CREATE_LOAN'" [routerLink]="['loans-accounts', 'create']">
           {{ 'labels.buttons.New Loan Account' | translate }}
-        </button>
-        <button
-          mat-menu-item
-          *mifosxHasPermission="'CREATE_SAVINGSACCOUNT'"
-          [routerLink]="['savings-accounts', 'create']"
-        >
-          {{ 'labels.buttons.New Savings Account' | translate }}
-        </button>
-        <button mat-menu-item *mifosxHasPermission="'CREATE_SHAREACCOUNT'" [routerLink]="['shares-accounts', 'create']">
-          {{ 'labels.buttons.New Share Account' | translate }}
-        </button>
-        <button
-          mat-menu-item
-          *mifosxHasPermission="'CREATE_RECURRINGDEPOSITACCOUNT'"
-          [routerLink]="['recurring-deposits-accounts', 'create-recurring-deposits-account']"
-        >
-          {{ 'labels.buttons.New Recurring Deposit Account' | translate }}
-        </button>
-        <button
-          mat-menu-item
-          *mifosxHasPermission="'CREATE_FIXEDDEPOSITACCOUNT'"
-          [routerLink]="['fixed-deposits-accounts', 'create']"
-        >
-          {{ 'labels.buttons.New Fixed Deposits Account' | translate }}
         </button>
       </mat-menu>
 
@@ -363,13 +323,6 @@
         </button>
         <button mat-menu-item (click)="doAction('Survey')" [disabled]="true">
           {{ 'labels.buttons.Survey' | translate }}
-        </button>
-        <button
-          mat-menu-item
-          (click)="doAction('Update Default Savings')"
-          *mifosxHasPermission="'UPDATESAVINGSACCOUNT_CLIENT'"
-        >
-          {{ 'labels.buttons.Update Default Savings' | translate }}
         </button>
         <button mat-menu-item (click)="doAction('Upload Signature')" *mifosxHasPermission="'CREATE_CLIENTIMAGE'">
           {{ 'labels.buttons.Upload Signature' | translate }}

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -12,6 +12,8 @@ import { environment } from '../../../environments/environment';
 import { ActivatedRoute, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MatDialog } from '@angular/material/dialog';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 /** Custom Dialogs */
 import { UnassignStaffDialogComponent } from './custom-dialogs/unassign-staff-dialog/unassign-staff-dialog.component';
@@ -142,6 +144,12 @@ export class ClientsViewComponent implements OnInit {
   clientDatatables: any;
   clientImage: any;
   clientTemplateData: any;
+  headerEntityId: string | number | null = null;
+  private readonly headerEntityIdColumnNames = [
+    'EntityID',
+    'Entity Id',
+    'entity_id'
+  ];
 
   constructor() {
     this.route.data.subscribe((data: { clientViewData: any; clientTemplateData: any; clientDatatables: any }) => {
@@ -151,6 +159,7 @@ export class ClientsViewComponent implements OnInit {
         data.clientViewData?.legalForm?.id
       );
       this.clientTemplateData = data.clientTemplateData;
+      this.loadHeaderEntityId();
     });
   }
 
@@ -164,6 +173,60 @@ export class ClientsViewComponent implements OnInit {
     }
     const subtype = legalFormId === LegalFormId.PERSON ? 'person' : 'entity';
     return datatables.filter((dt: any) => !dt.entitySubType || dt.entitySubType.toLowerCase() === subtype);
+  }
+
+  private loadHeaderEntityId(): void {
+    this.headerEntityId = null;
+    const clientId = this.clientViewData?.id?.toString();
+    const datatableNames = (this.clientDatatables || [])
+      .map((datatable: any) => datatable.registeredTableName)
+      .filter((datatableName: string) => !!datatableName);
+
+    if (!clientId || datatableNames.length === 0) {
+      return;
+    }
+
+    const datatableRequests = datatableNames.map((datatableName: string) =>
+      this.clientsService.getClientDatatable(clientId, datatableName).pipe(catchError(() => of(null)))
+    );
+
+    forkJoin(datatableRequests).subscribe((datatables: any[]) => {
+      this.headerEntityId = this.getFirstHeaderEntityId(datatables);
+    });
+  }
+
+  private getFirstHeaderEntityId(datatables: any[]): string | number | null {
+    for (const datatable of datatables) {
+      const entityId = this.getDatatableColumnValue(datatable, this.headerEntityIdColumnNames);
+      if (entityId !== null) {
+        return entityId;
+      }
+    }
+    return null;
+  }
+
+  private getDatatableColumnValue(datatable: any, columnNames: string[]): string | number | null {
+    const row = datatable?.data?.[0]?.row;
+    const columnHeaders = datatable?.columnHeaders || [];
+    if (!row || columnHeaders.length === 0) {
+      return null;
+    }
+
+    const normalizedColumnNames = columnNames.map((columnName: string) => this.normalizeColumnName(columnName));
+    const columnIndex = columnHeaders.findIndex((columnHeader: any) =>
+      normalizedColumnNames.includes(this.normalizeColumnName(columnHeader?.columnName))
+    );
+
+    if (columnIndex === -1) {
+      return null;
+    }
+
+    const value = row[columnIndex];
+    return value === undefined || value === null || value === '' ? null : value;
+  }
+
+  private normalizeColumnName(columnName: string): string {
+    return (columnName || '').replace(/[_\s-]/g, '').toLowerCase();
   }
 
   ngOnInit() {
@@ -200,7 +263,6 @@ export class ClientsViewComponent implements OnInit {
       case 'Reject':
       case 'Activate':
       case 'Withdraw':
-      case 'Update Default Savings':
       case 'Transfer Client':
       case 'Undo Transfer':
       case 'Accept Transfer':

--- a/src/app/clients/clients-view/general-tab/general-tab.component.html
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.html
@@ -20,13 +20,6 @@
               <br />
             </p>
           </td>
-          <td>
-            <p>
-              {{ 'labels.inputs.No. of Active Savings' | translate }} :{{ performanceHistory.activeSavings }} <br />
-              {{ 'labels.inputs.Total Savings' | translate }} :{{ performanceHistory.totalSavings | formatNumber }}
-              <br />
-            </p>
-          </td>
         </tr>
       </tbody>
     </table>
@@ -369,611 +362,613 @@
     </table>
   }
 
-  <!-- Saving overview Table -->
-  <div class="heading-content">
-    <div class="layout-column flex-50">
-      <div class="heading-name">
-        <h3>{{ 'labels.heading.Saving Accounts' | translate }}</h3>
+  @if (showNonLoanAccounts) {
+    <!-- Saving overview Table -->
+    <div class="heading-content">
+      <div class="layout-column flex-50">
+        <div class="heading-name">
+          <h3>{{ 'labels.heading.Saving Accounts' | translate }}</h3>
+        </div>
+      </div>
+      <div class="layout-column flex-50">
+        <div class="layout-row align-flex-end">
+          <button mat-raised-button class="f-right" color="primary" (click)="toggleSavingAccountsOverview()">
+            {{ viewAccountsLabel(showClosedSavingAccounts) | translate }}
+          </button>
+        </div>
       </div>
     </div>
-    <div class="layout-column flex-50">
-      <div class="layout-row align-flex-end">
-        <button mat-raised-button class="f-right" color="primary" (click)="toggleSavingAccountsOverview()">
-          {{ viewAccountsLabel(showClosedSavingAccounts) | translate }}
-        </button>
+
+    @if (!showClosedSavingAccounts) {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isSavings'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Savings Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Last Active">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Balance">
+          <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
+          <td mat-cell class="r-amount" *matCellDef="let element">
+            {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Actions">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            @if (element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Deposit']"
+              >
+                <i class="fa fa-arrow-up"></i>
+              </button>
+            }
+            @if (element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Withdrawal']"
+              >
+                <i class="fa fa-arrow-down"></i>
+              </button>
+            }
+            @if (element.status.submittedAndPendingApproval) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Approve']"
+              >
+                <i class="fa fa-check"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Undo Approval']"
+              >
+                <i class="fa fa-undo"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Activate']"
+              >
+                <i class="fa fa-check-circle"></i>
+              </button>
+            }
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="no-data">
+          <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
+            <div class="table-empty-state">
+              <p>{{ 'labels.messages.No Active Saving Accounts Found' | translate }}</p>
+            </div>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: openSavingsColumns"
+          [routerLink]="['../', 'savings-accounts', row.id, 'general']"
+        ></tr>
+        <tr
+          mat-footer-row
+          *matFooterRowDef="
+            (savingAccounts | accountsFilter: 'saving' : 'open' : 'isSavings')?.length === 0 ? ['no-data'] : []
+          "
+        ></tr>
+      </table>
+    }
+
+    <!-- Closed Saving Accounts -->
+    @if (showClosedSavingAccounts) {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isSavings'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Savings Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Closed Date">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="no-data">
+          <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
+            <div class="table-empty-state">
+              <p>{{ 'labels.messages.No Closed Saving Accounts Found' | translate }}</p>
+            </div>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: closedSavingsColumns"
+          [routerLink]="['../', 'savings-accounts', row.id, 'general']"
+        ></tr>
+        <tr
+          mat-footer-row
+          *matFooterRowDef="
+            (savingAccounts | accountsFilter: 'saving' : 'closed' : 'isSavings')?.length === 0 ? ['no-data'] : []
+          "
+        ></tr>
+      </table>
+    }
+
+    <!-- Fixed Deposit Table -->
+    <div class="heading-content">
+      <div class="layout-column flex-50">
+        <div class="heading-name">
+          <h3>{{ 'labels.heading.Fixed Deposit Accounts' | translate }}</h3>
+        </div>
+      </div>
+      <div class="layout-column flex-50">
+        <div class="layout-row align-flex-end">
+          <button mat-raised-button class="f-right" color="primary" (click)="toggleFixedAccountsOverview()">
+            {{ viewAccountsLabel(showClosedFixedAccounts) | translate }}
+          </button>
+        </div>
       </div>
     </div>
-  </div>
 
-  @if (!showClosedSavingAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isSavings'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Savings Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Last Active">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Balance">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let element">
-          {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Actions">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          @if (element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Deposit']"
-            >
-              <i class="fa fa-arrow-up"></i>
-            </button>
-          }
-          @if (element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Withdrawal']"
-            >
-              <i class="fa fa-arrow-down"></i>
-            </button>
-          }
-          @if (element.status.submittedAndPendingApproval) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Approve']"
-            >
-              <i class="fa fa-check"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Undo Approval']"
-            >
-              <i class="fa fa-undo"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Activate']"
-            >
-              <i class="fa fa-check-circle"></i>
-            </button>
-          }
-        </td>
-      </ng-container>
+    @if (!showClosedFixedAccounts) {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isFixed'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fixed Deposit Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Last Active">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Balance">
+          <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
+          <td mat-cell class="r-amount" *matCellDef="let element">
+            {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Actions">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            @if (element.status.submittedAndPendingApproval) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Approve']"
+              >
+                <i class="fa fa-check"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Undo Approval']"
+              >
+                <i class="fa fa-undo"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Activate']"
+              >
+                <i class="fa fa-check-circle"></i>
+              </button>
+            }
+          </td>
+        </ng-container>
 
-      <ng-container matColumnDef="no-data">
-        <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
-          <div class="table-empty-state">
-            <p>{{ 'labels.messages.No Active Saving Accounts Found' | translate }}</p>
-          </div>
-        </td>
-      </ng-container>
+        <ng-container matColumnDef="no-data">
+          <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
+            <div class="table-empty-state">
+              <p>{{ 'labels.messages.No Active Fixed Deposit Accounts Found' | translate }}</p>
+            </div>
+          </td>
+        </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: openSavingsColumns"
-        [routerLink]="['../', 'savings-accounts', row.id, 'general']"
-      ></tr>
-      <tr
-        mat-footer-row
-        *matFooterRowDef="
-          (savingAccounts | accountsFilter: 'saving' : 'open' : 'isSavings')?.length === 0 ? ['no-data'] : []
-        "
-      ></tr>
-    </table>
-  }
+        <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: openSavingsColumns"
+          [routerLink]="['../', 'fixed-deposits-accounts', row.id, 'general']"
+        ></tr>
+        <tr
+          mat-footer-row
+          *matFooterRowDef="
+            (savingAccounts | accountsFilter: 'saving' : 'open' : 'isFixed')?.length === 0 ? ['no-data'] : []
+          "
+        ></tr>
+      </table>
+    }
 
-  <!-- Closed Saving Accounts -->
-  @if (showClosedSavingAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isSavings'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Savings Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Closed Date">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
-      </ng-container>
+    <!-- Closed Fixed Deposit Accounts -->
 
-      <ng-container matColumnDef="no-data">
-        <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
-          <div class="table-empty-state">
-            <p>{{ 'labels.messages.No Closed Saving Accounts Found' | translate }}</p>
-          </div>
-        </td>
-      </ng-container>
+    @if (showClosedFixedAccounts) {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isFixed'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fixed Deposit Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Closed Date">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+        </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: closedSavingsColumns"
-        [routerLink]="['../', 'savings-accounts', row.id, 'general']"
-      ></tr>
-      <tr
-        mat-footer-row
-        *matFooterRowDef="
-          (savingAccounts | accountsFilter: 'saving' : 'closed' : 'isSavings')?.length === 0 ? ['no-data'] : []
-        "
-      ></tr>
-    </table>
-  }
+        <ng-container matColumnDef="no-data">
+          <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
+            <div class="table-empty-state">
+              <p>{{ 'labels.messages.No Closed Fixed Deposit Accounts Found' | translate }}</p>
+            </div>
+          </td>
+        </ng-container>
 
-  <!-- Fixed Deposit Table -->
-  <div class="heading-content">
-    <div class="layout-column flex-50">
-      <div class="heading-name">
-        <h3>{{ 'labels.heading.Fixed Deposit Accounts' | translate }}</h3>
+        <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: closedSavingsColumns"
+          [routerLink]="['../', 'fixed-deposits-accounts', row.id, 'general']"
+        ></tr>
+        <tr
+          mat-footer-row
+          *matFooterRowDef="
+            (savingAccounts | accountsFilter: 'saving' : 'closed' : 'isFixed')?.length === 0 ? ['no-data'] : []
+          "
+        ></tr>
+      </table>
+    }
+
+    <!-- Recurring Deposit Table -->
+    <div class="heading-content">
+      <div class="layout-column flex-50">
+        <div class="heading-name">
+          <h3>{{ 'labels.heading.Recurring Deposit Accounts' | translate }}</h3>
+        </div>
+      </div>
+      <div class="layout-column flex-50">
+        <div class="layout-row align-flex-end">
+          <button mat-raised-button class="f-right" color="primary" (click)="toggleRecurringAccountsOverview()">
+            {{ viewAccountsLabel(showClosedRecurringAccounts) | translate }}
+          </button>
+        </div>
       </div>
     </div>
-    <div class="layout-column flex-50">
-      <div class="layout-row align-flex-end">
-        <button mat-raised-button class="f-right" color="primary" (click)="toggleFixedAccountsOverview()">
-          {{ viewAccountsLabel(showClosedFixedAccounts) | translate }}
-        </button>
+
+    @if (!showClosedRecurringAccounts) {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isRecurring'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Recurring Deposit Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Last Active">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Balance">
+          <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
+          <td mat-cell class="r-amount" *matCellDef="let element">
+            {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Actions">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            @if (element.status.submittedAndPendingApproval) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                *mifosxHasPermission="'APPROVE_SAVINGSACCOUNT'"
+                [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Approve']"
+                color="primary"
+              >
+                <i class="fa fa-check"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                *mifosxHasPermission="'APPROVALUNDO_SAVINGSACCOUNT'"
+                [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Undo Approval']"
+              >
+                <i class="fa fa-undo"></i>
+              </button>
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                *mifosxHasPermission="'ACTIVATE_SAVINGSACCOUNT'"
+                [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Activate']"
+              >
+                <i class="fa fa-check-circle"></i>
+              </button>
+            }
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="no-data">
+          <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
+            <div class="table-empty-state">
+              <p>{{ 'labels.messages.No Active Recurring Deposit Accounts Found' | translate }}</p>
+            </div>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: openSavingsColumns"
+          [routerLink]="['../', 'recurring-deposits-accounts', row.id, 'general']"
+          class="select-row"
+        ></tr>
+        <tr
+          mat-footer-row
+          *matFooterRowDef="
+            (savingAccounts | accountsFilter: 'saving' : 'open' : 'isRecurring')?.length === 0 ? ['no-data'] : []
+          "
+        ></tr>
+      </table>
+    }
+
+    <!-- Closed Recurring Deposit Accounts -->
+    @if (showClosedRecurringAccounts) {
+      <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isRecurring'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Saving Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Recurring Deposit Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Closed Date">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="no-data">
+          <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
+            <div class="table-empty-state">
+              <p>{{ 'labels.messages.No Closed Recurring Deposit Accounts Found' | translate }}</p>
+            </div>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: closedSavingsColumns"
+          [routerLink]="['../', 'recurring-deposits-accounts', row.id, 'general']"
+          class="select-row"
+        ></tr>
+        <tr
+          mat-footer-row
+          *matFooterRowDef="
+            (savingAccounts | accountsFilter: 'saving' : 'closed' : 'isRecurring')?.length === 0 ? ['no-data'] : []
+          "
+        ></tr>
+      </table>
+    }
+
+    <!-- Shares overview Table -->
+    <div class="heading-content">
+      <div class="layout-column flex-50">
+        <div class="heading-name">
+          <h3>{{ 'labels.inputs.Shares Accounts' | translate }}</h3>
+        </div>
+      </div>
+      <div class="layout-column flex-50">
+        <div class="layout-row align-flex-end">
+          <button mat-raised-button class="f-right" color="primary" (click)="toggleShareAccountsOverview()">
+            {{ viewAccountsLabel(showClosedShareAccounts) | translate }}
+          </button>
+        </div>
       </div>
     </div>
-  </div>
 
-  @if (!showClosedFixedAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isFixed'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fixed Deposit Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Last Active">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Balance">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let element">
-          {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Actions">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          @if (element.status.submittedAndPendingApproval) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Approve']"
-            >
-              <i class="fa fa-check"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Undo Approval']"
-            >
-              <i class="fa fa-undo"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              [routerLink]="['../', 'fixed-deposits-accounts', element.id, 'actions', 'Activate']"
-            >
-              <i class="fa fa-check-circle"></i>
-            </button>
-          }
-        </td>
-      </ng-container>
+    @if (!showClosedShareAccounts) {
+      <table mat-table [dataSource]="shareAccounts | accountsFilter: 'share'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Share Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Share Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Approved Shares">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Approved Shares' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.totalApprovedShares }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Pending For Approval Shares">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Pending For Approval Shares' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.totalPendingForApprovalShares }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Actions">
+          <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell class="center" *matCellDef="let element">
+            @if (element.status.submittedAndPendingApproval) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Approve']"
+              >
+                <i class="fa fa-check"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Undo Approval']"
+              >
+                <i class="fa fa-undo"></i>
+              </button>
+            }
+            @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+              <button
+                class="account-action-button"
+                mat-raised-button
+                color="primary"
+                (click)="routeEdit($event)"
+                [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Activate']"
+              >
+                <i class="fa fa-check-circle"></i>
+              </button>
+            }
+          </td>
+        </ng-container>
 
-      <ng-container matColumnDef="no-data">
-        <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
-          <div class="table-empty-state">
-            <p>{{ 'labels.messages.No Active Fixed Deposit Accounts Found' | translate }}</p>
-          </div>
-        </td>
-      </ng-container>
+        <ng-container matColumnDef="no-data">
+          <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSharesColumns.length">
+            <div class="table-empty-state">
+              <p>{{ 'labels.messages.No Active Share Accounts Found' | translate }}</p>
+            </div>
+          </td>
+        </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: openSavingsColumns"
-        [routerLink]="['../', 'fixed-deposits-accounts', row.id, 'general']"
-      ></tr>
-      <tr
-        mat-footer-row
-        *matFooterRowDef="
-          (savingAccounts | accountsFilter: 'saving' : 'open' : 'isFixed')?.length === 0 ? ['no-data'] : []
-        "
-      ></tr>
-    </table>
-  }
+        <tr mat-header-row *matHeaderRowDef="openSharesColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: openSharesColumns"
+          [routerLink]="['../', 'shares-accounts', row.id, 'general']"
+        ></tr>
+        <tr
+          mat-footer-row
+          *matFooterRowDef="(shareAccounts | accountsFilter: 'share')?.length === 0 ? ['no-data'] : []"
+        ></tr>
+      </table>
+    }
 
-  <!-- Closed Fixed Deposit Accounts -->
+    <!-- Closed Share Accounts -->
+    @if (showClosedShareAccounts) {
+      <table mat-table [dataSource]="shareAccounts | accountsFilter: 'share' : 'closed'">
+        <ng-container matColumnDef="Account No">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <td mat-cell *matCellDef="let element">
+            <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
+            <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="Share Account">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Share Product' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Approved Shares">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Approved Shares' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.totalApprovedShares }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Pending For Approval Shares">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Pending For Approval Shares' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.totalPendingForApprovalShares }}</td>
+        </ng-container>
+        <ng-container matColumnDef="Closed Date">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
+          <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+        </ng-container>
 
-  @if (showClosedFixedAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isFixed'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Fixed Deposit Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Closed Date">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
-      </ng-container>
+        <ng-container matColumnDef="no-data">
+          <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSharesColumns.length">
+            <div class="table-empty-state">
+              <p>{{ 'labels.messages.No Closed Share Accounts Found' | translate }}</p>
+            </div>
+          </td>
+        </ng-container>
 
-      <ng-container matColumnDef="no-data">
-        <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
-          <div class="table-empty-state">
-            <p>{{ 'labels.messages.No Closed Fixed Deposit Accounts Found' | translate }}</p>
-          </div>
-        </td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: closedSavingsColumns"
-        [routerLink]="['../', 'fixed-deposits-accounts', row.id, 'general']"
-      ></tr>
-      <tr
-        mat-footer-row
-        *matFooterRowDef="
-          (savingAccounts | accountsFilter: 'saving' : 'closed' : 'isFixed')?.length === 0 ? ['no-data'] : []
-        "
-      ></tr>
-    </table>
-  }
-
-  <!-- Recurring Deposit Table -->
-  <div class="heading-content">
-    <div class="layout-column flex-50">
-      <div class="heading-name">
-        <h3>{{ 'labels.heading.Recurring Deposit Accounts' | translate }}</h3>
-      </div>
-    </div>
-    <div class="layout-column flex-50">
-      <div class="layout-row align-flex-end">
-        <button mat-raised-button class="f-right" color="primary" (click)="toggleRecurringAccountsOverview()">
-          {{ viewAccountsLabel(showClosedRecurringAccounts) | translate }}
-        </button>
-      </div>
-    </div>
-  </div>
-
-  @if (!showClosedRecurringAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'open' : 'isRecurring'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Recurring Deposit Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Last Active">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Balance">
-        <th mat-header-cell class="r-amount" *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
-        <td mat-cell class="r-amount" *matCellDef="let element">
-          {{ element.accountBalance | currency: element.currency?.code || 'USD' : 'symbol-narrow' : '1.2-2' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Actions">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          @if (element.status.submittedAndPendingApproval) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              *mifosxHasPermission="'APPROVE_SAVINGSACCOUNT'"
-              [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Approve']"
-              color="primary"
-            >
-              <i class="fa fa-check"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              *mifosxHasPermission="'APPROVALUNDO_SAVINGSACCOUNT'"
-              [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Undo Approval']"
-            >
-              <i class="fa fa-undo"></i>
-            </button>
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              *mifosxHasPermission="'ACTIVATE_SAVINGSACCOUNT'"
-              [routerLink]="['../', 'recurring-deposits-accounts', element.id, 'actions', 'Activate']"
-            >
-              <i class="fa fa-check-circle"></i>
-            </button>
-          }
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="no-data">
-        <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSavingsColumns.length">
-          <div class="table-empty-state">
-            <p>{{ 'labels.messages.No Active Recurring Deposit Accounts Found' | translate }}</p>
-          </div>
-        </td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: openSavingsColumns"
-        [routerLink]="['../', 'recurring-deposits-accounts', row.id, 'general']"
-        class="select-row"
-      ></tr>
-      <tr
-        mat-footer-row
-        *matFooterRowDef="
-          (savingAccounts | accountsFilter: 'saving' : 'open' : 'isRecurring')?.length === 0 ? ['no-data'] : []
-        "
-      ></tr>
-    </table>
-  }
-
-  <!-- Closed Recurring Deposit Accounts -->
-  @if (showClosedRecurringAccounts) {
-    <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed' : 'isRecurring'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Saving Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Recurring Deposit Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Closed Date">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="no-data">
-        <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSavingsColumns.length">
-          <div class="table-empty-state">
-            <p>{{ 'labels.messages.No Closed Recurring Deposit Accounts Found' | translate }}</p>
-          </div>
-        </td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: closedSavingsColumns"
-        [routerLink]="['../', 'recurring-deposits-accounts', row.id, 'general']"
-        class="select-row"
-      ></tr>
-      <tr
-        mat-footer-row
-        *matFooterRowDef="
-          (savingAccounts | accountsFilter: 'saving' : 'closed' : 'isRecurring')?.length === 0 ? ['no-data'] : []
-        "
-      ></tr>
-    </table>
-  }
-
-  <!-- Shares overview Table -->
-  <div class="heading-content">
-    <div class="layout-column flex-50">
-      <div class="heading-name">
-        <h3>{{ 'labels.inputs.Shares Accounts' | translate }}</h3>
-      </div>
-    </div>
-    <div class="layout-column flex-50">
-      <div class="layout-row align-flex-end">
-        <button mat-raised-button class="f-right" color="primary" (click)="toggleShareAccountsOverview()">
-          {{ viewAccountsLabel(showClosedShareAccounts) | translate }}
-        </button>
-      </div>
-    </div>
-  </div>
-
-  @if (!showClosedShareAccounts) {
-    <table mat-table [dataSource]="shareAccounts | accountsFilter: 'share'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Share Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Share Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <mifosx-long-text textValue="{{ element.productName }}" chars="35"></mifosx-long-text>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Approved Shares">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Approved Shares' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.totalApprovedShares }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Pending For Approval Shares">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Pending For Approval Shares' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.totalPendingForApprovalShares }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Actions">
-        <th mat-header-cell class="center" *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-        <td mat-cell class="center" *matCellDef="let element">
-          @if (element.status.submittedAndPendingApproval) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Approve']"
-            >
-              <i class="fa fa-check"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Undo Approval']"
-            >
-              <i class="fa fa-undo"></i>
-            </button>
-          }
-          @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-            <button
-              class="account-action-button"
-              mat-raised-button
-              color="primary"
-              (click)="routeEdit($event)"
-              [routerLink]="['../', 'shares-accounts', element.id, 'actions', 'Activate']"
-            >
-              <i class="fa fa-check-circle"></i>
-            </button>
-          }
-        </td>
-      </ng-container>
-
-      <ng-container matColumnDef="no-data">
-        <td mat-footer-cell *matFooterCellDef [attr.colspan]="openSharesColumns.length">
-          <div class="table-empty-state">
-            <p>{{ 'labels.messages.No Active Share Accounts Found' | translate }}</p>
-          </div>
-        </td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="openSharesColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: openSharesColumns"
-        [routerLink]="['../', 'shares-accounts', row.id, 'general']"
-      ></tr>
-      <tr
-        mat-footer-row
-        *matFooterRowDef="(shareAccounts | accountsFilter: 'share')?.length === 0 ? ['no-data'] : []"
-      ></tr>
-    </table>
-  }
-
-  <!-- Closed Share Accounts -->
-  @if (showClosedShareAccounts) {
-    <table mat-table [dataSource]="shareAccounts | accountsFilter: 'share' : 'closed'">
-      <ng-container matColumnDef="Account No">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
-        <td mat-cell *matCellDef="let element">
-          <i class="fa fa-stop" [ngClass]="element.status.code | statusLookup"></i>
-          <mifosx-account-number accountNo="{{ element.accountNo }}"></mifosx-account-number>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="Share Account">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Share Product' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Approved Shares">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Approved Shares' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.totalApprovedShares }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Pending For Approval Shares">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Pending For Approval Shares' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.totalPendingForApprovalShares }}</td>
-      </ng-container>
-      <ng-container matColumnDef="Closed Date">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
-        <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
-      </ng-container>
-
-      <ng-container matColumnDef="no-data">
-        <td mat-footer-cell *matFooterCellDef [attr.colspan]="closedSharesColumns.length">
-          <div class="table-empty-state">
-            <p>{{ 'labels.messages.No Closed Share Accounts Found' | translate }}</p>
-          </div>
-        </td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="closedSharesColumns"></tr>
-      <tr
-        mat-row
-        *matRowDef="let row; columns: closedSharesColumns"
-        [routerLink]="['../', 'shares-accounts', row.id, 'general']"
-      ></tr>
-      <tr
-        mat-footer-row
-        *matFooterRowDef="(shareAccounts | accountsFilter: 'share' : 'closed')?.length === 0 ? ['no-data'] : []"
-      ></tr>
-    </table>
+        <tr mat-header-row *matHeaderRowDef="closedSharesColumns"></tr>
+        <tr
+          mat-row
+          *matRowDef="let row; columns: closedSharesColumns"
+          [routerLink]="['../', 'shares-accounts', row.id, 'general']"
+        ></tr>
+        <tr
+          mat-footer-row
+          *matFooterRowDef="(shareAccounts | accountsFilter: 'share' : 'closed')?.length === 0 ? ['no-data'] : []"
+        ></tr>
+      </table>
+    }
   }
 
   <!-- Collateral Data Table -->

--- a/src/app/clients/clients-view/general-tab/general-tab.component.ts
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.ts
@@ -255,6 +255,8 @@ export class GeneralTabComponent implements OnDestroy {
 
   /** Show Closed Loan Accounts */
   showClosedLoanAccounts = false;
+  /** Show hidden deposit/share account sections when the full account interface is needed again. */
+  showNonLoanAccounts = false;
   /** Show Closed Saving Accounts */
   showClosedSavingAccounts = false;
   /** Show Closed Share Accounts */

--- a/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.html
+++ b/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.html
@@ -130,12 +130,6 @@
         <span class="label">{{ 'labels.inputs.Staff' | translate }}</span>
         <span class="value">{{ clientViewData.staffName || ('labels.inputs.Unassigned' | translate) }}</span>
       </div>
-      @if (clientViewData.savingsAccountId) {
-        <div class="data-item">
-          <span class="label">{{ 'labels.inputs.Default Savings Account' | translate }}</span>
-          <span class="value">{{ clientViewData.savingsAccountId }}</span>
-        </div>
-      }
     </div>
   </div>
 

--- a/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.ts
+++ b/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.ts
@@ -60,8 +60,6 @@ interface ClientViewData {
   officeName?: string;
   staffId?: number;
   staffName?: string;
-  savingsProductId?: number;
-  savingsProductName?: string;
   [key: string]: any; // Allow additional properties from API
 }
 

--- a/src/app/clients/common-resolvers/client-actions.resolver.ts
+++ b/src/app/clients/common-resolvers/client-actions.resolver.ts
@@ -53,7 +53,6 @@ export class ClientActionsResolver {
       case 'Client Screen Reports':
         return this.clientsService.getClientReportTemplates();
       case 'Assign Staff':
-      case 'Update Default Savings':
         return this.clientsService.getClientDataAndTemplate(clientId);
       case 'Undo Transfer':
       case 'Accept Transfer':

--- a/src/app/groups/groups-view/general-tab/general-tab.component.html
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.html
@@ -220,45 +220,47 @@
     </div>
   }
 
-  @if (gsimAccounts) {
-    <div>
-      <div class="layout-row align-start table-header">
-        <div class="m-b-10">
-          <h3>{{ 'labels.heading.GSIM Account Overview' | translate }}</h3>
+  @if (showNonLoanAccounts) {
+    @if (gsimAccounts) {
+      <div>
+        <div class="layout-row align-start table-header">
+          <div class="m-b-10">
+            <h3>{{ 'labels.heading.GSIM Account Overview' | translate }}</h3>
+          </div>
         </div>
+        <!-- GSIM Accounts Table -->
+        <table mat-table [dataSource]="gsimAccounts" class="mat-elevation-z1 m-b-30">
+          <ng-container matColumnDef="GSIM Id">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.GSIM Id' | translate }}</th>
+            <td mat-cell *matCellDef="let element">
+              {{ element.gsimId }}
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="Account Number">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account Number' | translate }}</th>
+            <td mat-cell *matCellDef="let element">{{ element.accountNumber }}</td>
+          </ng-container>
+          <ng-container matColumnDef="Product">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Product' | translate }}</th>
+            <td mat-cell *matCellDef="let element">{{ element.childGSIMAccounts[0].productName }}</td>
+          </ng-container>
+          <ng-container matColumnDef="Balance">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
+            <td mat-cell *matCellDef="let element">{{ element.parentBalance }}</td>
+          </ng-container>
+          <ng-container matColumnDef="Status">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Status' | translate }}</th>
+            <td mat-cell *matCellDef="let element">{{ element.savingsStatus }}</td>
+          </ng-container>
+          <tr mat-header-row *matHeaderRowDef="gsimAccountsColumns"></tr>
+          <tr
+            mat-row
+            *matRowDef="let row; columns: gsimAccountsColumns"
+            [routerLink]="['../', 'savings-accounts', 'gsim-account', row.accountNumber]"
+          ></tr>
+        </table>
       </div>
-      <!-- GSIM Accounts Table -->
-      <table mat-table [dataSource]="gsimAccounts" class="mat-elevation-z1 m-b-30">
-        <ng-container matColumnDef="GSIM Id">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.GSIM Id' | translate }}</th>
-          <td mat-cell *matCellDef="let element">
-            {{ element.gsimId }}
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="Account Number">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account Number' | translate }}</th>
-          <td mat-cell *matCellDef="let element">{{ element.accountNumber }}</td>
-        </ng-container>
-        <ng-container matColumnDef="Product">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Product' | translate }}</th>
-          <td mat-cell *matCellDef="let element">{{ element.childGSIMAccounts[0].productName }}</td>
-        </ng-container>
-        <ng-container matColumnDef="Balance">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
-          <td mat-cell *matCellDef="let element">{{ element.parentBalance }}</td>
-        </ng-container>
-        <ng-container matColumnDef="Status">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Status' | translate }}</th>
-          <td mat-cell *matCellDef="let element">{{ element.savingsStatus }}</td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="gsimAccountsColumns"></tr>
-        <tr
-          mat-row
-          *matRowDef="let row; columns: gsimAccountsColumns"
-          [routerLink]="['../', 'savings-accounts', 'gsim-account', row.accountNumber]"
-        ></tr>
-      </table>
-    </div>
+    }
   }
 
   @if (glimAccounts) {
@@ -302,148 +304,150 @@
     </div>
   }
 
-  @if (savingAccounts) {
-    <div>
-      <div class="layout-row align-start table-header">
-        <div class="m-b-10">
-          <h3>{{ 'labels.heading.Saving Accounts' | translate }}</h3>
+  @if (showNonLoanAccounts) {
+    @if (savingAccounts) {
+      <div>
+        <div class="layout-row align-start table-header">
+          <div class="m-b-10">
+            <h3>{{ 'labels.heading.Saving Accounts' | translate }}</h3>
+          </div>
+          <div class="action-button m-b-10">
+            @if ((savingAccounts | accountsFilter: 'saving' : 'closed').length) {
+              <button mat-raised-button class="f-right" color="primary" (click)="toggleSavingAccountsOverview()">
+                {{ showClosedSavingAccounts ? 'View Active Accounts' : 'View Closed Accounts' }}
+              </button>
+            }
+          </div>
         </div>
-        <div class="action-button m-b-10">
-          @if ((savingAccounts | accountsFilter: 'saving' : 'closed').length) {
-            <button mat-raised-button class="f-right" color="primary" (click)="toggleSavingAccountsOverview()">
-              {{ showClosedSavingAccounts ? 'View Active Accounts' : 'View Closed Accounts' }}
-            </button>
-          }
-        </div>
+        <!-- Open Savings Accounts Table -->
+        @if (!showClosedSavingAccounts) {
+          <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving'" class="mat-elevation-z1 m-b-30">
+            <ng-container matColumnDef="Account No">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}.</th>
+              <td mat-cell *matCellDef="let element">
+                <i
+                  class="fa fa-stop"
+                  [ngClass]="element.status.code | statusLookup"
+                  [matTooltip]="element.status.value"
+                ></i>
+                {{ element.accountNo }}
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="Saving Account">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Saving Account' | translate }}</th>
+              <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
+            </ng-container>
+            <ng-container matColumnDef="Last Active">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
+              <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
+            </ng-container>
+            <ng-container matColumnDef="Balance">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
+              <td mat-cell *matCellDef="let element">{{ element.accountBalance }}</td>
+            </ng-container>
+            <ng-container matColumnDef="Actions">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+              <td mat-cell *matCellDef="let element">
+                @if (element.status.active) {
+                  <button
+                    class="account-action-button"
+                    mat-raised-button
+                    color="primary"
+                    (click)="routeEdit($event)"
+                    [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Deposit']"
+                  >
+                    <i class="fa fa-arrow-up" matTooltip="{{ 'tooltips.Deposit' | translate }}"></i>
+                  </button>
+                }
+                @if (element.status.active) {
+                  <button
+                    class="account-action-button"
+                    mat-raised-button
+                    color="primary"
+                    (click)="routeEdit($event)"
+                    [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Withdrawal']"
+                  >
+                    <i class="fa fa-arrow-down" matTooltip="{{ 'tooltips.Withdraw' | translate }}"></i>
+                  </button>
+                }
+                @if (element.status.submittedAndPendingApproval) {
+                  <button
+                    class="account-action-button"
+                    mat-raised-button
+                    color="primary"
+                    (click)="routeEdit($event)"
+                    [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Approve']"
+                  >
+                    <i class="fa fa-check" matTooltip="{{ 'tooltips.Approve' | translate }}"></i>
+                  </button>
+                }
+                @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+                  <button
+                    class="account-action-button"
+                    mat-raised-button
+                    color="primary"
+                    (click)="routeEdit($event)"
+                    [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Undo Approval']"
+                  >
+                    <i class="fa fa-undo" matTooltip="{{ 'tooltips.Undo Approval' | translate }}"></i>
+                  </button>
+                }
+                @if (!element.status.submittedAndPendingApproval && !element.status.active) {
+                  <button
+                    class="account-action-button"
+                    mat-raised-button
+                    color="primary"
+                    (click)="routeEdit($event)"
+                    [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Activate']"
+                  >
+                    <i class="fa fa-check-circle" matTooltip="{{ 'tooltips.Activate' | translate }}"></i>
+                  </button>
+                }
+              </td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
+            <tr
+              mat-row
+              *matRowDef="let row; columns: openSavingsColumns"
+              [routerLink]="['../', 'savings-accounts', row.id, 'transactions']"
+            ></tr>
+          </table>
+        }
+        <!-- Closed Saving Accounts Table -->
+        @if (showClosedSavingAccounts) {
+          <table
+            mat-table
+            [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed'"
+            class="mat-elevation-z1 m-b-30"
+          >
+            <ng-container matColumnDef="Account No">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}.</th>
+              <td mat-cell *matCellDef="let element">
+                <i
+                  class="fa fa-stop"
+                  [ngClass]="element.status.code | statusLookup"
+                  [matTooltip]="element.status.value"
+                ></i>
+                {{ element.accountNo }}
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="Saving Account">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Saving Account' | translate }}</th>
+              <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
+            </ng-container>
+            <ng-container matColumnDef="Closed Date">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
+              <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
+            <tr
+              mat-row
+              *matRowDef="let row; columns: closedSavingsColumns"
+              [routerLink]="['../', 'savings-accounts', row.id, 'transactions']"
+            ></tr>
+          </table>
+        }
       </div>
-      <!-- Open Savings Accounts Table -->
-      @if (!showClosedSavingAccounts) {
-        <table mat-table [dataSource]="savingAccounts | accountsFilter: 'saving'" class="mat-elevation-z1 m-b-30">
-          <ng-container matColumnDef="Account No">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}.</th>
-            <td mat-cell *matCellDef="let element">
-              <i
-                class="fa fa-stop"
-                [ngClass]="element.status.code | statusLookup"
-                [matTooltip]="element.status.value"
-              ></i>
-              {{ element.accountNo }}
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="Saving Account">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Saving Account' | translate }}</th>
-            <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
-          </ng-container>
-          <ng-container matColumnDef="Last Active">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Last Active' | translate }}</th>
-            <td mat-cell *matCellDef="let element">{{ element.lastActiveTransactionDate | dateFormat }}</td>
-          </ng-container>
-          <ng-container matColumnDef="Balance">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Balance' | translate }}</th>
-            <td mat-cell *matCellDef="let element">{{ element.accountBalance }}</td>
-          </ng-container>
-          <ng-container matColumnDef="Actions">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-            <td mat-cell *matCellDef="let element">
-              @if (element.status.active) {
-                <button
-                  class="account-action-button"
-                  mat-raised-button
-                  color="primary"
-                  (click)="routeEdit($event)"
-                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Deposit']"
-                >
-                  <i class="fa fa-arrow-up" matTooltip="{{ 'tooltips.Deposit' | translate }}"></i>
-                </button>
-              }
-              @if (element.status.active) {
-                <button
-                  class="account-action-button"
-                  mat-raised-button
-                  color="primary"
-                  (click)="routeEdit($event)"
-                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Withdrawal']"
-                >
-                  <i class="fa fa-arrow-down" matTooltip="{{ 'tooltips.Withdraw' | translate }}"></i>
-                </button>
-              }
-              @if (element.status.submittedAndPendingApproval) {
-                <button
-                  class="account-action-button"
-                  mat-raised-button
-                  color="primary"
-                  (click)="routeEdit($event)"
-                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Approve']"
-                >
-                  <i class="fa fa-check" matTooltip="{{ 'tooltips.Approve' | translate }}"></i>
-                </button>
-              }
-              @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-                <button
-                  class="account-action-button"
-                  mat-raised-button
-                  color="primary"
-                  (click)="routeEdit($event)"
-                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Undo Approval']"
-                >
-                  <i class="fa fa-undo" matTooltip="{{ 'tooltips.Undo Approval' | translate }}"></i>
-                </button>
-              }
-              @if (!element.status.submittedAndPendingApproval && !element.status.active) {
-                <button
-                  class="account-action-button"
-                  mat-raised-button
-                  color="primary"
-                  (click)="routeEdit($event)"
-                  [routerLink]="['../', 'savings-accounts', element.id, 'actions', 'Activate']"
-                >
-                  <i class="fa fa-check-circle" matTooltip="{{ 'tooltips.Activate' | translate }}"></i>
-                </button>
-              }
-            </td>
-          </ng-container>
-          <tr mat-header-row *matHeaderRowDef="openSavingsColumns"></tr>
-          <tr
-            mat-row
-            *matRowDef="let row; columns: openSavingsColumns"
-            [routerLink]="['../', 'savings-accounts', row.id, 'transactions']"
-          ></tr>
-        </table>
-      }
-      <!-- Closed Saving Accounts Table -->
-      @if (showClosedSavingAccounts) {
-        <table
-          mat-table
-          [dataSource]="savingAccounts | accountsFilter: 'saving' : 'closed'"
-          class="mat-elevation-z1 m-b-30"
-        >
-          <ng-container matColumnDef="Account No">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}.</th>
-            <td mat-cell *matCellDef="let element">
-              <i
-                class="fa fa-stop"
-                [ngClass]="element.status.code | statusLookup"
-                [matTooltip]="element.status.value"
-              ></i>
-              {{ element.accountNo }}
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="Saving Account">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Saving Account' | translate }}</th>
-            <td mat-cell *matCellDef="let element">{{ element.productName }}</td>
-          </ng-container>
-          <ng-container matColumnDef="Closed Date">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Closed Date' | translate }}</th>
-            <td mat-cell *matCellDef="let element">{{ element.timeline.closedOnDate | dateFormat }}</td>
-          </ng-container>
-          <tr mat-header-row *matHeaderRowDef="closedSavingsColumns"></tr>
-          <tr
-            mat-row
-            *matRowDef="let row; columns: closedSavingsColumns"
-            [routerLink]="['../', 'savings-accounts', row.id, 'transactions']"
-          ></tr>
-        </table>
-      }
-    </div>
+    }
   }
 </div>

--- a/src/app/groups/groups-view/general-tab/general-tab.component.ts
+++ b/src/app/groups/groups-view/general-tab/general-tab.component.ts
@@ -132,6 +132,8 @@ export class GeneralTabComponent {
   ];
   /** Boolean for toggling loan accounts table */
   showClosedLoanAccounts = false;
+  /** Show hidden savings account sections when the full account interface is needed again. */
+  showNonLoanAccounts = false;
   /** Boolean for toggling savings accounts table */
   showClosedSavingAccounts = false;
 

--- a/src/app/groups/groups-view/groups-view.component.html
+++ b/src/app/groups/groups-view/groups-view.component.html
@@ -129,13 +129,6 @@
               </button></span
             >
           }
-          <button
-            mat-menu-item
-            *mifosxHasPermission="'CREATE_SAVINGSACCOUNT'"
-            [routerLink]="['savings-accounts', 'create']"
-          >
-            {{ 'labels.buttons.Group Saving Application' | translate }}
-          </button>
           <button mat-menu-item *mifosxHasPermission="'CREATE_LOAN'" [routerLink]="['loans-accounts', 'create']">
             {{ 'labels.buttons.Group Loan Application' | translate }}
           </button>
@@ -147,17 +140,6 @@
                 [routerLink]="['loans-accounts', 'glim-account', 'create']"
               >
                 {{ 'labels.buttons.GLIM Application' | translate }}
-              </button>
-            </span>
-          }
-          @if (groupViewData.clientMembers) {
-            <span>
-              <button
-                mat-menu-item
-                *mifosxHasPermission="'CREATE_GSIMACCOUNT'"
-                [routerLink]="['savings-accounts', 'gsim-account', 'create']"
-              >
-                {{ 'labels.buttons.GSIM Application' | translate }}
               </button>
             </span>
           }

--- a/src/app/navigation/center-navigation/center-navigation.component.html
+++ b/src/app/navigation/center-navigation/center-navigation.component.html
@@ -158,13 +158,5 @@
         <mifosx-loan-account-table [loanAccountData]="centerAccountsData.loanAccounts"></mifosx-loan-account-table>
       </mat-tab>
     }
-
-    @if (centerAccountsData && centerAccountsData.savingsAccounts) {
-      <mat-tab label="Savings Accounts">
-        <mifosx-savings-account-table
-          [savingsAccountData]="centerAccountsData.savingsAccounts"
-        ></mifosx-savings-account-table>
-      </mat-tab>
-    }
   </mat-tab-group>
 </mat-card-content>

--- a/src/app/navigation/center-navigation/center-navigation.component.ts
+++ b/src/app/navigation/center-navigation/center-navigation.component.ts
@@ -11,7 +11,6 @@ import { Component, Input, ViewChild } from '@angular/core';
 
 /** Custom Components */
 import { LoanAccountTableComponent } from '../loan-account-table/loan-account-table.component';
-import { SavingsAccountTableComponent } from '../savings-account-table/savings-account-table.component';
 import {
   MatCardHeader,
   MatCardTitleGroup,
@@ -45,14 +44,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatTabGroup,
     MatTab,
     LoanAccountTableComponent,
-    SavingsAccountTableComponent,
     StatusLookupPipe,
     DateFormatPipe
   ]
 })
 export class CenterNavigationComponent {
   @ViewChild(LoanAccountTableComponent) loanAccountTableComponent: LoanAccountTableComponent;
-  @ViewChild(SavingsAccountTableComponent) savingsAccountTableComponent: SavingsAccountTableComponent;
 
   @Input() centerData: any;
   @Input() centerAccountsData: any;

--- a/src/app/navigation/client-navigation/client-navigation.component.html
+++ b/src/app/navigation/client-navigation/client-navigation.component.html
@@ -137,20 +137,6 @@
       </mat-tab>
     }
 
-    @if (clientAccountsData && clientAccountsData.savingsAccounts) {
-      <mat-tab label="Savings Accounts">
-        <mifosx-savings-account-table
-          [savingsAccountData]="clientAccountsData.savingsAccounts"
-        ></mifosx-savings-account-table>
-      </mat-tab>
-    }
-
-    @if (clientAccountsData && clientAccountsData.shareAccounts) {
-      <mat-tab label="Share Accounts">
-        <mifosx-share-account-table [shareAccountData]="clientAccountsData.shareAccounts"></mifosx-share-account-table>
-      </mat-tab>
-    }
-
     @if (clientData.groups && clientData.groups.length !== 0) {
       <mat-tab label="Group Members">
         <mifosx-member-groups [memberGroupData]="clientData.groups"></mifosx-member-groups>

--- a/src/app/navigation/client-navigation/client-navigation.component.ts
+++ b/src/app/navigation/client-navigation/client-navigation.component.ts
@@ -11,8 +11,6 @@ import { Component, Input, ViewChild } from '@angular/core';
 
 /** Custom Components */
 import { LoanAccountTableComponent } from '../loan-account-table/loan-account-table.component';
-import { SavingsAccountTableComponent } from '../savings-account-table/savings-account-table.component';
-import { ShareAccountTableComponent } from '../share-account-table/share-account-table.component';
 import { MemberGroupsComponent } from '../member-groups/member-groups.component';
 import {
   MatCardHeader,
@@ -43,8 +41,6 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatTabGroup,
     MatTab,
     LoanAccountTableComponent,
-    SavingsAccountTableComponent,
-    ShareAccountTableComponent,
     MemberGroupsComponent,
     StatusLookupPipe,
     DateFormatPipe
@@ -52,8 +48,6 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ClientNavigationComponent {
   @ViewChild(LoanAccountTableComponent) loanAccountTableComponent: LoanAccountTableComponent;
-  @ViewChild(SavingsAccountTableComponent) savingsAccountTableComponent: SavingsAccountTableComponent;
-  @ViewChild(ShareAccountTableComponent) shareAccountTableComponent: ShareAccountTableComponent;
   @ViewChild(MemberGroupsComponent) memberGroupsComponent: MemberGroupsComponent;
 
   @Input() clientData: any;

--- a/src/app/navigation/group-navigation/group-navigation.component.html
+++ b/src/app/navigation/group-navigation/group-navigation.component.html
@@ -104,13 +104,5 @@
         <mifosx-loan-account-table [loanAccountData]="groupAccountsData.loanAccounts"></mifosx-loan-account-table>
       </mat-tab>
     }
-
-    @if (groupAccountsData && groupAccountsData.savingsAccounts) {
-      <mat-tab label="Savings Accounts">
-        <mifosx-savings-account-table
-          [savingsAccountData]="groupAccountsData.savingsAccounts"
-        ></mifosx-savings-account-table>
-      </mat-tab>
-    }
   </mat-tab-group>
 </mat-card-content>

--- a/src/app/navigation/group-navigation/group-navigation.component.ts
+++ b/src/app/navigation/group-navigation/group-navigation.component.ts
@@ -11,7 +11,6 @@ import { Component, Input, ViewChild } from '@angular/core';
 
 /** Custom Components */
 import { LoanAccountTableComponent } from '../loan-account-table/loan-account-table.component';
-import { SavingsAccountTableComponent } from '../savings-account-table/savings-account-table.component';
 import {
   MatCardHeader,
   MatCardTitleGroup,
@@ -41,14 +40,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatTabGroup,
     MatTab,
     LoanAccountTableComponent,
-    SavingsAccountTableComponent,
     StatusLookupPipe,
     DateFormatPipe
   ]
 })
 export class GroupNavigationComponent {
   @ViewChild(LoanAccountTableComponent) loanAccountTableComponent: LoanAccountTableComponent;
-  @ViewChild(SavingsAccountTableComponent) savingsAccountTableComponent: SavingsAccountTableComponent;
 
   @Input() groupData: any;
   @Input() groupAccountsData: any;

--- a/src/app/search/search-page/search-page.component.html
+++ b/src/app/search/search-page/search-page.component.html
@@ -22,9 +22,9 @@
           <td mat-cell *matCellDef="let entity" class="view-details">{{ entity.entityName }}</td>
         </ng-container>
         <ng-container matColumnDef="entityAccount">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Account No' | translate }}</th>
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.EntityID' | translate }}</th>
           <td mat-cell *matCellDef="let entity" class="view-details">
-            <mifosx-account-number display="left" accountNo="{{ entity.entityAccountNo }}"></mifosx-account-number>
+            {{ getSearchEntityId(entity) }}
           </td>
         </ng-container>
         <ng-container matColumnDef="externalId">

--- a/src/app/search/search-page/search-page.component.ts
+++ b/src/app/search/search-page/search-page.component.ts
@@ -24,12 +24,14 @@ import {
 } from '@angular/material/table';
 import { Router, ActivatedRoute } from '@angular/router';
 import { SearchData } from '../search.model';
-import { AccountNumberComponent } from '../../shared/account-number/account-number.component';
 import { ExternalIdentifierComponent } from '../../shared/external-identifier/external-identifier.component';
 import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { ClientsService } from 'app/clients/clients.service';
+import { forkJoin, Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 
 /**
  * Search Page Component
@@ -46,7 +48,6 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatHeaderCell,
     MatCellDef,
     MatCell,
-    AccountNumberComponent,
     ExternalIdentifierComponent,
     MatIconButton,
     MatTooltip,
@@ -61,6 +62,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class SearchPageComponent {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private clientsService = inject(ClientsService);
+  private readonly entityIdColumnNames = [
+    'EntityID',
+    'Entity Id',
+    'entity_id'
+  ];
 
   /** Flags if number of search results exceed 200 */
   overload: boolean;
@@ -87,14 +94,118 @@ export class SearchPageComponent {
    */
   constructor() {
     this.route.data.subscribe((data: { searchResults: any }) => {
-      this.dataSource = new MatTableDataSource(data.searchResults);
+      const hiddenEntityTypes = [
+        'SAVING',
+        'SHARE'
+      ];
+      const searchResults = data.searchResults.filter(
+        (result: SearchData) => !hiddenEntityTypes.includes(result.entityType)
+      );
+      this.overload = searchResults.length > 200 ? true : false;
+      const visibleResults = this.overload ? searchResults.slice(0, 200) : searchResults;
+      this.dataSource = new MatTableDataSource(visibleResults);
       this.dataSource.paginator = this.paginator;
-      this.hasResults = data.searchResults.length > 0;
-      this.overload = data.searchResults.length > 200 ? true : false;
-      if (this.overload) {
-        this.dataSource = new MatTableDataSource(data.searchResults.slice(0, 200));
-      }
+      this.hasResults = visibleResults.length > 0;
+      this.loadClientEntityIds(visibleResults);
     });
+  }
+
+  getSearchEntityId(entity: SearchData): string | number {
+    if (entity.entityType === 'CLIENT' || entity.entityType === 'CLIENTIDENTIFIER') {
+      return entity.entityNumber ?? '';
+    }
+    return entity.entityNumber ?? entity.entityAccountNo;
+  }
+
+  private loadClientEntityIds(searchResults: SearchData[]): void {
+    const clientEntityTypes = [
+      'CLIENT',
+      'CLIENTIDENTIFIER'
+    ];
+    const clientResults = searchResults.filter((result: SearchData) => clientEntityTypes.includes(result.entityType));
+
+    if (clientResults.length === 0) {
+      return;
+    }
+
+    this.clientsService
+      .getClientDatatables()
+      .pipe(catchError(() => of([])))
+      .subscribe((clientDatatables: any[]) => {
+        const datatableNames = (clientDatatables || [])
+          .map((datatable: any) => datatable.registeredTableName)
+          .filter((datatableName: string) => !!datatableName);
+
+        if (datatableNames.length === 0) {
+          return;
+        }
+
+        const entityIdRequests = clientResults.map((result: SearchData) =>
+          this.getClientEntityId(this.getClientIdForSearchResult(result), datatableNames)
+        );
+
+        forkJoin(entityIdRequests).subscribe((entityIds: Array<string | number | null>) => {
+          entityIds.forEach((entityId: string | number | null, index: number) => {
+            if (entityId !== null) {
+              clientResults[index].entityNumber = entityId;
+            }
+          });
+          this.dataSource.data = [...this.dataSource.data];
+        });
+      });
+  }
+
+  private getClientEntityId(clientId: string, datatableNames: string[]): Observable<string | number | null> {
+    if (!clientId) {
+      return of(null);
+    }
+
+    const datatableRequests = datatableNames.map((datatableName: string) =>
+      this.clientsService.getClientDatatable(clientId, datatableName).pipe(catchError(() => of(null)))
+    );
+
+    return forkJoin(datatableRequests).pipe(
+      map((datatables: any[]) => this.getFirstDatatableColumnValue(datatables, this.entityIdColumnNames)),
+      catchError(() => of(null))
+    );
+  }
+
+  private getFirstDatatableColumnValue(datatables: any[], columnNames: string[]): string | number | null {
+    for (const datatable of datatables) {
+      const columnValue = this.getDatatableColumnValue(datatable, columnNames);
+      if (columnValue !== null) {
+        return columnValue;
+      }
+    }
+    return null;
+  }
+
+  private getDatatableColumnValue(datatable: any, columnNames: string[]): string | number | null {
+    const row = datatable?.data?.[0]?.row;
+    const columnHeaders = datatable?.columnHeaders || [];
+    if (!row || columnHeaders.length === 0) {
+      return null;
+    }
+
+    const normalizedColumnNames = columnNames.map((columnName: string) => this.normalizeColumnName(columnName));
+    const columnIndex = columnHeaders.findIndex((columnHeader: any) =>
+      normalizedColumnNames.includes(this.normalizeColumnName(columnHeader?.columnName))
+    );
+
+    if (columnIndex === -1) {
+      return null;
+    }
+
+    const value = row[columnIndex];
+    return value === undefined || value === null || value === '' ? null : value;
+  }
+
+  private getClientIdForSearchResult(result: SearchData): string {
+    return (result.entityType === 'CLIENTIDENTIFIER' ? result.parentId : result.entityId)?.toString();
+  }
+
+  private normalizeColumnName(columnName: string): string {
+    return (columnName || '').replace(/[_\s-]/g, '').toLowerCase();
   }
 
   /**

--- a/src/app/search/search.model.ts
+++ b/src/app/search/search.model.ts
@@ -9,6 +9,7 @@
 export interface SearchData {
   entityId: number;
   entityAccountNo: string;
+  entityNumber?: string | number;
   entityExternalId: string;
   entityName: string;
   entityType: string;

--- a/src/app/shared/search-tool/search-tool.component.ts
+++ b/src/app/shared/search-tool/search-tool.component.ts
@@ -55,7 +55,7 @@ export class SearchToolComponent {
   resourceOptions: any[] = [
     {
       name: 'All',
-      value: 'clients,clientIdentifiers,groups,savings,shares,loans'
+      value: 'clients,clientIdentifiers,groups,loans'
     },
     {
       name: 'Clients',
@@ -64,14 +64,6 @@ export class SearchToolComponent {
     {
       name: 'Groups',
       value: 'groups'
-    },
-    {
-      name: 'Savings',
-      value: 'savings'
-    },
-    {
-      name: 'Shares',
-      value: 'shares'
     },
     {
       name: 'Loans',
@@ -83,7 +75,7 @@ export class SearchToolComponent {
    * @param {Router} router Router
    */
   constructor() {
-    this.resource.patchValue('clients,clientIdentifiers,groups,savings,shares,loans');
+    this.resource.patchValue('clients,clientIdentifiers,groups,loans');
   }
 
   /**

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2009,6 +2009,7 @@
       "Entity Name": "Entity Name",
       "Entity SubType": "Entity SubType",
       "Entity Type": "Entity Type",
+      "EntityID": "EntityID",
       "Entry ID": "Entry ID",
       "Equal Amortization": "Equal Amortization",
       "Equity": "Equity",


### PR DESCRIPTION
Created a new web interface that only shows what we need here at WSCREDIT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added EntityID field display for clients and groups across search results and account views.

* **Changes**
  * Restructured account navigation; loan accounts now display as primary view, with non-loan accounts separately toggled.
  * Removed savings account creation and management features.
  * Removed share account functionality and navigation tabs.
  * Updated search results to display EntityID instead of Account Number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->