### PR TITLE
WEB-953 The payment type selection must be enforced preventing this field from having a null value

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/disburse/disburse.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/disburse/disburse.component.html
@@ -69,6 +69,12 @@
                 </mat-option>
               }
             </mat-select>
+            @if (environment.productionMode && disbursementLoanForm.controls.paymentTypeId.hasError('required')) {
+              <mat-error>
+                {{ 'labels.inputs.Payment Type' | translate }}
+                <strong>{{ 'labels.commons.required' | translate }}</strong>
+              </mat-error>
+            }
           </mat-form-field>
 
           <div class="flex-fill">

--- a/src/app/loans/loans-view/loan-account-actions/disburse/disburse.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/disburse/disburse.component.ts
@@ -19,6 +19,7 @@ import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { FormatNumberPipe } from '../../../../pipes/format-number.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { LoanAccountActionsBaseComponent } from '../loan-account-actions-base.component';
+import { environment } from '../../../../../environments/environment';
 
 /**
  * Disburse Loan Option
@@ -40,6 +41,8 @@ export class DisburseComponent extends LoanAccountActionsBaseComponent implement
   private formBuilder = inject(UntypedFormBuilder);
   private dateUtils = inject(Dates);
 
+  /** Environment configuration */
+  protected environment = environment;
   /** Payment Type Options */
   paymentTypes: any;
   /** Show payment details */
@@ -51,8 +54,8 @@ export class DisburseComponent extends LoanAccountActionsBaseComponent implement
   /** Maximum Date allowed. */
   maxDate = new Date();
   /** Disbursement Loan Form */
-  disbursementLoanForm: UntypedFormGroup;
-  currency: Currency;
+  disbursementLoanForm!: UntypedFormGroup;
+  currency!: Currency;
 
   constructor() {
     super();
@@ -85,7 +88,10 @@ export class DisburseComponent extends LoanAccountActionsBaseComponent implement
         Validators.required
       ],
       externalId: '',
-      paymentTypeId: '',
+      paymentTypeId: [
+        '',
+        environment.productionMode ? Validators.required : []
+      ],
       note: ''
     });
     if (this.isWorkingCapital) {


### PR DESCRIPTION
**Changes Made :-**  

-Make Payment Type a required field in the Disburse component under production mode.

[WEB-953](https://mifosforge.jira.com/browse/WEB-953)

[WEB-953]: https://mifosforge.jira.com/browse/WEB-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment Type field now displays validation error messages when required validation fails in loan disbursement forms, with enhanced messaging in production environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->