### PR TITLE
WEB-958: Add interaction feedback to account number copy button

### DIFF
--- a/src/app/shared/account-number/account-number.component.html
+++ b/src/app/shared/account-number/account-number.component.html
@@ -8,9 +8,14 @@
 
 <span (mouseenter)="mouseEnter()" (mouseleave)="mouseLeave()">
   @if (displayL && iconVisible) {
-    <span class="m-l-5" (click)="copyValue()"
-      ><b><fa-icon icon="copy" size="sm" title="{{ 'labels.text.Copy Account Number' | translate }}"></fa-icon></b
-    ></span>
+    <button
+      mat-icon-button
+      class="copy-btn m-l-5"
+      (click)="copyValue(); $event.stopPropagation()"
+      [attr.aria-label]="'labels.text.Copy Account Number' | translate"
+    >
+      <fa-icon icon="copy" size="sm" [title]="'labels.text.Copy Account Number' | translate"></fa-icon>
+    </button>
   }
   @if (accountType) {
     <span class="m-l-5">
@@ -21,8 +26,13 @@
     <span class="m-l-5">{{ accountNo }}</span>
   }
   @if (displayR && iconVisible) {
-    <span class="m-l-3" (click)="copyValue()"
-      ><b><fa-icon icon="copy" size="sm" title="{{ 'labels.text.Copy Account Number' | translate }}"></fa-icon></b
-    ></span>
+    <button
+      mat-icon-button
+      class="copy-btn m-l-3"
+      (click)="copyValue(); $event.stopPropagation()"
+      [attr.aria-label]="'labels.text.Copy Account Number' | translate"
+    >
+      <fa-icon icon="copy" size="sm" [title]="'labels.text.Copy Account Number' | translate"></fa-icon>
+    </button>
   }
 </span>

--- a/src/app/shared/account-number/account-number.component.scss
+++ b/src/app/shared/account-number/account-number.component.scss
@@ -5,3 +5,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+
+button.copy-btn {
+  border: none;
+  opacity: var(--mdc-icon-button-disabled-icon-opacity, 0.7);
+  transition:
+    opacity 0.15s ease-in-out,
+    transform 0.1s ease-in-out;
+
+  .mat-mdc-button-persistent-ripple,
+  .mat-ripple {
+    opacity: 0.3;
+  }
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &:active {
+    transform: scale(0.85);
+  }
+
+  &:focus-visible {
+    outline: 1px dashed var(--mdc-outlined-button-outline-color, rgb(255 255 255 / 40%));
+    outline-offset: 8px;
+  }
+}


### PR DESCRIPTION
## Description

Adds visible interaction feedback to the account number copy button.

Previously, when users clicked the copy button, there was no clear hover or click feedback, so it was difficult to understand whether the account number had actually been copied or not.

This update improves the user interaction experience by adding visible interaction states to the copy control.

## Related issues and discussion

#WEB-958

## Screenshots, if any

### Before
https://github.com/user-attachments/assets/6e9b0b3f-ecfc-4b1f-962a-d482eb07245f

### After

https://github.com/user-attachments/assets/f7194ace-5d00-4e09-a84d-45535685eb1b

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Copy controls now use semantic buttons with translated accessible labels and improved keyboard/screen-reader support.

* **User Interface**
  * Copy buttons receive visual and interaction enhancements: hover/active animations, opacity transitions, hidden ripples, and visible focus outlines for clearer feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->