### PR TITLE
WEB-579: make API gateway tenant header name configurable

### DIFF
--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -208,8 +208,8 @@ export class LoginComponent implements OnInit, OnDestroy {
     }
     const tenantIds = environment.fineractPlatformTenantIds
       .split(',')
-      .map((id) => id.trim())
-      .filter((id) => id.length > 0);
+      .map((id: string) => id.trim())
+      .filter((id: string) => id.length > 0);
     if (tenantIds.length === 0 || (tenantIds.length === 1 && tenantIds[0] === 'default')) {
       return false;
     }

--- a/src/app/zitadel/token.interceptor.ts
+++ b/src/app/zitadel/token.interceptor.ts
@@ -19,11 +19,15 @@ export class TokenInterceptor implements HttpInterceptor {
 
   public environment = environment;
   FINERACT_PLATFORM_TENANT_IDENTIFIER = environment.fineractPlatformTenantId;
+  // Name used to send the Fineract tenant identifier header.
+  // The runtime key is `apiGatewayHeaderName` to allow gateway/runtime injection,
+  // but this value represents the Fineract tenant header name.
+  FINERACT_TENANT_HEADER_NAME = environment.apiGatewayHeaderName || 'Fineract-Platform-TenantId';
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     const token = this.authService.getAccessToken();
     let headersConfig: { [key: string]: string } = {
-      'Fineract-Platform-TenantId': this.FINERACT_PLATFORM_TENANT_IDENTIFIER,
+      [this.FINERACT_TENANT_HEADER_NAME]: this.FINERACT_PLATFORM_TENANT_IDENTIFIER,
       'Content-Type': req.headers.get('Content-Type') || 'application/json'
     };
     const publicEndpoints = [
@@ -56,7 +60,7 @@ export class TokenInterceptor implements HttpInterceptor {
         const retriedReq = request.clone({
           setHeaders: {
             Authorization: `Bearer ${newToken}`,
-            'Fineract-Platform-TenantId': this.FINERACT_PLATFORM_TENANT_IDENTIFIER,
+            [this.FINERACT_TENANT_HEADER_NAME]: this.FINERACT_PLATFORM_TENANT_IDENTIFIER,
             'Content-Type': request.headers.get('Content-Type') || 'application/json'
           }
         });

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -17,6 +17,13 @@ const provider = loadedEnv['apiProvider'];
 const parsedMinLength = Number(loadedEnv.minPasswordLength);
 const resolvedMinPasswordLength = Number.isInteger(parsedMinLength) && parsedMinLength > 0 ? parsedMinLength : 8;
 
+// Validate and normalize apiGatewayHeaderName (RFC 7230 token format)
+const resolvedApiGatewayHeaderName =
+  typeof loadedEnv.apiGatewayHeaderName === 'string' &&
+  /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(loadedEnv.apiGatewayHeaderName.trim())
+    ? loadedEnv.apiGatewayHeaderName.trim()
+    : 'Fineract-Platform-TenantId';
+
 export const environment = {
   production: true,
   version: env.mifos_x.version,
@@ -145,7 +152,13 @@ export const environment = {
     oidcClientId: loadedEnv['oidcClientId'] || loadedEnv['FINERACT_PLUGIN_OIDC_CLIENT_ID'] || '',
     oidcApiUrl: loadedEnv['oidcApiUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_API_URL'] || '',
     oidcFrontUrl: loadedEnv['oidcFrontUrl'] || loadedEnv['FINERACT_PLUGIN_OIDC_FRONTEND_URL'] || ''
-  }
+  },
+  /**
+   * Name of the header used to signal the tenant/platform to the API gateway
+   * Default kept for backward compatibility with existing deployments and tests
+   * Validated against RFC 7230 token format; whitespace trimmed; invalid values fallback to default.
+   */
+  apiGatewayHeaderName: resolvedApiGatewayHeaderName
 };
 
 // Server URL

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -20,6 +20,13 @@ const loadedEnv = window.env || {};
 const parsedMinLength = Number(loadedEnv.minPasswordLength);
 const resolvedMinPasswordLength = Number.isInteger(parsedMinLength) && parsedMinLength > 0 ? parsedMinLength : 8;
 
+// Validate and normalize apiGatewayHeaderName (RFC 7230 token format)
+const resolvedApiGatewayHeaderName =
+  typeof loadedEnv.apiGatewayHeaderName === 'string' &&
+  /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(loadedEnv.apiGatewayHeaderName.trim())
+    ? loadedEnv.apiGatewayHeaderName.trim()
+    : 'Fineract-Platform-TenantId';
+
 export const environment = {
   production: false,
   version: env.mifos_x.version,
@@ -149,7 +156,13 @@ export const environment = {
     oidcClientId: loadedEnv.oidcClientId || loadedEnv.FINERACT_PLUGIN_OIDC_CLIENT_ID || '',
     oidcApiUrl: loadedEnv.oidcApiUrl || loadedEnv.FINERACT_PLUGIN_OIDC_API_URL || '',
     oidcFrontUrl: loadedEnv.oidcFrontUrl || loadedEnv.FINERACT_PLUGIN_OIDC_FRONTEND_URL || ''
-  }
+  },
+  /**
+   * Name of the header used to signal the tenant/platform to the API gateway
+   * Default kept for backward compatibility with existing deployments and tests
+   * Validated against RFC 7230 token format; whitespace trimmed; invalid values fallback to default.
+   */
+  apiGatewayHeaderName: resolvedApiGatewayHeaderName
 };
 
 // Server URL


### PR DESCRIPTION
## Description

Make the API Gateway (Mifos Endpoint) tenant header name configurable so different deployments (or API gateways) can use a custom header name without code changes.

- Add `apiGatewayHeaderName` to runtime environment defaults (default: `Fineract-Platform-TenantId`).
- Update `TokenInterceptor` to read `environment.apiGatewayHeaderName` and use it when setting the tenant header on outgoing requests.
- Preserve existing behavior by default to remain backward compatible with tests and deployments.

## Related issues and discussion

[WEB-579](https://mifosforge.jira.com/browse/WEB-579)

## Deployment / Ops notes

- To override the header name at runtime set `apiGatewayHeaderName` in your `window.env` or deployment environment (same mechanism used for other `loadedEnv` values).
- No DB or backend migration required.

## Screenshots, if any

N/A

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

[WEB-579]: https://mifosforge.jira.com/browse/WEB-579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made the API gateway tenant header name configurable via environment with validation and a safe default, and ensured the app consistently uses this configured header.
  * Explicitly typed the environment configuration to include the new setting.
  * Minor cleanup: tenant selector trimming/filtering improved for more reliable display.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3573)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->