### PR TITLE
WEB-965: use parsed errorBody consistently in ErrorHandlerInterceptor

### DIFF
--- a/src/app/core/http/error-handler.interceptor.ts
+++ b/src/app/core/http/error-handler.interceptor.ts
@@ -92,18 +92,17 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
         : nestedMessage
       : topLevelMessage;
     let parameterName: string | null = null;
-    if (response.error.errors) {
-      if (response.error.errors[0]) {
-        if (
-          response.error.errors[0].userMessageGlobalisationCode &&
-          this.databaseErrorCodes.indexOf(response.error.errors[0].userMessageGlobalisationCode) > -1
-        ) {
-          errorMessage = this.translate.instant('errors.error.msg.data.integrity.issue');
-        } else {
-          errorMessage =
-            response.error.errors[0].defaultUserMessage.replace(/\\./g, ' ') ||
-            response.error.errors[0].developerMessage.replace(/\\./g, ' ');
-        }
+    if (errorBody?.errors?.[0]) {
+      if (
+        errorBody.errors[0].userMessageGlobalisationCode &&
+        this.databaseErrorCodes.includes(errorBody.errors[0].userMessageGlobalisationCode)
+      ) {
+        errorMessage = this.translate.instant('errors.error.msg.data.integrity.issue');
+      } else {
+        errorMessage =
+          errorBody.errors[0].defaultUserMessage?.replace(/\\./g, ' ') ||
+          errorBody.errors[0].developerMessage?.replace(/\\./g, ' ') ||
+          errorMessage;
       }
       if ('parameterName' in errorBody.errors[0]) {
         parameterName = errorBody.errors[0].parameterName;


### PR DESCRIPTION
## Description

Prevents runtime crashes in `ErrorHandlerInterceptor` when handling malformed or `ArrayBuffer`-based API error responses.

This change updates the interceptor to consistently use the parsed `errorBody` instead of directly accessing `response.error`. It also safely handles nullable error fields using optional chaining and preserves fallback error message behavior.

This fixes cases where the global error handler could fail when:

- API errors were returned as `ArrayBuffer`
- `errors[0]` was missing
- `defaultUserMessage` or `developerMessage` was `null`/`undefined`

---

## Related Issues and Discussion

[#WEB-965](#)

---

## Reproduction Steps

To validate the unsafe cases, the interceptor's `intercept()` method was temporarily modified to force specific error payloads.

### Scenario 1: Empty `errors` array

<details>
<summary>Temporary code used</summary>

```ts
intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
  return throwError(() =>
    new HttpErrorResponse({
      status: 400,
      url: request.url,
      error: { errors: [] }
    })
  ).pipe(catchError((error) => this.handleError(error, request)));
}
```

</details>

**Expected issue before fix:** Runtime error when the code tries to access `errorBody.errors[0]`.

---

### Scenario 2: `null` `defaultUserMessage`

<details>
<summary>Temporary code used</summary>

```ts
intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
  return throwError(() =>
    new HttpErrorResponse({
      status: 400,
      url: request.url,
      error: {
        errors: [{
          defaultUserMessage: null,
          developerMessage: "Detailed logs"
        }]
      }
    })
  ).pipe(catchError((error) => this.handleError(error, request)));
}
```

</details>

**Expected issue before fix:** Runtime error when `.replace()` is called on `null`.

---

## Screenshots & Videos

### Before Fix

<details>
<summary>1. Empty errors array — crash</summary>

https://github.com/user-attachments/assets/0e418932-5f62-4b57-aaa5-0fe8a60e4224

</details>

<details>
<summary>2. Null defaultUserMessage — crash</summary>

https://github.com/user-attachments/assets/8f7ff271-1bc3-4da5-8dff-0b414c38eee3

</details>

### After Fix

<details>
<summary>1. Empty errors array — handled gracefully</summary>

https://github.com/user-attachments/assets/abb2d978-70be-42c6-b413-bd65a54277a2

</details>

<details>
<summary>2. Null defaultUserMessage — handled gracefully</summary>

https://github.com/user-attachments/assets/7c569fe6-ee42-4b1e-bb77-7a084d778153

</details>

<details>
<summary>3. Error handler working correctly</summary>

https://github.com/user-attachments/assets/b5df14c0-1344-45f4-9bfa-09558f9a7520

</details>

---

## Checklist

Please make sure these boxes are checked before submitting your pull request — thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.