### PR TITLE
WEB-950 Add support to view pentaho reports in pdf format the report is currently not displayed

### DIFF
--- a/src/app/reports/run-report/pentaho/pentaho.component.html
+++ b/src/app/reports/run-report/pentaho/pentaho.component.html
@@ -7,5 +7,5 @@
 -->
 
 @if (!hideOutput) {
-  <iframe [src]="pentahoUrl" frameborder="0" width="100%" height="750px;"></iframe>
+  <iframe [src]="pentahoUrl" frameborder="0" width="100%" height="750px"></iframe>
 }

--- a/src/app/reports/run-report/pentaho/pentaho.component.ts
+++ b/src/app/reports/run-report/pentaho/pentaho.component.ts
@@ -7,8 +7,16 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnChanges, OnDestroy, Input, inject } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnChanges,
+  OnDestroy,
+  Input,
+  inject,
+  ChangeDetectorRef
+} from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 /** Custom Services */
 import { ReportsService } from '../../reports.service';
@@ -33,6 +41,7 @@ export class PentahoComponent implements OnChanges, OnDestroy {
   private reportsService = inject(ReportsService);
   private settingsService = inject(SettingsService);
   private progressBarService = inject(ProgressBarService);
+  private changeDetectorRef = inject(ChangeDetectorRef);
 
   /** Run Report Data */
   @Input() dataObject: any;
@@ -40,7 +49,7 @@ export class PentahoComponent implements OnChanges, OnDestroy {
   /** substitute for resolver */
   hideOutput = true;
   /** trusted resource url for pentaho output */
-  pentahoUrl: any;
+  pentahoUrl: SafeResourceUrl | null = null;
   /** current blob URL to track and revoke */
   private currentBlobUrl: string | null = null;
 
@@ -63,7 +72,14 @@ export class PentahoComponent implements OnChanges, OnDestroy {
       )
       .subscribe((res: any) => {
         const contentType = res.headers.get('Content-Type');
-        const file = new Blob([res.body], { type: contentType });
+        const outputType = this.dataObject.formData['output-type'];
+        let type: string = contentType ?? 'application/octet-stream';
+
+        if (outputType === 'PDF') {
+          type = 'application/pdf';
+        }
+
+        const file = new Blob([res.body], { type });
 
         if (this.currentBlobUrl) {
           URL.revokeObjectURL(this.currentBlobUrl);
@@ -78,6 +94,7 @@ export class PentahoComponent implements OnChanges, OnDestroy {
 
         this.pentahoUrl = this.sanitizer.bypassSecurityTrustResourceUrl(filecontent);
         this.hideOutput = false;
+        this.changeDetectorRef.markForCheck();
         this.progressBarService.decrease();
       });
   }


### PR DESCRIPTION
**Changes Made :-**

-Fix blank screen issue when viewing Pentaho reports in PDF format. 

[WEB-950](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-950)


[WEB-950]: https://mifosforge.jira.com/browse/WEB-950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a display issue with Pentaho report output rendering
  * Enhanced MIME type handling for downloading Pentaho reports, ensuring correct file format detection especially for PDF files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->