### PR TITLE
WEB-112: Sanitize GSIM fields before calculateLoanSchedule to avoid NPE

### DIFF
--- a/src/app/loans/loans.service.spec.ts
+++ b/src/app/loans/loans.service.spec.ts
@@ -1,0 +1,94 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { LoansService } from './loans.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
+
+describe('LoansService', () => {
+  let service: LoansService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    const mockSettings: Partial<SettingsService> = {
+      language: { name: 'English', code: 'en' },
+      dateFormat: 'yyyy-MM-dd',
+      businessDate: new Date(),
+      maxFutureDate: new Date()
+    };
+    const mockDates: Partial<Dates> = {
+      formatDate: (d: any) => d,
+      formatDateAsString: (d: any) => String(d)
+    } as any;
+
+    TestBed.configureTestingModule({
+      providers: [
+        LoansService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: SettingsService, useValue: mockSettings },
+        { provide: Dates, useValue: mockDates }]
+    });
+    service = TestBed.inject(LoansService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should sanitize all GSIM fields before posting calculateLoanSchedule', () => {
+    const payload = {
+      principal: 1000,
+      linkAccountId: 42,
+      linkAccountOwnerName: 'Alice',
+      linkedSavingsAccount: { id: 5 },
+      nested: {
+        linkAccountOwnerId: 7,
+        linkAccountOwnerName: 'Bob',
+        ok: 'keep'
+      },
+      members: [
+        { id: 1, linkAccountId: 99 },
+        { id: 2, name: 'foo', linkedSavingsAccount: { id: 9 } }
+      ]
+    } as any;
+
+    const original = JSON.parse(JSON.stringify(payload));
+
+    service.calculateLoanSchedule(payload).subscribe(() => {});
+
+    const req = httpMock.expectOne('/loans?command=calculateLoanSchedule');
+    expect(req.request.method).toBe('POST');
+
+    const body = req.request.body;
+
+    // All forbidden keys should be removed at every depth
+    expect(body.linkAccountId).toBeUndefined();
+    expect(body.linkAccountOwnerName).toBeUndefined();
+    expect(body.linkedSavingsAccount).toBeUndefined();
+    expect(body.nested.linkAccountOwnerId).toBeUndefined();
+    expect(body.nested.linkAccountOwnerName).toBeUndefined();
+    expect(body.members[0].linkAccountId).toBeUndefined();
+    expect(body.members[1].linkedSavingsAccount).toBeUndefined();
+
+    // Allowed keys should be preserved
+    expect(body.principal).toBe(1000);
+    expect(body.nested.ok).toBe('keep');
+    expect(body.members[1].name).toBe('foo');
+
+    // Original caller payload must remain unmutated
+    expect(payload).toEqual(original);
+
+    req.flush({});
+  });
+
+  it('should keep non-object primitives intact', () => {
+    const payload = { value: 1, text: 'abc' };
+    service.calculateLoanSchedule(payload).subscribe(() => {});
+    const req = httpMock.expectOne('/loans?command=calculateLoanSchedule');
+    expect(req.request.body.value).toBe(1);
+    expect(req.request.body.text).toBe('abc');
+    req.flush({});
+  });
+});

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -30,6 +30,13 @@ export interface WorkingCapitalLoanDiscountUpdateRequest {
   providedIn: 'root'
 })
 export class LoansService {
+  private static readonly FORBIDDEN_LOAN_PAYLOAD_KEYS: ReadonlySet<string> = new Set([
+    'linkAccountId',
+    'linkAccountOwnerId',
+    'linkAccountOwnerName',
+    'linkedSavingsAccount'
+  ]);
+
   private http = inject(HttpClient);
   private settingsService = inject(SettingsService);
   private dateUtils = inject(Dates);
@@ -701,8 +708,29 @@ export class LoansService {
     return this.http.post('/batches?enclosingTransaction=true', payload);
   }
 
+  /**
+   * Calculate repayment schedule preview.
+   * Sanitize payload to avoid sending GSIM-linked fields that may crash backend.
+   */
   calculateLoanSchedule(payload: any): Observable<any> {
-    return this.http.post('/loans?command=calculateLoanSchedule', payload);
+    const sanitized = this.sanitizeLoanPayload(payload);
+    return this.http.post('/loans?command=calculateLoanSchedule', sanitized);
+  }
+
+  /**
+   * Remove potentially unsafe GSIM linkage fields from payload recursively.
+   * This is a defensive workaround until backend validation is fixed in Fineract.
+   * Does not mutate the caller's payload; returns a new sanitized copy.
+   */
+  private sanitizeLoanPayload(obj: any): any {
+    if (obj === null || typeof obj !== 'object') return obj;
+    if (Array.isArray(obj)) return obj.map((item) => this.sanitizeLoanPayload(item));
+    const out: Record<string, any> = {};
+    for (const key of Object.keys(obj)) {
+      if (LoansService.FORBIDDEN_LOAN_PAYLOAD_KEYS.has(key)) continue;
+      out[key] = this.sanitizeLoanPayload(obj[key]);
+    }
+    return out;
   }
 
   attachLoanOriginator(loanId: string, originatorId: string): Observable<any> {


### PR DESCRIPTION
## Description

This PR adds a frontend safeguard to prevent GSIM-linked fields from being sent to the backend loan schedule calculation endpoint, which was causing a 500 Internal Server Error.

**Changes Made:**
- Added `sanitizeLoanPayload()` private method to `LoansService` that recursively removes unsafe GSIM linkage fields (`linkAccountId`, `linkAccountOwnerId`, `linkAccountOwnerName`, `linkedSavingsAccount`) from loan payloads
- Applied sanitization in `calculateLoanSchedule()` endpoint before posting to `/loans?command=calculateLoanSchedule`
- Added comprehensive Jest unit tests to verify forbidden fields are removed at all nesting levels while allowed fields are preserved

**Why These Changes:**
The root cause of the 500 error is a `NullPointerException` in the Fineract backend (`LoanScheduleCalculationPlatformServiceImpl`) during GLIM + GSIM validation. While a permanent fix should be made in Apache Fineract, this frontend safeguard prevents invalid payloads from being sent, providing immediate relief for users.

**Dependencies:**
No new dependencies required. Uses existing Angular testing utilities (`provideHttpClient`, `provideHttpClientTesting` for Angular 20 compatibility).

## Related issues and discussion

[WEB-112](https://mifosforge.jira.com/browse/WEB-112)

## Screenshots, if any

N/A - Backend API safeguard (no UI changes)

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
- [x] Code follows project style (ran `npm run lint`, `npm run headers:add`)
- [x] Unit tests added and passing (`npm run test` - 2/2 tests passing)
- [x] Tested on dockerized Fineract backend - schedule generation no longer throws 500

[WEB-112]: https://mifosforge.jira.com/browse/WEB-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Loan schedule calculation requests now filter out certain account linkage fields before sending to the server, ensuring cleaner request payloads.

* **Tests**
  * Added comprehensive unit tests for loan schedule calculation to verify proper request sanitization and field handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3569)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->