### PR TITLE
WEB-854 Parameters button misaligned on standing instructions history page

### DIFF
--- a/src/app/organization/standing-instructions-history/standing-instructions-history.component.scss
+++ b/src/app/organization/standing-instructions-history/standing-instructions-history.component.scss
@@ -11,6 +11,20 @@
 }
 
 .output {
+  mat-card {
+    > .m-b-20 {
+      padding: 16px;
+    }
+
+    > table {
+      margin: 0 16px;
+    }
+
+    > mat-paginator {
+      padding: 0 16px;
+    }
+  }
+
   .error-log {
     min-width: 26px;
     padding: 0 6px;


### PR DESCRIPTION
**Changes Made :-** 

-Fix Parameters button alignment on Standing Instructions History page by adding consistent padding to card content .

[WEB-854](https://mifosforge.jira.com/browse/WEB-854?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)

Before :- 
<img width="1840" height="963" alt="image" src="https://github.com/user-attachments/assets/b5b0e851-c8fc-4bb7-a1ee-ad216c8fdcf9" />

After :- 
<img width="1365" height="575" alt="image" src="https://github.com/user-attachments/assets/a11bc8a3-7c50-47a6-953f-74bdef1e0b37" />


[WEB-854]: https://mifosforge.jira.com/browse/WEB-854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ