### PR TITLE
WEB-954: Migrate Subscription management : organization

### DIFF
--- a/src/app/organization/adhoc-query/adhoc-query.component.ts
+++ b/src/app/organization/adhoc-query/adhoc-query.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -25,8 +26,6 @@ import {
 } from '@angular/material/table';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
-/** rxjs Imports */
-import { of } from 'rxjs';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatTooltip } from '@angular/material/tooltip';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -60,6 +59,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class AdhocQueryComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Adhoc Queries data. */
   adhocQueriesData: any;
@@ -86,7 +86,7 @@ export class AdhocQueryComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { adhocQueries: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { adhocQueries: any }) => {
       this.adhocQueriesData = data.adhocQueries;
     });
   }

--- a/src/app/organization/adhoc-query/create-adhoc-query/create-adhoc-query.component.ts
+++ b/src/app/organization/adhoc-query/create-adhoc-query/create-adhoc-query.component.ts
@@ -7,14 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -36,27 +32,21 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateAdhocQueryComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
   /** Adhoc Query form. */
-  adhocQueryForm: UntypedFormGroup;
+  adhocQueryForm: FormGroup;
   /** Adhoc Query template data. */
   adhocQueryTemplateData: any;
   /** Report run frequencies data. */
   reportRunFrequencyData: any;
 
-  /**
-   * Retrieves the adhoc query template data from `resolve`.
-   * @param {FormBuilder} formBuilder Form Builder.
-   * @param {OrganizationService} organizationService Organization Service.
-   * @param {ActivatedRoute} route Activated Route.
-   * @param {Router} router Router for navigation.
-   */
   constructor() {
-    this.route.data.subscribe((data: { adhocQueryTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { adhocQueryTemplate: any }) => {
       this.adhocQueryTemplateData = data.adhocQueryTemplate;
     });
   }
@@ -104,19 +94,22 @@ export class CreateAdhocQueryComponent implements OnInit {
    * Sets the conditional controls of the adhoc query form
    */
   setConditionalControls() {
-    this.adhocQueryForm.get('reportRunFrequency').valueChanges.subscribe((reportRunFrequencyId) => {
-      if (reportRunFrequencyId === 5) {
-        this.adhocQueryForm.addControl(
-          'reportRunEvery',
-          new UntypedFormControl('', [
-            Validators.required,
-            Validators.min(1)
-          ])
-        );
-      } else {
-        this.adhocQueryForm.removeControl('reportRunEvery');
-      }
-    });
+    this.adhocQueryForm
+      .get('reportRunFrequency')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((reportRunFrequencyId) => {
+        if (reportRunFrequencyId === 5) {
+          this.adhocQueryForm.addControl(
+            'reportRunEvery',
+            new FormControl('', [
+              Validators.required,
+              Validators.min(1)
+            ])
+          );
+        } else {
+          this.adhocQueryForm.removeControl('reportRunEvery');
+        }
+      });
   }
 
   /**
@@ -124,14 +117,17 @@ export class CreateAdhocQueryComponent implements OnInit {
    * if successful redirects to view adhoc query.
    */
   submit() {
-    this.organizationService.createAdhocQuery(this.adhocQueryForm.value).subscribe((response: any) => {
-      this.router.navigate(
-        [
-          '../',
-          response.resourceId
-        ],
-        { relativeTo: this.route }
-      );
-    });
+    this.organizationService
+      .createAdhocQuery(this.adhocQueryForm.value)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(
+          [
+            '../',
+            response.resourceId
+          ],
+          { relativeTo: this.route }
+        );
+      });
   }
 }

--- a/src/app/organization/adhoc-query/edit-adhoc-query/edit-adhoc-query.component.ts
+++ b/src/app/organization/adhoc-query/edit-adhoc-query/edit-adhoc-query.component.ts
@@ -7,14 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -36,27 +32,21 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditAdhocQueryComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
   /** Edit Adhoc Query form. */
-  editAdhocQueryForm: UntypedFormGroup;
+  editAdhocQueryForm: FormGroup;
   /** Adhoc Query template data. */
   adhocQueryTemplateData: any;
   /** Report run frequencies data. */
   reportRunFrequencyData: any;
 
-  /**
-   * Retrieves the adhoc query template data from `resolve`.
-   * @param {FormBuilder} formBuilder Form Builder.
-   * @param {OrganizationService} organizationService Organization Service.
-   * @param {ActivatedRoute} route Activated Route.
-   * @param {Router} router Router for navigation.
-   */
   constructor() {
-    this.route.data.subscribe((data: { adhocQueryAndTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { adhocQueryAndTemplate: any }) => {
       this.adhocQueryTemplateData = data.adhocQueryAndTemplate;
     });
   }
@@ -104,20 +94,23 @@ export class EditAdhocQueryComponent implements OnInit {
    * Sets the conditional controls of the adhoc query form
    */
   setConditionalControls() {
-    this.editAdhocQueryForm.get('reportRunFrequency').valueChanges.subscribe((reportRunFrequencyId) => {
-      if (reportRunFrequencyId === 5) {
-        this.editAdhocQueryForm.addControl(
-          'reportRunEvery',
-          new UntypedFormControl('', [
-            Validators.required,
-            Validators.min(1)
-          ])
-        );
-        this.editAdhocQueryForm.get('reportRunEvery').patchValue(this.adhocQueryTemplateData.reportRunEvery);
-      } else {
-        this.editAdhocQueryForm.removeControl('reportRunEvery');
-      }
-    });
+    this.editAdhocQueryForm
+      .get('reportRunFrequency')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((reportRunFrequencyId) => {
+        if (reportRunFrequencyId === 5) {
+          this.editAdhocQueryForm.addControl(
+            'reportRunEvery',
+            new FormControl('', [
+              Validators.required,
+              Validators.min(1)
+            ])
+          );
+          this.editAdhocQueryForm.get('reportRunEvery').patchValue(this.adhocQueryTemplateData.reportRunEvery);
+        } else {
+          this.editAdhocQueryForm.removeControl('reportRunEvery');
+        }
+      });
     this.editAdhocQueryForm.get('reportRunFrequency').patchValue(this.adhocQueryTemplateData.reportRunFrequency);
   }
 
@@ -128,6 +121,7 @@ export class EditAdhocQueryComponent implements OnInit {
   submit() {
     this.organizationService
       .updateAdhocQuery(this.adhocQueryTemplateData.id, this.editAdhocQueryForm.value)
+      .pipe(take(1))
       .subscribe(() => {
         this.router.navigate(['../'], { relativeTo: this.route });
       });

--- a/src/app/organization/adhoc-query/view-adhoc-query/view-adhoc-query.component.ts
+++ b/src/app/organization/adhoc-query/view-adhoc-query/view-adhoc-query.component.ts
@@ -7,7 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -34,6 +36,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewAdhocQueryComponent {
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dialog = inject(MatDialog);
@@ -41,15 +44,8 @@ export class ViewAdhocQueryComponent {
   /** Adhoc query data. */
   adhocQueryData: any;
 
-  /**
-   * Retrieves the adhoc query data from `resolve`.
-   * @param {OrganizationService} organizationService Organization Service.
-   * @param {ActivatedRoute} route Activated Route.
-   * @param {Router} router Router for navigation.
-   * @param {MatDialog} dialog Dialog reference.
-   */
   constructor() {
-    this.route.data.subscribe((data: { adhocQuery: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { adhocQuery: any }) => {
       this.adhocQueryData = data.adhocQuery;
     });
   }
@@ -75,9 +71,12 @@ export class ViewAdhocQueryComponent {
     });
     deleteAdhocQueryDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
-        this.organizationService.deleteAdhocQuery(this.adhocQueryData.id).subscribe(() => {
-          this.router.navigate(['/organization/adhoc-query']);
-        });
+        this.organizationService
+          .deleteAdhocQuery(this.adhocQueryData.id)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.router.navigate(['/organization/adhoc-query']);
+          });
       }
     });
   }

--- a/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.ts
+++ b/src/app/organization/bulk-import/view-bulk-import/view-bulk-import.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -24,7 +25,8 @@ import {
   MatRowDef,
   MatRow
 } from '@angular/material/table';
-import { UntypedFormGroup, UntypedFormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
+import { FormGroup, FormBuilder, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Imports */
 import { OrganizationService } from '../../organization.service';
@@ -68,8 +70,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewBulkImportComponent implements OnInit {
   private route = inject(ActivatedRoute);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
 
   /** offices Data */
   officeData: any;
@@ -80,7 +83,7 @@ export class ViewBulkImportComponent implements OnInit {
   /** imports Data */
   importsData: any;
   /** bulk-import form. */
-  bulkImportForm: UntypedFormGroup;
+  bulkImportForm: FormGroup;
   /** array of deined bulk-imports */
   bulkImportsArray = BulkImports;
   /** bulk-import which user navigated to */
@@ -114,7 +117,7 @@ export class ViewBulkImportComponent implements OnInit {
    */
   constructor() {
     this.bulkImport.name = this.route.snapshot.params['import-name'];
-    this.route.data.subscribe((data: any) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: any) => {
       this.officeData = data.offices;
       this.importsData = data.imports;
     });
@@ -145,13 +148,19 @@ export class ViewBulkImportComponent implements OnInit {
    * Subscribe to value changes and fetches select options accordingly.
    */
   buildDependencies() {
-    this.bulkImportForm.get('officeId').valueChanges.subscribe((value: any) => {
-      if (this.bulkImport.formFields >= 2) {
-        this.organizationService.getStaff(value).subscribe((data: any) => {
-          this.staffData = data;
-        });
-      }
-    });
+    this.bulkImportForm
+      .get('officeId')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value: any) => {
+        if (this.bulkImport.formFields >= 2) {
+          this.organizationService
+            .getStaff(value)
+            .pipe(take(1))
+            .subscribe((data: any) => {
+              this.staffData = data;
+            });
+        }
+      });
   }
 
   /**
@@ -181,6 +190,7 @@ export class ViewBulkImportComponent implements OnInit {
     }
     this.organizationService
       .getImportTemplate(this.bulkImport.urlSuffix, officeId, staffId, legalFormType)
+      .pipe(take(1))
       .subscribe((res: any) => {
         const contentType = res.headers.get('Content-Type');
         const blob = new Blob([res.body], { type: contentType });
@@ -214,6 +224,7 @@ export class ViewBulkImportComponent implements OnInit {
     }
     this.organizationService
       .uploadImportDocument(this.template, this.bulkImport.urlSuffix, legalFormType)
+      .pipe(take(1))
       .subscribe(() => {});
   }
 
@@ -221,10 +232,13 @@ export class ViewBulkImportComponent implements OnInit {
    * Reloads imports data table.
    */
   refreshDocuments() {
-    this.organizationService.getImports(this.bulkImport.entityType).subscribe((data: any) => {
-      this.dataSource = new MatTableDataSource(data);
-      this.importsTableRef.renderRows();
-    });
+    this.organizationService
+      .getImports(this.bulkImport.entityType)
+      .pipe(take(1))
+      .subscribe((data: any) => {
+        this.dataSource = new MatTableDataSource(data);
+        this.importsTableRef.renderRows();
+      });
   }
 
   /**
@@ -233,11 +247,14 @@ export class ViewBulkImportComponent implements OnInit {
    * @param {any} id ImportID
    */
   downloadDocument(name: string, id: any) {
-    this.organizationService.getImportDocument(id).subscribe((res: any) => {
-      const contentType = res.headers.get('Content-Type');
-      const blob = new Blob([res.body], { type: contentType });
-      const fileOfBlob = new File([blob], name, { type: contentType });
-      window.open(window.URL.createObjectURL(fileOfBlob));
-    });
+    this.organizationService
+      .getImportDocument(id)
+      .pipe(take(1))
+      .subscribe((res: any) => {
+        const contentType = res.headers.get('Content-Type');
+        const blob = new Blob([res.body], { type: contentType });
+        const fileOfBlob = new File([blob], name, { type: contentType });
+        window.open(window.URL.createObjectURL(fileOfBlob));
+      });
   }
 }

--- a/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.ts
+++ b/src/app/organization/bulk-loan-reassignmnet/bulk-loan-reassignmnet.component.ts
@@ -7,14 +7,10 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 /** Custom Services. */
@@ -38,15 +34,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class BulkLoanReassignmnetComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private organizationSevice = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private settingsService = inject(SettingsService);
   private dateUtils = inject(Dates);
   private router = inject(Router);
 
   /** Bulk Loan form. */
-  bulkLoanForm: UntypedFormGroup;
+  bulkLoanForm: FormGroup;
   /** Office data. */
   offices: any;
   /** To Loan Officers. */
@@ -73,7 +70,7 @@ export class BulkLoanReassignmnetComponent implements OnInit {
    * @param {Router} router Router.
    */
   constructor() {
-    this.route.data.subscribe((data: { offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { offices: any }) => {
       this.offices = data.offices;
     });
   }
@@ -108,11 +105,14 @@ export class BulkLoanReassignmnetComponent implements OnInit {
    * @param officeId Office Id.
    */
   getOffice(officeId: string) {
-    this.organizationSevice.getOfficeTemplate(officeId).subscribe((response: any) => {
-      this.officeTemplate = response;
-      this.fromLoanOfficers = this.officeTemplate.loanOfficerOptions;
-      this.bulkLoanForm.addControl('fromLoanOfficerId', new UntypedFormControl('', Validators.required));
-    });
+    this.organizationSevice
+      .getOfficeTemplate(officeId)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.officeTemplate = response;
+        this.fromLoanOfficers = this.officeTemplate.loanOfficerOptions;
+        this.bulkLoanForm.addControl('fromLoanOfficerId', new FormControl('', Validators.required));
+      });
   }
 
   /**
@@ -122,9 +122,12 @@ export class BulkLoanReassignmnetComponent implements OnInit {
   getFromOfficers(officerId: any) {
     this.toLoanOfficers = this.fromLoanOfficers?.filter((officer: any) => officer.id !== officerId) || [];
     if (officerId && this.officeTemplate && this.officeTemplate.officeId) {
-      this.organizationSevice.getOfficerTemplate(officerId, this.officeTemplate.officeId).subscribe((response: any) => {
-        this.officerTemplate = response;
-      });
+      this.organizationSevice
+        .getOfficerTemplate(officerId, this.officeTemplate.officeId)
+        .pipe(take(1))
+        .subscribe((response: any) => {
+          this.officerTemplate = response;
+        });
     } else {
       this.officerTemplate = undefined;
     }
@@ -162,8 +165,11 @@ export class BulkLoanReassignmnetComponent implements OnInit {
       locale
     };
     data.loans = this.loans;
-    this.organizationSevice.createLoanReassignment(data).subscribe((response: any) => {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizationSevice
+      .createLoanReassignment(data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/currencies/currencies.component.ts
+++ b/src/app/organization/currencies/currencies.component.ts
@@ -15,8 +15,10 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -33,9 +35,6 @@ import {
   MatRow
 } from '@angular/material/table';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-
-/** rxjs Imports */
-import { of } from 'rxjs';
 
 /** Custom Services */
 import { PopoverService } from '../../configuration-wizard/popover/popover.service';
@@ -74,6 +73,7 @@ export class CurrenciesComponent implements OnInit, AfterViewInit {
   private router = inject(Router);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private destroyRef = inject(DestroyRef);
 
   /** Currencies data. */
   currenciesData: any;
@@ -107,7 +107,7 @@ export class CurrenciesComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { currencies: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { currencies: any }) => {
       this.currenciesData = data.currencies.selectedCurrencyOptions;
     });
   }

--- a/src/app/organization/currencies/manage-currencies/manage-currencies.component.ts
+++ b/src/app/organization/currencies/manage-currencies/manage-currencies.component.ts
@@ -15,14 +15,16 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  OnDestroy,
   OnChanges,
   SimpleChanges,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { UntypedFormBuilder, UntypedFormControl, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 
 /** Custom Dialogs */
@@ -35,8 +37,7 @@ import { ConfigurationWizardService } from '../../../configuration-wizard/config
 
 /** Custom Dialog Component */
 import { ContinueSetupDialogComponent } from '../../../configuration-wizard/continue-setup-dialog/continue-setup-dialog.component';
-import { takeUntil } from 'rxjs/operators';
-import { ReplaySubject, Subject } from 'rxjs';
+import { ReplaySubject } from 'rxjs';
 import { Currency } from 'app/shared/models/general.model';
 import { NgxMatSelectSearchModule } from 'ngx-mat-select-search';
 import { AsyncPipe } from '@angular/common';
@@ -61,15 +62,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ManageCurrenciesComponent implements OnInit, AfterViewInit, OnDestroy, OnChanges {
+export class ManageCurrenciesComponent implements OnInit, AfterViewInit, OnChanges {
   private route = inject(ActivatedRoute);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationservice = inject(OrganizationService);
   dialog = inject(MatDialog);
   private router = inject(Router);
   private translateService = inject(TranslateService);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private destroyRef = inject(DestroyRef);
 
   //** Defining PlaceHolders for the search bar */
   placeHolderLabel = '';
@@ -90,10 +92,7 @@ export class ManageCurrenciesComponent implements OnInit, AfterViewInit, OnDestr
   protected currencyData: ReplaySubject<Currency[]> = new ReplaySubject<Currency[]>(1);
 
   /** control for the filter select */
-  protected filterFormCtrl: UntypedFormControl = new UntypedFormControl('');
-
-  /** Subject that emits when the component has been destroyed. */
-  protected _onDestroy = new Subject<void>();
+  protected filterFormCtrl: FormControl = new FormControl('');
 
   /**
    * Retrieves the currency data from `resolve`.
@@ -103,7 +102,7 @@ export class ManageCurrenciesComponent implements OnInit, AfterViewInit, OnDestr
    * @param {MatDialog} dialog Mat Dialog
    */
   constructor() {
-    this.route.parent.data.subscribe((data: { currencies: any }) => {
+    this.route.parent.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { currencies: any }) => {
       this.selectedCurrencies = data.currencies.selectedCurrencyOptions;
       this.currencyList = data.currencies.currencyOptions;
     });
@@ -112,15 +111,10 @@ export class ManageCurrenciesComponent implements OnInit, AfterViewInit, OnDestr
   ngOnInit() {
     this.placeHolderLabel = this.translateService.instant('labels.text.Search');
     this.noEntriesFoundLabel = this.translateService.instant('labels.text.No data found');
-    this.filterFormCtrl.valueChanges.pipe(takeUntil(this._onDestroy)).subscribe(() => {
+    this.filterFormCtrl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.searchItem();
     });
     this.createCurrencyForm();
-  }
-
-  ngOnDestroy(): void {
-    this._onDestroy.next();
-    this._onDestroy.complete();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -165,14 +159,17 @@ export class ManageCurrenciesComponent implements OnInit, AfterViewInit, OnDestr
     const selectedCurrencyCodes: any[] = this.selectedCurrencies.map((currency) => currency.code);
     if (!selectedCurrencyCodes.includes(newCurrency.code)) {
       selectedCurrencyCodes.push(newCurrency.code);
-      this.organizationservice.updateCurrencies(selectedCurrencyCodes).subscribe((response: any) => {
-        this.selectedCurrencies.push(newCurrency);
-        this.formRef.resetForm();
-        if (this.configurationWizardService.showCurrencyForm) {
-          this.configurationWizardService.showCurrencyForm = false;
-          this.openDialog();
-        }
-      });
+      this.organizationservice
+        .updateCurrencies(selectedCurrencyCodes)
+        .pipe(take(1))
+        .subscribe((response: any) => {
+          this.selectedCurrencies.push(newCurrency);
+          this.formRef.resetForm();
+          if (this.configurationWizardService.showCurrencyForm) {
+            this.configurationWizardService.showCurrencyForm = false;
+            this.openDialog();
+          }
+        });
     }
   }
 
@@ -189,10 +186,13 @@ export class ManageCurrenciesComponent implements OnInit, AfterViewInit, OnDestr
     });
     deleteCurrencyDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
-        this.organizationservice.updateCurrencies(selectedCurrencyCodes).subscribe(() => {
-          this.selectedCurrencies.splice(index, 1);
-          this.formRef.resetForm();
-        });
+        this.organizationservice
+          .updateCurrencies(selectedCurrencyCodes)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.selectedCurrencies.splice(index, 1);
+            this.formRef.resetForm();
+          });
       }
     });
   }

--- a/src/app/organization/employees/create-employee/create-employee.component.ts
+++ b/src/app/organization/employees/create-employee/create-employee.component.ts
@@ -15,9 +15,12 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -47,8 +50,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateEmployeeComponent implements OnInit, AfterViewInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private settingsService = inject(SettingsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
@@ -62,7 +66,7 @@ export class CreateEmployeeComponent implements OnInit, AfterViewInit {
   /** Maximum joining date allowed. */
   maxDate = new Date();
   /** Employee form. */
-  employeeForm: UntypedFormGroup;
+  employeeForm: FormGroup;
   /** Office data. */
   officeData: any;
 
@@ -84,7 +88,7 @@ export class CreateEmployeeComponent implements OnInit, AfterViewInit {
    * @param {MatDialog} dialog MatDialog.
    */
   constructor() {
-    this.route.data.subscribe((data: { offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { offices: any }) => {
       this.officeData = data.offices;
     });
   }
@@ -151,14 +155,17 @@ export class CreateEmployeeComponent implements OnInit, AfterViewInit {
       dateFormat,
       locale
     };
-    this.organizationService.createEmployee(data).subscribe((response: any) => {
-      if (this.configurationWizardService.showEmployeeForm) {
-        this.configurationWizardService.showEmployeeForm = false;
-        this.openDialog();
-      } else {
-        this.router.navigate(['../'], { relativeTo: this.route });
-      }
-    });
+    this.organizationService
+      .createEmployee(data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        if (this.configurationWizardService.showEmployeeForm) {
+          this.configurationWizardService.showEmployeeForm = false;
+          this.openDialog();
+        } else {
+          this.router.navigate(['../'], { relativeTo: this.route });
+        }
+      });
   }
 
   /**

--- a/src/app/organization/employees/edit-employee/edit-employee.component.ts
+++ b/src/app/organization/employees/edit-employee/edit-employee.component.ts
@@ -7,9 +7,11 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 
 /** Custom Services */
 import { OrganizationService } from '../../organization.service';
@@ -32,8 +34,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditEmployeeComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private settingsService = inject(SettingsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
@@ -46,21 +49,12 @@ export class EditEmployeeComponent implements OnInit {
   /** Maximum joining date allowed. */
   maxDate = new Date();
   /** Employee form. */
-  editEmployeeForm: UntypedFormGroup;
+  editEmployeeForm: FormGroup;
   /** Office data. */
   officeData: any;
 
-  /**
-   * Retrieves the offices data from `resolve`.
-   * @param {FormBuilder} formBuilder Form Builder.
-   * @param {OrganizationService} organizationService Organization Service.
-   * @param {SettingsService} settingsService Settings Service.
-   * @param {ActivatedRoute} route Activated Route.
-   * @param {Router} router Router for navigation.
-   * @param {Dates} dateUtils Date Utils to format date.
-   */
   constructor() {
-    this.route.data.subscribe((data: { employee: any; offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { employee: any; offices: any }) => {
       this.employeeData = data.employee;
       this.officeData = data.employee.allowedOffices;
     });
@@ -124,14 +118,17 @@ export class EditEmployeeComponent implements OnInit {
       dateFormat,
       locale
     };
-    this.organizationService.updateEmployee(this.employeeData.id, data).subscribe((response: any) => {
-      this.router.navigate(
-        [
-          '../../',
-          response.resourceId
-        ],
-        { relativeTo: this.route }
-      );
-    });
+    this.organizationService
+      .updateEmployee(this.employeeData.id, data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(
+          [
+            '../../',
+            response.resourceId
+          ],
+          { relativeTo: this.route }
+        );
+      });
   }
 }

--- a/src/app/organization/employees/employees.component.ts
+++ b/src/app/organization/employees/employees.component.ts
@@ -15,8 +15,10 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -33,9 +35,6 @@ import {
   MatRow
 } from '@angular/material/table';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-
-/** rxjs Imports */
-import { of } from 'rxjs';
 
 /** Custom Services */
 import { PopoverService } from '../../configuration-wizard/popover/popover.service';
@@ -76,6 +75,7 @@ export class EmployeesComponent implements OnInit, AfterViewInit {
   private router = inject(Router);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private destroyRef = inject(DestroyRef);
 
   /** Employees data. */
   employeesData: any;
@@ -112,7 +112,7 @@ export class EmployeesComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { employees: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { employees: any }) => {
       this.employeesData = data.employees;
     });
   }

--- a/src/app/organization/employees/view-employee/view-employee.component.ts
+++ b/src/app/organization/employees/view-employee/view-employee.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
@@ -31,16 +32,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewEmployeeComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Employee data. */
   employeeData: any;
 
-  /**
-   * Retrieves the employee data from `resolve`.
-   * @param {ActivatedRoute} route Activated Route.
-   */
   constructor() {
-    this.route.data.subscribe((data: { employee: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { employee: any }) => {
       this.employeeData = data.employee;
     });
   }

--- a/src/app/organization/entity-data-table-checks/create-entity-data-table-checks/create-entity-data-table-checks.component.ts
+++ b/src/app/organization/entity-data-table-checks/create-entity-data-table-checks/create-entity-data-table-checks.component.ts
@@ -7,14 +7,10 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormBuilder,
-  UntypedFormGroup,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 /** Custom Services. */
@@ -34,13 +30,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateEntityDataTableChecksComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private organizationService = inject(OrganizationService);
   private router = inject(Router);
 
   /** Create Entity Datatable Checks form. */
-  createEntityForm: UntypedFormGroup;
+  createEntityForm: FormGroup;
   /** Entity Datatable Checks data. */
   createEntityData: any;
   /** Selected entity type. */
@@ -52,15 +49,8 @@ export class CreateEntityDataTableChecksComponent implements OnInit {
   /** Loan and Savings status list. */
   statusList: any[];
 
-  /**
-   * Retrieves Entity Datatable Checks data from `resolve`.
-   * @param {FormBuilder} formBuilder Form Builder.
-   * @param {ActivatedRoute} route Activated Route.
-   * @param {OrganizationService} organizationService Organization Service.
-   * @param {Router} router Router.
-   */
   constructor() {
-    this.route.data.subscribe((data: { dataTableEntity: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { dataTableEntity: any }) => {
       this.createEntityData = data.dataTableEntity;
       // hardcoded, because data.dataTableEntity.entities might change anytime its order
       this.entityTypes = [
@@ -102,48 +92,54 @@ export class CreateEntityDataTableChecksComponent implements OnInit {
    * @param entity Selected Entity.
    */
   getEntityType() {
-    this.createEntityForm.get('entity').valueChanges.subscribe((option: any) => {
-      switch (option) {
-        case 'm_client': {
-          this.entityType = 'm_client';
-          this.dataTableList = this.createEntityData.datatables.filter((data: any) => data.entity === 'm_client');
-          this.statusList = this.createEntityData.statusClient;
-          this.createEntityForm.removeControl('productId');
-          break;
+    this.createEntityForm
+      .get('entity')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((option: any) => {
+        switch (option) {
+          case 'm_client': {
+            this.entityType = 'm_client';
+            this.dataTableList = this.createEntityData.datatables.filter((data: any) => data.entity === 'm_client');
+            this.statusList = this.createEntityData.statusClient;
+            this.createEntityForm.removeControl('productId');
+            break;
+          }
+          case 'm_loan': {
+            this.entityType = 'm_loan';
+            this.dataTableList = this.createEntityData.datatables.filter((data: any) => data.entity === 'm_loan');
+            this.statusList = this.createEntityData.statusLoans;
+            this.createEntityForm.addControl('productId', new FormControl('', Validators.required));
+            break;
+          }
+          case 'm_group': {
+            this.entityType = 'm_group';
+            this.dataTableList = this.createEntityData.datatables.filter((data: any) => data.entity === 'm_group');
+            this.statusList = this.createEntityData.statusGroup;
+            this.createEntityForm.removeControl('productId');
+            break;
+          }
+          default: {
+            this.entityType = 'm_savings_account';
+            this.dataTableList = this.createEntityData.datatables.filter(
+              (data: any) => data.entity === 'm_savings_account'
+            );
+            this.statusList = this.createEntityData.statusSavings;
+            this.createEntityForm.addControl('productId', new FormControl('', Validators.required));
+            break;
+          }
         }
-        case 'm_loan': {
-          this.entityType = 'm_loan';
-          this.dataTableList = this.createEntityData.datatables.filter((data: any) => data.entity === 'm_loan');
-          this.statusList = this.createEntityData.statusLoans;
-          this.createEntityForm.addControl('productId', new UntypedFormControl('', Validators.required));
-          break;
-        }
-        case 'm_group': {
-          this.entityType = 'm_group';
-          this.dataTableList = this.createEntityData.datatables.filter((data: any) => data.entity === 'm_group');
-          this.statusList = this.createEntityData.statusGroup;
-          this.createEntityForm.removeControl('productId');
-          break;
-        }
-        default: {
-          this.entityType = 'm_savings_account';
-          this.dataTableList = this.createEntityData.datatables.filter(
-            (data: any) => data.entity === 'm_savings_account'
-          );
-          this.statusList = this.createEntityData.statusSavings;
-          this.createEntityForm.addControl('productId', new UntypedFormControl('', Validators.required));
-          break;
-        }
-      }
-    });
+      });
   }
 
   /**
    * Submits Entity Datble Form.
    */
   submit() {
-    this.organizationService.createEntityDataTableChecks(this.createEntityForm.value).subscribe((response: any) => {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizationService
+      .createEntityDataTableChecks(this.createEntityForm.value)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/entity-data-table-checks/entity-data-table-checks.component.ts
+++ b/src/app/organization/entity-data-table-checks/entity-data-table-checks.component.ts
@@ -7,7 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -66,6 +68,7 @@ export class EntityDataTableChecksComponent implements OnInit {
   private organizationService = inject(OrganizationService);
   private route = inject(ActivatedRoute);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Entity Data Table Checks data. */
   entityDataTableChecksData: any;
@@ -112,7 +115,7 @@ export class EntityDataTableChecksComponent implements OnInit {
    * @param {MatDialog} dialog Dialog reference.
    */
   constructor() {
-    this.route.data.subscribe((data: { entityDataTableChecks: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { entityDataTableChecks: any }) => {
       this.entityDataTableChecksData = data.entityDataTableChecks.pageItems;
     });
   }
@@ -174,12 +177,15 @@ export class EntityDataTableChecksComponent implements OnInit {
     });
     deleteEntityDataTableCheckDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
-        this.organizationService.deleteEntityDataTableCheck(entityDataTableCheckId).subscribe(() => {
-          this.entityDataTableChecksData = this.entityDataTableChecksData.filter(
-            (entityDataTableChecks: any) => entityDataTableChecks.id !== entityDataTableCheckId
-          );
-          this.dataSource.data = this.entityDataTableChecksData;
-        });
+        this.organizationService
+          .deleteEntityDataTableCheck(entityDataTableCheckId)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.entityDataTableChecksData = this.entityDataTableChecksData.filter(
+              (entityDataTableChecks: any) => entityDataTableChecks.id !== entityDataTableCheckId
+            );
+            this.dataSource.data = this.entityDataTableChecksData;
+          });
       }
     });
   }

--- a/src/app/organization/fund-mapping/fund-mapping.component.ts
+++ b/src/app/organization/fund-mapping/fund-mapping.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -23,13 +24,8 @@ import {
   MatRowDef,
   MatRow
 } from '@angular/material/table';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { FormGroup, FormBuilder, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -68,18 +64,19 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FundMappingComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
   private route = inject(ActivatedRoute);
   private dateUtils = inject(Dates);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum Date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum Date allowed. */
   maxDate = new Date();
   /** Fund mapping form. */
-  fundMappingForm: UntypedFormGroup;
+  fundMappingForm: FormGroup;
   /** Advance Search Template */
   advanceSearchTemplate: any;
   /** Toggles b/w form and table */
@@ -110,7 +107,7 @@ export class FundMappingComponent implements OnInit {
    * @param {Dates} dateUtils Date Utils to format date.
    */
   constructor() {
-    this.route.data.subscribe((data: { advanceSearchTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { advanceSearchTemplate: any }) => {
       this.advanceSearchTemplate = data.advanceSearchTemplate;
     });
   }
@@ -150,90 +147,102 @@ export class FundMappingComponent implements OnInit {
    * Sets conditional child controls.
    */
   buildDependencies() {
-    this.fundMappingForm.get('includeOutStandingAmountPercentage').valueChanges.subscribe((value: boolean) => {
-      if (value) {
-        this.fundMappingForm.addControl(
-          'outStandingAmountPercentageCondition',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.fundMappingForm.get('outStandingAmountPercentageCondition').valueChanges.subscribe((_value: string) => {
-          if (_value === 'between') {
-            this.fundMappingForm.addControl(
-              'minOutStandingAmountPercentage',
-              new UntypedFormControl('', [
-                Validators.required,
-                Validators.min(0)
-              ])
-            );
-            this.fundMappingForm.addControl(
-              'maxOutStandingAmountPercentage',
-              new UntypedFormControl('', [
-                Validators.required,
-                Validators.min(0)
-              ])
-            );
-            this.fundMappingForm.removeControl('outStandingAmountPercentage');
-          } else {
-            this.fundMappingForm.addControl(
-              'outStandingAmountPercentage',
-              new UntypedFormControl('', [
-                Validators.required,
-                Validators.min(0)
-              ])
-            );
-            this.fundMappingForm.removeControl('minOutStandingAmountPercentage');
-            this.fundMappingForm.removeControl('maxOutStandingAmountPercentage');
-          }
-        });
-        this.fundMappingForm.get('outStandingAmountPercentageCondition').patchValue('between');
-      } else {
-        this.fundMappingForm.removeControl('outStandingAmountPercentageCondition');
-        this.fundMappingForm.removeControl('minOutStandingAmountPercentage');
-        this.fundMappingForm.removeControl('maxOutStandingAmountPercentage');
-        this.fundMappingForm.removeControl('outStandingAmountPercentage');
-      }
-    });
+    this.fundMappingForm
+      .get('includeOutStandingAmountPercentage')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value: boolean) => {
+        if (value) {
+          this.fundMappingForm.addControl(
+            'outStandingAmountPercentageCondition',
+            new FormControl('', Validators.required)
+          );
+          this.fundMappingForm
+            .get('outStandingAmountPercentageCondition')
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((_value: string) => {
+              if (_value === 'between') {
+                this.fundMappingForm.addControl(
+                  'minOutStandingAmountPercentage',
+                  new FormControl('', [
+                    Validators.required,
+                    Validators.min(0)
+                  ])
+                );
+                this.fundMappingForm.addControl(
+                  'maxOutStandingAmountPercentage',
+                  new FormControl('', [
+                    Validators.required,
+                    Validators.min(0)
+                  ])
+                );
+                this.fundMappingForm.removeControl('outStandingAmountPercentage');
+              } else {
+                this.fundMappingForm.addControl(
+                  'outStandingAmountPercentage',
+                  new FormControl('', [
+                    Validators.required,
+                    Validators.min(0)
+                  ])
+                );
+                this.fundMappingForm.removeControl('minOutStandingAmountPercentage');
+                this.fundMappingForm.removeControl('maxOutStandingAmountPercentage');
+              }
+            });
+          this.fundMappingForm.get('outStandingAmountPercentageCondition').patchValue('between');
+        } else {
+          this.fundMappingForm.removeControl('outStandingAmountPercentageCondition');
+          this.fundMappingForm.removeControl('minOutStandingAmountPercentage');
+          this.fundMappingForm.removeControl('maxOutStandingAmountPercentage');
+          this.fundMappingForm.removeControl('outStandingAmountPercentage');
+        }
+      });
     this.fundMappingForm.get('includeOutStandingAmountPercentage').patchValue(true);
-    this.fundMappingForm.get('includeOutstandingAmount').valueChanges.subscribe((value: boolean) => {
-      if (value) {
-        this.fundMappingForm.addControl('outstandingAmountCondition', new UntypedFormControl('', Validators.required));
-        this.fundMappingForm.get('outstandingAmountCondition').valueChanges.subscribe((_value: string) => {
-          if (_value === 'between') {
-            this.fundMappingForm.addControl(
-              'minOutstandingAmount',
-              new UntypedFormControl('', [
-                Validators.required,
-                Validators.min(0)
-              ])
-            );
-            this.fundMappingForm.addControl(
-              'maxOutstandingAmount',
-              new UntypedFormControl('', [
-                Validators.required,
-                Validators.min(0)
-              ])
-            );
-            this.fundMappingForm.removeControl('outstandingAmount');
-          } else {
-            this.fundMappingForm.addControl(
-              'outstandingAmount',
-              new UntypedFormControl('', [
-                Validators.required,
-                Validators.min(0)
-              ])
-            );
-            this.fundMappingForm.removeControl('minOutstandingAmount');
-            this.fundMappingForm.removeControl('maxOutstandingAmount');
-          }
-        });
-        this.fundMappingForm.get('outstandingAmountCondition').patchValue('between');
-      } else {
-        this.fundMappingForm.removeControl('outstandingAmountCondition');
-        this.fundMappingForm.removeControl('minOutstandingAmount');
-        this.fundMappingForm.removeControl('maxOutstandingAmount');
-        this.fundMappingForm.removeControl('outstandingAmount');
-      }
-    });
+    this.fundMappingForm
+      .get('includeOutstandingAmount')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value: boolean) => {
+        if (value) {
+          this.fundMappingForm.addControl('outstandingAmountCondition', new FormControl('', Validators.required));
+          this.fundMappingForm
+            .get('outstandingAmountCondition')
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((_value: string) => {
+              if (_value === 'between') {
+                this.fundMappingForm.addControl(
+                  'minOutstandingAmount',
+                  new FormControl('', [
+                    Validators.required,
+                    Validators.min(0)
+                  ])
+                );
+                this.fundMappingForm.addControl(
+                  'maxOutstandingAmount',
+                  new FormControl('', [
+                    Validators.required,
+                    Validators.min(0)
+                  ])
+                );
+                this.fundMappingForm.removeControl('outstandingAmount');
+              } else {
+                this.fundMappingForm.addControl(
+                  'outstandingAmount',
+                  new FormControl('', [
+                    Validators.required,
+                    Validators.min(0)
+                  ])
+                );
+                this.fundMappingForm.removeControl('minOutstandingAmount');
+                this.fundMappingForm.removeControl('maxOutstandingAmount');
+              }
+            });
+          this.fundMappingForm.get('outstandingAmountCondition').patchValue('between');
+        } else {
+          this.fundMappingForm.removeControl('outstandingAmountCondition');
+          this.fundMappingForm.removeControl('minOutstandingAmount');
+          this.fundMappingForm.removeControl('maxOutstandingAmount');
+          this.fundMappingForm.removeControl('outstandingAmount');
+        }
+      });
     this.fundMappingForm.get('includeOutstandingAmount').patchValue(true);
   }
 
@@ -273,8 +282,11 @@ export class FundMappingComponent implements OnInit {
       dateFormat,
       locale
     };
-    this.organizationService.retrieveAdvanceSearchResults(data).subscribe((response: any) => {
-      this.setLoans(response);
-    });
+    this.organizationService
+      .retrieveAdvanceSearchResults(data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.setLoans(response);
+      });
   }
 }

--- a/src/app/organization/holidays/create-holiday/create-holiday.component.ts
+++ b/src/app/organization/holidays/create-holiday/create-holiday.component.ts
@@ -8,14 +8,10 @@
 
 /** Angular Imports. */
 import { SelectionModel } from '@angular/cdk/collections';
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, Injectable, inject } from '@angular/core';
-import {
-  UntypedFormBuilder,
-  UntypedFormGroup,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, Injectable, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 import {
@@ -62,8 +58,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateHolidayComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
   private dateUtils = inject(Dates);
   private organizationService = inject(OrganizationService);
   private settings = inject(SettingsService);
@@ -72,7 +69,7 @@ export class CreateHolidayComponent implements OnInit {
   private createHoliday = inject(CreateHoliday);
 
   /** Create Holiday form. */
-  holidayForm: UntypedFormGroup;
+  holidayForm: FormGroup;
   /** Repayment Scheduling data. */
   repaymentSchedulingTypes: any;
   /** Offices Data */
@@ -122,20 +119,22 @@ export class CreateHolidayComponent implements OnInit {
   constructor() {
     const _database = this._database;
 
-    this.route.data.subscribe((data: { offices: any; holidayTemplate: any }) => {
-      this.officesData = data.offices;
-      this.repaymentSchedulingTypes = data.holidayTemplate;
-      // Constructs trie everytime data changes
-      this.constructOfficeHierarchy();
-      // Updates data in the CheckListDatabase
-      _database.initialize(this.officesTrie);
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { offices: any; holidayTemplate: any }) => {
+        this.officesData = data.offices;
+        this.repaymentSchedulingTypes = data.holidayTemplate;
+        // Constructs trie everytime data changes
+        this.constructOfficeHierarchy();
+        // Updates data in the CheckListDatabase
+        _database.initialize(this.officesTrie);
+      });
     this.treeFlattener = new MatTreeFlattener(this.transformer, this.getLevel, this.isExpandable, this.getChildren);
     this.treeControl = new FlatTreeControl<OfficeItemFlatNode>(this.getLevel, this.isExpandable);
     this.dataSource = new MatTreeFlatDataSource(this.treeControl, this.treeFlattener);
 
     // Listens for changes in CheckListDatabase
-    this._database.dataChange.subscribe((data) => {
+    this._database.dataChange.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data) => {
       this.dataSource.data = data;
     });
   }
@@ -325,13 +324,16 @@ export class CreateHolidayComponent implements OnInit {
    * Sets the conditional controls.
    */
   buildDependencies() {
-    this.holidayForm.get('reschedulingType').valueChanges.subscribe((option: any) => {
-      if (option === 2) {
-        this.holidayForm.addControl('repaymentsRescheduledTo', new UntypedFormControl('', Validators.required));
-      } else {
-        this.holidayForm.removeControl('repaymentsRescheduledTo');
-      }
-    });
+    this.holidayForm
+      .get('reschedulingType')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((option: any) => {
+        if (option === 2) {
+          this.holidayForm.addControl('repaymentsRescheduledTo', new FormControl('', Validators.required));
+        } else {
+          this.holidayForm.removeControl('repaymentsRescheduledTo');
+        }
+      });
   }
 
   /**
@@ -374,14 +376,17 @@ export class CreateHolidayComponent implements OnInit {
       locale,
       offices
     };
-    this.organizationService.createHoliday(data).subscribe((response: any) => {
-      this.router.navigate(
-        [
-          '../',
-          response.resourceId
-        ],
-        { relativeTo: this.route }
-      );
-    });
+    this.organizationService
+      .createHoliday(data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(
+          [
+            '../',
+            response.resourceId
+          ],
+          { relativeTo: this.route }
+        );
+      });
   }
 }

--- a/src/app/organization/holidays/edit-holiday/edit-holiday.component.ts
+++ b/src/app/organization/holidays/edit-holiday/edit-holiday.component.ts
@@ -7,14 +7,10 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormBuilder,
-  UntypedFormGroup,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -39,7 +35,8 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class EditHolidayComponent implements OnInit {
   private alertService = inject(AlertService);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private dateUtils = inject(Dates);
   private organizatioService = inject(OrganizationService);
@@ -48,7 +45,7 @@ export class EditHolidayComponent implements OnInit {
   private translateService = inject(TranslateService);
 
   /** Edit Holiday form. */
-  holidayForm: UntypedFormGroup;
+  holidayForm: FormGroup;
   /** Holiday data. */
   holidayData: any;
   /** Rescheduling Type. */
@@ -68,16 +65,18 @@ export class EditHolidayComponent implements OnInit {
    * @param {Router} router Router.
    */
   constructor() {
-    this.route.data.subscribe((data: { holiday: any; holidayTemplate: any }) => {
-      this.holidayData = data.holiday;
-      this.holidayData.repaymentSchedulingTypes = data.holidayTemplate;
-      this.reSchedulingType = this.holidayData.reschedulingType;
-      if (this.holidayData.status.value === 'Active') {
-        this.isActiveHoliday = true;
-      } else {
-        this.isActiveHoliday = false;
-      }
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { holiday: any; holidayTemplate: any }) => {
+        this.holidayData = data.holiday;
+        this.holidayData.repaymentSchedulingTypes = data.holidayTemplate;
+        this.reSchedulingType = this.holidayData.reschedulingType;
+        if (this.holidayData.status.value === 'Active') {
+          this.isActiveHoliday = true;
+        } else {
+          this.isActiveHoliday = false;
+        }
+      });
   }
 
   ngOnInit() {
@@ -102,20 +101,20 @@ export class EditHolidayComponent implements OnInit {
     if (!this.isActiveHoliday) {
       this.holidayForm.addControl(
         'fromDate',
-        new UntypedFormControl(this.holidayData.fromDate && new Date(this.holidayData.fromDate), Validators.required)
+        new FormControl(this.holidayData.fromDate && new Date(this.holidayData.fromDate), Validators.required)
       );
       this.holidayForm.addControl(
         'toDate',
-        new UntypedFormControl(this.holidayData.toDate && new Date(this.holidayData.toDate), Validators.required)
+        new FormControl(this.holidayData.toDate && new Date(this.holidayData.toDate), Validators.required)
       );
       this.holidayForm.addControl(
         'reschedulingType',
-        new UntypedFormControl(this.holidayData.reschedulingType, Validators.required)
+        new FormControl(this.holidayData.reschedulingType, Validators.required)
       );
       if (this.reSchedulingType === 2) {
         this.holidayForm.addControl(
           'repaymentsRescheduledTo',
-          new UntypedFormControl(
+          new FormControl(
             this.holidayData.repaymentsRescheduledTo && new Date(this.holidayData.repaymentsRescheduledTo),
             Validators.required
           )
@@ -128,14 +127,17 @@ export class EditHolidayComponent implements OnInit {
    * Get Rescheduling Type.
    */
   getReschedulingType() {
-    this.holidayForm.get('reschedulingType').valueChanges.subscribe((option: any) => {
-      this.reSchedulingType = option;
-      if (option === 2) {
-        this.holidayForm.addControl('repaymentsRescheduledTo', new UntypedFormControl(new Date(), Validators.required));
-      } else {
-        this.holidayForm.removeControl('repaymentsRescheduledTo');
-      }
-    });
+    this.holidayForm
+      .get('reschedulingType')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((option: any) => {
+        this.reSchedulingType = option;
+        if (option === 2) {
+          this.holidayForm.addControl('repaymentsRescheduledTo', new FormControl(new Date(), Validators.required));
+        } else {
+          this.holidayForm.removeControl('repaymentsRescheduledTo');
+        }
+      });
   }
 
   /**
@@ -184,9 +186,12 @@ export class EditHolidayComponent implements OnInit {
       dateFormat,
       locale
     };
-    this.organizatioService.updateHoliday(this.holidayData.id, data).subscribe((response) => {
-      /** TODO Add Redirects to ViewMakerCheckerTask page. */
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizatioService
+      .updateHoliday(this.holidayData.id, data)
+      .pipe(take(1))
+      .subscribe((response) => {
+        /** TODO Add Redirects to ViewMakerCheckerTask page. */
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/holidays/holidays.component.ts
+++ b/src/app/organization/holidays/holidays.component.ts
@@ -15,8 +15,10 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -33,10 +35,10 @@ import {
   MatRow
 } from '@angular/material/table';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 /** rxjs Imports */
-import { of } from 'rxjs';
+import { of, take } from 'rxjs';
 
 /** Custom Services */
 import { OrganizationService } from '../organization.service';
@@ -79,9 +81,10 @@ export class HolidaysComponent implements OnInit, AfterViewInit {
   private router = inject(Router);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private destroyRef = inject(DestroyRef);
 
   /** Office selector. */
-  officeSelector = new UntypedFormControl();
+  officeSelector = new FormControl();
   /** Holidays data. */
   holidaysData: any;
   /** Offices data. */
@@ -121,7 +124,7 @@ export class HolidaysComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { offices: any }) => {
       this.officeData = data.offices;
     });
   }
@@ -145,13 +148,18 @@ export class HolidaysComponent implements OnInit, AfterViewInit {
    * Retrieves the holidays data on changing office and sets the holidays table.
    */
   onChangeOffice() {
-    this.officeSelector.valueChanges.subscribe((officeId = this.officeSelector.value) => {
-      this.holidaysData = [];
-      this.organizationService.getHolidays(officeId).subscribe((holidays: any) => {
-        this.holidaysData = holidays.filter((holiday: any) => holiday.status.value !== 'Deleted');
-        this.setHolidays();
+    this.officeSelector.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((officeId = this.officeSelector.value) => {
+        this.holidaysData = [];
+        this.organizationService
+          .getHolidays(officeId)
+          .pipe(take(1))
+          .subscribe((holidays: any) => {
+            this.holidaysData = holidays.filter((holiday: any) => holiday.status.value !== 'Deleted');
+            this.setHolidays();
+          });
       });
-    });
   }
 
   /**

--- a/src/app/organization/holidays/view-holidays/view-holidays.component.ts
+++ b/src/app/organization/holidays/view-holidays/view-holidays.component.ts
@@ -7,7 +7,9 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -42,6 +44,7 @@ export class ViewHolidaysComponent {
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
 
   /** Holiday data. */
   holidayData: any;
@@ -51,7 +54,7 @@ export class ViewHolidaysComponent {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { holidays: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { holidays: any }) => {
       this.holidayData = data.holidays;
     });
   }
@@ -65,9 +68,12 @@ export class ViewHolidaysComponent {
     });
     deleteHolidayDialogRef.afterClosed().subscribe((response: any) => {
       if (response?.delete) {
-        this.organizationService.deleteHoliday(this.holidayData.id).subscribe(() => {
-          this.router.navigate(['../'], { relativeTo: this.route });
-        });
+        this.organizationService
+          .deleteHoliday(this.holidayData.id)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.router.navigate(['../'], { relativeTo: this.route });
+          });
       }
     });
   }
@@ -87,9 +93,12 @@ export class ViewHolidaysComponent {
     });
     unAssignStaffDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
       if (response?.confirm) {
-        this.organizationService.activateHoliday(this.holidayData.id).subscribe(() => {
-          this.router.navigate(['/organization/holidays']);
-        });
+        this.organizationService
+          .activateHoliday(this.holidayData.id)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.router.navigate(['/organization/holidays']);
+          });
       }
     });
   }

--- a/src/app/organization/investors/investors.component.ts
+++ b/src/app/organization/investors/investors.component.ts
@@ -8,7 +8,8 @@
 
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
@@ -76,11 +77,11 @@ export class InvestorsComponent implements OnInit {
   maxDate = new Date();
 
   searchResults: any[] = [];
-  searchText = new UntypedFormControl('');
-  effectiveFromDate = new UntypedFormControl('');
-  effectiveToDate = new UntypedFormControl('');
-  settlementFromDate = new UntypedFormControl('');
-  settlementToDate = new UntypedFormControl('');
+  searchText = new FormControl('');
+  effectiveFromDate = new FormControl('');
+  effectiveToDate = new FormControl('');
+  settlementFromDate = new FormControl('');
+  settlementToDate = new FormControl('');
 
   dataSource: MatTableDataSource<any> = new MatTableDataSource();
   existsDataToFilter = false;
@@ -100,7 +101,7 @@ export class InvestorsComponent implements OnInit {
   @ViewChild(MatSort) sort: MatSort;
 
   /** Entry type filter form control. */
-  entryTypeFilter = new UntypedFormControl('');
+  entryTypeFilter = new FormControl('');
   /** Entry type filter data. */
   entryTypeFilterData = [
     {
@@ -188,13 +189,16 @@ export class InvestorsComponent implements OnInit {
       request['settlementToDate'] = this.dateUtils.formatDate(this.settlementToDate.value, dateFormat);
     }
     payload['request'] = request;
-    this.externalAssetOwnerService.searchExternalAssetOwnerTransfer(payload).subscribe((response: any) => {
-      this.totalRows = response.totalElements;
-      this.existsDataToFilter = response.totalElements > 0;
-      this.dataSource.data = response.content;
-      this.searchResults = response.content;
-      this.isLoading = false;
-    });
+    this.externalAssetOwnerService
+      .searchExternalAssetOwnerTransfer(payload)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.totalRows = response.totalElements;
+        this.existsDataToFilter = response.totalElements > 0;
+        this.dataSource.data = response.content;
+        this.searchResults = response.content;
+        this.isLoading = false;
+      });
   }
 
   transform(data: any): any {
@@ -218,6 +222,7 @@ export class InvestorsComponent implements OnInit {
         };
         this.externalAssetOwnerService
           .executeExternalAssetOwnerTransferCommand(transfer.transferId, payload, 'cancel')
+          .pipe(take(1))
           .subscribe((result: any) => {
             this.reload();
           });

--- a/src/app/organization/loan-originators/create-loan-originator/create-loan-originator.component.ts
+++ b/src/app/organization/loan-originators/create-loan-originator/create-loan-originator.component.ts
@@ -7,8 +7,19 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, TemplateRef, ElementRef, ViewChild, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  TemplateRef,
+  ElementRef,
+  ViewChild,
+  inject,
+  DestroyRef
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -29,13 +40,14 @@ import { CodeValue } from 'app/shared/models/general.model';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateLoanOriginatorComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
   /** Loan Originator form. */
-  loanOriginatorForm: UntypedFormGroup;
+  loanOriginatorForm: FormGroup;
   /** Form data. */
   loanOriginatorsTemplateData: any;
   statusOptions: string[] = [];
@@ -48,12 +60,14 @@ export class CreateLoanOriginatorComponent implements OnInit {
   @ViewChild('templateCreateLoanOriginatorForm') templateCreateLoanOriginatorForm: TemplateRef<any>;
 
   constructor() {
-    this.route.data.subscribe((data: { loanOriginatorsTemplateData: any }) => {
-      this.loanOriginatorsTemplateData = data.loanOriginatorsTemplateData;
-      this.statusOptions = data.loanOriginatorsTemplateData.statusOptions;
-      this.originatorTypeOptions = data.loanOriginatorsTemplateData.originatorTypeOptions;
-      this.channelTypeOptions = data.loanOriginatorsTemplateData.channelTypeOptions;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { loanOriginatorsTemplateData: any }) => {
+        this.loanOriginatorsTemplateData = data.loanOriginatorsTemplateData;
+        this.statusOptions = data.loanOriginatorsTemplateData.statusOptions;
+        this.originatorTypeOptions = data.loanOriginatorsTemplateData.originatorTypeOptions;
+        this.channelTypeOptions = data.loanOriginatorsTemplateData.channelTypeOptions;
+      });
   }
 
   /**
@@ -101,8 +115,11 @@ export class CreateLoanOriginatorComponent implements OnInit {
     const data = {
       ...loanOriginatorFormData
     };
-    this.organizationService.createLoanOriginator(data).subscribe((response: any) => {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizationService
+      .createLoanOriginator(data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/loan-originators/edit-loan-originator/edit-loan-originator.component.ts
+++ b/src/app/organization/loan-originators/edit-loan-originator/edit-loan-originator.component.ts
@@ -7,8 +7,19 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, TemplateRef, ElementRef, ViewChild, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  TemplateRef,
+  ElementRef,
+  ViewChild,
+  inject,
+  DestroyRef
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -30,13 +41,14 @@ import { LoanOriginator } from 'app/loans/models/loan-account.model';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditLoanOriginatorComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
   /** Loan Originator form. */
-  loanOriginatorForm: UntypedFormGroup | null = null;
+  loanOriginatorForm: FormGroup | null = null;
   /** Form data. */
   loanOriginatorsData: LoanOriginator;
   loanOriginatorsTemplateData: any;
@@ -50,13 +62,15 @@ export class EditLoanOriginatorComponent implements OnInit {
   @ViewChild('templateCreateLoanOriginatorForm') templateCreateLoanOriginatorForm: TemplateRef<any>;
 
   constructor() {
-    this.route.data.subscribe((data: { loanOriginatorData: LoanOriginator; loanOriginatorsTemplateData: any }) => {
-      this.loanOriginatorsData = data.loanOriginatorData;
-      this.loanOriginatorsTemplateData = data.loanOriginatorsTemplateData;
-      this.statusOptions = data.loanOriginatorsTemplateData.statusOptions;
-      this.originatorTypeOptions = data.loanOriginatorsTemplateData.originatorTypeOptions;
-      this.channelTypeOptions = data.loanOriginatorsTemplateData.channelTypeOptions;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { loanOriginatorData: LoanOriginator; loanOriginatorsTemplateData: any }) => {
+        this.loanOriginatorsData = data.loanOriginatorData;
+        this.loanOriginatorsTemplateData = data.loanOriginatorsTemplateData;
+        this.statusOptions = data.loanOriginatorsTemplateData.statusOptions;
+        this.originatorTypeOptions = data.loanOriginatorsTemplateData.originatorTypeOptions;
+        this.channelTypeOptions = data.loanOriginatorsTemplateData.channelTypeOptions;
+      });
   }
 
   /**
@@ -107,8 +121,11 @@ export class EditLoanOriginatorComponent implements OnInit {
     const data = {
       ...loanOriginatorFormData
     };
-    this.organizationService.updateLoanOriginator(this.loanOriginatorsData.id, data).subscribe((response: any) => {
-      this.router.navigate(['../..'], { relativeTo: this.route });
-    });
+    this.organizationService
+      .updateLoanOriginator(this.loanOriginatorsData.id, data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(['../..'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/loan-originators/loan-originators.component.ts
+++ b/src/app/organization/loan-originators/loan-originators.component.ts
@@ -7,7 +7,18 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, TemplateRef, ElementRef, ViewChild, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  TemplateRef,
+  ElementRef,
+  ViewChild,
+  inject,
+  DestroyRef
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -70,6 +81,7 @@ export class LoanOriginatorsComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);
 
@@ -99,9 +111,11 @@ export class LoanOriginatorsComponent implements OnInit {
   @ViewChild('templateTableLoanOriginators') templateTableLoanOriginators: TemplateRef<any>;
 
   constructor() {
-    this.route.data.subscribe((data: { loanOriginatorsData: LoanOriginator[] }) => {
-      this.loanOriginatorsData = data.loanOriginatorsData;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { loanOriginatorsData: LoanOriginator[] }) => {
+        this.loanOriginatorsData = data.loanOriginatorsData;
+      });
   }
 
   /**
@@ -136,9 +150,12 @@ export class LoanOriginatorsComponent implements OnInit {
     });
     deleteCodeDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
-        this.organizationService.deleteLoanOriginator(loanOriginator.id).subscribe(() => {
-          this.router.navigate(['/organization/manage-loan-originators']);
-        });
+        this.organizationService
+          .deleteLoanOriginator(loanOriginator.id)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.router.navigate(['/organization/manage-loan-originators']);
+          });
       }
     });
   }

--- a/src/app/organization/loan-originators/view-loan-originator/view-loan-originator.component.ts
+++ b/src/app/organization/loan-originators/view-loan-originator/view-loan-originator.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -28,17 +29,16 @@ import { LoanOriginator } from 'app/loans/models/loan-account.model';
 })
 export class ViewLoanOriginatorComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Employee data. */
   loanOriginatorData: LoanOriginator;
 
-  /**
-   * Retrieves the Loan Originator data from `resolve`.
-   * @param {ActivatedRoute} route Activated Route.
-   */
   constructor() {
-    this.route.data.subscribe((data: { loanOriginatorData: LoanOriginator }) => {
-      this.loanOriginatorData = data.loanOriginatorData;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { loanOriginatorData: LoanOriginator }) => {
+        this.loanOriginatorData = data.loanOriginatorData;
+      });
   }
 }

--- a/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/create-loan-provisioning-criteria/create-loan-provisioning-criteria.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import {
   MatTableDataSource,
@@ -68,8 +70,9 @@ import { TranslateService } from '@ngx-translate/core';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateLoanProvisioningCriteriaComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private settingsService = inject(SettingsService);
   private router = inject(Router);
   dialog = inject(MatDialog);
@@ -77,7 +80,7 @@ export class CreateLoanProvisioningCriteriaComponent implements OnInit {
   private translateService = inject(TranslateService);
 
   /** Loan Provisioning Criteria form. */
-  provisioningCriteriaForm: UntypedFormGroup;
+  provisioningCriteriaForm: FormGroup;
   /** Loan Provisioning Criteria Template */
   loanProvisioningCriteriaTemplate: any;
   /** Liability Accounts */
@@ -117,16 +120,18 @@ export class CreateLoanProvisioningCriteriaComponent implements OnInit {
    * @param {Router} router Router for navigation.
    */
   constructor() {
-    this.route.data.subscribe((data: { loanProvisioningCriteriaTemplate: any }) => {
-      this.loanProvisioningCriteriaTemplate = data.loanProvisioningCriteriaTemplate;
-      this.definitions = this.loanProvisioningCriteriaTemplate.definitions;
-      this.liabilityAccounts = this.loanProvisioningCriteriaTemplate.glAccounts.filter(
-        (account: any) => account.type.value === 'LIABILITY'
-      );
-      this.expenseAccounts = this.loanProvisioningCriteriaTemplate.glAccounts.filter(
-        (account: any) => account.type.value === 'EXPENSE'
-      );
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { loanProvisioningCriteriaTemplate: any }) => {
+        this.loanProvisioningCriteriaTemplate = data.loanProvisioningCriteriaTemplate;
+        this.definitions = this.loanProvisioningCriteriaTemplate.definitions;
+        this.liabilityAccounts = this.loanProvisioningCriteriaTemplate.glAccounts.filter(
+          (account: any) => account.type.value === 'LIABILITY'
+        );
+        this.expenseAccounts = this.loanProvisioningCriteriaTemplate.glAccounts.filter(
+          (account: any) => account.type.value === 'EXPENSE'
+        );
+      });
   }
 
   ngOnInit() {
@@ -262,14 +267,17 @@ export class CreateLoanProvisioningCriteriaComponent implements OnInit {
       definitions: this.definitions,
       locale
     };
-    this.organizationService.createProvisioningCriteria(loanProvisioningCriteria).subscribe((response: any) => {
-      this.router.navigate(
-        [
-          '../',
-          response.resourceId
-        ],
-        { relativeTo: this.route }
-      );
-    });
+    this.organizationService
+      .createProvisioningCriteria(loanProvisioningCriteria)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(
+          [
+            '../',
+            response.resourceId
+          ],
+          { relativeTo: this.route }
+        );
+      });
   }
 }

--- a/src/app/organization/loan-provisioning-criteria/edit-loan-provisioning-criteria/edit-loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/edit-loan-provisioning-criteria/edit-loan-provisioning-criteria.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import {
   MatTableDataSource,
@@ -68,8 +70,9 @@ import { TranslateService } from '@ngx-translate/core';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditLoanProvisioningCriteriaComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   dialog = inject(MatDialog);
@@ -77,7 +80,7 @@ export class EditLoanProvisioningCriteriaComponent implements OnInit {
   private translateService = inject(TranslateService);
 
   /** Loan Provisioning Criteria form. */
-  provisioningCriteriaForm: UntypedFormGroup;
+  provisioningCriteriaForm: FormGroup;
   /** Loan Provisioning Criteria Template */
   loanProvisioningCriteriaAndTemplate: any;
   /** Liability Accounts */
@@ -117,19 +120,21 @@ export class EditLoanProvisioningCriteriaComponent implements OnInit {
    * @param {Router} router Router for navigation.
    */
   constructor() {
-    this.route.data.subscribe((data: { loanProvisioningCriteriaAndTemplate: any }) => {
-      this.loanProvisioningCriteriaAndTemplate = data.loanProvisioningCriteriaAndTemplate;
-      this.definitions = this.loanProvisioningCriteriaAndTemplate.definitions;
-      this.loanProducts = this.loanProvisioningCriteriaAndTemplate.loanProducts.concat(
-        this.loanProvisioningCriteriaAndTemplate.selectedLoanProducts
-      );
-      this.liabilityAccounts = this.loanProvisioningCriteriaAndTemplate.glAccounts.filter(
-        (account: any) => account.type.value === 'LIABILITY'
-      );
-      this.expenseAccounts = this.loanProvisioningCriteriaAndTemplate.glAccounts.filter(
-        (account: any) => account.type.value === 'EXPENSE'
-      );
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { loanProvisioningCriteriaAndTemplate: any }) => {
+        this.loanProvisioningCriteriaAndTemplate = data.loanProvisioningCriteriaAndTemplate;
+        this.definitions = this.loanProvisioningCriteriaAndTemplate.definitions;
+        this.loanProducts = this.loanProvisioningCriteriaAndTemplate.loanProducts.concat(
+          this.loanProvisioningCriteriaAndTemplate.selectedLoanProducts
+        );
+        this.liabilityAccounts = this.loanProvisioningCriteriaAndTemplate.glAccounts.filter(
+          (account: any) => account.type.value === 'LIABILITY'
+        );
+        this.expenseAccounts = this.loanProvisioningCriteriaAndTemplate.glAccounts.filter(
+          (account: any) => account.type.value === 'EXPENSE'
+        );
+      });
   }
 
   ngOnInit() {
@@ -269,6 +274,7 @@ export class EditLoanProvisioningCriteriaComponent implements OnInit {
     };
     this.organizationService
       .updateProvisioningCriteria(this.loanProvisioningCriteriaAndTemplate.criteriaId, loanProvisioningCriteria)
+      .pipe(take(1))
       .subscribe((response: any) => {
         this.router.navigate(['../'], { relativeTo: this.route });
       });

--- a/src/app/organization/loan-provisioning-criteria/loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/loan-provisioning-criteria.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -25,8 +26,6 @@ import {
 } from '@angular/material/table';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
-/** rxjs Imports */
-import { of } from 'rxjs';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
@@ -58,6 +57,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class LoanProvisioningCriteriaComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Loan Provisioning Criteria data. */
   loanProvisioningCriteriaData: any;
@@ -74,12 +74,8 @@ export class LoanProvisioningCriteriaComponent implements OnInit {
   /** Sorter for loan provisioning criteria table. */
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 
-  /**
-   * Retrieves the loan provisioning criteria data from `resolve`.
-   * @param {ActivatedRoute} route Activated Route.
-   */
   constructor() {
-    this.route.data.subscribe((data: { loanProvisioningCriterias: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanProvisioningCriterias: any }) => {
       this.loanProvisioningCriteriaData = data.loanProvisioningCriterias;
     });
   }

--- a/src/app/organization/loan-provisioning-criteria/view-loan-provisioning-criteria/view-loan-provisioning-criteria.component.ts
+++ b/src/app/organization/loan-provisioning-criteria/view-loan-provisioning-criteria/view-loan-provisioning-criteria.component.ts
@@ -7,7 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import {
@@ -61,6 +63,7 @@ import { LoanProduct } from 'app/products/loan-products/models/loan-product.mode
 })
 export class ViewLoanProvisioningCriteriaComponent implements OnInit {
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   dialog = inject(MatDialog);
@@ -89,7 +92,7 @@ export class ViewLoanProvisioningCriteriaComponent implements OnInit {
    * @param {MatDialog} dialog Dialog reference.
    */
   constructor() {
-    this.route.data.subscribe((data: { loanProvisioningCriteria: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanProvisioningCriteria: any }) => {
       this.provisioningData = data.loanProvisioningCriteria;
     });
   }
@@ -124,14 +127,17 @@ export class ViewLoanProvisioningCriteriaComponent implements OnInit {
     });
     deleteCriteriaDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
-        this.organizationService.deleteProvisioningCriteria(this.provisioningData.criteriaId).subscribe(
-          () => {
-            this.router.navigate(['/organization/provisioning-criteria']);
-          },
-          (error) => {
-            console.error('Failed to delete provisioning criteria:', error);
-          }
-        );
+        this.organizationService
+          .deleteProvisioningCriteria(this.provisioningData.criteriaId)
+          .pipe(take(1))
+          .subscribe(
+            () => {
+              this.router.navigate(['/organization/provisioning-criteria']);
+            },
+            (error) => {
+              console.error('Failed to delete provisioning criteria:', error);
+            }
+          );
       }
     });
   }

--- a/src/app/organization/manage-funds/create-fund/create-fund.component.ts
+++ b/src/app/organization/manage-funds/create-fund/create-fund.component.ts
@@ -7,7 +7,8 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { OrganizationService } from 'app/organization/organization.service';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -23,12 +24,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class CreateFundComponent implements OnInit {
   private organizationService = inject(OrganizationService);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
 
   /** Charge form. */
-  fundForm: UntypedFormGroup;
+  fundForm: FormGroup;
 
   ngOnInit() {
     this.createFundForm();
@@ -49,8 +50,11 @@ export class CreateFundComponent implements OnInit {
 
   submit() {
     const payload = this.fundForm.getRawValue();
-    this.organizationService.createFund(payload).subscribe((response: any) => {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizationService
+      .createFund(payload)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/manage-funds/edit-fund/edit-fund.component.ts
+++ b/src/app/organization/manage-funds/edit-fund/edit-fund.component.ts
@@ -6,8 +6,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { OrganizationService } from 'app/organization/organization.service';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -23,24 +25,18 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class EditFundComponent implements OnInit {
   private organizationService = inject(OrganizationService);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
 
   /** Selected Data. */
   fundData: any;
   /** Charge form. */
-  fundForm: UntypedFormGroup;
+  fundForm: FormGroup;
 
-  /**
-   * Retrieves the charge data from `resolve`.
-   * @param {ProductsService} productsService Products Service.
-   * @param {FormBuilder} formBuilder Form Builder.
-   * @param {ActivatedRoute} route Activated Route.
-   * @param {Router} router Router for navigation.
-   */
   constructor() {
-    this.route.data.subscribe((data: { fundData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { fundData: any }) => {
       this.fundData = data.fundData;
     });
   }
@@ -64,8 +60,11 @@ export class EditFundComponent implements OnInit {
 
   submit() {
     const payload = this.fundForm.getRawValue();
-    this.organizationService.editFund(this.fundData.id.toString(), payload).subscribe((response: any) => {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizationService
+      .editFund(this.fundData.id.toString(), payload)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/manage-funds/manage-funds.component.ts
+++ b/src/app/organization/manage-funds/manage-funds.component.ts
@@ -15,11 +15,14 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { UntypedFormBuilder, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
+import { take } from 'rxjs';
 
 /** Custom Dialogs */
 import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
@@ -83,8 +86,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ManageFundsComponent implements OnInit, AfterViewInit {
   private route = inject(ActivatedRoute);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationservice = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   dialog = inject(MatDialog);
   private router = inject(Router);
   private configurationWizardService = inject(ConfigurationWizardService);
@@ -125,7 +129,7 @@ export class ManageFundsComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { funds: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { funds: any }) => {
       this.fundsData = data.funds;
     });
   }
@@ -161,17 +165,20 @@ export class ManageFundsComponent implements OnInit, AfterViewInit {
    */
   addFund() {
     const newFund = this.fundForm.value;
-    this.organizationservice.createFund(newFund).subscribe((response: any) => {
-      this.fundsData.push({
-        id: response.resourceId,
-        name: newFund.name
+    this.organizationservice
+      .createFund(newFund)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.fundsData.push({
+          id: response.resourceId,
+          name: newFund.name
+        });
+        this.formRef.resetForm();
+        if (this.configurationWizardService.showManageFunds) {
+          this.configurationWizardService.showManageFunds = false;
+          this.openDialog();
+        }
       });
-      this.formRef.resetForm();
-      if (this.configurationWizardService.showManageFunds) {
-        this.configurationWizardService.showManageFunds = false;
-        this.openDialog();
-      }
-    });
   }
 
   /**
@@ -198,9 +205,12 @@ export class ManageFundsComponent implements OnInit, AfterViewInit {
     const editFundDialogRef = this.dialog.open(FormDialogComponent, { data });
     editFundDialogRef.afterClosed().subscribe((response: any) => {
       if (response.data) {
-        this.organizationservice.editFund(fundId, response.data.value).subscribe(() => {
-          this.fundsData[index].name = response.data.value.name;
-        });
+        this.organizationservice
+          .editFund(fundId, response.data.value)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.fundsData[index].name = response.data.value.name;
+          });
       }
     });
   }

--- a/src/app/organization/manage-funds/view-fund/view-fund.component.ts
+++ b/src/app/organization/manage-funds/view-fund/view-fund.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { ExternalIdentifierComponent } from '../../../shared/external-identifier/external-identifier.component';
@@ -25,16 +26,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewFundComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Fund data. */
   fundData: any;
 
-  /**
-   * Retrieves the charge data from `resolve`.
-   * @param {Router} router Router for navigation.
-   */
   constructor() {
-    this.route.data.subscribe((data: { fundData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { fundData: any }) => {
       this.fundData = data.fundData;
     });
   }

--- a/src/app/organization/offices/create-office/create-office.component.ts
+++ b/src/app/organization/offices/create-office/create-office.component.ts
@@ -15,9 +15,12 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -45,8 +48,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateOfficeComponent implements OnInit, AfterViewInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private settingsService = inject(SettingsService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
@@ -56,7 +60,7 @@ export class CreateOfficeComponent implements OnInit, AfterViewInit {
   dialog = inject(MatDialog);
 
   /** Office form. */
-  officeForm: UntypedFormGroup;
+  officeForm: FormGroup;
   /** Office Data */
   officeData: any;
   /** Minimum Date allowed. */
@@ -82,7 +86,7 @@ export class CreateOfficeComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { offices: any }) => {
       this.officeData = data.offices;
     });
   }
@@ -130,14 +134,17 @@ export class CreateOfficeComponent implements OnInit, AfterViewInit {
       dateFormat,
       locale
     };
-    this.organizationService.createOffice(data).subscribe((response) => {
-      if (this.configurationWizardService.showOfficeForm) {
-        this.configurationWizardService.showOfficeForm = false;
-        this.openDialog();
-      } else {
-        this.router.navigate(['../'], { relativeTo: this.route });
-      }
-    });
+    this.organizationService
+      .createOffice(data)
+      .pipe(take(1))
+      .subscribe((response) => {
+        if (this.configurationWizardService.showOfficeForm) {
+          this.configurationWizardService.showOfficeForm = false;
+          this.openDialog();
+        } else {
+          this.router.navigate(['../'], { relativeTo: this.route });
+        }
+      });
   }
 
   /**

--- a/src/app/organization/offices/edit-office/edit-office.component.ts
+++ b/src/app/organization/offices/edit-office/edit-office.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -32,7 +34,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class EditOfficeComponent implements OnInit {
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
@@ -40,24 +43,14 @@ export class EditOfficeComponent implements OnInit {
   /** Selected Data. */
   officeData: any;
   /** Office form. */
-  officeForm: UntypedFormGroup;
+  officeForm: FormGroup;
   /** Minimum Date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum Date allowed. */
   maxDate = new Date();
 
-  /**
-   * Retrieves the charge data from `resolve`.
-   * @param {ProductsService} organizationService Organization Service.
-   * @param {SettingsService} settingsService Settings Service.
-   * @param {FormBuilder} formBuilder Form Builder.
-   * @param {ActivatedRoute} route Activated Route.
-   * @param {Router} router Router for navigation.
-   * @param {MatDialog} dialog Dialog reference.
-   * @param {Dates} dateUtils Date Utils
-   */
   constructor() {
-    this.route.data.subscribe((data: { officeTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { officeTemplate: any }) => {
       this.officeData = data.officeTemplate;
     });
   }
@@ -103,8 +96,11 @@ export class EditOfficeComponent implements OnInit {
       dateFormat,
       locale
     };
-    this.organizationService.updateOffice(this.officeData.id, data).subscribe((response: any) => {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizationService
+      .updateOffice(this.officeData.id, data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/offices/offices.component.ts
+++ b/src/app/organization/offices/offices.component.ts
@@ -15,8 +15,10 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -40,7 +42,7 @@ import { of } from 'rxjs';
 /** Custom Services */
 import { PopoverService } from '../../configuration-wizard/popover/popover.service';
 import { ConfigurationWizardService } from '../../configuration-wizard/configuration-wizard.service';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { OfficeNode } from './office-node.model';
 import { NestedTreeControl } from '@angular/cdk/tree';
 import {
@@ -112,9 +114,10 @@ export class OfficesComponent implements OnInit, AfterViewInit {
   private treeControlService = inject(TreeControlService);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private destroyRef = inject(DestroyRef);
 
   /** Button toggle group form control for type of view. (list/tree) */
-  viewGroup = new UntypedFormControl('listView');
+  viewGroup = new FormControl('listView');
 
   /** Offices data. */
   officesData: any;
@@ -163,11 +166,13 @@ export class OfficesComponent implements OnInit, AfterViewInit {
   constructor() {
     const officeTreeService = this.officeTreeService;
 
-    this.route.data.subscribe((data: { offices: any; officeDataTables: any }) => {
-      this.officesData = data.offices;
-      officeTreeService.initialize(this.officesData);
-      this.dataTablesData = data.officeDataTables;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { offices: any; officeDataTables: any }) => {
+        this.officesData = data.offices;
+        officeTreeService.initialize(this.officesData);
+        this.dataTablesData = data.officeDataTables;
+      });
     this.nestedTreeControl = new NestedTreeControl<OfficeNode>(this.getChildren);
     this.nestedTreeDataSource = new MatTreeNestedDataSource<OfficeNode>();
   }
@@ -185,11 +190,13 @@ export class OfficesComponent implements OnInit, AfterViewInit {
    */
   ngOnInit() {
     this.setOffices();
-    this.officeTreeService.treeDataChange.subscribe((officeTreeData: OfficeNode[]) => {
-      this.nestedTreeDataSource.data = officeTreeData;
-      this.nestedTreeControl.expand(this.nestedTreeDataSource.data[0]);
-      this.nestedTreeControl.dataNodes = officeTreeData;
-    });
+    this.officeTreeService.treeDataChange
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((officeTreeData: OfficeNode[]) => {
+        this.nestedTreeDataSource.data = officeTreeData;
+        this.nestedTreeControl.expand(this.nestedTreeDataSource.data[0]);
+        this.nestedTreeControl.dataNodes = officeTreeData;
+      });
   }
 
   /**

--- a/src/app/organization/offices/view-office/datatable-tabs/datatable-tabs.component.ts
+++ b/src/app/organization/offices/view-office/datatable-tabs/datatable-tabs.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -27,6 +28,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class DatatableTabsComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   entityId: string;
   /** Office Datatable */
@@ -34,14 +36,10 @@ export class DatatableTabsComponent {
   /** Multi Row Datatable Flag */
   multiRowDatatableFlag: boolean;
 
-  /**
-   * Fetches data table data from `resolve`
-   * @param {ActivatedRoute} route Activated Route.
-   */
   constructor() {
     this.entityId = this.route.parent.parent.snapshot.paramMap.get('officeId');
 
-    this.route.data.subscribe((data: { officeDatatable: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { officeDatatable: any }) => {
       this.entityDatatable = data.officeDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
     });

--- a/src/app/organization/offices/view-office/general-tab/general-tab.component.ts
+++ b/src/app/organization/offices/view-office/general-tab/general-tab.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { ExternalIdentifierComponent } from '../../../../shared/external-identifier/external-identifier.component';
 import { DateFormatPipe } from '../../../../pipes/date-format.pipe';
@@ -29,16 +30,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class GeneralTabComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Office data */
   officeData: any;
 
-  /**
-   * Fetches office data from `resolve`
-   * @param {ActivatedRoute} route Activated Route
-   */
   constructor() {
-    this.route.data.subscribe((data: { office: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { office: any }) => {
       this.officeData = data.office;
     });
   }

--- a/src/app/organization/offices/view-office/view-office.component.ts
+++ b/src/app/organization/offices/view-office/view-office.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -31,16 +32,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewOfficeComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Office datatables data */
   officeDatatables: any;
 
-  /**
-   * Fetches office datatables from `resolve`
-   * @param {ActivatedRoute} route Activated Route
-   */
   constructor() {
-    this.route.data.subscribe((data: { officeDatatables: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { officeDatatables: any }) => {
       this.officeDatatables = data.officeDatatables;
     });
   }

--- a/src/app/organization/password-preferences/password-preferences.component.ts
+++ b/src/app/organization/password-preferences/password-preferences.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -31,27 +33,23 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PasswordPreferencesComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
   /** Password preferences form. */
-  passwordPreferencesForm: UntypedFormGroup;
+  passwordPreferencesForm: FormGroup;
   /** Password preferences data. */
   passwordPreferencesData: any;
 
-  /**
-   * Retrieves the password preferences data from `resolve`.
-   * @param {FormBuilder} formBuilder Form Builder.
-   * @param {OrganizationService} organizationService Organization Service.
-   * @param {ActivatedRoute} route Activated Route.
-   * @param {Router} router Router for navigation.
-   */
   constructor() {
-    this.route.data.subscribe((data: { passwordPreferencesTemplate: any }) => {
-      this.passwordPreferencesData = data.passwordPreferencesTemplate;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { passwordPreferencesTemplate: any }) => {
+        this.passwordPreferencesData = data.passwordPreferencesTemplate;
+      });
   }
 
   /**
@@ -113,8 +111,11 @@ export class PasswordPreferencesComponent implements OnInit {
    */
   submit() {
     const passwordPreferences = this.passwordPreferencesForm.value;
-    this.organizationService.updatePasswordPreferences(passwordPreferences).subscribe((response: any) => {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizationService
+      .updatePasswordPreferences(passwordPreferences)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/payment-types/create-payment-type/create-payment-type.component.ts
+++ b/src/app/organization/payment-types/create-payment-type/create-payment-type.component.ts
@@ -8,7 +8,8 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -32,13 +33,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreatePaymentTypeComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
 
   /** Payment Type form. */
-  paymentTypeForm: UntypedFormGroup;
+  paymentTypeForm: FormGroup;
 
   /**
    * Creates and sets the payment type form.
@@ -74,8 +75,11 @@ export class CreatePaymentTypeComponent implements OnInit {
    */
   submit() {
     const paymentType = this.paymentTypeForm.value;
-    this.organizationService.createPaymentType(paymentType).subscribe((response) => {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizationService
+      .createPaymentType(paymentType)
+      .pipe(take(1))
+      .subscribe((response) => {
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/payment-types/edit-payment-type/edit-payment-type.component.ts
+++ b/src/app/organization/payment-types/edit-payment-type/edit-payment-type.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 
@@ -34,15 +36,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditPaymentTypeComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private alertService = inject(AlertService);
   private translateService = inject(TranslateService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
 
   /** Payment Type form. */
-  paymentTypeForm: UntypedFormGroup;
+  paymentTypeForm: FormGroup;
   /** Payment Type Data. */
   paymentTypeData: any;
   /** Flag to check if payment type is system defined. */
@@ -56,7 +59,7 @@ export class EditPaymentTypeComponent implements OnInit {
    * @param {Router} router Router for navigation.
    */
   constructor() {
-    this.route.data.subscribe((data: { paymentType: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { paymentType: any }) => {
       this.paymentTypeData = data.paymentType;
       this.isSystemDefined = data.paymentType.isSystemDefined;
     });
@@ -103,33 +106,39 @@ export class EditPaymentTypeComponent implements OnInit {
         name: paymentType.name,
         description: paymentType.description
       };
-      this.organizationService.updatePaymentType(this.paymentTypeData.id, systemDefinedPayload).subscribe({
-        next: (response) => {
-          this.router.navigate(['../../'], { relativeTo: this.route });
-        },
-        error: (error) => {
-          this.alertService.alert({
-            type: 'Error',
-            message:
-              error.error?.defaultUserMessage ||
-              this.translateService.instant('labels.text.Failed to update payment type. Please try again.')
-          });
-        }
-      });
+      this.organizationService
+        .updatePaymentType(this.paymentTypeData.id, systemDefinedPayload)
+        .pipe(take(1))
+        .subscribe({
+          next: (response) => {
+            this.router.navigate(['../../'], { relativeTo: this.route });
+          },
+          error: (error) => {
+            this.alertService.alert({
+              type: 'Error',
+              message:
+                error.error?.defaultUserMessage ||
+                this.translateService.instant('labels.text.Failed to update payment type. Please try again.')
+            });
+          }
+        });
     } else {
-      this.organizationService.updatePaymentType(this.paymentTypeData.id, paymentType).subscribe({
-        next: (response) => {
-          this.router.navigate(['../../'], { relativeTo: this.route });
-        },
-        error: (error) => {
-          this.alertService.alert({
-            type: 'Error',
-            message:
-              error.error?.defaultUserMessage ||
-              this.translateService.instant('labels.text.Failed to update payment type. Please try again.')
-          });
-        }
-      });
+      this.organizationService
+        .updatePaymentType(this.paymentTypeData.id, paymentType)
+        .pipe(take(1))
+        .subscribe({
+          next: (response) => {
+            this.router.navigate(['../../'], { relativeTo: this.route });
+          },
+          error: (error) => {
+            this.alertService.alert({
+              type: 'Error',
+              message:
+                error.error?.defaultUserMessage ||
+                this.translateService.instant('labels.text.Failed to update payment type. Please try again.')
+            });
+          }
+        });
     }
   }
 }

--- a/src/app/organization/payment-types/payment-types.component.ts
+++ b/src/app/organization/payment-types/payment-types.component.ts
@@ -7,7 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -66,6 +68,7 @@ export class PaymentTypesComponent implements OnInit {
   private organizationService = inject(OrganizationService);
   private route = inject(ActivatedRoute);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Payment Types data. */
   paymentTypesData: any;
@@ -94,7 +97,7 @@ export class PaymentTypesComponent implements OnInit {
    * @param {MatDialog} dialog Dialog reference.
    */
   constructor() {
-    this.route.data.subscribe((data: { paymentTypes: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { paymentTypes: any }) => {
       this.paymentTypesData = data.paymentTypes;
     });
   }
@@ -133,10 +136,15 @@ export class PaymentTypesComponent implements OnInit {
     });
     deletePaymentTypeDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
-        this.organizationService.deletePaymentType(paymentTypeId).subscribe(() => {
-          this.paymentTypesData = this.paymentTypesData.filter((paymentType: any) => paymentType.id !== paymentTypeId);
-          this.setPaymentTypes();
-        });
+        this.organizationService
+          .deletePaymentType(paymentTypeId)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.paymentTypesData = this.paymentTypesData.filter(
+              (paymentType: any) => paymentType.id !== paymentTypeId
+            );
+            this.setPaymentTypes();
+          });
       }
     });
   }

--- a/src/app/organization/sms-campaigns/create-campaign/create-campaign.component.ts
+++ b/src/app/organization/sms-campaigns/create-campaign/create-campaign.component.ts
@@ -7,7 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 
 /** Custom Components */
@@ -47,6 +49,7 @@ export class CreateCampaignComponent {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private settingsService = inject(SettingsService);
   private dateUtils = inject(Dates);
 
@@ -60,16 +63,8 @@ export class CreateCampaignComponent {
   /** Campaign Message Step */
   @ViewChild(CampaignMessageStepComponent, { static: true }) campaignMessageStep: CampaignMessageStepComponent;
 
-  /**
-   * Fetches campaign template from `resolve`
-   * @param {ActivatedRoute} route Activated Route
-   * @param {Router} router Router
-   * @param {OrganizationService} organizationService Organization Service
-   * @param {SettingsService} settingsService Settings Service
-   * @param {Dates} dateUtils Date Utils
-   */
   constructor() {
-    this.route.data.subscribe((data: { smsCampaignTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { smsCampaignTemplate: any }) => {
       this.smsCampaignTemplate = data.smsCampaignTemplate;
     });
   }
@@ -119,14 +114,17 @@ export class CreateCampaignComponent {
       const prevRecurrenceDate: Date = smsCampaign.recurrenceStartDate;
       smsCampaign.recurrenceStartDate = this.dateUtils.formatDate(prevRecurrenceDate, dateTimeFormat);
     }
-    this.organizationService.createSmsCampaign(smsCampaign).subscribe((response: any) => {
-      this.router.navigate(
-        [
-          '../',
-          response.resourceId
-        ],
-        { relativeTo: this.route }
-      );
-    });
+    this.organizationService
+      .createSmsCampaign(smsCampaign)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(
+          [
+            '../',
+            response.resourceId
+          ],
+          { relativeTo: this.route }
+        );
+      });
   }
 }

--- a/src/app/organization/sms-campaigns/edit-campaign/edit-campaign.component.ts
+++ b/src/app/organization/sms-campaigns/edit-campaign/edit-campaign.component.ts
@@ -7,7 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -49,6 +51,7 @@ export class EditCampaignComponent {
   private dateUtils = inject(Dates);
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** smsCampaign */
   smsCampaign: any;
@@ -69,11 +72,13 @@ export class EditCampaignComponent {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { smsCampaign: any; smsCampaignTemplate: any }) => {
-      this.smsCampaignTemplate = data.smsCampaignTemplate;
-      this.smsCampaign = data.smsCampaign;
-      this.smsCampaign.editFlag = true;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { smsCampaign: any; smsCampaignTemplate: any }) => {
+        this.smsCampaignTemplate = data.smsCampaignTemplate;
+        this.smsCampaign = data.smsCampaign;
+        this.smsCampaign.editFlag = true;
+      });
   }
 
   /**
@@ -118,8 +123,11 @@ export class EditCampaignComponent {
         dateTimeFormat
       );
     }
-    this.organizationService.updateSmsCampaign(smsCampaign, this.smsCampaign.id).subscribe((response: any) => {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizationService
+      .updateSmsCampaign(smsCampaign, this.smsCampaign.id)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/sms-campaigns/sms-campaign-stepper/campaign-message-step/campaign-message-step.component.ts
+++ b/src/app/organization/sms-campaigns/sms-campaign-stepper/campaign-message-step/campaign-message-step.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -37,7 +37,7 @@ export class CampaignMessageStepComponent implements OnChanges {
   @Input() editCampaignMessage: any;
 
   /** Camapaign Message */
-  message = new UntypedFormControl('');
+  message = new FormControl('');
   /** Column header names */
   parameterLabels: any[];
 

--- a/src/app/organization/sms-campaigns/sms-campaign-stepper/edit-sms-campaign-step/edit-business-rule-parameters/edit-business-rule-parameters.component.ts
+++ b/src/app/organization/sms-campaigns/sms-campaign-stepper/edit-sms-campaign-step/edit-business-rule-parameters/edit-business-rule-parameters.component.ts
@@ -15,12 +15,14 @@ import {
   Output,
   EventEmitter,
   OnInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
-import { Validators, UntypedFormGroup, UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Validators, FormGroup, FormControl, ReactiveFormsModule } from '@angular/forms';
 
 /** Rxjs Imports */
-import { distinctUntilChanged } from 'rxjs/operators';
+import { distinctUntilChanged, take } from 'rxjs/operators';
 
 /** Custom Services */
 import { ReportsService } from 'app/reports/reports.service';
@@ -58,6 +60,7 @@ export class EditBusinessRuleParametersComponent implements OnInit, OnChanges {
   private reportsService = inject(ReportsService);
   private settingsService = inject(SettingsService);
   private dateUtils = inject(Dates);
+  private destroyRef = inject(DestroyRef);
 
   /** Run Report Parameters Data */
   @Input() paramData: any;
@@ -67,7 +70,7 @@ export class EditBusinessRuleParametersComponent implements OnInit, OnChanges {
   @Output() templateParameters = new EventEmitter();
 
   /** Initializes new form group ReportForm */
-  ReportForm = new UntypedFormGroup({});
+  ReportForm = new FormGroup({});
   /** Array of all parent parameters */
   parentParameters: any[] = [];
   /** Displayed user choices */
@@ -83,7 +86,7 @@ export class EditBusinessRuleParametersComponent implements OnInit, OnChanges {
 
   ngOnChanges() {
     if (this.paramData) {
-      this.ReportForm = new UntypedFormGroup({});
+      this.ReportForm = new FormGroup({});
       this.paramValue = JSON.parse(this.smsCampaign.paramValue);
       this.createRunReportForm();
       this.disableFormWhenValid();
@@ -99,7 +102,7 @@ export class EditBusinessRuleParametersComponent implements OnInit, OnChanges {
     this.paramData.forEach((param: any) => {
       if (!param.parentParameterName) {
         // Non Child Parameter
-        this.ReportForm.addControl(param.name, new UntypedFormControl('', Validators.required));
+        this.ReportForm.addControl(param.name, new FormControl('', Validators.required));
         const controlValue = this.paramValue[param.variable].toString();
         switch (param.displayType) {
           case 'text':
@@ -145,19 +148,21 @@ export class EditBusinessRuleParametersComponent implements OnInit, OnChanges {
    */
   setChildControls() {
     this.parentParameters.forEach((param: ReportParameter) => {
-      this.ReportForm.get(param.name).valueChanges.subscribe((option: any) => {
-        param.childParameters.forEach((child: ReportParameter) => {
-          if (child.displayType === 'none') {
-            this.ReportForm.addControl(child.name, new UntypedFormControl(child.defaultVal));
-          } else {
-            this.ReportForm.addControl(child.name, new UntypedFormControl('', Validators.required));
-          }
-          if (child.displayType === 'select') {
-            const inputstring = `${child.name}?${param.inputName}=${option.id}`;
-            this.fetchSelectOptions(child, inputstring);
-          }
+      this.ReportForm.get(param.name)
+        .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((option: any) => {
+          param.childParameters.forEach((child: ReportParameter) => {
+            if (child.displayType === 'none') {
+              this.ReportForm.addControl(child.name, new FormControl(child.defaultVal));
+            } else {
+              this.ReportForm.addControl(child.name, new FormControl('', Validators.required));
+            }
+            if (child.displayType === 'select') {
+              const inputstring = `${child.name}?${param.inputName}=${option.id}`;
+              this.fetchSelectOptions(child, inputstring);
+            }
+          });
         });
-      });
     });
   }
 
@@ -167,15 +172,18 @@ export class EditBusinessRuleParametersComponent implements OnInit, OnChanges {
    * @param {string} inputstring url substring for API call.
    */
   fetchSelectOptions(param: ReportParameter, inputstring: string) {
-    this.reportsService.getSelectOptions(inputstring).subscribe((options: SelectOption[]) => {
-      param.selectOptions = options;
-      if (param.selectAll === 'Y') {
-        param.selectOptions.push({ id: '-1', name: 'All' });
-      }
-      const optionId = this.paramValue[param.variable].toString();
-      const option = options.find((entry) => entry.id === optionId);
-      this.ReportForm.controls[param.name].patchValue({ id: optionId, name: option.name });
-    });
+    this.reportsService
+      .getSelectOptions(inputstring)
+      .pipe(take(1))
+      .subscribe((options: SelectOption[]) => {
+        param.selectOptions = options;
+        if (param.selectAll === 'Y') {
+          param.selectOptions.push({ id: '-1', name: 'All' });
+        }
+        const optionId = this.paramValue[param.variable].toString();
+        const option = options.find((entry) => entry.id === optionId);
+        this.ReportForm.get(param.name).patchValue({ id: optionId, name: option.name });
+      });
   }
 
   /**
@@ -192,11 +200,13 @@ export class EditBusinessRuleParametersComponent implements OnInit, OnChanges {
    * Disable the Report Form once all values are patched.
    */
   disableFormWhenValid() {
-    this.ReportForm.statusChanges.pipe(distinctUntilChanged()).subscribe((status: string) => {
-      if (status === 'VALID') {
-        this.ReportForm.disable();
-      }
-    });
+    this.ReportForm.statusChanges
+      .pipe(distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
+      .subscribe((status: string) => {
+        if (status === 'VALID') {
+          this.ReportForm.disable();
+        }
+      });
   }
 
   /**
@@ -226,14 +236,17 @@ export class EditBusinessRuleParametersComponent implements OnInit, OnChanges {
     const reportName = this.paramValue.reportName;
     delete this.paramValue.reportName;
     const formattedResponse = this.formatUserResponse(this.paramValue, true);
-    this.reportsService.getRunReportData(reportName, formattedResponse).subscribe(
-      (response: any) => {
-        this.templateParameters.emit(response.columnHeaders);
-      },
-      (error: any) => {
-        this.templateParameters.emit(null);
-        this.ReportForm.disable();
-      }
-    );
+    this.reportsService
+      .getRunReportData(reportName, formattedResponse)
+      .pipe(take(1))
+      .subscribe(
+        (response: any) => {
+          this.templateParameters.emit(response.columnHeaders);
+        },
+        (error: any) => {
+          this.templateParameters.emit(null);
+          this.ReportForm.disable();
+        }
+      );
   }
 }

--- a/src/app/organization/sms-campaigns/sms-campaign-stepper/edit-sms-campaign-step/edit-sms-campaign-step.component.ts
+++ b/src/app/organization/sms-campaigns/sms-campaign-stepper/edit-sms-campaign-step/edit-sms-campaign-step.component.ts
@@ -8,13 +8,8 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, Output, Input, EventEmitter, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  Validators,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { FormGroup, Validators, FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 
 /** Custom Services */
 import { ReportsService } from 'app/reports/reports.service';
@@ -41,7 +36,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditSmsCampaignStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private reportService = inject(ReportsService);
   private settingsService = inject(SettingsService);
 
@@ -51,7 +46,7 @@ export class EditSmsCampaignStepComponent implements OnInit {
   @Input() smsCampaign: any;
 
   /** SMS Campaign Form */
-  smsCampaignDetailsForm: UntypedFormGroup;
+  smsCampaignDetailsForm: FormGroup;
   /** Data to be passed to sub component */
   paramData: any;
   /** Trigger types options */
@@ -122,9 +117,12 @@ export class EditSmsCampaignStepComponent implements OnInit {
    * Gets Template parameters and disables the SMS form.
    */
   getParameters() {
-    this.reportService.getReportParams(this.smsCampaign.reportName).subscribe((response: ReportParameter[]) => {
-      this.paramData = response;
-    });
+    this.reportService
+      .getReportParams(this.smsCampaign.reportName)
+      .pipe(take(1))
+      .subscribe((response: ReportParameter[]) => {
+        this.paramData = response;
+      });
     this.smsCampaignDetailsForm.disable();
   }
 
@@ -142,7 +140,7 @@ export class EditSmsCampaignStepComponent implements OnInit {
     if (this.smsCampaign.triggerType.value === 'Schedule') {
       this.smsCampaignDetailsForm.addControl(
         'recurrenceStartDate',
-        new UntypedFormControl(new Date(this.smsCampaign.recurrenceStartDate))
+        new FormControl(new Date(this.smsCampaign.recurrenceStartDate))
       );
     }
   }

--- a/src/app/organization/sms-campaigns/sms-campaign-stepper/sms-campaign-step/business-rule-parameters/business-rule-parameters.component.ts
+++ b/src/app/organization/sms-campaigns/sms-campaign-stepper/sms-campaign-step/business-rule-parameters/business-rule-parameters.component.ts
@@ -15,9 +15,12 @@ import {
   Output,
   EventEmitter,
   OnInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
-import { Validators, UntypedFormGroup, UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
+import { Validators, FormGroup, FormControl, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { ReportsService } from 'app/reports/reports.service';
@@ -52,6 +55,7 @@ export class BusinessRuleParametersComponent implements OnInit, OnChanges {
   private reportsService = inject(ReportsService);
   private settingsService = inject(SettingsService);
   private dateUtils = inject(Dates);
+  private destroyRef = inject(DestroyRef);
 
   /** Run Report Parameters Data */
   @Input() paramData: any;
@@ -59,7 +63,7 @@ export class BusinessRuleParametersComponent implements OnInit, OnChanges {
   /** Report Name */
   reportName: string;
   /** Initializes new form group ReportForm */
-  ReportForm = new UntypedFormGroup({});
+  ReportForm = new FormGroup({});
   /** Array of all parent parameters */
   parentParameters: any[] = [];
   /** Minimum Date allowed. */
@@ -76,7 +80,7 @@ export class BusinessRuleParametersComponent implements OnInit, OnChanges {
 
   ngOnChanges() {
     if (this.paramData) {
-      this.ReportForm = new UntypedFormGroup({});
+      this.ReportForm = new FormGroup({});
       this.reportName = this.paramData.reportName;
       this.paramData = this.paramData.response;
       this.createRunReportForm();
@@ -100,7 +104,7 @@ export class BusinessRuleParametersComponent implements OnInit, OnChanges {
     this.paramData.forEach((param: any) => {
       if (!param.parentParameterName) {
         // Non-Child Parameter
-        this.ReportForm.addControl(param.name, new UntypedFormControl('', Validators.required));
+        this.ReportForm.addControl(param.name, new FormControl('', Validators.required));
         if (param.displayType === 'select') {
           this.fetchSelectOptions(param, param.name);
         }
@@ -135,19 +139,21 @@ export class BusinessRuleParametersComponent implements OnInit, OnChanges {
    */
   setChildControls() {
     this.parentParameters.forEach((param: ReportParameter) => {
-      this.ReportForm.get(param.name).valueChanges.subscribe((option: any) => {
-        param.childParameters.forEach((child: ReportParameter) => {
-          if (child.displayType === 'none') {
-            this.ReportForm.addControl(child.name, new UntypedFormControl(child.defaultVal));
-          } else {
-            this.ReportForm.addControl(child.name, new UntypedFormControl('', Validators.required));
-          }
-          if (child.displayType === 'select') {
-            const inputstring = `${child.name}?${param.inputName}=${option.id}`;
-            this.fetchSelectOptions(child, inputstring);
-          }
+      this.ReportForm.get(param.name)
+        .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((option: any) => {
+          param.childParameters.forEach((child: ReportParameter) => {
+            if (child.displayType === 'none') {
+              this.ReportForm.addControl(child.name, new FormControl(child.defaultVal));
+            } else {
+              this.ReportForm.addControl(child.name, new FormControl('', Validators.required));
+            }
+            if (child.displayType === 'select') {
+              const inputstring = `${child.name}?${param.inputName}=${option.id}`;
+              this.fetchSelectOptions(child, inputstring);
+            }
+          });
         });
-      });
     });
   }
 
@@ -157,12 +163,15 @@ export class BusinessRuleParametersComponent implements OnInit, OnChanges {
    * @param {string} inputstring url substring for API call.
    */
   fetchSelectOptions(param: ReportParameter, inputstring: string) {
-    this.reportsService.getSelectOptions(inputstring).subscribe((options: SelectOption[]) => {
-      param.selectOptions = options;
-      if (param.selectAll === 'Y') {
-        param.selectOptions.push({ id: '-1', name: 'All' });
-      }
-    });
+    this.reportsService
+      .getSelectOptions(inputstring)
+      .pipe(take(1))
+      .subscribe((options: SelectOption[]) => {
+        param.selectOptions = options;
+        if (param.selectAll === 'Y') {
+          param.selectOptions.push({ id: '-1', name: 'All' });
+        }
+      });
   }
 
   /**
@@ -204,13 +213,16 @@ export class BusinessRuleParametersComponent implements OnInit, OnChanges {
    */
   getResponseHeaders() {
     const formattedresponse = this.formatUserResponse(this.ReportForm.value, true);
-    this.reportsService.getRunReportData(this.reportName, formattedresponse).subscribe(
-      (response: any) => {
-        this.templateParameters.emit(response.columnHeaders);
-      },
-      (error: any) => {
-        this.templateParameters.emit(null);
-      }
-    );
+    this.reportsService
+      .getRunReportData(this.reportName, formattedresponse)
+      .pipe(take(1))
+      .subscribe({
+        next: (response: any) => {
+          this.templateParameters.emit(response.columnHeaders);
+        },
+        error: (error: any) => {
+          this.templateParameters.emit(null);
+        }
+      });
   }
 }

--- a/src/app/organization/sms-campaigns/sms-campaign-stepper/sms-campaign-step/sms-campaign-step.component.ts
+++ b/src/app/organization/sms-campaigns/sms-campaign-stepper/sms-campaign-step/sms-campaign-step.component.ts
@@ -15,15 +15,12 @@ import {
   ViewChild,
   EventEmitter,
   Output,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 
 /** Custom Services */
 import { ReportsService } from 'app/reports/reports.service';
@@ -56,8 +53,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SmsCampaignStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private reportService = inject(ReportsService);
+  private destroyRef = inject(DestroyRef);
 
   /** SMS Campaign Template */
   @Input() smsCampaignTemplate: any;
@@ -70,7 +68,7 @@ export class SmsCampaignStepComponent implements OnInit {
   maxDate = new Date(new Date().setFullYear(new Date().getFullYear() + 10));
 
   /** SMS Campaign Form */
-  smsCampaignDetailsForm: UntypedFormGroup;
+  smsCampaignDetailsForm: FormGroup;
   /** Data to be passed to sub component */
   paramData: any;
   /** Trigger types options */
@@ -107,14 +105,14 @@ export class SmsCampaignStepComponent implements OnInit {
    * Else returns a cumulative form group.
    */
   get smsCampaignFormGroup() {
-    let smsCampaignFormGroup: UntypedFormGroup;
+    let smsCampaignFormGroup: FormGroup;
     if (this.businessRuleParametersComponent) {
-      smsCampaignFormGroup = new UntypedFormGroup({
+      smsCampaignFormGroup = new FormGroup({
         smsCampaign: this.smsCampaignDetailsForm,
         businessRule: this.businessRuleParametersComponent.ReportForm
       });
     } else {
-      smsCampaignFormGroup = new UntypedFormGroup({
+      smsCampaignFormGroup = new FormGroup({
         smsCampaign: this.smsCampaignDetailsForm
       });
     }
@@ -171,86 +169,101 @@ export class SmsCampaignStepComponent implements OnInit {
    * Gets reports parameters and passes it to subcomponent on business rule value changes.
    */
   buildDependencies() {
-    this.smsCampaignDetailsForm.get('isNotification').valueChanges.subscribe((value: boolean) => {
-      if (!value) {
-        this.smsCampaignDetailsForm.addControl('providerId', new UntypedFormControl(null));
-      } else {
-        this.smsCampaignDetailsForm.removeControl('providerId');
-      }
-    });
-    this.smsCampaignDetailsForm.get('runReportId').valueChanges.subscribe((value: number) => {
-      if (value) {
-        const report = this.businessRules.find((rule: any) => rule.reportId === value);
-        this.reportService.getReportParams(report.reportName).subscribe((response: ReportParameter[]) => {
-          this.paramData = { response, reportName: report.reportName };
-        });
-      }
-    });
-    this.smsCampaignDetailsForm.get('triggerType').valueChanges.subscribe((value: number) => {
-      this.templateParameters.emit(null);
-      this.businessRules = this.smsCampaignTemplate.businessRulesOptions;
-      if (this.smsCampaignDetailsForm.controls.runReportId.value) {
-        this.smsCampaignDetailsForm.get('runReportId').patchValue('');
-      }
-      if (value === 3) {
-        this.businessRules = this.businessRules.filter((rule: any) => rule.reportSubType === 'Triggered');
-      } else {
-        this.businessRules = this.businessRules.filter((rule: any) => rule.reportSubType !== 'Triggered');
-      }
-      if (value === 2) {
-        this.smsCampaignDetailsForm.addControl('recurrenceStartDate', new UntypedFormControl('', Validators.required));
-        this.smsCampaignDetailsForm.addControl('frequency', new UntypedFormControl('', Validators.required));
-        this.smsCampaignDetailsForm.addControl('interval', new UntypedFormControl('', Validators.required));
-        this.smsCampaignDetailsForm.get('frequency').valueChanges.subscribe((frequency: number) => {
+    this.smsCampaignDetailsForm
+      .get('isNotification')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value: boolean) => {
+        if (!value) {
+          this.smsCampaignDetailsForm.addControl('providerId', new FormControl(null));
+        } else {
+          this.smsCampaignDetailsForm.removeControl('providerId');
+        }
+      });
+    this.smsCampaignDetailsForm
+      .get('runReportId')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value: number) => {
+        if (value) {
+          const report = this.businessRules.find((rule: any) => rule.reportId === value);
+          this.reportService
+            .getReportParams(report.reportName)
+            .pipe(take(1))
+            .subscribe((response: ReportParameter[]) => {
+              this.paramData = { response, reportName: report.reportName };
+            });
+        }
+      });
+    this.smsCampaignDetailsForm
+      .get('triggerType')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value: number) => {
+        this.templateParameters.emit(null);
+        this.businessRules = this.smsCampaignTemplate.businessRulesOptions;
+        if (this.smsCampaignDetailsForm.controls.runReportId.value) {
+          this.smsCampaignDetailsForm.get('runReportId').patchValue('');
+        }
+        if (value === 3) {
+          this.businessRules = this.businessRules.filter((rule: any) => rule.reportSubType === 'Triggered');
+        } else {
+          this.businessRules = this.businessRules.filter((rule: any) => rule.reportSubType !== 'Triggered');
+        }
+        if (value === 2) {
+          this.smsCampaignDetailsForm.addControl('recurrenceStartDate', new FormControl('', Validators.required));
+          this.smsCampaignDetailsForm.addControl('frequency', new FormControl('', Validators.required));
+          this.smsCampaignDetailsForm.addControl('interval', new FormControl('', Validators.required));
+          this.smsCampaignDetailsForm
+            .get('frequency')
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((frequency: number) => {
+              this.smsCampaignDetailsForm.removeControl('repeatsOnDay');
+              switch (frequency) {
+                case 1: // Daily
+                  this.repetitionIntervals = [
+                    '1',
+                    '2',
+                    '3'
+                  ];
+                  break;
+                case 2: // Weekly
+                  this.repetitionIntervals = [
+                    '1',
+                    '2',
+                    '3'
+                  ];
+                  this.smsCampaignDetailsForm.addControl('repeatsOnDay', new FormControl('', Validators.required));
+                  break;
+                case 3: // Monthly
+                  this.repetitionIntervals = [
+                    '1',
+                    '2',
+                    '3',
+                    '4',
+                    '5',
+                    '6',
+                    '7',
+                    '8',
+                    '9',
+                    '10',
+                    '11'
+                  ];
+                  break;
+                case 4: // Yearly
+                  this.repetitionIntervals = [
+                    '1',
+                    '2',
+                    '3',
+                    '4',
+                    '5'
+                  ];
+                  break;
+              }
+            });
+        } else {
+          this.smsCampaignDetailsForm.removeControl('recurrenceStartDate');
+          this.smsCampaignDetailsForm.removeControl('frequency');
+          this.smsCampaignDetailsForm.removeControl('interval');
           this.smsCampaignDetailsForm.removeControl('repeatsOnDay');
-          switch (frequency) {
-            case 1: // Daily
-              this.repetitionIntervals = [
-                '1',
-                '2',
-                '3'
-              ];
-              break;
-            case 2: // Weekly
-              this.repetitionIntervals = [
-                '1',
-                '2',
-                '3'
-              ];
-              this.smsCampaignDetailsForm.addControl('repeatsOnDay', new UntypedFormControl('', Validators.required));
-              break;
-            case 3: // Monthly
-              this.repetitionIntervals = [
-                '1',
-                '2',
-                '3',
-                '4',
-                '5',
-                '6',
-                '7',
-                '8',
-                '9',
-                '10',
-                '11'
-              ];
-              break;
-            case 4: // Yearly
-              this.repetitionIntervals = [
-                '1',
-                '2',
-                '3',
-                '4',
-                '5'
-              ];
-              break;
-          }
-        });
-      } else {
-        this.smsCampaignDetailsForm.removeControl('recurrenceStartDate');
-        this.smsCampaignDetailsForm.removeControl('frequency');
-        this.smsCampaignDetailsForm.removeControl('interval');
-        this.smsCampaignDetailsForm.removeControl('repeatsOnDay');
-      }
-    });
+        }
+      });
   }
 }

--- a/src/app/organization/sms-campaigns/sms-campaigns.component.ts
+++ b/src/app/organization/sms-campaigns/sms-campaigns.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -25,8 +26,6 @@ import {
 } from '@angular/material/table';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
-/** rxjs Imports */
-import { of } from 'rxjs';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatTooltip } from '@angular/material/tooltip';
 import { TitleCasePipe } from '@angular/common';
@@ -64,6 +63,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class SmsCampaignsComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** SMS Campaigns data. */
   smsCampaignsData: any;
@@ -89,7 +89,7 @@ export class SmsCampaignsComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { smsCampaigns: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { smsCampaigns: any }) => {
       this.smsCampaignsData = data.smsCampaigns.pageItems;
     });
   }

--- a/src/app/organization/sms-campaigns/view-campaign/view-campaign.component.ts
+++ b/src/app/organization/sms-campaigns/view-campaign/view-campaign.component.ts
@@ -7,11 +7,11 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, ViewChild, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, ViewChild, inject, DestroyRef } from '@angular/core';
+import { FormGroup, FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { take } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   MatTableDataSource,
   MatTable,
@@ -78,15 +78,16 @@ export class ViewCampaignComponent implements OnInit, OnDestroy {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private dialog = inject(MatDialog);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private dateUtils = inject(Dates);
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
   private dataReloadService = inject(DataReloadService);
+  private destroyRef = inject(DestroyRef);
 
   minDate = new Date(2000, 0, 1);
   maxDate = new Date();
-  smsForm: UntypedFormGroup;
+  smsForm: FormGroup;
   smsCampaignData: any;
   status: any;
   displayedColumns: string[] = [
@@ -98,7 +99,6 @@ export class ViewCampaignComponent implements OnInit, OnDestroy {
   dataSource = new MatTableDataSource();
 
   private reloadContext!: string;
-  private destroy$ = new Subject<void>();
 
   /** Message Table Reference */
   @ViewChild('messageTable') messageTableRef: MatTable<Element>;
@@ -128,14 +128,14 @@ export class ViewCampaignComponent implements OnInit, OnDestroy {
   ];
 
   ngOnInit(): void {
-    this.route.data.pipe(takeUntil(this.destroy$)).subscribe((data: { smsCampaign: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { smsCampaign: any }) => {
       this.smsCampaignData = data.smsCampaign;
       this.reloadContext = `sms-campaign-${this.smsCampaignData.id}`;
 
       // Subscribe to reload events after we have the campaign ID
       this.dataReloadService
         .getReloadObservable(this.reloadContext)
-        .pipe(takeUntil(this.destroy$))
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe(() => {
           this.refreshData();
         });
@@ -146,8 +146,6 @@ export class ViewCampaignComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
     if (this.reloadContext) {
       this.dataReloadService.cleanup(this.reloadContext);
     }
@@ -208,6 +206,7 @@ export class ViewCampaignComponent implements OnInit, OnDestroy {
         };
         this.organizationService
           .executeSmsCampaignCommand(this.smsCampaignData.id, dataObject, 'close')
+          .pipe(take(1))
           .subscribe(() => {
             this.reload();
           });
@@ -245,6 +244,7 @@ export class ViewCampaignComponent implements OnInit, OnDestroy {
         };
         this.organizationService
           .executeSmsCampaignCommand(this.smsCampaignData.id, dataObject, 'activate')
+          .pipe(take(1))
           .subscribe(() => {
             this.reload();
           });
@@ -282,6 +282,7 @@ export class ViewCampaignComponent implements OnInit, OnDestroy {
         };
         this.organizationService
           .executeSmsCampaignCommand(this.smsCampaignData.id, dataObject, 'reactivate')
+          .pipe(take(1))
           .subscribe(() => {
             this.reload();
           });
@@ -298,9 +299,12 @@ export class ViewCampaignComponent implements OnInit, OnDestroy {
     });
     deleteSmsCampaignDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
-        this.organizationService.deleteSmsCampaign(this.smsCampaignData.id).subscribe(() => {
-          this.router.navigate(['../'], { relativeTo: this.route });
-        });
+        this.organizationService
+          .deleteSmsCampaign(this.smsCampaignData.id)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.router.navigate(['../'], { relativeTo: this.route });
+          });
       }
     });
   }
@@ -318,7 +322,7 @@ export class ViewCampaignComponent implements OnInit, OnDestroy {
   private refreshData(): void {
     this.organizationService
       .getSmsCampaign(this.smsCampaignData.id)
-      .pipe(takeUntil(this.destroy$))
+      .pipe(take(1))
       .subscribe((data: any) => {
         this.smsCampaignData = data;
       });
@@ -346,9 +350,12 @@ export class ViewCampaignComponent implements OnInit, OnDestroy {
       dateFormat,
       locale
     };
-    this.organizationService.getMessagebyStatus(data).subscribe((response: any) => {
-      this.dataSource.data = response.pageItems;
-      this.messageTableRef.renderRows();
-    });
+    this.organizationService
+      .getMessagebyStatus(data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.dataSource.data = response.pageItems;
+        this.messageTableRef.renderRows();
+      });
   }
 }

--- a/src/app/organization/standing-instructions-history/standing-instructions-history.component.ts
+++ b/src/app/organization/standing-instructions-history/standing-instructions-history.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -23,7 +24,8 @@ import {
   MatRowDef,
   MatRow
 } from '@angular/material/table';
-import { UntypedFormGroup, UntypedFormBuilder, UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -64,8 +66,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class StandingInstructionsHistoryComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   private settingsService = inject(SettingsService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
@@ -76,7 +79,7 @@ export class StandingInstructionsHistoryComponent implements OnInit {
   /** Maximum Date allowed. */
   maxDate = new Date();
   /** Instruction  form. */
-  instructionForm: UntypedFormGroup;
+  instructionForm: FormGroup;
   /** Standing Instructions Template */
   standingInstructionsTemplate: any;
   /** Toggles b/w form and table */
@@ -111,9 +114,11 @@ export class StandingInstructionsHistoryComponent implements OnInit {
    * @param {Dates} dateUtils Date Utils to format date.
    */
   constructor() {
-    this.route.data.subscribe((data: { standingInstructionsTemplate: any }) => {
-      this.standingInstructionsTemplate = data.standingInstructionsTemplate;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { standingInstructionsTemplate: any }) => {
+        this.standingInstructionsTemplate = data.standingInstructionsTemplate;
+      });
   }
 
   ngOnInit() {
@@ -140,9 +145,12 @@ export class StandingInstructionsHistoryComponent implements OnInit {
    * Sets conditional child controls.
    */
   buildDependencies() {
-    this.instructionForm.get('fromAccountType').valueChanges.subscribe(() => {
-      this.instructionForm.addControl('fromAccountId', new UntypedFormControl(''));
-    });
+    this.instructionForm
+      .get('fromAccountType')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.instructionForm.addControl('fromAccountId', new FormControl(''));
+      });
   }
 
   /**
@@ -176,8 +184,11 @@ export class StandingInstructionsHistoryComponent implements OnInit {
       dateFormat,
       locale
     };
-    this.organizationService.getStandingInstructions(data).subscribe((response: any) => {
-      this.setInstructions(response.pageItems);
-    });
+    this.organizationService
+      .getStandingInstructions(data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.setInstructions(response.pageItems);
+      });
   }
 }

--- a/src/app/organization/tellers/cashiers/allocate-cash/allocate-cash.component.ts
+++ b/src/app/organization/tellers/cashiers/allocate-cash/allocate-cash.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -30,12 +32,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AllocateCashComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private dateUtils = inject(Dates);
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum Date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -44,7 +47,7 @@ export class AllocateCashComponent implements OnInit {
   /** Cashier data. */
   cashierData: any;
   /** Cashier Form. */
-  allocateCashForm: UntypedFormGroup;
+  allocateCashForm: FormGroup;
 
   /**
    * Get cashier data from `Resolver`.
@@ -56,7 +59,7 @@ export class AllocateCashComponent implements OnInit {
    * @param {Router} router Router.
    */
   constructor() {
-    this.route.data.subscribe((data: { cashierTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { cashierTemplate: any }) => {
       this.cashierData = data.cashierTemplate;
     });
   }
@@ -120,6 +123,7 @@ export class AllocateCashComponent implements OnInit {
     };
     this.organizationService
       .allocateCash(this.cashierData.tellerId, this.cashierData.cashierId, data)
+      .pipe(take(1))
       .subscribe((response: any) => {
         this.router.navigate(['../'], { relativeTo: this.route });
       });

--- a/src/app/organization/tellers/cashiers/cashiers.component.ts
+++ b/src/app/organization/tellers/cashiers/cashiers.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -61,6 +62,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class CashiersComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Cashiers data. */
   cashiersData: any;
@@ -84,7 +86,7 @@ export class CashiersComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { cashiersData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { cashiersData: any }) => {
       this.cashiersData = data.cashiersData.cashiers;
     });
   }

--- a/src/app/organization/tellers/cashiers/create-cashier/create-cashier.component.ts
+++ b/src/app/organization/tellers/cashiers/create-cashier/create-cashier.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -32,12 +34,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateCashierComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum Date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -46,7 +49,7 @@ export class CreateCashierComponent implements OnInit {
   /** Cashier Template. */
   cashierTemplate: any;
   /** Create cashier form. */
-  createCashierForm: UntypedFormGroup;
+  createCashierForm: FormGroup;
   /** Hours options for time selection (00-23). */
   hours: string[] = Array.from({ length: 24 }, (_, i) => i.toString().padStart(2, '0'));
   /** Minutes options for time selection (00-59). */
@@ -62,7 +65,7 @@ export class CreateCashierComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { cashierTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { cashierTemplate: any }) => {
       this.cashierTemplate = data.cashierTemplate;
     });
   }
@@ -147,8 +150,11 @@ export class CreateCashierComponent implements OnInit {
       data.startTime = `${hourStart}:${minStart}`;
       data.endTime = `${hourEnd}:${minEnd}`;
     }
-    this.organizationService.createCashier(this.cashierTemplate.tellerId, data).subscribe((response: any) => {
-      this.router.navigate(['../'], { relativeTo: this.route });
-    });
+    this.organizationService
+      .createCashier(this.cashierTemplate.tellerId, data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(['../'], { relativeTo: this.route });
+      });
   }
 }

--- a/src/app/organization/tellers/cashiers/edit-cashier/edit-cashier.component.ts
+++ b/src/app/organization/tellers/cashiers/edit-cashier/edit-cashier.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -32,17 +34,18 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditCashierComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Cashier Data. */
   cashierData: any = new Object();
   /** Edit cashier form. */
-  editCashierForm: UntypedFormGroup;
+  editCashierForm: FormGroup;
   /** Is Staff ID present. */
   isStaffId = true;
   /** Minimum Date allowed. */
@@ -64,13 +67,15 @@ export class EditCashierComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { cashier: any; cashierTemplate: any }) => {
-      this.cashierData.data = data.cashier;
-      this.cashierData.template = data.cashierTemplate;
-      this.isStaffId = this.cashierData.template.staffOptions.some(
-        (element: any) => element.id === this.cashierData.data.staffId
-      );
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { cashier: any; cashierTemplate: any }) => {
+        this.cashierData.data = data.cashier;
+        this.cashierData.template = data.cashierTemplate;
+        this.isStaffId = this.cashierData.template.staffOptions.some(
+          (element: any) => element.id === this.cashierData.data.staffId
+        );
+      });
   }
 
   ngOnInit() {
@@ -172,6 +177,7 @@ export class EditCashierComponent implements OnInit {
     }
     this.organizationService
       .updateCashier(this.cashierData.data.tellerId, this.cashierData.data.id, data)
+      .pipe(take(1))
       .subscribe((response: any) => {
         this.router.navigate(['../'], { relativeTo: this.route });
       });

--- a/src/app/organization/tellers/cashiers/settle-cash/settle-cash.component.ts
+++ b/src/app/organization/tellers/cashiers/settle-cash/settle-cash.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -27,12 +29,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SettleCashComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private dateUtils = inject(Dates);
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum Date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -41,7 +44,7 @@ export class SettleCashComponent implements OnInit {
   /** Cashier data. */
   cashierData: any;
   /** Cashier Form. */
-  settleCashForm: UntypedFormGroup;
+  settleCashForm: FormGroup;
 
   /**
    * Get cashier data from `Resolver`.
@@ -53,7 +56,7 @@ export class SettleCashComponent implements OnInit {
    * @param {Router} router Router.
    */
   constructor() {
-    this.route.data.subscribe((data: { cashierTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { cashierTemplate: any }) => {
       this.cashierData = data.cashierTemplate;
     });
   }
@@ -117,6 +120,7 @@ export class SettleCashComponent implements OnInit {
     };
     this.organizationService
       .settleCash(this.cashierData.tellerId, this.cashierData.cashierId, data)
+      .pipe(take(1))
       .subscribe((response: any) => {
         this.router.navigate(['../'], { relativeTo: this.route });
       });

--- a/src/app/organization/tellers/cashiers/transactions/transactions.component.ts
+++ b/src/app/organization/tellers/cashiers/transactions/transactions.component.ts
@@ -7,7 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -24,7 +26,7 @@ import {
   MatRow
 } from '@angular/material/table';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { OrganizationService } from 'app/organization/organization.service';
@@ -64,9 +66,10 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class TransactionsComponent implements OnInit {
   private organizationService = inject(OrganizationService);
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Currency selector. */
-  currencySelector = new UntypedFormControl();
+  currencySelector = new FormControl();
   /** Cashier Id */
   cashierId: any;
   /** Teller Id */
@@ -98,7 +101,7 @@ export class TransactionsComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { currencies: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { currencies: any }) => {
       this.currencyData = data.currencies.selectedCurrencyOptions;
     });
     this.tellerId = this.route.parent.parent.parent.snapshot.params['id'];
@@ -124,9 +127,10 @@ export class TransactionsComponent implements OnInit {
    * Retrieves the transactions data on changing currency and sets the transactions table.
    */
   onChangeCurrency() {
-    this.currencySelector.valueChanges.subscribe((currencyCode: any) => {
+    this.currencySelector.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((currencyCode: any) => {
       this.organizationService
         .getCashierSummaryAndTransactions(this.tellerId, this.cashierId, currencyCode)
+        .pipe(take(1))
         .subscribe((response: any) => {
           this.cashierData = response;
           this.setTransactions();

--- a/src/app/organization/tellers/cashiers/view-cashier/view-cashier.component.ts
+++ b/src/app/organization/tellers/cashiers/view-cashier/view-cashier.component.ts
@@ -7,7 +7,9 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 /** Custom Dialogs */
@@ -38,6 +40,7 @@ export class ViewCashierComponent {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
   dialog = inject(MatDialog);
 
   /** Cashier data. */
@@ -51,7 +54,7 @@ export class ViewCashierComponent {
    * @param {MatDialog} dialog Mat Dialog
    */
   constructor() {
-    this.route.data.subscribe((data: { cashier: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { cashier: any }) => {
       this.cashierData = data.cashier;
     });
   }
@@ -65,9 +68,12 @@ export class ViewCashierComponent {
     });
     deleteCashierDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
-        this.organizationService.deleteCashier(this.cashierData.tellerId, this.cashierData.id).subscribe(() => {
-          this.router.navigate(['../'], { relativeTo: this.route });
-        });
+        this.organizationService
+          .deleteCashier(this.cashierData.tellerId, this.cashierData.id)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.router.navigate(['../'], { relativeTo: this.route });
+          });
       }
     });
   }

--- a/src/app/organization/tellers/create-teller/create-teller.component.ts
+++ b/src/app/organization/tellers/create-teller/create-teller.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -32,19 +34,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateTellerComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Teller form. */
-  tellerForm: UntypedFormGroup;
+  tellerForm: FormGroup;
   /** Office data. */
   officeData: any;
   /** TellerStatuses data. */
@@ -60,7 +63,7 @@ export class CreateTellerComponent implements OnInit {
    * @param {Dates} dateUtils Date Utils to format date.
    */
   constructor() {
-    this.route.data.subscribe((data: { offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { offices: any }) => {
       this.officeData = data.offices;
     });
     this.tellerStatusesData = [
@@ -127,14 +130,17 @@ export class CreateTellerComponent implements OnInit {
       dateFormat,
       locale
     };
-    this.organizationService.createTeller(data).subscribe((response: any) => {
-      this.router.navigate(
-        [
-          '../',
-          response.resourceId
-        ],
-        { relativeTo: this.route }
-      );
-    });
+    this.organizationService
+      .createTeller(data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(
+          [
+            '../',
+            response.resourceId
+          ],
+          { relativeTo: this.route }
+        );
+      });
   }
 }

--- a/src/app/organization/tellers/edit-teller/edit-teller.component.ts
+++ b/src/app/organization/tellers/edit-teller/edit-teller.component.ts
@@ -7,8 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -31,19 +33,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditTellerComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Teller form. */
-  tellerForm: UntypedFormGroup;
+  tellerForm: FormGroup;
   /** Office data. */
   officeData: any;
   /** TellerStatuses data. */
@@ -61,7 +64,7 @@ export class EditTellerComponent implements OnInit {
    * @param {Dates} dateUtils Date Utils to format date.
    */
   constructor() {
-    this.route.data.subscribe((data: { teller: any; offices: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { teller: any; offices: any }) => {
       this.tellerData = data.teller;
       this.officeData = data.offices;
     });
@@ -135,14 +138,17 @@ export class EditTellerComponent implements OnInit {
       dateFormat,
       locale
     };
-    this.organizationService.updateTeller(this.tellerData.id, data).subscribe((response: any) => {
-      this.router.navigate(
-        [
-          '../../',
-          response.resourceId
-        ],
-        { relativeTo: this.route }
-      );
-    });
+    this.organizationService
+      .updateTeller(this.tellerData.id, data)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.router.navigate(
+          [
+            '../../',
+            response.resourceId
+          ],
+          { relativeTo: this.route }
+        );
+      });
   }
 }

--- a/src/app/organization/tellers/tellers.component.ts
+++ b/src/app/organization/tellers/tellers.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -25,8 +26,6 @@ import {
 } from '@angular/material/table';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
-/** rxjs Imports */
-import { of } from 'rxjs';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatTooltip } from '@angular/material/tooltip';
 import { DateFormatPipe } from '../../pipes/date-format.pipe';
@@ -62,6 +61,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class TellersComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Tellers data. */
   tellersData: any;
@@ -86,7 +86,7 @@ export class TellersComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { tellers: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { tellers: any }) => {
       this.tellersData = data.tellers;
     });
   }

--- a/src/app/organization/tellers/view-teller/view-teller.component.ts
+++ b/src/app/organization/tellers/view-teller/view-teller.component.ts
@@ -7,7 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { take } from 'rxjs';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -40,6 +42,7 @@ export class ViewTellerComponent {
   private organizationService = inject(OrganizationService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
   dialog = inject(MatDialog);
 
   /** Teller data. */
@@ -53,7 +56,7 @@ export class ViewTellerComponent {
    * @param {MatDialog} dialog Dialog reference.
    */
   constructor() {
-    this.route.data.subscribe((data: { teller: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { teller: any }) => {
       this.tellerData = data.teller;
     });
   }
@@ -67,9 +70,12 @@ export class ViewTellerComponent {
     });
     deleteTellerDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
-        this.organizationService.deleteTeller(this.tellerData.id).subscribe(() => {
-          this.router.navigate(['/organization/tellers']);
-        });
+        this.organizationService
+          .deleteTeller(this.tellerData.id)
+          .pipe(take(1))
+          .subscribe(() => {
+            this.router.navigate(['/organization/tellers']);
+          });
       }
     });
   }

--- a/src/app/organization/working-days/working-days.component.ts
+++ b/src/app/organization/working-days/working-days.component.ts
@@ -15,15 +15,12 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  UntypedFormArray,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, FormArray, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -55,8 +52,9 @@ const recurrenceDefaultValue = 'FREQ=WEEKLY;INTERVAL=1;BYDAY=';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class WorkingDaysComponent implements OnInit, AfterViewInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
   private organizationService = inject(OrganizationService);
   private settingsService = inject(SettingsService);
   private router = inject(Router);
@@ -65,7 +63,7 @@ export class WorkingDaysComponent implements OnInit, AfterViewInit {
   private popoverService = inject(PopoverService);
 
   /** Working days form. */
-  workingDaysForm: UntypedFormGroup;
+  workingDaysForm: FormGroup;
   /** Working days data. */
   workingDaysData: any;
   /** Week days */
@@ -98,7 +96,7 @@ export class WorkingDaysComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { workingDays: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { workingDays: any }) => {
       this.workingDaysData = data.workingDays;
     });
   }
@@ -126,8 +124,8 @@ export class WorkingDaysComponent implements OnInit, AfterViewInit {
   /**
    * @returns {FormArray} recurrence form array.
    */
-  get recurrence(): UntypedFormArray {
-    return this.workingDaysForm.get('recurrence') as UntypedFormArray;
+  get recurrence(): FormArray {
+    return this.workingDaysForm.get('recurrence') as FormArray;
   }
 
   /**
@@ -144,7 +142,7 @@ export class WorkingDaysComponent implements OnInit, AfterViewInit {
    * Creates the recurrence form array.
    */
   createRecurrenceFormArray() {
-    return this.weekDays.map((weekDay) => new UntypedFormControl(weekDay.checked));
+    return this.weekDays.map((weekDay) => new FormControl(weekDay.checked));
   }
 
   /**
@@ -162,14 +160,17 @@ export class WorkingDaysComponent implements OnInit, AfterViewInit {
       }
     }
     workingDays.recurrence = recurrence;
-    this.organizationService.updateWorkingDays(workingDays).subscribe((response) => {
-      if (this.configurationWizardService.showDefineWorkingDays) {
-        this.configurationWizardService.showDefineWorkingDays = false;
-        this.openNextStepDialog();
-      } else {
-        this.router.navigate(['../'], { relativeTo: this.route });
-      }
-    });
+    this.organizationService
+      .updateWorkingDays(workingDays)
+      .pipe(take(1))
+      .subscribe((response) => {
+        if (this.configurationWizardService.showDefineWorkingDays) {
+          this.configurationWizardService.showDefineWorkingDays = false;
+          this.openNextStepDialog();
+        } else {
+          this.router.navigate(['../'], { relativeTo: this.route });
+        }
+      });
   }
 
   /**


### PR DESCRIPTION
## Description

Replace manual subscribe/unsubscribe patterns with DestroyRef + takeUntilDestroyed across 43 components and directives. Also replace UntypedFormBuilder/Group/Control/Array with typed Angular equivalents.

Modules covered: settings, search, navigation, notifications, collaterals, collections, remittances, templates, login, reports, users, home/dashboard, account-transfers, tasks, core/shell (breadcrumb, shell, toolbar) and configuration-wizard popover directive.

## Related issues and discussion

[WEB-954](https://github.com/openMF/web-app/pull/WEB-954)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-954]: https://mifosforge.jira.com/browse/WEB-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release includes internal code quality improvements with no changes visible to end-users. The application's functionality, features, and user interface remain unchanged.

* **Refactor**
  * Improved internal code patterns and subscription management to enhance maintainability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->