### PR TITLE
WEB-966: Prevent duplicate disbursement submissions

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/disburse-to-savings-account/disburse-to-savings-account.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/disburse-to-savings-account/disburse-to-savings-account.component.html
@@ -65,7 +65,7 @@
           <button
             mat-raised-button
             color="primary"
-            [disabled]="!disbursementForm.valid"
+            [disabled]="!disbursementForm.valid || isSubmitting"
             *mifosxHasPermission="'DISBURSETOSAVINGS_LOAN'"
           >
             {{ 'labels.buttons.Submit' | translate }}

--- a/src/app/loans/loans-view/loan-account-actions/disburse-to-savings-account/disburse-to-savings-account.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/disburse-to-savings-account/disburse-to-savings-account.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, ChangeDetectorRef } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { Dates } from 'app/core/utils/dates';
 import { Currency } from 'app/shared/models/general.model';
@@ -31,6 +31,7 @@ import { LoanAccountActionsBaseComponent } from '../loan-account-actions-base.co
 export class DisburseToSavingsAccountComponent extends LoanAccountActionsBaseComponent implements OnInit {
   private formBuilder = inject(UntypedFormBuilder);
   private dateUtils = inject(Dates);
+  private cdr = inject(ChangeDetectorRef);
 
   /** Minimum Date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -39,6 +40,8 @@ export class DisburseToSavingsAccountComponent extends LoanAccountActionsBaseCom
   /** Disbursement Loan form. */
   disbursementForm: UntypedFormGroup;
   currency: Currency;
+  /** Prevents duplicate submissions */
+  isSubmitting = false;
 
   constructor() {
     super();
@@ -92,6 +95,12 @@ export class DisburseToSavingsAccountComponent extends LoanAccountActionsBaseCom
    * Submit Disburse Form.
    */
   submit() {
+    if (this.disbursementForm.invalid || this.isSubmitting) {
+      return;
+    }
+    this.isSubmitting = true;
+    this.cdr.markForCheck();
+
     const disbursementLoanFormData = this.disbursementForm.value;
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;
@@ -108,13 +117,19 @@ export class DisburseToSavingsAccountComponent extends LoanAccountActionsBaseCom
       locale
     };
     data['transactionAmount'] = data['transactionAmount'] * 1;
-    this.loanService.loanActionButtons(this.loanId, 'disbursetosavings', data).subscribe((response: any) => {
-      this.router.navigate(['../../general'], {
-        queryParams: {
-          productType: this.loanProductService.productType.value
-        },
-        relativeTo: this.route
-      });
+    this.loanService.loanActionButtons(this.loanId, 'disbursetosavings', data).subscribe({
+      next: (response: any) => {
+        this.router.navigate(['../../general'], {
+          queryParams: {
+            productType: this.loanProductService.productType.value
+          },
+          relativeTo: this.route
+        });
+      },
+      error: (error: any) => {
+        this.isSubmitting = false;
+        this.cdr.markForCheck();
+      }
     });
   }
 }


### PR DESCRIPTION
## Description

This PR prevents duplicate disbursement submissions in the "Disburse to Savings" workflow.

Previously, rapid repeated clicks on the Submit button could dispatch multiple concurrent HTTP POST requests before the initial request completed and navigation occurred.

This resulted in backend validation conflicts such as:

* "Loan Disbursal is not allowed. Loan Account is not in approved and not disbursed state."
* "Loan can't be disbursed, disburse amount is exceeding approved principal."

The issue occurred because the submit button remained interactive during the async request lifecycle.

This PR introduces:

* local `isSubmitting` state locking
* immediate submit button disabling during request processing
* proper unlock handling on request failure
* `markForCheck()` updates for OnPush change detection compatibility

## Screenshots, if any

Attached:

* before fix video

https://github.com/user-attachments/assets/635ac39c-1581-48f1-95f0-8ce93ec57bbc

* after fix video

https://github.com/user-attachments/assets/162fc788-d6b6-4e23-ba89-9d3ea3ebda5d

## Checklist

* [x] If you have multiple commits please combine them into one commit by squashing them.
* [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Submit button for loan disbursement now remains disabled while a request is being processed, preventing users from accidentally submitting multiple duplicate disbursement requests.
  * Error handling has been improved to properly reset the form submission state when a disbursement request fails, allowing users to immediately retry without refreshing the page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openMF/web-app/pull/3616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->