### PR TITLE
WEB-947 Add checker role to the maker-checker tray permissions

### DIFF
--- a/src/app/core/shell/sidenav/sidenav.component.html
+++ b/src/app/core/shell/sidenav/sidenav.component.html
@@ -99,7 +99,7 @@
           matTooltip="{{ 'tooltips.Checker Inbox and Tasks' | translate }}"
           routerLinkActive="active-menu"
           [routerLinkActiveOptions]="{ exact: false }"
-          *mifosxHasPermission="['READ_MAKERCHECKER', 'APPROVE_LOAN']"
+          *mifosxHasPermission="['ALL_FUNCTIONS_READ', 'READ_MAKERCHECKER', 'APPROVE_LOAN', 'APPROVE_LOAN_CHECKER']"
         >
           <mat-icon matListIcon>
             <i class="fa fa-check"></i>

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/council-approval/council-approval.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/council-approval/council-approval.component.html
@@ -19,7 +19,7 @@
       <button
         mat-raised-button
         color="success"
-        *mifosxHasPermission="'APPROVE_LOAN'"
+        *mifosxHasPermission="['APPROVE_LOAN', 'APPROVE_LOAN_CHECKER']"
         (click)="approveLoan()"
         class="tasks-action-btn"
       >

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component.html
@@ -19,7 +19,7 @@
       <button
         mat-raised-button
         color="success"
-        *mifosxHasPermission="'APPROVE_LOAN'"
+        *mifosxHasPermission="['APPROVE_LOAN', 'APPROVE_LOAN_CHECKER']"
         (click)="approveLoan()"
         class="tasks-action-btn"
       >

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component.html
@@ -20,7 +20,7 @@
       <button
         mat-raised-button
         color="success"
-        *mifosxHasPermission="'APPROVE_LOAN'"
+        *mifosxHasPermission="['APPROVE_LOAN', 'APPROVE_LOAN_CHECKER']"
         (click)="disburseLoan()"
         class="tasks-action-btn"
       >

--- a/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
@@ -18,7 +18,7 @@
           routerLinkActive
           #checkerInbox="routerLinkActive"
           [active]="checkerInbox.isActive"
-          *mifosxHasPermission="['ALL_FUNCTIONS_READ', 'READ_MAKERCHECKER', 'APPROVE_LOAN']"
+          *mifosxHasPermission="['ALL_FUNCTIONS_READ', 'READ_MAKERCHECKER', 'APPROVE_LOAN', 'APPROVE_LOAN_CHECKER']"
         >
           {{ 'labels.inputs.Checker Inbox' | translate }}
         </a>
@@ -48,7 +48,7 @@
           routerLinkActive
           #councilApproval="routerLinkActive"
           [active]="councilApproval.isActive"
-          *mifosxHasPermission="['ALL_FUNCTIONS_READ', 'READ_MAKERCHECKER', 'APPROVE_LOAN']"
+          *mifosxHasPermission="['ALL_FUNCTIONS_READ', 'READ_MAKERCHECKER', 'APPROVE_LOAN', 'APPROVE_LOAN_CHECKER']"
         >
           {{ 'labels.text.Council Approval' | translate }}
         </a>


### PR DESCRIPTION
**Changes Made :-** 

-Enable APPROVE_LOAN_CHECKER role to access Checker Inbox and perform loan approval actions. 

[WEB-947](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-947)

[WEB-947]: https://mifosforge.jira.com/browse/WEB-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded access to Checker Inbox and related tabs so users with additional approval roles can view and act on items.
  * Loan approval workflows — including council approval, approval actions, and disbursal — now allow a broader set of authorized users to perform approval and disbursement actions, improving workflow coverage and reducing manual handoffs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3579)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->