### PR TITLE
WEB-613 Allow to display iban account number in the external id section in the general tab of a saving account currently it is truncated

### DIFF
--- a/src/app/savings/savings-account-view/general-tab/general-tab.component.html
+++ b/src/app/savings/savings-account-view/general-tab/general-tab.component.html
@@ -26,6 +26,7 @@
                   <td>
                     <mifosx-external-identifier
                       externalId="{{ savingsAccountData.externalId }}"
+                      [completed]="true"
                     ></mifosx-external-identifier>
                   </td>
                 }
@@ -338,6 +339,7 @@
                 <td>
                   <mifosx-external-identifier
                     externalId="{{ savingsAccountData.externalId }}"
+                    [completed]="true"
                   ></mifosx-external-identifier>
                 </td>
               }


### PR DESCRIPTION
**Changes Made :-** 

- Fix IBAN truncation in Savings Account General Tab external ID display .

[WEB-613](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?assignee=712020%3A5685dc80-2da8-4d54-80e6-7b69c296926e&selectedIssue=WEB-613)

[WEB-613]: https://mifosforge.jira.com/browse/WEB-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the external identifier display in the savings account details view to properly reflect its completion status across all display modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->