### PR TITLE
WEB-955: implement default font customization setting

### DIFF
--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -91,7 +91,7 @@
 
         <mat-form-field>
           <mat-label>{{ 'labels.inputs.Default Font' | translate }}</mat-label>
-          <mat-select>
+          <mat-select [formControl]="fontFamily">
             @for (font of fonts; track font) {
               <mat-option [value]="font">
                 {{ font }}

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -103,8 +103,14 @@ export class SettingsComponent implements OnInit, OnDestroy {
     '7',
     '8'
   ];
-  /** Placeholder for fonts. */
-  fonts: any;
+  /** List of available fonts. */
+  fonts: string[] = [
+    'Roboto',
+    'Inter',
+    'Open Sans',
+    'Outfit',
+    'Montserrat'
+  ];
 
   /** Date Format Setting */
   dateFormat = new FormControl('');
@@ -112,27 +118,37 @@ export class SettingsComponent implements OnInit, OnDestroy {
   datetimeFormat = new FormControl('');
   /** Decimals to Display Setting */
   decimalsToDisplay = new FormControl('');
+  /** Font Family Setting */
+  fontFamily = new FormControl('');
 
   private initialValues: {
     dateFormat: string;
     datetimeFormat: string;
     decimals: string;
+    fontFamily: string;
   };
 
   ngOnInit() {
     this.initialValues = {
       dateFormat: this.settingsService.dateFormat,
       datetimeFormat: this.settingsService.datetimeFormat,
-      decimals: this.settingsService.decimals
+      decimals: this.settingsService.decimals,
+      fontFamily: this.settingsService.fontFamily
     };
     this.dateFormat.patchValue(this.initialValues.dateFormat, { emitEvent: false });
     this.datetimeFormat.patchValue(this.initialValues.datetimeFormat, { emitEvent: false });
     this.decimalsToDisplay.patchValue(this.initialValues.decimals, { emitEvent: false });
+    this.fontFamily.patchValue(this.initialValues.fontFamily, { emitEvent: false });
     this.trackChanges();
   }
 
   trackChanges(): void {
-    merge(this.dateFormat.valueChanges, this.datetimeFormat.valueChanges, this.decimalsToDisplay.valueChanges)
+    merge(
+      this.dateFormat.valueChanges,
+      this.datetimeFormat.valueChanges,
+      this.decimalsToDisplay.valueChanges,
+      this.fontFamily.valueChanges
+    )
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.hasChanges = this.hasFormChanged();
@@ -143,7 +159,8 @@ export class SettingsComponent implements OnInit, OnDestroy {
     return (
       (this.dateFormat.value ?? '') !== this.initialValues.dateFormat ||
       (this.datetimeFormat.value ?? '') !== this.initialValues.datetimeFormat ||
-      (this.decimalsToDisplay.value ?? '') !== this.initialValues.decimals
+      (this.decimalsToDisplay.value ?? '') !== this.initialValues.decimals ||
+      (this.fontFamily.value ?? '') !== this.initialValues.fontFamily
     );
   }
 
@@ -151,10 +168,12 @@ export class SettingsComponent implements OnInit, OnDestroy {
     this.settingsService.setDateFormat(this.dateFormat.value ?? this.initialValues.dateFormat);
     this.settingsService.setDatetimeFormat(this.datetimeFormat.value ?? this.initialValues.datetimeFormat);
     this.settingsService.setDecimalToDisplay(this.decimalsToDisplay.value ?? this.initialValues.decimals);
+    this.settingsService.setFontFamily(this.fontFamily.value ?? this.initialValues.fontFamily);
     this.initialValues = {
       dateFormat: this.dateFormat.value ?? '',
       datetimeFormat: this.datetimeFormat.value ?? '',
-      decimals: this.decimalsToDisplay.value ?? ''
+      decimals: this.decimalsToDisplay.value ?? '',
+      fontFamily: this.fontFamily.value ?? ''
     };
     this.hasChanges = false;
     this.alertService.alert({

--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -299,4 +299,16 @@ export class SettingsService {
   get themeDarkEnabled(): boolean {
     return JSON.parse(localStorage.getItem('mifosXThemeDarkEnabled'));
   }
+
+  setFontFamily(font: string) {
+    localStorage.setItem('mifosXFontFamily', JSON.stringify(font));
+  }
+
+  get fontFamily(): string {
+    const userSetting = localStorage.getItem('mifosXFontFamily');
+    if (userSetting) {
+      return JSON.parse(userSetting);
+    }
+    return 'Roboto';
+  }
 }

--- a/src/app/web-app.component.ts
+++ b/src/app/web-app.component.ts
@@ -157,6 +157,12 @@ export class WebAppComponent implements OnInit, OnDestroy {
     this.themingService.setInitialDarkMode();
     this.themingService.setDarkMode(!!this.settingsService.themeDarkEnabled);
 
+    // Apply saved font preference
+    const activeFont = this.settingsService.fontFamily;
+    if (activeFont) {
+      document.body.style.fontFamily = `"${activeFont}", sans-serif`;
+    }
+
     // Setup logger
     if (environment.production) {
       Logger.enableProductionMode();
@@ -213,6 +219,12 @@ export class WebAppComponent implements OnInit, OnDestroy {
 
     // Setup alerts with hover behavior
     this.alertService.alertEvent.subscribe((alertEvent: Alert) => {
+      if (alertEvent.type === 'Settings Update') {
+        const activeFont = this.settingsService.fontFamily;
+        if (activeFont) {
+          document.body.style.fontFamily = `"${activeFont}", sans-serif`;
+        }
+      }
       const snackBarRef = this.snackBar.open(
         `${alertEvent.message}`,
         this.translateService.instant('labels.buttons.Close'),

--- a/src/index.html
+++ b/src/index.html
@@ -28,6 +28,10 @@
       rel="stylesheet"
     />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Roboto+Mono:300" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700&family=Montserrat:wght@300;400;500;700&family=Open+Sans:wght@300;400;500;700&family=Outfit:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <!-- Load environment variables -->
   </head>
   <body class="h-full">


### PR DESCRIPTION
## Description

Implemented the missing "Default Font" customization setting in the Settings view.

This change enables users to select and persist their preferred application font across sessions. The selected font is dynamically applied globally throughout the application at runtime.

The implementation includes:

* Adding local storage persistence support for selected fonts
* Initializing supported font options in the settings component
* Binding the font selector using Angular Reactive Forms
* Applying the selected font globally during application startup
* Dynamically updating typography after settings changes
* Loading required Google Fonts for proper rendering support

## Related issues and discussion

#WEB-955

## Screenshots, if any

### Before
<img width="1916" height="1040" alt="Before" src="https://github.com/user-attachments/assets/5ef5f7d3-1d06-4b7b-9aba-23b9cca8f16a" />

Empty and non-functional Default Font dropdown.

### After
<img width="1918" height="1027" alt="After" src="https://github.com/user-attachments/assets/815d93d8-ad57-4fc8-acdb-0cd3d5246e3f" />

Working Default Font selector with persisted global typography changes.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

* [x] If you have multiple commits please combine them into one commit by squashing them.

* [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now select their preferred font from Settings
* Font preferences are automatically saved and applied across the app
* New font options available: Inter, Montserrat, Open Sans, and Outfit

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->