### PR TITLE
WEB-959: Prevent zero amount savings transactions

### DIFF
--- a/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.html
+++ b/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.html
@@ -52,6 +52,7 @@
                 [isRequired]="true"
                 [inputFormControl]="savingAccountTransactionForm.controls.transactionAmount"
                 [inputLabel]="'Transaction Amount'"
+                [minVal]="0.001"
               >
               </mifosx-input-amount>
 

--- a/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.ts
+++ b/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.ts
@@ -24,6 +24,7 @@ import { SavingsService } from '../../savings.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { Dates } from 'app/core/utils/dates';
 import { Currency } from 'app/shared/models/general.model';
+import { amountValueValidator } from 'app/shared/validators/amount-value.validator';
 import { InputAmountComponent } from '../../../shared/input-amount/input-amount.component';
 import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
@@ -124,8 +125,12 @@ export class SavingsAccountTransactionsComponent implements OnInit {
         Validators.required
       ],
       transactionAmount: [
-        0,
-        Validators.required
+        '',
+        [
+          Validators.required,
+          amountValueValidator(),
+          Validators.min(0.001)
+        ]
       ],
       paymentTypeId: [
         '',


### PR DESCRIPTION
## Description

This PR prevents savings deposit and withdrawal transactions from accepting zero-value transaction amounts.

Previously, the frontend form only used `Validators.required`, which treated `0` as a valid value. Users could proceed to the confirmation step, and the backend later rejected the request.

This PR adds:

* `Validators.min(0.001)`
* minimum validation UI using `minVal`

This aligns savings transaction validation behavior with existing repayment validation patterns already used in the application.

## Related issues and discussion

WEB-959

## Screenshots, if any

### Before

Frontend allowed zero-value transaction and backend rejected request later.

<img width="1471" height="952" alt="Before bug" src="https://github.com/user-attachments/assets/de7ff7e1-2688-4998-a94f-c85983af7938" />


### After

Frontend blocks invalid values before submission.

<img width="1393" height="981" alt="After fix" src="https://github.com/user-attachments/assets/baf36a2d-da0b-4acf-b9fa-23c10d0f4c77" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

* [x] If you have multiple commits please combine them into one commit by squashing them.

* [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a minimum savings transaction amount of 0.001 to prevent zero-value submissions.
  * Amount field now initializes empty so validations consistently run on entry.
  * Improved input validation and user feedback in the transaction form to reduce invalid submissions and clarify errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->