### PR TITLE
WEB-657: Working Capital Loan Disbursement and Discount fix

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/approve-loan/approve-loan.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/approve-loan/approve-loan.component.ts
@@ -98,7 +98,13 @@ export class ApproveLoanComponent extends LoanAccountActionsBaseComponent implem
       note: ['']
     });
     if (this.isWorkingCapital) {
-      this.approveLoanForm.addControl('discountAmount', new UntypedFormControl());
+      this.approveLoanForm.addControl(
+        'discountAmount',
+        new UntypedFormControl({
+          value: this.loanData.discountAmount,
+          disabled: this.loanData.overrideDiscountDisabled
+        })
+      );
     }
   }
 

--- a/src/app/loans/loans-view/loan-account-actions/disburse/disburse.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/disburse/disburse.component.ts
@@ -92,7 +92,13 @@ export class DisburseComponent extends LoanAccountActionsBaseComponent implement
       note: ''
     });
     if (this.isWorkingCapital) {
-      this.disbursementLoanForm.addControl('discountAmount', new UntypedFormControl());
+      this.disbursementLoanForm.addControl(
+        'discountAmount',
+        new UntypedFormControl({
+          value: this.dataObject.discountAmount,
+          disabled: this.dataObject.overrideDiscountDisabled
+        })
+      );
       this.disbursementLoanForm.addControl(
         'discountExternalId',
         new UntypedFormControl('', Validators.maxLength(this.maxExternalIdLength))

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
@@ -347,6 +347,7 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
       transaction.type.chargeoff ||
       this.isReAgoeOrReAmortize(transaction.type) ||
       transaction.type.interestRefund ||
+      this.isDiscountFee(transaction.type) ||
       transaction.type.contractTermination
     );
   }
@@ -565,6 +566,10 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
 
   private isReAgoeOrReAmortize(transactionType: LoanTransactionType): boolean {
     return this.isReAmortize(transactionType) || this.isReAge(transactionType);
+  }
+
+  private isDiscountFee(transactionType: LoanTransactionType): boolean {
+    return transactionType.discountFee || transactionType.code === 'loanTransactionType.discountFee';
   }
 
   isBuyDownFee(transactionType: LoanTransactionType): boolean {

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
@@ -140,7 +140,8 @@ export class ViewTransactionComponent extends LoanAccountActionsBaseComponent im
         !this.transactionData.manuallyReversed && !this.allowTransactionEdition(this.transactionData.type.id);
       this.allowUndo = this.allowUndoTransaction(
         this.transactionData.manuallyReversed || this.transactionData.reversed,
-        this.transactionType
+        this.transactionType,
+        !!this.transactionData.wcLoanId
       );
       this.allowChargeback =
         this.allowChargebackTransaction(this.transactionType) && !this.transactionData.manuallyReversed;
@@ -209,14 +210,19 @@ export class ViewTransactionComponent extends LoanAccountActionsBaseComponent im
     );
   }
 
-  allowUndoTransaction(manuallyReversed: boolean, transactionType: LoanTransactionType): boolean {
+  allowUndoTransaction(
+    manuallyReversed: boolean,
+    transactionType: LoanTransactionType,
+    isWorkingCapital: boolean
+  ): boolean {
     if (manuallyReversed) {
       return false;
     }
-    if (transactionType.interestRefund) {
-      return false;
-    }
-    return true;
+    return !(
+      transactionType.interestRefund ||
+      transactionType.id === 44 ||
+      (isWorkingCapital && transactionType.disbursement)
+    );
   }
 
   isWriteOff(transactionType: LoanTransactionType): boolean {

--- a/src/app/loans/models/loan-transaction-type.model.ts
+++ b/src/app/loans/models/loan-transaction-type.model.ts
@@ -51,6 +51,7 @@ export interface LoanTransactionType {
   buyDownFee: boolean;
   buyDownFeeAdjustment: boolean;
   buyDownFeeAmortizationAdjustment: boolean;
+  discountFee: boolean;
 }
 
 export interface LoanTransactionTemplate {


### PR DESCRIPTION
## Description

Working capital loan product
* Approve Loan, discount field is populated on init and disabled according to template
* Disburse Loan, discount field is populated on init and disabled according to template
* Discount transaction popup on transactions tab no longer supports manual undo

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Discount amount fields in loan approval and disbursement forms now initialize with stored values and honor disabled state.
  * Discount-fee transaction types are correctly recognized in the UI.

* **New Features**
  * Discount-fee transactions and working-capital disbursements are now prevented from being undone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ