### PR TITLE
WEB-954: Migrate Subscription management : small modules

### DIFF
--- a/src/app/account-transfers/create-standing-instructions/create-standing-instructions.component.ts
+++ b/src/app/account-transfers/create-standing-instructions/create-standing-instructions.component.ts
@@ -10,7 +10,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { AccountTransfersService } from '../account-transfers.service';
@@ -31,7 +31,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateStandingInstructionsComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private accountTransfersService = inject(AccountTransfersService);
@@ -49,7 +49,7 @@ export class CreateStandingInstructionsComponent implements OnInit {
   /** Allow Client Edit */
   allowclientedit = true;
   /** Edit Standing Instructions form. */
-  createStandingInstructionsForm: UntypedFormGroup;
+  createStandingInstructionsForm: FormGroup;
   /** Priority Type Data */
   priorityTypeData: any;
   /** Status Type Data */
@@ -99,11 +99,13 @@ export class CreateStandingInstructionsComponent implements OnInit {
    * @param {Dates} dateUtils Date Utils
    */
   constructor() {
-    this.route.data.subscribe((data: { standingIntructionsTemplate: any }) => {
-      this.standingIntructionsTemplate = data.standingIntructionsTemplate;
-      this.setParams();
-      this.setOptions();
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { standingIntructionsTemplate: any }) => {
+        this.standingIntructionsTemplate = data.standingIntructionsTemplate;
+        this.setParams();
+        this.setOptions();
+      });
   }
 
   /** Sets the value from the URL */

--- a/src/app/account-transfers/edit-standing-instructions/edit-standing-instructions.component.ts
+++ b/src/app/account-transfers/edit-standing-instructions/edit-standing-instructions.component.ts
@@ -7,9 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { AccountTransfersService } from '../account-transfers.service';
@@ -30,12 +31,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditStandingInstructionsComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private accountTransfersService = inject(AccountTransfersService);
   private settingsService = inject(SettingsService);
   private dateUtils = inject(Dates);
+  private destroyRef = inject(DestroyRef);
 
   /** Standing Instructions Data */
   standingInstructionsData: any;
@@ -44,7 +46,7 @@ export class EditStandingInstructionsComponent implements OnInit {
   /** Allow Client Edit */
   allowclientedit = false;
   /** Edit Standing Instructions form. */
-  editStandingInstructionsForm: UntypedFormGroup;
+  editStandingInstructionsForm: FormGroup;
   /** Priority Type Data */
   priorityTypeData: any;
   /** Status Type Data */
@@ -70,14 +72,16 @@ export class EditStandingInstructionsComponent implements OnInit {
    * @param {Dates} dateUtils Date Utils
    */
   constructor() {
-    this.route.data.subscribe((data: { standingInstructionsDataAndTemplate: any }) => {
-      this.standingInstructionsData = data.standingInstructionsDataAndTemplate;
-      this.standingInstructionsId = data.standingInstructionsDataAndTemplate.id;
-      if (this.standingInstructionsData.fromClient.id === this.standingInstructionsData.toClient.id) {
-        this.allowclientedit = false;
-      }
-      this.setOptions();
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { standingInstructionsDataAndTemplate: any }) => {
+        this.standingInstructionsData = data.standingInstructionsDataAndTemplate;
+        this.standingInstructionsId = data.standingInstructionsDataAndTemplate.id;
+        if (this.standingInstructionsData.fromClient.id === this.standingInstructionsData.toClient.id) {
+          this.allowclientedit = false;
+        }
+        this.setOptions();
+      });
   }
 
   /**

--- a/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.ts
+++ b/src/app/account-transfers/list-standing-instructions/list-standing-instructions.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import {
@@ -24,7 +25,7 @@ import {
   MatRow
 } from '@angular/material/table';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { AccountTransfersService } from '../account-transfers.service';
@@ -66,19 +67,20 @@ export class ListStandingInstructionsComponent {
   private accountTransfersService = inject(AccountTransfersService);
   private settingsService = inject(SettingsService);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Recurring Deposits Data */
   standingIntructionsTemplateData: any;
   /** Instructions Data */
   instructionsData: any[];
   /** Name form control. */
-  transferType = new UntypedFormControl();
+  transferType = new FormControl();
   /** ExternalId form control. */
-  fromAccountId = new UntypedFormControl();
+  fromAccountId = new FormControl();
   /** Name form control. */
-  clientNameControl = new UntypedFormControl();
+  clientNameControl = new FormControl();
   /** ExternalId form control. */
-  fromClientId = new UntypedFormControl();
+  fromClientId = new FormControl();
   /** Client Name */
   clientName: any;
   /** Transfer Type Options Data */
@@ -117,15 +119,17 @@ export class ListStandingInstructionsComponent {
    * @param {AccountTransfersService} accountTransfersService Account Transfers Service
    */
   constructor() {
-    this.route.data.subscribe((data: { standingIntructionsTemplate: any }) => {
-      this.standingIntructionsTemplateData = data.standingIntructionsTemplate;
-      if (data.standingIntructionsTemplate.fromClient) {
-        this.clientName = this.standingIntructionsTemplateData.fromClient.displayName;
-        this.getStandingInstructions();
-      }
-      this.setParams();
-      this.transferTypeDatas = this.standingIntructionsTemplateData.transferTypeOptions;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { standingIntructionsTemplate: any }) => {
+        this.standingIntructionsTemplateData = data.standingIntructionsTemplate;
+        if (data.standingIntructionsTemplate.fromClient) {
+          this.clientName = this.standingIntructionsTemplateData.fromClient.displayName;
+          this.getStandingInstructions();
+        }
+        this.setParams();
+        this.transferTypeDatas = this.standingIntructionsTemplateData.transferTypeOptions;
+      });
   }
 
   setParams() {

--- a/src/app/account-transfers/list-transactions/list-transactions.component.ts
+++ b/src/app/account-transfers/list-transactions/list-transactions.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { MatPaginator } from '@angular/material/paginator';
 import {
@@ -56,6 +57,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ListTransactionsComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** List Transactions Data */
   listTransactionData: any;
@@ -77,7 +79,7 @@ export class ListTransactionsComponent {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { listTransactionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { listTransactionData: any }) => {
       this.listTransactionData = data.listTransactionData;
       this.dataSource = new MatTableDataSource(this.listTransactionData.transactions.pageItems);
       this.dataSource.paginator = this.paginator;

--- a/src/app/account-transfers/make-account-transfers/make-account-transfers.component.ts
+++ b/src/app/account-transfers/make-account-transfers/make-account-transfers.component.ts
@@ -7,16 +7,18 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, AfterViewInit, ViewChild, inject } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
 import {
-  AbstractControl,
-  UntypedFormBuilder,
-  UntypedFormGroup,
-  ValidationErrors,
-  Validators,
-  FormsModule
-} from '@angular/forms';
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  AfterViewInit,
+  ViewChild,
+  inject,
+  DestroyRef
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { AbstractControl, FormBuilder, FormGroup, ValidationErrors, Validators, FormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { AccountTransfersService } from '../account-transfers.service';
@@ -70,7 +72,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MakeAccountTransfersComponent implements OnInit, AfterViewInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private accountTransfersService = inject(AccountTransfersService);
@@ -78,6 +80,7 @@ export class MakeAccountTransfersComponent implements OnInit, AfterViewInit {
   private settingsService = inject(SettingsService);
   private clientsService = inject(ClientsService);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Stepper reference */
   @ViewChild('transferStepper') transferStepper: MatStepper;
@@ -89,9 +92,9 @@ export class MakeAccountTransfersComponent implements OnInit, AfterViewInit {
   /** Maximum date allowed. */
   maxDate = new Date(2100, 0, 1);
   /** Beneficiary selection form (Step 1) */
-  beneficiaryForm: UntypedFormGroup;
+  beneficiaryForm: FormGroup;
   /** Transfer details form (Step 2) */
-  transferDetailsForm: UntypedFormGroup;
+  transferDetailsForm: FormGroup;
   /** To Office Type Data */
   toOfficeTypeData: any;
   /** To Client Type Data */
@@ -124,7 +127,7 @@ export class MakeAccountTransfersComponent implements OnInit, AfterViewInit {
    * Retrieves the standing instructions template from `resolve`.
    */
   constructor() {
-    this.route.data.subscribe((data: { accountTransferTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { accountTransferTemplate: any }) => {
       this.accountTransferTemplateData = data.accountTransferTemplate;
       this.setParams();
       this.setOptions();
@@ -308,15 +311,17 @@ export class MakeAccountTransfersComponent implements OnInit, AfterViewInit {
    */
   ngAfterViewInit() {
     if (!this.interbank && this.beneficiaryForm) {
-      this.beneficiaryForm.controls.toClientId.valueChanges.subscribe((value: any) => {
-        if (typeof value === 'string' && value.length >= 2) {
-          this.clientsService.getFilteredClients('displayName', 'ASC', true, value).subscribe((data: any) => {
-            this.clientsData = data.pageItems;
-          });
-        } else if (typeof value === 'number') {
-          this.changeEvent();
-        }
-      });
+      this.beneficiaryForm.controls.toClientId.valueChanges
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((value: any) => {
+          if (typeof value === 'string' && value.length >= 2) {
+            this.clientsService.getFilteredClients('displayName', 'ASC', true, value).subscribe((data: any) => {
+              this.clientsData = data.pageItems;
+            });
+          } else if (typeof value === 'number') {
+            this.changeEvent();
+          }
+        });
     }
   }
 

--- a/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
+++ b/src/app/account-transfers/view-account-transfer/view-account-transfer.component.ts
@@ -8,7 +8,8 @@
 
 /** Angular Imports */
 import { Location, NgIf, NgClass } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -41,6 +42,7 @@ export class ViewAccountTransferComponent {
   private dialog = inject(MatDialog);
   private accountTransfersService = inject(AccountTransfersService);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   viewAccountTransferData: any;
   /**
@@ -49,7 +51,7 @@ export class ViewAccountTransferComponent {
    * @param {Location} location Location.
    */
   constructor() {
-    this.route.data.subscribe((data: { viewAccountTransferData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { viewAccountTransferData: any }) => {
       this.viewAccountTransferData = data.viewAccountTransferData;
     });
   }

--- a/src/app/account-transfers/view-standing-instructions/view-standing-instructions.component.ts
+++ b/src/app/account-transfers/view-standing-instructions/view-standing-instructions.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatDivider } from '@angular/material/divider';
@@ -28,6 +29,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewStandingInstructionsComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Standing Instructions Data */
   standingInstructionsData: any;
@@ -39,7 +41,7 @@ export class ViewStandingInstructionsComponent {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { standingInstructionsData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { standingInstructionsData: any }) => {
       this.standingInstructionsData = data.standingInstructionsData;
       if (this.standingInstructionsData.fromClient.id === this.standingInstructionsData.toClient.id) {
         this.allowclientedit = false;

--- a/src/app/collaterals/edit-collateral/edit-collateral.component.ts
+++ b/src/app/collaterals/edit-collateral/edit-collateral.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -26,14 +27,15 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditCollateralComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private collateralService = inject(CollateralsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Client Collateral Form */
-  clientCollateralForm: UntypedFormGroup;
+  clientCollateralForm: FormGroup;
   /** Client Collateral Options */
   clientCollateralOptions: any;
   /** Client Id */
@@ -50,7 +52,7 @@ export class EditCollateralComponent implements OnInit {
    * @param {CollateralsService} collateralService Collateral Service
    */
   constructor() {
-    this.route.data.subscribe((data: { clientCollateralData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientCollateralData: any }) => {
       this.collateralDetails = data.clientCollateralData;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];

--- a/src/app/collaterals/view-collateral/view-collateral.component.ts
+++ b/src/app/collaterals/view-collateral/view-collateral.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { CollateralsService } from '../collaterals.service';
 import { MatDialog } from '@angular/material/dialog';
@@ -57,6 +58,7 @@ export class ViewCollateralComponent {
   private collateralsService = inject(CollateralsService);
   private router = inject(Router);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   clientCollateralData: any;
 
@@ -68,7 +70,7 @@ export class ViewCollateralComponent {
   ];
 
   constructor() {
-    this.route.data.subscribe((data: { clientCollateralData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientCollateralData: any }) => {
       this.clientCollateralData = data.clientCollateralData;
     });
   }

--- a/src/app/collections/collection-sheet/collection-sheet.component.ts
+++ b/src/app/collections/collection-sheet/collection-sheet.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { CollectionsService } from '../collections.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { SettingsService } from 'app/settings/settings.service';
@@ -33,7 +34,7 @@ import { Logger } from 'app/core/logger/logger.service';
 })
 export class CollectionSheetComponent implements OnInit {
   private readonly log = new Logger('CollectionSheetComponent');
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private centerService = inject(CentersService);
   private collectionsService = inject(CollectionsService);
   private organizationService = inject(OrganizationService);
@@ -41,6 +42,7 @@ export class CollectionSheetComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private settingsService = inject(SettingsService);
   private dateUtils = inject(Dates);
+  private destroyRef = inject(DestroyRef);
 
   /** Offices Data */
   officesData: any;
@@ -55,7 +57,7 @@ export class CollectionSheetComponent implements OnInit {
   /** Maximum Date allowed. */
   maxDate = new Date();
   /** Collection Sheet form. */
-  collectionSheetForm: UntypedFormGroup;
+  collectionSheetForm: FormGroup;
 
   officeId: number | null = null;
   meetingFallCenters: MeetingFallCenter[] | null = null;
@@ -71,7 +73,7 @@ export class CollectionSheetComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { officesData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { officesData: any }) => {
       this.officesData = data.officesData;
     });
   }
@@ -109,18 +111,21 @@ export class CollectionSheetComponent implements OnInit {
    * Checks for the office id value change
    */
   buildDependencies() {
-    this.collectionSheetForm.get('officeId').valueChanges.subscribe((officeId: any) => {
-      this.officeId = officeId;
-      this.organizationService.getStaffs(officeId).subscribe((response: any) => {
-        this.loanOfficerData = response;
+    this.collectionSheetForm
+      .get('officeId')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((officeId: any) => {
+        this.officeId = officeId;
+        this.organizationService.getStaffs(officeId).subscribe((response: any) => {
+          this.loanOfficerData = response;
+        });
+        this.organizationService.getCenters(officeId).subscribe((response: any) => {
+          this.centersData = response;
+        });
+        this.organizationService.getGroups(officeId).subscribe((response: any) => {
+          this.groupsData = response;
+        });
       });
-      this.organizationService.getCenters(officeId).subscribe((response: any) => {
-        this.centersData = response;
-      });
-      this.organizationService.getGroups(officeId).subscribe((response: any) => {
-        this.groupsData = response;
-      });
-    });
   }
 
   previewCollectionSheet() {

--- a/src/app/collections/individual-collection-sheet/individual-collection-sheet.component.ts
+++ b/src/app/collections/individual-collection-sheet/individual-collection-sheet.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -24,7 +25,7 @@ import {
   MatRowDef,
   MatRow
 } from '@angular/material/table';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil, switchMap } from 'rxjs/operators';
@@ -75,7 +76,7 @@ import { OrganizationService } from 'app/organization/organization.service';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class IndividualCollectionSheetComponent implements OnInit, OnDestroy {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private collectionsService = inject(CollectionsService);
   private organizationService = inject(OrganizationService);
   private route = inject(ActivatedRoute);
@@ -84,6 +85,7 @@ export class IndividualCollectionSheetComponent implements OnInit, OnDestroy {
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private dataReloadService = inject(DataReloadService);
+  private destroyRef = inject(DestroyRef);
 
   officesData: any;
   loanOfficerData: any = [];
@@ -91,12 +93,11 @@ export class IndividualCollectionSheetComponent implements OnInit, OnDestroy {
   savingsData: any = [];
   minDate = new Date(2000, 0, 1);
   maxDate = new Date();
-  collectionSheetForm: UntypedFormGroup;
+  collectionSheetForm: FormGroup;
   isCollapsed = false;
   collectionSheetData: any;
 
   private reloadContext = 'individual-collection-sheet';
-  private destroy$ = new Subject<void>();
   private buildDependencies$ = new Subject<void>();
   /** checks and stores the local storage values */
   Success: boolean;
@@ -152,14 +153,14 @@ export class IndividualCollectionSheetComponent implements OnInit, OnDestroy {
    * @param {SettingsService} settingsService Settings Service
    */
   ngOnInit(): void {
-    this.route.data.pipe(takeUntil(this.destroy$)).subscribe((data: { officesData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { officesData: any }) => {
       this.officesData = data.officesData;
     });
 
     // Subscribe to reload events
     this.dataReloadService
       .getReloadObservable(this.reloadContext)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.refreshData();
       });
@@ -177,8 +178,6 @@ export class IndividualCollectionSheetComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
     this.buildDependencies$.next();
     this.buildDependencies$.complete();
     if (this.reloadContext) {
@@ -214,7 +213,7 @@ export class IndividualCollectionSheetComponent implements OnInit, OnDestroy {
       .get('officeId')
       .valueChanges.pipe(
         takeUntil(this.buildDependencies$),
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
         switchMap((value: any) => this.organizationService.getStaffs(value))
       )
       .subscribe((response: any) => {

--- a/src/app/configuration-wizard/popover/popover-arrow.directive.ts
+++ b/src/app/configuration-wizard/popover/popover-arrow.directive.ts
@@ -7,11 +7,8 @@
  */
 
 /* Angular Imports */
-import { Directive, Renderer2, ElementRef, HostBinding, ChangeDetectorRef, OnDestroy, inject } from '@angular/core';
-
-/* rxjs Imports */
-import { Subscription } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Directive, Renderer2, ElementRef, HostBinding, ChangeDetectorRef, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /* Popover Ref */
 import { PopoverRef } from './popover-ref';
@@ -20,9 +17,10 @@ import { PopoverRef } from './popover-ref';
  * Internal directive that shows the popover arrow.
  */
 @Directive({ selector: '[mifosxPopoverArrow]' })
-export class PopoverArrowDirective implements OnDestroy {
+export class PopoverArrowDirective {
   private popoverRef = inject(PopoverRef);
   private cd = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
 
   @HostBinding('style.width.px')
   @HostBinding('style.height.px')
@@ -40,30 +38,21 @@ export class PopoverArrowDirective implements OnDestroy {
   @HostBinding('style.left.px')
   offsetLeft: number;
 
-  private subscription = new Subscription();
-
-  /**
-   * @param {PopoverRef} popoverRef PopoverRef.
-   * @param {ChangeDetectorRef} cd ChangeDetectorRef
-   */
   constructor() {
-    const popoverRef = this.popoverRef;
+    this.arrowSize = this.popoverRef.config.arrowSize;
 
-    this.arrowSize = popoverRef.config.arrowSize;
+    this.popoverRef
+      .positionChanges()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((p) => {
+        const { offsetX, offsetY } = p.connectionPair;
 
-    this.subscription = popoverRef.positionChanges().subscribe((p) => {
-      const { offsetX, offsetY } = p.connectionPair;
+        this.offsetTop = offsetY >= 0 ? offsetY * -1 : null;
+        this.offsetLeft = offsetX < 0 ? offsetX * -1 : null;
+        this.offsetBottom = offsetY < 0 ? offsetY : null;
+        this.offsetRight = offsetX >= 0 ? offsetX : null;
 
-      this.offsetTop = offsetY >= 0 ? offsetY * -1 : null;
-      this.offsetLeft = offsetX < 0 ? offsetX * -1 : null;
-      this.offsetBottom = offsetY < 0 ? offsetY : null;
-      this.offsetRight = offsetX >= 0 ? offsetX : null;
-
-      this.cd.detectChanges();
-    });
-  }
-
-  ngOnDestroy(): void {
-    this.subscription.unsubscribe();
+        this.cd.detectChanges();
+      });
   }
 }

--- a/src/app/core/shell/breadcrumb/breadcrumb.component.ts
+++ b/src/app/core/shell/breadcrumb/breadcrumb.component.ts
@@ -11,18 +11,19 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   TemplateRef,
   ElementRef,
   ViewChild,
   AfterViewInit,
-  OnDestroy,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, NavigationEnd, Data } from '@angular/router';
 
 /** rxjs Imports */
-import { filter, takeUntil } from 'rxjs/operators';
-import { merge, Subject } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { merge } from 'rxjs';
 
 /** Custom Model */
 import { Breadcrumb } from './breadcrumb.model';
@@ -77,14 +78,14 @@ const routeAddBreadcrumbLink = 'addBreadcrumbLink';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BreadcrumbComponent implements AfterViewInit, OnDestroy {
+export class BreadcrumbComponent implements AfterViewInit {
   private activatedRoute = inject(ActivatedRoute);
   private router = inject(Router);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
   private translateService = inject(TranslateService);
   private cdr = inject(ChangeDetectorRef);
-  private destroy$ = new Subject<void>();
+  private destroyRef = inject(DestroyRef);
 
   /** Array of breadcrumbs. */
   breadcrumbs: Breadcrumb[];
@@ -112,7 +113,7 @@ export class BreadcrumbComponent implements AfterViewInit, OnDestroy {
 
     // Merge navigation events with language change events to regenerate breadcrumbs when language changes
     merge(onNavigationEnd, this.translateService.onLangChange)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.breadcrumbs = [];
         let currentRoute = this.activatedRoute.root;
@@ -333,13 +334,5 @@ export class BreadcrumbComponent implements AfterViewInit, OnDestroy {
 
     // If no translation found, return the original text
     return text;
-  }
-
-  /**
-   * Clean up subscriptions on component destroy.
-   */
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/src/app/core/shell/shell.component.ts
+++ b/src/app/core/shell/shell.component.ts
@@ -8,10 +8,11 @@
 
 /** Angular Imports */
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 /** rxjs Imports */
-import { Observable, Subscription } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 /** Custom Services */
@@ -47,10 +48,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ShellComponent implements OnInit, OnDestroy {
+export class ShellComponent implements OnInit {
   private breakpointObserver = inject(BreakpointObserver);
   private progressBarService = inject(ProgressBarService);
   private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
 
   /** Subscription to breakpoint observer for handset. */
   isHandset$: Observable<boolean> = this.breakpointObserver
@@ -60,14 +62,12 @@ export class ShellComponent implements OnInit, OnDestroy {
   sidenavCollapsed = true;
   /** Progress bar mode. */
   progressBarMode: string;
-  /** Subscription to progress bar. */
-  progressBar$: Subscription;
 
   /**
    * Subscribes to progress bar to update its mode.
    */
   ngOnInit() {
-    this.progressBar$ = this.progressBarService.updateProgressBar.subscribe((mode: string) => {
+    this.progressBarService.updateProgressBar.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((mode: string) => {
       this.progressBarMode = mode;
       this.cdr.detectChanges();
     });
@@ -80,14 +80,5 @@ export class ShellComponent implements OnInit, OnDestroy {
   toggleCollapse($event: boolean) {
     this.sidenavCollapsed = $event;
     this.cdr.detectChanges();
-  }
-
-  /**
-   * Unsubscribes from progress bar.
-   */
-  ngOnDestroy() {
-    if (this.progressBar$) {
-      this.progressBar$.unsubscribe();
-    }
   }
 }

--- a/src/app/core/shell/toolbar/toolbar.component.ts
+++ b/src/app/core/shell/toolbar/toolbar.component.ts
@@ -20,8 +20,10 @@ import {
   TemplateRef,
   AfterContentChecked,
   ChangeDetectorRef,
+  DestroyRef,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSidenav } from '@angular/material/sidenav';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
@@ -85,6 +87,7 @@ export class ToolbarComponent implements OnInit, AfterViewInit, AfterContentChec
   private dialog = inject(MatDialog);
   private changeDetector = inject(ChangeDetectorRef);
   private documentationLinks = inject(DocumentationLinksService);
+  private destroyRef = inject(DestroyRef);
 
   /* Reference of institution */
   @ViewChild('institution') institution: ElementRef<any>;
@@ -113,7 +116,7 @@ export class ToolbarComponent implements OnInit, AfterViewInit, AfterContentChec
    * Subscribes to breakpoint for handset.
    */
   ngOnInit() {
-    this.isHandset$.subscribe((isHandset) => {
+    this.isHandset$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((isHandset) => {
       if (isHandset && this.sidenavCollapsed) {
         this.toggleSidenavCollapse(false);
       }

--- a/src/app/home/dashboard/amount-collected-pie/amount-collected-pie.component.ts
+++ b/src/app/home/dashboard/amount-collected-pie/amount-collected-pie.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -51,7 +51,7 @@ export class AmountCollectedPieComponent implements OnInit {
   private currentTheme = 'light-theme';
 
   /** Static Form control for office Id */
-  officeId = new UntypedFormControl();
+  officeId = new FormControl();
   /** Office Data */
   officeData: any;
   /** Chart.js chart */
@@ -67,7 +67,7 @@ export class AmountCollectedPieComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { offices: any }) => {
       this.officeData = data.offices;
     });
   }
@@ -92,7 +92,7 @@ export class AmountCollectedPieComponent implements OnInit {
    * Subscribes to value changes of office Id fetches chart data accordingly.
    */
   getChartData() {
-    this.officeId.valueChanges.subscribe((value: number) => {
+    this.officeId.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value: number) => {
       this.homeService.getCollectedAmount(value).subscribe((response: any) => {
         const data = Object.entries(response[0]).map((entry) => entry[1]);
         if (!(data[0] === 0 && data[1] === 0)) {

--- a/src/app/home/dashboard/amount-disbursed-pie/amount-disbursed-pie.component.ts
+++ b/src/app/home/dashboard/amount-disbursed-pie/amount-disbursed-pie.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -51,7 +51,7 @@ export class AmountDisbursedPieComponent implements OnInit {
   private currentTheme = 'light-theme';
 
   /** Static Form control for office Id */
-  officeId = new UntypedFormControl();
+  officeId = new FormControl();
   /** Office Data */
   officeData: any;
   /** Chart.js chart */
@@ -67,7 +67,7 @@ export class AmountDisbursedPieComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { offices: any }) => {
       this.officeData = data.offices;
     });
   }
@@ -92,7 +92,7 @@ export class AmountDisbursedPieComponent implements OnInit {
    * Subscribes to value changes of office Id fetches chart data accordingly.
    */
   getChartData() {
-    this.officeId.valueChanges.subscribe((value: number) => {
+    this.officeId.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value: number) => {
       this.homeService.getDisbursedAmount(value).subscribe((response: any) => {
         const data = Object.entries(response[0]).map((entry) => entry[1]);
         if (!(data[0] === 0 && data[1] === 0)) {

--- a/src/app/home/dashboard/client-trends-bar/client-trends-bar.component.ts
+++ b/src/app/home/dashboard/client-trends-bar/client-trends-bar.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -60,9 +60,9 @@ export class ClientTrendsBarComponent implements OnInit {
   private currentTheme = 'light-theme';
 
   /** Static Form control for office Id */
-  officeId = new UntypedFormControl();
+  officeId = new FormControl();
   /** Static Form control for time scale */
-  timescale = new UntypedFormControl();
+  timescale = new FormControl();
   /** Office Data */
   officeData: any;
   /** Chart.js chart */
@@ -77,7 +77,7 @@ export class ClientTrendsBarComponent implements OnInit {
    * @param {Dates} dateUtils Date Utils
    */
   constructor() {
-    this.route.data.subscribe((data: { offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { offices: any }) => {
       this.officeData = data.offices;
     });
   }
@@ -108,7 +108,7 @@ export class ClientTrendsBarComponent implements OnInit {
    */
   getChartData() {
     merge(this.officeId.valueChanges, this.timescale.valueChanges)
-      .pipe(skip(1))
+      .pipe(skip(1), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         const officeId = this.officeId.value;
         const timescale = this.timescale.value;

--- a/src/app/home/dashboard/dashboard.component.ts
+++ b/src/app/home/dashboard/dashboard.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -38,9 +39,10 @@ import { GLOBAL_ANALYTICS_DASHBOARD } from 'app/analytics/global-dashboard.confi
 })
 export class DashboardComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Search Text. */
-  searchText: UntypedFormControl = new UntypedFormControl();
+  searchText: FormControl = new FormControl();
   /** Filtered Activities. */
   filteredActivities!: Observable<any[]>;
   /** All User Activities. */
@@ -51,7 +53,7 @@ export class DashboardComponent implements OnInit {
   offices: any[] = [];
 
   constructor() {
-    this.route.data.subscribe((data: { offices: any[] }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { offices: any[] }) => {
       this.offices = data.offices || [];
     });
   }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -18,7 +18,7 @@ import {
   inject
 } from '@angular/core';
 import { ActivatedRoute, Router, NavigationEnd, RouterLink } from '@angular/router';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 /** rxjs Imports */
@@ -79,7 +79,7 @@ export class HomeComponent implements OnInit, AfterViewInit {
   /** Activity Form. */
   activityForm: any;
   /** Search Text. */
-  searchText: UntypedFormControl = new UntypedFormControl();
+  searchText: FormControl = new FormControl();
   /** Filtered Activities. */
   filteredActivities: Observable<any[]>;
   /** All User Activities. */

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -7,12 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-
-/** rxjs Imports */
-
-import { Subscription } from 'rxjs';
 import { take } from 'rxjs/operators';
 /**
  * Interface for version information.
@@ -74,7 +71,7 @@ import { VersionService } from '../system/version.service';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class LoginComponent implements OnInit, OnDestroy {
+export class LoginComponent implements OnInit {
   /** Whether to show the tenant selector dropdown */
   showTenantSelector = true;
   /** Show version info table if env allows */
@@ -86,9 +83,9 @@ export class LoginComponent implements OnInit, OnDestroy {
   private settingsService = inject(SettingsService);
   private themingService = inject(ThemingService);
   private router = inject(Router);
-
   private versionService = inject(VersionService);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   public environment = environment;
 
@@ -107,12 +104,8 @@ export class LoginComponent implements OnInit, OnDestroy {
   resetPassword = false;
   /** True if user requires two factor authentication. */
   twoFactorAuthenticationRequired = false;
-  /** Subscription to alerts. */
-  alert$: Subscription;
   logoPath = 'assets/images/default_home.png';
   logoPathDark = 'assets/images/white-mifos.png';
-  /** Subscription to theme changes. */
-  theme$: Subscription;
 
   themeDarkEnabled: boolean = false;
 
@@ -124,7 +117,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     this.updateLogo();
     this.themeDarkEnabled = this.settingsService.themeDarkEnabled;
     // Subscribe to theme changes
-    this.theme$ = this.themingService.theme.subscribe((value: string) => {
+    this.themingService.theme.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.themeDarkEnabled = this.settingsService.themeDarkEnabled;
     });
 
@@ -132,7 +125,7 @@ export class LoginComponent implements OnInit, OnDestroy {
     this.themingService.setDarkMode(!!this.settingsService.themeDarkEnabled);
 
     // Subscribe to alerts
-    this.alert$ = this.alertService.alertEvent.subscribe((alertEvent: Alert) => {
+    this.alertService.alertEvent.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((alertEvent: Alert) => {
       const alertType = alertEvent.type;
       if (alertType === this.translateService.instant('errors.auth.passwordExpired.type')) {
         this.twoFactorAuthenticationRequired = false;
@@ -177,18 +170,6 @@ export class LoginComponent implements OnInit, OnDestroy {
         }
       );
     this.server = this.settingsService.server;
-  }
-
-  /**
-   * Unsubscribes from alerts and theme changes.
-   */
-  ngOnDestroy() {
-    if (this.alert$) {
-      this.alert$.unsubscribe();
-    }
-    if (this.theme$) {
-      this.theme$.unsubscribe();
-    }
   }
 
   reloadSettings(): void {

--- a/src/app/login/reset-password/reset-password.component.ts
+++ b/src/app/login/reset-password/reset-password.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 
 /** rxjs Imports */
 import { finalize } from 'rxjs/operators';
@@ -44,12 +44,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ResetPasswordComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private authenticationService = inject(AuthenticationService);
   private passwordsUtility = inject(PasswordsUtility);
 
   /** Reset password form group. */
-  resetPasswordForm: UntypedFormGroup;
+  resetPasswordForm: FormGroup;
   /** Password input field type. */
   passwordInputType: string;
   /** True if loading. */

--- a/src/app/login/two-factor-authentication/two-factor-authentication.component.ts
+++ b/src/app/login/two-factor-authentication/two-factor-authentication.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 
 /** rxjs Imports */
 import { finalize } from 'rxjs/operators';
@@ -42,7 +42,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TwoFactorAuthenticationComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private authenticationService = inject(AuthenticationService);
 
   /** Available delivery methods to receive OTP. */
@@ -54,9 +54,9 @@ export class TwoFactorAuthenticationComponent implements OnInit {
   /** Time for which OTP is valid. */
   tokenValidityTime: number;
   /** Two factor authentication delivery method form group. */
-  twoFactorAuthenticationDeliveryMethodForm: UntypedFormGroup;
+  twoFactorAuthenticationDeliveryMethodForm: FormGroup;
   /** Two factor authentication form group. */
-  twoFactorAuthenticationForm: UntypedFormGroup;
+  twoFactorAuthenticationForm: FormGroup;
   /** True if loading. */
   loading = false;
   /** True if loading. */

--- a/src/app/navigation/navigation.component.ts
+++ b/src/app/navigation/navigation.component.ts
@@ -7,9 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, ActivatedRoute } from '@angular/router';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { NavigationService } from './navigation.service';
@@ -43,6 +44,7 @@ export class NavigationComponent implements OnInit {
   private navigationService = inject(NavigationService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   /** Navigation Components */
   @ViewChild(OfficeNavigationComponent) officeNavigationComponent: OfficeNavigationComponent;
@@ -63,15 +65,15 @@ export class NavigationComponent implements OnInit {
   clientData: any;
 
   /** Office selector */
-  officeSelector = new UntypedFormControl();
+  officeSelector = new FormControl();
   /** Employee selector */
-  employeeSelector = new UntypedFormControl();
+  employeeSelector = new FormControl();
   /** Center selector */
-  centerSelector = new UntypedFormControl();
+  centerSelector = new FormControl();
   /** Group selector */
-  groupSelector = new UntypedFormControl();
+  groupSelector = new FormControl();
   /** Client selector */
-  clientSelector = new UntypedFormControl();
+  clientSelector = new FormControl();
 
   /** Selected Item */
   selectedItem: any;
@@ -88,7 +90,7 @@ export class NavigationComponent implements OnInit {
    * @param {Router} router Router for navigation.
    */
   constructor() {
-    this.route.data.subscribe((data: { offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { offices: any }) => {
       this.officeData = data.offices;
     });
   }
@@ -108,7 +110,7 @@ export class NavigationComponent implements OnInit {
    * Sets the office selector
    */
   setOfficeSelector() {
-    this.officeSelector.valueChanges.subscribe((officeId) => {
+    this.officeSelector.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((officeId) => {
       this.employeeSelector.reset(null, { emitEvent: false });
       this.centerSelector.reset(null, { emitEvent: false });
       this.groupSelector.reset(null, { emitEvent: false });
@@ -134,7 +136,7 @@ export class NavigationComponent implements OnInit {
    * Sets the employee selector
    */
   setEmployeeSelector() {
-    this.employeeSelector.valueChanges.subscribe((employeeId) => {
+    this.employeeSelector.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((employeeId) => {
       if (employeeId) {
         this.centerSelector.reset(null, { emitEvent: false });
         this.groupSelector.reset(null, { emitEvent: false });
@@ -160,7 +162,7 @@ export class NavigationComponent implements OnInit {
    * Sets the center selector
    */
   setCenterSelector() {
-    this.centerSelector.valueChanges.subscribe((centerId) => {
+    this.centerSelector.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((centerId) => {
       if (centerId) {
         this.groupSelector.reset(null, { emitEvent: false });
         this.clientSelector.reset(null, { emitEvent: false });
@@ -192,7 +194,7 @@ export class NavigationComponent implements OnInit {
    * Sets the group selector
    */
   setGroupSelector() {
-    this.groupSelector.valueChanges.subscribe((groupId) => {
+    this.groupSelector.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((groupId) => {
       if (groupId) {
         this.clientSelector.reset(null, { emitEvent: false });
         this.clientData = null;
@@ -218,7 +220,7 @@ export class NavigationComponent implements OnInit {
    * Sets the client selector
    */
   setClientSelector() {
-    this.clientSelector.valueChanges.subscribe((clientId) => {
+    this.clientSelector.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((clientId) => {
       if (clientId) {
         this.selectedItemAccounts = null;
         this.navigationService.getClient(clientId).subscribe((client: any) => {

--- a/src/app/notifications/notifications-page/notifications-page.component.ts
+++ b/src/app/notifications/notifications-page/notifications-page.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -58,6 +59,7 @@ export class NotificationsPageComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private notificationsService = inject(NotificationsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Notifications data. */
   notificationsData: any;
@@ -96,7 +98,7 @@ export class NotificationsPageComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { notifications: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { notifications: any }) => {
       this.notificationsData = data.notifications.pageItems;
     });
   }

--- a/src/app/reports/reports.component.ts
+++ b/src/app/reports/reports.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -54,6 +55,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class ReportsComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   /** Reports data. */
   reportsData: any;
@@ -81,7 +83,7 @@ export class ReportsComponent implements OnInit {
    */
   constructor() {
     this.router.routeReuseStrategy.shouldReuseRoute = () => false;
-    this.route.data.subscribe((data: { reports: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { reports: any }) => {
       this.reportsData = data.reports;
     });
     this.filter = this.route.snapshot.params['filter'];

--- a/src/app/reports/run-report/run-report.component.ts
+++ b/src/app/reports/run-report/run-report.component.ts
@@ -7,9 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
-import { AbstractControl, UntypedFormControl, UntypedFormGroup, ValidatorFn, Validators } from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
 
 /** Custom Services */
 import { ReportsService } from '../reports.service';
@@ -59,6 +60,7 @@ export class RunReportComponent implements OnInit {
   private alertService = inject(AlertService);
   private translateService = inject(TranslateService);
   private dateUtils = inject(Dates);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -77,9 +79,9 @@ export class RunReportComponent implements OnInit {
   dataObject: any;
 
   /** Initializes new form group eportForm */
-  reportForm = new UntypedFormGroup({});
+  reportForm = new FormGroup({});
   /** Static Form control for decimal places in output */
-  decimalChoice = new UntypedFormControl();
+  decimalChoice = new FormControl();
 
   /** Toggles Report form */
   isCollapsed = false;
@@ -109,32 +111,36 @@ export class RunReportComponent implements OnInit {
    */
   constructor() {
     this.report.name = this.route.snapshot.params['name'];
-    this.route.queryParams.subscribe((queryParams: { type: any; id: any }) => {
-      this.report.type = queryParams.type;
-      this.report.id = queryParams.id;
-    });
-    this.route.data.subscribe((data: { reportParameters: ReportParameter[]; configurations: any }) => {
-      this.paramData = data.reportParameters;
-      if (this.isTableReport()) {
-        const amazonS3Config = data.configurations.globalConfiguration.find(
-          (config: GlobalConfiguration) => config.name === 'amazon-s3'
-        );
-        const reportExportS3Config = data.configurations.globalConfiguration.find(
-          (config: GlobalConfiguration) => config.name === 'report-export-s3-folder-name'
-        );
+    this.route.queryParams
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((queryParams: { type: any; id: any }) => {
+        this.report.type = queryParams.type;
+        this.report.id = queryParams.id;
+      });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { reportParameters: ReportParameter[]; configurations: any }) => {
+        this.paramData = data.reportParameters;
+        if (this.isTableReport()) {
+          const amazonS3Config = data.configurations.globalConfiguration.find(
+            (config: GlobalConfiguration) => config.name === 'amazon-s3'
+          );
+          const reportExportS3Config = data.configurations.globalConfiguration.find(
+            (config: GlobalConfiguration) => config.name === 'report-export-s3-folder-name'
+          );
 
-        if (
-          amazonS3Config &&
-          amazonS3Config.enabled &&
-          reportExportS3Config &&
-          reportExportS3Config.enabled &&
-          reportExportS3Config.stringValue
-        ) {
-          this.exportToS3Allowed = true;
-          this.exportToS3Repository = reportExportS3Config.stringValue;
+          if (
+            amazonS3Config &&
+            amazonS3Config.enabled &&
+            reportExportS3Config &&
+            reportExportS3Config.enabled &&
+            reportExportS3Config.stringValue
+          ) {
+            this.exportToS3Allowed = true;
+            this.exportToS3Repository = reportExportS3Config.stringValue;
+          }
         }
-      }
-    });
+      });
   }
 
   isTableReport(): boolean {
@@ -165,7 +171,7 @@ export class RunReportComponent implements OnInit {
     this.paramData.forEach((param: ReportParameter) => {
       if (!param.parentParameterName) {
         // Non Child Parameter
-        this.reportForm.addControl(param.name, new UntypedFormControl('', Validators.required));
+        this.reportForm.addControl(param.name, new FormControl('', Validators.required));
         if (param.displayType === 'select') {
           this.fetchSelectOptions(param, param.name);
         }
@@ -179,7 +185,7 @@ export class RunReportComponent implements OnInit {
       }
     });
     if (this.isPentahoReport()) {
-      this.reportForm.addControl('outputType', new UntypedFormControl('', Validators.required));
+      this.reportForm.addControl('outputType', new FormControl('', Validators.required));
       this.outputTypeOptions = [
         { name: 'PDF format', value: 'PDF' },
         { name: 'Normal format', value: 'HTML' },
@@ -190,7 +196,7 @@ export class RunReportComponent implements OnInit {
       this.mapPentahoParams();
     }
     if (this.isBirtReport()) {
-      this.reportForm.addControl('outputType', new UntypedFormControl('', Validators.required));
+      this.reportForm.addControl('outputType', new FormControl('', Validators.required));
       this.outputTypeOptions = [
         { name: 'PDF format', value: 'PDF' },
         { name: 'Normal format', value: 'HTML' },
@@ -201,7 +207,7 @@ export class RunReportComponent implements OnInit {
       this.mapBirtParams();
     }
     if (this.exportToS3Allowed) {
-      this.reportForm.addControl('exportOutputToS3', new UntypedFormControl(false));
+      this.reportForm.addControl('exportOutputToS3', new FormControl(false));
     }
     this.decimalChoice.patchValue('2');
     this.setChildControls();
@@ -274,7 +280,9 @@ export class RunReportComponent implements OnInit {
 
     endControl.addValidators(this.endDateAfterStartValidator(startParam.name));
     endControl.updateValueAndValidity({ emitEvent: false });
-    startControl.valueChanges.subscribe(() => endControl.updateValueAndValidity({ emitEvent: false }));
+    startControl.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => endControl.updateValueAndValidity({ emitEvent: false }));
   }
 
   endDateAfterStartValidator(startControlName: string): ValidatorFn {
@@ -317,19 +325,22 @@ export class RunReportComponent implements OnInit {
    */
   setChildControls() {
     this.parentParameters.forEach((param: ReportParameter) => {
-      this.reportForm.get(param.name).valueChanges.subscribe((option: any) => {
-        param.childParameters.forEach((child: ReportParameter) => {
-          if (child.displayType === 'none') {
-            this.reportForm.addControl(child.name, new UntypedFormControl(child.defaultVal));
-          } else {
-            this.reportForm.addControl(child.name, new UntypedFormControl('', Validators.required));
-          }
-          if (child.displayType === 'select') {
-            const inputstring = `${child.name}?${param.inputName}=${option.id}`;
-            this.fetchSelectOptions(child, inputstring);
-          }
+      this.reportForm
+        .get(param.name)
+        .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((option: any) => {
+          param.childParameters.forEach((child: ReportParameter) => {
+            if (child.displayType === 'none') {
+              this.reportForm.addControl(child.name, new FormControl(child.defaultVal));
+            } else {
+              this.reportForm.addControl(child.name, new FormControl('', Validators.required));
+            }
+            if (child.displayType === 'select') {
+              const inputstring = `${child.name}?${param.inputName}=${option.id}`;
+              this.fetchSelectOptions(child, inputstring);
+            }
+          });
         });
-      });
     });
   }
 

--- a/src/app/search/search-page/search-page.component.ts
+++ b/src/app/search/search-page/search-page.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import {
   MatTableDataSource,
@@ -63,6 +64,7 @@ export class SearchPageComponent {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
 
   /** Flags if number of search results exceed 200 */
   overload: boolean;
@@ -88,7 +90,7 @@ export class SearchPageComponent {
    * @param {Router} router Router
    */
   constructor() {
-    this.route.data.subscribe((data: { searchResults: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { searchResults: any }) => {
       this.dataSource = new MatTableDataSource(data.searchResults);
       this.dataSource.paginator = this.paginator;
       this.hasResults = data.searchResults.length > 0;

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -7,10 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { Subject, merge } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { merge } from 'rxjs';
 
 /** Custom Services */
 import { SettingsService } from './settings.service';
@@ -46,11 +46,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SettingsComponent implements OnInit, OnDestroy {
+export class SettingsComponent implements OnInit {
   private settingsService = inject(SettingsService);
   private alertService = inject(AlertService);
   private translateService = inject(TranslateService);
-  private destroy$ = new Subject<void>();
+  private destroyRef = inject(DestroyRef);
 
   hasChanges = false;
 
@@ -133,7 +133,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
   trackChanges(): void {
     merge(this.dateFormat.valueChanges, this.datetimeFormat.valueChanges, this.decimalsToDisplay.valueChanges)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.hasChanges = this.hasFormChanged();
       });
@@ -161,10 +161,5 @@ export class SettingsComponent implements OnInit, OnDestroy {
       type: 'Settings Update',
       message: this.translateService.instant('labels.text.Settings saved successfully')
     });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.ts
@@ -7,10 +7,11 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SelectionModel } from '@angular/cdk/collections';
-import { UntypedFormBuilder, UntypedFormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import {
   MatTableDataSource,
   MatTable,
@@ -71,7 +72,8 @@ export class CheckerInboxComponent implements OnInit {
   private translateService = inject(TranslateService);
   private tasksService = inject(TasksService);
   private settingsService = inject(SettingsService);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
 
   /** Data to be displayed */
   searchData: any;
@@ -84,7 +86,7 @@ export class CheckerInboxComponent implements OnInit {
   /** Show/hide advanced search form */
   showAdvancedSearch = false;
   /** Maker Checker Search Form */
-  makerCheckerSearchForm: UntypedFormGroup;
+  makerCheckerSearchForm: FormGroup;
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
@@ -115,15 +117,17 @@ export class CheckerInboxComponent implements OnInit {
    * @param {FormBuilder} formBuilder Form Builder.
    */
   constructor() {
-    this.route.data.subscribe((data: { makerCheckerResource: any; makerCheckerTemplate: any }) => {
-      this.searchData = data.makerCheckerResource;
-      if (this.searchData.length > 0) {
-        this.checkerData = true;
-      }
-      this.makerCheckerTemplate = data.makerCheckerTemplate;
-      this.dataSource = new MatTableDataSource(this.searchData);
-      this.selection = new SelectionModel(true, []);
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { makerCheckerResource: any; makerCheckerTemplate: any }) => {
+        this.searchData = data.makerCheckerResource;
+        if (this.searchData.length > 0) {
+          this.checkerData = true;
+        }
+        this.makerCheckerTemplate = data.makerCheckerTemplate;
+        this.dataSource = new MatTableDataSource(this.searchData);
+        this.selection = new SelectionModel(true, []);
+      });
   }
 
   ngOnInit() {

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/client-approval/client-approval.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/client-approval/client-approval.component.ts
@@ -11,15 +11,15 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
-  OnDestroy,
+  DestroyRef,
   QueryList,
   ViewChildren,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SelectionModel } from '@angular/cdk/collections';
 import * as _ from 'lodash';
-import { Subscription } from 'rxjs';
 import { MatPaginator } from '@angular/material/paginator';
 import {
   MatTableDataSource,
@@ -72,13 +72,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ClientApprovalComponent implements AfterViewInit, OnDestroy {
+export class ClientApprovalComponent implements AfterViewInit {
   private route = inject(ActivatedRoute);
   private dialog = inject(MatDialog);
   private dateUtils = inject(Dates);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private tasksService = inject(TasksService);
+  private destroyRef = inject(DestroyRef);
   private accountsFilterPipe = new AccountsFilterPipe();
 
   /** Grouped Clients Data */
@@ -91,7 +92,6 @@ export class ClientApprovalComponent implements AfterViewInit, OnDestroy {
   batchRequests: any[];
   /** Row Selection Data */
   selection: SelectionModel<any>;
-  private paginatorChangesSub?: Subscription;
   @ViewChildren(MatPaginator) paginators!: QueryList<MatPaginator>;
   /** Displayed Columns */
   displayedColumns: string[] = [
@@ -111,7 +111,7 @@ export class ClientApprovalComponent implements AfterViewInit, OnDestroy {
    * @param {TasksService} tasksService Tasks Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { groupedClientData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { groupedClientData: any }) => {
       this.groupedClients = _.groupBy(data.groupedClientData.pageItems, 'officeName');
       this.groupedClientEntries = Object.entries(this.groupedClients).map(
         ([
@@ -135,11 +135,7 @@ export class ClientApprovalComponent implements AfterViewInit, OnDestroy {
 
   ngAfterViewInit() {
     this.bindPaginators();
-    this.paginatorChangesSub = this.paginators.changes.subscribe(() => this.bindPaginators());
-  }
-
-  ngOnDestroy() {
-    this.paginatorChangesSub?.unsubscribe();
+    this.paginators.changes.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.bindPaginators());
   }
 
   /** Whether the number of selected elements matches the total number of rows. */

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/council-approval/council-approval.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/council-approval/council-approval.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SelectionModel } from '@angular/cdk/collections';
 import * as _ from 'lodash';
@@ -105,6 +106,7 @@ export class CouncilApprovalComponent {
   private translateService = inject(TranslateService);
   private settingsService = inject(SettingsService);
   private tasksService = inject(TasksService);
+  private destroyRef = inject(DestroyRef);
 
   /** Offices Data */
   offices: any[];
@@ -130,7 +132,7 @@ export class CouncilApprovalComponent {
   ];
 
   constructor() {
-    this.route.data.subscribe((data: ResolverData) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: ResolverData) => {
       this.offices = data.officesData;
       this.loans = data.loansData.pageItems;
       this.setOfficeData();

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component.ts
@@ -11,15 +11,15 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
-  OnDestroy,
+  DestroyRef,
   QueryList,
   ViewChildren,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SelectionModel } from '@angular/cdk/collections';
 import * as _ from 'lodash';
-import { Subscription } from 'rxjs';
 import { MatPaginator } from '@angular/material/paginator';
 import {
   MatTableDataSource,
@@ -78,7 +78,7 @@ interface OfficeNode {
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class LoanApprovalComponent implements AfterViewInit, OnDestroy {
+export class LoanApprovalComponent implements AfterViewInit {
   private route = inject(ActivatedRoute);
   private dialog = inject(MatDialog);
   private dateUtils = inject(Dates);
@@ -86,6 +86,7 @@ export class LoanApprovalComponent implements AfterViewInit, OnDestroy {
   private translateService = inject(TranslateService);
   private settingsService = inject(SettingsService);
   private tasksService = inject(TasksService);
+  private destroyRef = inject(DestroyRef);
 
   /** Offices Data */
   offices: any;
@@ -104,7 +105,6 @@ export class LoanApprovalComponent implements AfterViewInit, OnDestroy {
   officesArray: any[];
   /** List of Requests */
   batchRequests: any[];
-  private paginatorChangesSub?: Subscription;
   @ViewChildren(MatPaginator) paginators!: QueryList<MatPaginator>;
   /** Displayed Columns */
   displayedColumns: string[] = [
@@ -125,20 +125,18 @@ export class LoanApprovalComponent implements AfterViewInit, OnDestroy {
    * @param {TasksService} tasksService Tasks Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { officesData: any; loansData: any }) => {
-      this.offices = data.officesData;
-      this.loans = data.loansData.pageItems;
-      this.setOfficeData();
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { officesData: any; loansData: any }) => {
+        this.offices = data.officesData;
+        this.loans = data.loansData.pageItems;
+        this.setOfficeData();
+      });
   }
 
   ngAfterViewInit() {
     this.bindPaginators();
-    this.paginatorChangesSub = this.paginators.changes.subscribe(() => this.bindPaginators());
-  }
-
-  ngOnDestroy() {
-    this.paginatorChangesSub?.unsubscribe();
+    this.paginators.changes.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.bindPaginators());
   }
 
   /** Group Office Data */

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { AfterViewInit, ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SelectionModel } from '@angular/cdk/collections';
 import {
@@ -69,6 +70,7 @@ export class LoanDisbursalComponent implements AfterViewInit {
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
   private tasksService = inject(TasksService);
+  private destroyRef = inject(DestroyRef);
 
   /** Loans Data */
   loans: any;
@@ -97,7 +99,7 @@ export class LoanDisbursalComponent implements AfterViewInit {
    * @param {TasksService} tasksService Tasks Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { loansData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loansData: any }) => {
       this.loans = data.loansData.pageItems;
       this.loans = this.loans.filter((account: any) => {
         return account.status.waitingForDisbursal === true;

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SelectionModel } from '@angular/cdk/collections';
 import * as _ from 'lodash';
@@ -76,6 +77,7 @@ export class RescheduleLoanComponent {
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
   private tasksService = inject(TasksService);
+  private destroyRef = inject(DestroyRef);
 
   /** Loans Data */
   loans: any;
@@ -105,7 +107,7 @@ export class RescheduleLoanComponent {
    * @param {TasksService} tasksService Tasks Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { rescheduleLoansData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { rescheduleLoansData: any }) => {
       this.loans = data.rescheduleLoansData;
       this.dataSource = new MatTableDataSource(this.loans);
       this.selection = new SelectionModel(true, []);

--- a/src/app/tasks/view-checker-inbox/view-checker-inbox.component.ts
+++ b/src/app/tasks/view-checker-inbox/view-checker-inbox.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import * as _ from 'lodash';
 import { MatDialog } from '@angular/material/dialog';
@@ -43,6 +44,7 @@ export class ViewCheckerInboxComponent {
   private router = inject(Router);
   private translateService = inject(TranslateService);
   private tasksService = inject(TasksService);
+  private destroyRef = inject(DestroyRef);
 
   /** Checker Inbox Details Data */
   checkerInboxDetail: any;
@@ -59,7 +61,7 @@ export class ViewCheckerInboxComponent {
    * @param {TasksService} tasksService Tasks Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { checkerInboxDetail: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { checkerInboxDetail: any }) => {
       this.checkerInboxDetail = data.checkerInboxDetail;
       this.jsondata = JSON.parse(this.checkerInboxDetail.commandAsJson);
       this.displayJSONData = !_.isEmpty(this.jsondata);

--- a/src/app/templates/create-edit-template/create-edit-template.component.ts
+++ b/src/app/templates/create-edit-template/create-edit-template.component.ts
@@ -9,13 +9,7 @@
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { FormGroup, FormBuilder, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Imports */
@@ -59,7 +53,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateEditComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private templateService = inject(TemplatesService);
@@ -95,7 +89,7 @@ export class CreateEditComponent implements OnInit {
   @ViewChild('tinymceEditor', { static: false }) tinymceEditor: EditorComponent;
 
   /** Template form. */
-  templateForm: UntypedFormGroup;
+  templateForm: FormGroup;
   /** Create or Edit Template Data. */
   templateData: any;
   /** Template Mappers */
@@ -128,8 +122,8 @@ export class CreateEditComponent implements OnInit {
         if (this.mode === 'edit') {
           this.mappers = this.templateData.template.mappers.map((mapper: any) => ({
             mappersorder: mapper.mapperorder,
-            mapperskey: new UntypedFormControl(mapper.mapperkey),
-            mappersvalue: new UntypedFormControl(mapper.mappervalue)
+            mapperskey: new FormControl(mapper.mapperkey),
+            mappersvalue: new FormControl(mapper.mappervalue)
           }));
         }
       });
@@ -204,17 +198,15 @@ export class CreateEditComponent implements OnInit {
           // client
           this.mappers.splice(0, 1, {
             mappersorder: 0,
-            mapperskey: new UntypedFormControl('client'),
-            mappersvalue: new UntypedFormControl('clients/{{clientId}}?tenantIdentifier=' + tenantIdentifier)
+            mapperskey: new FormControl('client'),
+            mappersvalue: new FormControl('clients/{{clientId}}?tenantIdentifier=' + tenantIdentifier)
           });
         } else {
           // loan
           this.mappers.splice(0, 1, {
             mappersorder: 0,
-            mapperskey: new UntypedFormControl('loan'),
-            mappersvalue: new UntypedFormControl(
-              'loans/{{loanId}}?associations=all&tenantIdentifier=' + tenantIdentifier
-            )
+            mapperskey: new FormControl('loan'),
+            mappersvalue: new FormControl('loans/{{loanId}}?associations=all&tenantIdentifier=' + tenantIdentifier)
           });
         }
         this.setEditorContent('');
@@ -231,8 +223,8 @@ export class CreateEditComponent implements OnInit {
   addMapper() {
     this.mappers.push({
       mappersorder: this.mappers.length,
-      mapperskey: new UntypedFormControl(''),
-      mappersvalue: new UntypedFormControl('')
+      mapperskey: new FormControl(''),
+      mappersvalue: new FormControl('')
     });
   }
 

--- a/src/app/templates/templates.component.ts
+++ b/src/app/templates/templates.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -55,6 +56,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class TemplatesComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Templates data. */
   templatesData: any;
@@ -77,7 +79,7 @@ export class TemplatesComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { templates: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { templates: any }) => {
       this.templatesData = data.templates;
     });
   }

--- a/src/app/templates/view-template/view-template.component.ts
+++ b/src/app/templates/view-template/view-template.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -37,6 +38,7 @@ export class ViewTemplateComponent {
   private templatesService = inject(TemplatesService);
   private router = inject(Router);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Template Data */
   templateData: any;
@@ -49,7 +51,7 @@ export class ViewTemplateComponent {
    * @param {MatDialog} dialog Dialog reference.
    */
   constructor() {
-    this.route.data.subscribe((data: { template: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { template: any }) => {
       this.templateData = data.template;
     });
   }

--- a/src/app/users/create-user/create-user.component.ts
+++ b/src/app/users/create-user/create-user.component.ts
@@ -15,15 +15,11 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -53,7 +49,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateUserComponent implements OnInit, AfterViewInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private usersService = inject(UsersService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
@@ -61,9 +57,10 @@ export class CreateUserComponent implements OnInit, AfterViewInit {
   private configurationWizardService = inject(ConfigurationWizardService);
   private dialog = inject(MatDialog);
   private passwordsUtility = inject(PasswordsUtility);
+  private destroyRef = inject(DestroyRef);
 
   /** User form. */
-  userForm: UntypedFormGroup;
+  userForm: FormGroup;
   /** Offices data. */
   officesData: any;
   /** Roles data. */
@@ -86,7 +83,7 @@ export class CreateUserComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { usersTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { usersTemplate: any }) => {
       this.officesData = data.usersTemplate.allowedOffices;
       this.rolesData = data.usersTemplate.availableRoles;
     });
@@ -152,39 +149,45 @@ export class CreateUserComponent implements OnInit, AfterViewInit {
    * Sets the staff data each time the user selects a new office
    */
   setStaffData() {
-    this.userForm.get('officeId').valueChanges.subscribe((officeId: string) => {
-      this.staffData = [];
-      this.usersService.getStaff(officeId).subscribe((staff: any) => {
-        this.staffData = staff;
+    this.userForm
+      .get('officeId')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((officeId: string) => {
+        this.staffData = [];
+        this.usersService.getStaff(officeId).subscribe((staff: any) => {
+          this.staffData = staff;
+        });
       });
-    });
   }
 
   /**
    * Sets the conditional controls of the user form
    */
   setConditionalControls() {
-    this.userForm.get('sendPasswordToEmail').valueChanges.subscribe((sendPasswordToEmail: boolean) => {
-      if (sendPasswordToEmail) {
-        this.userForm.removeControl('password');
-        this.userForm.removeControl('repeatPassword');
-        this.userForm.get('email').setValidators([
-          Validators.required,
-          Validators.email
-        ]);
-      } else {
-        this.userForm.addControl('password', new UntypedFormControl('', this.passwordsUtility.getPasswordValidators()));
-        this.userForm.addControl(
-          'repeatPassword',
-          new UntypedFormControl('', [
+    this.userForm
+      .get('sendPasswordToEmail')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((sendPasswordToEmail: boolean) => {
+        if (sendPasswordToEmail) {
+          this.userForm.removeControl('password');
+          this.userForm.removeControl('repeatPassword');
+          this.userForm.get('email').setValidators([
             Validators.required,
-            this.passwordsUtility.confirmPassword('password')
-          ])
-        );
-        this.userForm.get('email').setValidators([Validators.email]);
-      }
-      this.userForm.get('email').updateValueAndValidity();
-    });
+            Validators.email
+          ]);
+        } else {
+          this.userForm.addControl('password', new FormControl('', this.passwordsUtility.getPasswordValidators()));
+          this.userForm.addControl(
+            'repeatPassword',
+            new FormControl('', [
+              Validators.required,
+              this.passwordsUtility.confirmPassword('password')
+            ])
+          );
+          this.userForm.get('email').setValidators([Validators.email]);
+        }
+        this.userForm.get('email').updateValueAndValidity();
+      });
   }
 
   /**

--- a/src/app/users/edit-user/edit-user.component.ts
+++ b/src/app/users/edit-user/edit-user.component.ts
@@ -7,9 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { UsersService } from '../users.service';
@@ -30,10 +31,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditUserComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private usersService = inject(UsersService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   /** User Data */
   userData: any;
@@ -44,7 +46,7 @@ export class EditUserComponent implements OnInit {
   /** Roles Data */
   rolesData: any;
   /** Edit User form. */
-  editUserForm: UntypedFormGroup;
+  editUserForm: FormGroup;
 
   /**
    * Retrieves the offices data from `resolve`.
@@ -54,7 +56,7 @@ export class EditUserComponent implements OnInit {
    * @param {Router} router Router for navigation.
    */
   constructor() {
-    this.route.data.subscribe((data: { user: any; usersTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { user: any; usersTemplate: any }) => {
       this.userData = data.user;
       this.officesData = data.usersTemplate.allowedOffices;
       this.rolesData = data.usersTemplate.availableRoles;

--- a/src/app/users/users.component.ts
+++ b/src/app/users/users.component.ts
@@ -15,8 +15,10 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -74,6 +76,7 @@ export class UsersComponent implements OnInit, AfterViewInit {
   private router = inject(Router);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private destroyRef = inject(DestroyRef);
 
   /** Users data. */
   usersData: any;
@@ -111,7 +114,7 @@ export class UsersComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { users: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { users: any }) => {
       this.usersData = data.users;
     });
   }

--- a/src/app/users/view-user/view-user.component.ts
+++ b/src/app/users/view-user/view-user.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -39,6 +40,7 @@ export class ViewUserComponent {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** User Data. */
   userData: any;
@@ -51,7 +53,7 @@ export class ViewUserComponent {
    * @param {MatDialog} dialog Dialog reference.
    */
   constructor() {
-    this.route.data.subscribe((data: { user: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { user: any }) => {
       this.userData = data.user;
     });
   }


### PR DESCRIPTION
## Description

Replace manual subscribe/unsubscribe patterns with DestroyRef + takeUntilDestroyed across 43 components and directives. Also replace UntypedFormBuilder/Group/Control/Array with typed Angular equivalents.

Modules covered: settings, search, navigation, notifications, collaterals, collections, remittances, templates, login, reports, users, home/dashboard, account-transfers, tasks, core/shell (breadcrumb, shell, toolbar) and configuration-wizard popover directive.

## Related issues and discussion

[WEB-954](WEB-954)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-954]: https://mifosforge.jira.com/browse/WEB-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application stability through enhanced memory management and subscription lifecycle handling across multiple components and features.
  * Migrated to typed form controls for better type safety and reduced runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->