### PR TITLE
WEB-961: fix incorrect account action aria-labels

### DIFF
--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-view/recurring-deposits-account-view.component.html
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-view/recurring-deposits-account-view.component.html
@@ -86,7 +86,7 @@
               <button
                 mat-icon-button
                 [matMenuTriggerFor]="accountMenu"
-                aria-label="Loan account actions"
+                [attr.aria-label]="'labels.text.Recurring Deposits Account Actions' | translate"
                 yPosition="below"
               >
                 <mat-icon matListIcon class="actions-menu">

--- a/src/app/savings/savings-account-view/savings-account-view.component.html
+++ b/src/app/savings/savings-account-view/savings-account-view.component.html
@@ -105,7 +105,7 @@
             <button
               mat-icon-button
               [matMenuTriggerFor]="accountMenu"
-              aria-label="Loan account actions"
+              [attr.aria-label]="'labels.text.Savings Account Actions' | translate"
               yPosition="below"
             >
               <mat-icon matListIcon class="actions-menu">


### PR DESCRIPTION
## Description

Fixed incorrect `aria-label` values used in the account action menus for Savings Account View and Recurring Deposit Account View.

Previously, both views incorrectly used the label `"Loan account actions"` due to a copy-paste issue. This caused incorrect context for screen readers and accessibility tools.

The labels have been updated to reflect the correct account types:

* `"Savings account actions"`
* `"Recurring deposit account actions"`

This is a small accessibility improvement with no UI or behavioral changes.

## Related issues and discussion

#WEB-961

## Screenshots, if any

N/A (accessibility text-only change)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated accessibility labels for account action menus in recurring deposits and savings account views to use translated strings instead of hardcoded text.
  * Improves screen reader compatibility and ensures labels reflect localized wording for a more consistent, accessible user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->