### PR TITLE
fix: implement OnInit interface in UndoDialogComponent

### DIFF
--- a/src/app/shared/undo-dialog/undo-dialog.component.ts
+++ b/src/app/shared/undo-dialog/undo-dialog.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, inject } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import {
   MatDialogRef,
   MAT_DIALOG_DATA,
@@ -30,7 +30,7 @@ import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
     MatDialogClose
   ]
 })
-export class UndoDialogComponent {
+export class UndoDialogComponent implements OnInit {
   dialogRef = inject<MatDialogRef<UndoDialogComponent>>(MatDialogRef);
   data = inject(MAT_DIALOG_DATA);
   private formBuilder = inject(UntypedFormBuilder);


### PR DESCRIPTION
## Description

Added the missing `OnInit` lifecycle interface implementation in `UndoDialogComponent` to satisfy Angular ESLint rules and improve code consistency.

## Related issues and discussion

I attempted to create a Jira issue for this fix, but I currently do not have Jira issue creation permissions as a first-time contributor.

## Screenshots, if any

N/A

## Checklist

* [x] If you have multiple commits please combine them into one commit by squashing them.
* [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization of the undo dialog form to ensure proper functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->