### PR TITLE
docs(ci): replace outdated Travis CI references

### DIFF
--- a/.github/COMMIT_MESSAGE.md
+++ b/.github/COMMIT_MESSAGE.md
@@ -26,7 +26,7 @@ Must be one of the following:
 
 - **build**: Changes that affect the build system or external dependencies (example scopes: npm, webpack etc)
 - **chore**: Other changes that don't modify src or test files
-- **ci**: Changes to CI configuration files and scripts (example scopes: Travis etc)
+- **ci**: Changes to CI configuration files and scripts (example scopes: GitHub Actions, workflows etc)
 - **docs**: Documentation only changes
 - **feat**: A new feature
 - **fix**: A bug fix

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,8 +335,8 @@ git branch -D branch-name
 git pull upstream dev
 ```
 
-### Skipping a Travis CI Build
+### Skipping a GitHub Actions Build
 
-If running a build is not required for a particular commit (in some cases like an update to README.md), add [ci skip] or [skip ci] to the git commit message. Commits that have [ci skip] or [skip ci] anywhere in the commit messages are ignored by Travis CI.
+If running a build is not required for a particular commit (in some cases like an update to README.md), add [ci skip] or [skip ci] to the git commit message. Commits that contain [skip ci] or [ci skip] anywhere in the commit message will skip running the GitHub Actions workflows.
 
 **_Thank you for contributing!_**


### PR DESCRIPTION
## Description

Updated outdated Travis CI references in the documentation to reflect the project's current GitHub Actions-based CI workflow.

## Changes Made

* Replaced outdated "Travis CI" references with "GitHub Actions"
* Updated CI skip instructions in `CONTRIBUTING.md`
* Updated CI example scopes in `.github/COMMIT_MESSAGE.md`

## Related issues and discussion

Documentation cleanup to align contributor guidance with the current CI infrastructure.

## Screenshots, if any

N/A

## Checklist

* [x] If you have multiple commits please combine them into one commit by squashing them.
* [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build-skipping guidance in contribution documentation to reflect the current CI system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->