### PR TITLE
Web 963 add alt text for account profile images

### DIFF
--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -15,6 +15,7 @@
             mat-card-md-image
             class="profile-image"
             [src]="clientImage ? clientImage : 'assets/images/user_placeholder.png'"
+            [alt]="clientViewData.displayName || ('labels.inputs.Display Name' | translate)"
           />
         </div>
         <div class="m-b-5 flex-center">

--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-view/fixed-deposit-account-view.component.html
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-view/fixed-deposit-account-view.component.html
@@ -16,6 +16,7 @@
             class="profile-image"
             matTooltip="{{ 'tooltips.Fixed Deposits Account' | translate }}"
             [src]="'assets/images/fd_account_placeholder.png'"
+            alt="{{ 'tooltips.Fixed Deposits Account' | translate }}"
           />
         </div>
       </div>

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-view/recurring-deposits-account-view.component.html
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-view/recurring-deposits-account-view.component.html
@@ -16,6 +16,7 @@
             class="profile-image"
             matTooltip="{{ 'tooltips.Recurring Deposits Account' | translate }}"
             [src]="'assets/images/recurring-deposits_account_placeholder.png'"
+            alt="{{ 'tooltips.Recurring Deposits Account' | translate }}"
           />
         </div>
       </div>

--- a/src/app/savings/savings-account-view/savings-account-view.component.html
+++ b/src/app/savings/savings-account-view/savings-account-view.component.html
@@ -16,6 +16,7 @@
             class="profile-image"
             matTooltip="{{ 'tooltips.Savings Account' | translate }}"
             [src]="'assets/images/savings_account_placeholder.png'"
+            alt="{{ 'tooltips.Savings Account' | translate }}"
           />
         </div>
       </div>

--- a/src/app/shares/shares-account-view/shares-account-view.component.html
+++ b/src/app/shares/shares-account-view/shares-account-view.component.html
@@ -16,6 +16,7 @@
             class="profile-image"
             matTooltip="{{ 'tooltips.Shares Account' | translate }}"
             src="assets/images/shares_account_placeholder.png"
+            alt="{{ 'tooltips.Shares Account' | translate }}"
           />
         </div>
       </div>


### PR DESCRIPTION
## Description

Added missing `alt` text for account profile images across multiple account view pages to improve accessibility support for screen readers and assistive technologies.

Previously, several views used profile images without meaningful alternative text, which caused accessibility issues under WCAG 1.1.1 guidelines.

This update adds appropriate `alt` attributes by reusing existing translated tooltip values where applicable, while the client view uses the client display name for more descriptive image context.

Affected views:

* Savings Account View
* Fixed Deposit Account View
* Recurring Deposit Account View
* Shares Account View
* Client View

No UI or behavioral changes were introduced.

## Related issues and discussion

#WEB-963

## Screenshots, if any

N/A (accessibility text-only change)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

-  [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility across account views: profile images in client, savings, fixed deposit, recurring deposit, and shares screens now include descriptive, localized alt text to enhance screen reader support and provide clearer context for assistive technologies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->