### PR TITLE
WEB-964: Prevent duplicate repayment submissions

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.html
@@ -183,7 +183,7 @@
           <button
             mat-raised-button
             color="primary"
-            [disabled]="!repaymentLoanForm.valid"
+            [disabled]="!repaymentLoanForm.valid || isSubmitting"
             *mifosxHasPermission="'REPAYMENT_LOAN'"
           >
             {{ 'labels.buttons.Submit' | translate }}

--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, ChangeDetectorRef } from '@angular/core';
 import { UntypedFormGroup, UntypedFormBuilder, Validators, UntypedFormControl } from '@angular/forms';
 
 /** Custom Services */
@@ -43,6 +43,7 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
   private formBuilder = inject(UntypedFormBuilder);
   private dateUtils = inject(Dates);
   private penaltyManagementService = inject(PenaltyManagementService);
+  private cdr = inject(ChangeDetectorRef);
 
   /** Payment Type Options */
   paymentTypes: any;
@@ -50,6 +51,8 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
   showPaymentDetails = false;
   /** Waive Penalties toggle */
   waivePenalties = false;
+  /** Prevents duplicate submissions */
+  isSubmitting = false;
   /** Penalties list */
   penalties: any[] = [];
   /** Selected penalty IDs */
@@ -182,7 +185,6 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
         this.penalties = penalties;
       },
       error: (error: any) => {
-        console.error('Error loading penalties:', error);
         this.penalties = [];
       }
     });
@@ -308,6 +310,12 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
 
   /** Submits the repayment form */
   submit() {
+    if (this.repaymentLoanForm.invalid || this.isSubmitting) {
+      return;
+    }
+    this.isSubmitting = true;
+    this.cdr.markForCheck();
+
     const repaymentLoanFormData = this.repaymentLoanForm.value;
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;
@@ -333,7 +341,6 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
           this.submitRepayment(data);
         },
         error: (error: any) => {
-          console.error('Error waiving penalties:', error);
           // Continue with repayment even if waive fails
           this.submitRepayment(data);
         }
@@ -345,8 +352,14 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
 
   /** Submit the repayment after penalties are waived */
   private submitRepayment(data: any) {
-    this.loanService.submitLoanActionButton(this.loanId, data, this.command).subscribe((response: any) => {
-      this.gotoLoanView('transactions');
+    this.loanService.submitLoanActionButton(this.loanId, data, this.command).subscribe({
+      next: (response: any) => {
+        this.gotoLoanView('transactions');
+      },
+      error: (error: any) => {
+        this.isSubmitting = false;
+        this.cdr.markForCheck();
+      }
     });
   }
 }


### PR DESCRIPTION
## Description

This PR prevents duplicate repayment submissions in the Make Repayment flow.

Previously, rapid multiple clicks on the Submit button could dispatch parallel repayment requests before the initial request completed, resulting in duplicate repayment transactions for the same loan account.

### Changes Made

* Added local `isSubmitting` state handling
* Disabled the submit button during active repayment requests
* Restored submission state on request failure
* Added `markForCheck()` synchronization for `OnPush` change detection compatibility

The existing repayment and penalty waiver business logic remains unchanged.

## Related issues and discussion

WEB-964

## Screenshots, if any

### Before Fix

* Multiple repayment requests were triggered when the submit button was clicked rapidly.

https://github.com/user-attachments/assets/9f70d811-a31a-48fe-852e-faac5e099725

### After Fix

* The submit button is disabled immediately after the first click.
* Only one repayment request is processed.

https://github.com/user-attachments/assets/c76a7725-2855-428a-8e31-a2f9ee0df61e

## Checklist

* [x] If you have multiple commits please combine them into one commit by squashing them.
* [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced loan repayment form to prevent duplicate submissions by disabling the Submit button when a submission is already in progress.
  * Improved error handling by removing unnecessary logging for penalty-related operations while maintaining repayment functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->