### PR TITLE
WEB-954: Migrate Subscription management : clients and savings

### DIFF
--- a/src/app/clients/client-stepper/client-datatable-step/client-datatable-step.component.ts
+++ b/src/app/clients/client-stepper/client-datatable-step/client-datatable-step.component.ts
@@ -7,13 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormBuilder,
-  UntypedFormControl,
-  UntypedFormGroup,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Datatables } from 'app/core/utils/datatables';
 import { SettingsService } from 'app/settings/settings.service';
 import { MatCheckbox } from '@angular/material/checkbox';
@@ -35,14 +29,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ClientDatatableStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private settingsService = inject(SettingsService);
   private datatableService = inject(Datatables);
 
   /** Input Fields Data */
   @Input() datatableData: any;
   /** Create Input Form */
-  datatableForm: UntypedFormGroup;
+  datatableForm: FormGroup;
 
   datatableInputs: any = [];
 
@@ -53,12 +47,12 @@ export class ClientDatatableStepComponent implements OnInit {
       input.controlName = this.getInputName(input);
       if (!input.isColumnNullable) {
         if (this.isNumeric(input.columnDisplayType)) {
-          inputItems[input.controlName] = new UntypedFormControl(0, [Validators.required]);
+          inputItems[input.controlName] = new FormControl(0, [Validators.required]);
         } else {
-          inputItems[input.controlName] = new UntypedFormControl('', [Validators.required]);
+          inputItems[input.controlName] = new FormControl('', [Validators.required]);
         }
       } else {
-        inputItems[input.controlName] = new UntypedFormControl('');
+        inputItems[input.controlName] = new FormControl('');
       }
     });
     this.datatableForm = this.formBuilder.group(inputItems);

--- a/src/app/clients/client-stepper/client-family-members-step/client-family-member-dialog/client-family-member-dialog.component.ts
+++ b/src/app/clients/client-stepper/client-family-members-step/client-family-member-dialog/client-family-member-dialog.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   MatDialogRef,
   MAT_DIALOG_DATA,
@@ -15,7 +16,7 @@ import {
   MatDialogActions,
   MatDialogClose
 } from '@angular/material/dialog';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { SettingsService } from 'app/settings/settings.service';
@@ -41,16 +42,17 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ClientFamilyMemberDialogComponent implements OnInit {
   dialogRef = inject<MatDialogRef<ClientFamilyMemberDialogComponent>>(MatDialogRef);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private dateUtils = inject(Dates);
   data = inject(MAT_DIALOG_DATA);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Maximum Due Date allowed. */
   maxDate = new Date();
 
   /** Add/Edit family member form. */
-  familyMemberForm: UntypedFormGroup;
+  familyMemberForm: FormGroup;
 
   ngOnInit() {
     this.maxDate = this.settingsService.businessDate;
@@ -72,14 +74,17 @@ export class ClientFamilyMemberDialogComponent implements OnInit {
     }
 
     // Add subscription to date of birth changes to update age
-    this.familyMemberForm.get('dateOfBirth').valueChanges.subscribe((dateOfBirth: any) => {
-      if (dateOfBirth) {
-        const age = this.calculateAge(dateOfBirth);
-        this.familyMemberForm.get('age').setValue(age);
-      } else {
-        this.familyMemberForm.get('age').setValue('');
-      }
-    });
+    this.familyMemberForm
+      .get('dateOfBirth')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((dateOfBirth: any) => {
+        if (dateOfBirth) {
+          const age = this.calculateAge(dateOfBirth);
+          this.familyMemberForm.get('age').setValue(age);
+        } else {
+          this.familyMemberForm.get('age').setValue('');
+        }
+      });
 
     // If a date of birth is already set, calculate the age
     const currentDob = this.familyMemberForm.get('dateOfBirth').value;

--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
@@ -10,22 +10,16 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  OnInit,
-  OnDestroy,
-  Input,
-  Output,
+  DestroyRef,
   EventEmitter,
+  Input,
+  OnInit,
+  Output,
   inject
 } from '@angular/core';
-import {
-  UntypedFormBuilder,
-  UntypedFormGroup,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
-import { Subject } from 'rxjs';
-import { filter, switchMap, takeUntil } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { filter, switchMap } from 'rxjs/operators';
 import { ClientsService } from 'app/clients/clients.service';
 import { Dates } from 'app/core/utils/dates';
 import { LegalFormId } from 'app/clients/models/legal-form.enum';
@@ -59,15 +53,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ClientGeneralStepComponent implements OnInit, OnDestroy {
-  private formBuilder = inject(UntypedFormBuilder);
+export class ClientGeneralStepComponent implements OnInit {
+  private formBuilder = inject(FormBuilder);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
   private clientService = inject(ClientsService);
   externalNationalIdService = inject(ExternalNationalIdService);
-
-  /** Subject to trigger unsubscription on destroy */
-  private destroy$ = new Subject<void>();
+  private destroyRef = inject(DestroyRef);
 
   @Output() legalFormChangeEvent = new EventEmitter<{ legalForm: number }>();
 
@@ -82,7 +74,7 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
   /** Client Template */
   @Input() clientTemplate: any;
   /** Create Client Form */
-  createClientForm: UntypedFormGroup;
+  createClientForm: FormGroup;
 
   /** Office Options */
   officeOptions: any;
@@ -176,7 +168,7 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
   buildDependencies() {
     this.createClientForm
       .get('legalFormId')
-      .valueChanges.pipe(takeUntil(this.destroy$))
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((legalFormId: number) => {
         this.legalFormChangeEvent.emit({ legalForm: legalFormId });
         if (legalFormId === LegalFormId.PERSON) {
@@ -184,15 +176,15 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
           this.createClientForm.removeControl('clientNonPersonDetails');
           this.createClientForm.addControl(
             'firstname',
-            new UntypedFormControl('', [
+            new FormControl('', [
               Validators.required,
               Validators.pattern('(^[A-z]).*')
             ])
           );
-          this.createClientForm.addControl('middlename', new UntypedFormControl('', Validators.pattern('(^[A-z]).*')));
+          this.createClientForm.addControl('middlename', new FormControl('', Validators.pattern('(^[A-z]).*')));
           this.createClientForm.addControl(
             'lastname',
-            new UntypedFormControl('', [
+            new FormControl('', [
               Validators.required,
               Validators.pattern('(^[A-z]).*')
             ])
@@ -203,7 +195,7 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
           this.createClientForm.removeControl('lastname');
           this.createClientForm.addControl(
             'fullname',
-            new UntypedFormControl('', [
+            new FormControl('', [
               Validators.required,
               Validators.pattern('(^[A-z]).*')
             ])
@@ -226,20 +218,20 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
     this.createClientForm.get('legalFormId').patchValue(LegalFormId.PERSON);
     this.createClientForm
       .get('active')
-      .valueChanges.pipe(takeUntil(this.destroy$))
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((active: boolean) => {
         if (active) {
-          this.createClientForm.addControl('activationDate', new UntypedFormControl('', Validators.required));
+          this.createClientForm.addControl('activationDate', new FormControl('', Validators.required));
         } else {
           this.createClientForm.removeControl('activationDate');
         }
       });
     this.createClientForm
       .get('addSavings')
-      .valueChanges.pipe(takeUntil(this.destroy$))
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((active: boolean) => {
         if (active) {
-          this.createClientForm.addControl('savingsProductId', new UntypedFormControl('', Validators.required));
+          this.createClientForm.addControl('savingsProductId', new FormControl('', Validators.required));
         } else {
           this.createClientForm.removeControl('savingsProductId');
         }
@@ -249,16 +241,11 @@ export class ClientGeneralStepComponent implements OnInit, OnDestroy {
       .valueChanges.pipe(
         filter((officeId: number) => !!officeId),
         switchMap((officeId: number) => this.clientService.getClientWithOfficeTemplate(officeId)),
-        takeUntil(this.destroy$)
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((clientTemplate: any) => {
         this.staffOptions = clientTemplate.staffOptions;
       });
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   getDateLabel(legalFormId: number, values: string[]): string {

--- a/src/app/clients/clients-view/address-tab/address-tab.component.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.ts
@@ -7,9 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { UntypedFormGroup } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-base';
 import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
@@ -65,6 +66,7 @@ export class AddressTabComponent {
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
   private postalCodeLookup = inject(PostalCodeLookupService);
+  private destroyRef = inject(DestroyRef);
 
   /** Client Address Data */
   clientAddressData: any;
@@ -82,14 +84,14 @@ export class AddressTabComponent {
    * @param {TranslateService} translateService Translate Service.
    */
   constructor() {
-    this.route.data.subscribe(
-      (data: { clientAddressData: any; clientAddressFieldConfig: any; clientAddressTemplateData: any }) => {
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { clientAddressData: any; clientAddressFieldConfig: any; clientAddressTemplateData: any }) => {
         this.clientAddressData = data.clientAddressData;
         this.clientAddressFieldConfig = data.clientAddressFieldConfig;
         this.clientAddressTemplate = data.clientAddressTemplateData;
         this.clientId = this.route.parent.snapshot.paramMap.get('clientId');
-      }
-    );
+      });
   }
 
   /**
@@ -170,7 +172,7 @@ export class AddressTabComponent {
     let postalSub: Subscription;
 
     dialogRef.afterOpened().subscribe(() => {
-      const form: UntypedFormGroup = dialogRef.componentInstance.form;
+      const form: FormGroup = dialogRef.componentInstance.form;
       const postalCodeControl = form.get('postalCode');
       if (!postalCodeControl) return;
 
@@ -226,7 +228,7 @@ export class AddressTabComponent {
   /**
    * Gets the ISO country code for the currently selected country in the form.
    */
-  private getSelectedCountryCode(form: UntypedFormGroup): string | null {
+  private getSelectedCountryCode(form: FormGroup): string | null {
     const countryIdValue = form.get('countryId')?.value;
     if (!countryIdValue) return null;
 
@@ -245,7 +247,7 @@ export class AddressTabComponent {
    * Clears form fields that were previously set by auto-fill,
    * so stale data doesn't persist when a new lookup fails or returns different results.
    */
-  private clearAutoFilledFields(form: UntypedFormGroup) {
+  private clearAutoFilledFields(form: FormGroup) {
     for (const fieldName of this.autoFilledFields) {
       const control = form.get(fieldName);
       if (control) {
@@ -256,7 +258,7 @@ export class AddressTabComponent {
     this.autoFilledFields.clear();
   }
 
-  private applyResolvedAddress(form: UntypedFormGroup, address: ResolvedAddress) {
+  private applyResolvedAddress(form: FormGroup, address: ResolvedAddress) {
     const cityControl = form.get('city');
     if (cityControl && address.city) {
       cityControl.setValue(address.city);

--- a/src/app/clients/clients-view/charges/charges-overview/charges-overview.component.ts
+++ b/src/app/clients/clients-view/charges/charges-overview/charges-overview.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import {
@@ -58,6 +59,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class ChargesOverviewComponent implements OnInit {
   private route = inject(ActivatedRoute);
   dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Columns to be displayed in charge overview table. */
   displayedColumns: string[] = [
@@ -82,7 +84,7 @@ export class ChargesOverviewComponent implements OnInit {
    * @param {MatDialog} dialog Dialog reference.
    */
   constructor() {
-    this.route.data.subscribe((data: { clientChargesData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientChargesData: any }) => {
       this.chargeOverviewData = data.clientChargesData;
     });
   }

--- a/src/app/clients/clients-view/charges/client-pay-charges/client-pay-charges.component.ts
+++ b/src/app/clients/clients-view/charges/client-pay-charges/client-pay-charges.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 /** Custom Services. */
@@ -31,11 +32,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ClientPayChargesComponent implements OnInit {
   private clientsService = inject(ClientsService);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Transaction Form. */
   transactionForm: any;
@@ -53,7 +55,7 @@ export class ClientPayChargesComponent implements OnInit {
    * @param {SettingsService} settingsService Setting service
    */
   constructor() {
-    this.route.data.subscribe((data: { transactionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { transactionData: any }) => {
       this.transactionData = data.transactionData;
     });
   }

--- a/src/app/clients/clients-view/charges/view-charge/view-charge.component.ts
+++ b/src/app/clients/clients-view/charges/view-charge/view-charge.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ClientsService } from 'app/clients/clients.service';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -64,6 +65,7 @@ export class ViewChargeComponent {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private clientService = inject(ClientsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Charge Data. */
   chargeData: any;
@@ -83,7 +85,7 @@ export class ViewChargeComponent {
    * @param {Router} router Router for navigation.
    */
   constructor() {
-    this.route.data.subscribe((data: { clientChargeData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientChargeData: any }) => {
       this.chargeData = data.clientChargeData;
     });
   }

--- a/src/app/clients/clients-view/client-actions/accept-client-transfer/accept-client-transfer.component.ts
+++ b/src/app/clients/clients-view/client-actions/accept-client-transfer/accept-client-transfer.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -33,15 +34,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AcceptClientTransferComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly settingsService = inject(SettingsService);
   private readonly dateUtils = inject(Dates);
   private readonly route = inject(ActivatedRoute);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Accept Client Transfer form. */
-  acceptClientTransferForm: UntypedFormGroup;
+  acceptClientTransferForm: FormGroup;
   /** Client Id */
   clientId: any;
   /** Transfer Date */
@@ -51,7 +53,7 @@ export class AcceptClientTransferComponent implements OnInit {
    * constructor
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.transferDate = data.clientActionData;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];

--- a/src/app/clients/clients-view/client-actions/activate-client/activate-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/activate-client/activate-client.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -30,7 +31,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ActivateClientComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly dateUtils = inject(Dates);
   private readonly route = inject(ActivatedRoute);
@@ -42,7 +43,7 @@ export class ActivateClientComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Activate client form. */
-  activateClientForm: UntypedFormGroup;
+  activateClientForm: FormGroup;
   /** Client Id */
   clientId: any;
 

--- a/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.ts
+++ b/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.ts
@@ -7,14 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -37,19 +32,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AddClientChargeComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly route = inject(ActivatedRoute);
   private readonly dateUtils = inject(Dates);
   private readonly clientsService = inject(ClientsService);
   private readonly settingsService = inject(SettingsService);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum Due Date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum Due Date allowed. */
   maxDate = new Date();
   /** Add Clients Charge form. */
-  clientChargeForm: UntypedFormGroup;
+  clientChargeForm: FormGroup;
   /** clients charge options. */
   clientChargeOptions: any;
   /** clients Id */
@@ -61,7 +57,7 @@ export class AddClientChargeComponent implements OnInit {
    * Retrieves charge template data from `resolve`
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.clientChargeOptions = data.clientActionData.chargeOptions;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];
@@ -77,41 +73,43 @@ export class AddClientChargeComponent implements OnInit {
    * Subscribe to form controls value changes
    */
   buildDependencies() {
-    this.clientChargeForm.controls.chargeId.valueChanges.subscribe((chargeId) => {
-      this.clientsService.getChargeAndTemplate(chargeId).subscribe((data: any) => {
-        this.chargeDetails = data;
-        const chargeTimeType = data.chargeTimeType.id;
-        if (data.chargeTimeType.value === 'Withdrawal Fee' || data.chargeTimeType.value === 'Saving No Activity Fee') {
-          this.chargeDetails.dueDateNotRequired = true;
-        }
-        if (data.chargeTimeType.value === 'Annual Fee' || data.chargeTimeType.value === 'Monthly Fee') {
-          this.chargeDetails.chargeTimeTypeAnnualOrMonth = true;
-        }
-        if (!this.chargeDetails.dueDateNotRequired && !this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
-          this.clientChargeForm.addControl('dueDate', new UntypedFormControl('', Validators.required));
-        } else {
-          this.clientChargeForm.removeControl('dueDate');
-        }
-        if (!this.chargeDetails.dueDateNotRequired && this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
-          this.clientChargeForm.addControl('feeOnMonthDay', new UntypedFormControl('', Validators.required));
-        } else {
-          this.clientChargeForm.removeControl('feeOnMonthDay');
-        }
-        if (chargeTimeType.value === 'Monthly Fee') {
-          this.clientChargeForm.addControl(
-            'feeInterval',
-            new UntypedFormControl(data.feeInterval, Validators.required)
-          );
-        } else {
-          this.clientChargeForm.removeControl('feeInterval');
-        }
-        this.clientChargeForm.patchValue({
-          amount: data.amount,
-          chargeCalculationType: data.chargeCalculationType.id,
-          chargeTimeType: data.chargeTimeType.id
+    this.clientChargeForm.controls.chargeId.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((chargeId) => {
+        this.clientsService.getChargeAndTemplate(chargeId).subscribe((data: any) => {
+          this.chargeDetails = data;
+          const chargeTimeType = data.chargeTimeType.id;
+          if (
+            data.chargeTimeType.value === 'Withdrawal Fee' ||
+            data.chargeTimeType.value === 'Saving No Activity Fee'
+          ) {
+            this.chargeDetails.dueDateNotRequired = true;
+          }
+          if (data.chargeTimeType.value === 'Annual Fee' || data.chargeTimeType.value === 'Monthly Fee') {
+            this.chargeDetails.chargeTimeTypeAnnualOrMonth = true;
+          }
+          if (!this.chargeDetails.dueDateNotRequired && !this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
+            this.clientChargeForm.addControl('dueDate', new FormControl('', Validators.required));
+          } else {
+            this.clientChargeForm.removeControl('dueDate');
+          }
+          if (!this.chargeDetails.dueDateNotRequired && this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
+            this.clientChargeForm.addControl('feeOnMonthDay', new FormControl('', Validators.required));
+          } else {
+            this.clientChargeForm.removeControl('feeOnMonthDay');
+          }
+          if (chargeTimeType.value === 'Monthly Fee') {
+            this.clientChargeForm.addControl('feeInterval', new FormControl(data.feeInterval, Validators.required));
+          } else {
+            this.clientChargeForm.removeControl('feeInterval');
+          }
+          this.clientChargeForm.patchValue({
+            amount: data.amount,
+            chargeCalculationType: data.chargeCalculationType.id,
+            chargeTimeType: data.chargeTimeType.id
+          });
         });
       });
-    });
   }
 
   /**

--- a/src/app/clients/clients-view/client-actions/add-client-collateral/add-client-collateral.component.ts
+++ b/src/app/clients/clients-view/client-actions/add-client-collateral/add-client-collateral.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /**
@@ -29,15 +30,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AddClientCollateralComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly route = inject(ActivatedRoute);
   private readonly productsService = inject(ProductsService);
   private readonly clientsService = inject(ClientsService);
   private readonly settingsService = inject(SettingsService);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Client Collateral Form */
-  clientCollateralForm: UntypedFormGroup;
+  clientCollateralForm: FormGroup;
   /** Client Collateral Options */
   clientCollateralOptions: any;
   /** Client Id */
@@ -52,7 +54,7 @@ export class AddClientCollateralComponent implements OnInit {
    * @param {ProductsService} productsService Products Service
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.clientCollateralOptions = data.clientActionData;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];
@@ -67,24 +69,28 @@ export class AddClientCollateralComponent implements OnInit {
    * Subscribe to Form controls value changes
    */
   buildDependencies() {
-    this.clientCollateralForm.controls.collateralId.valueChanges.subscribe((collateralId) => {
-      this.productsService.getCollateral(collateralId).subscribe((data: any) => {
-        this.collateralDetails = data;
-        this.clientCollateralForm.patchValue({
-          name: data.name,
-          quality: data.quality,
-          unitType: data.unitType,
-          basePrice: this.collateralDetails.basePrice,
-          pctToBase: this.collateralDetails.pctToBase
+    this.clientCollateralForm.controls.collateralId.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((collateralId) => {
+        this.productsService.getCollateral(collateralId).subscribe((data: any) => {
+          this.collateralDetails = data;
+          this.clientCollateralForm.patchValue({
+            name: data.name,
+            quality: data.quality,
+            unitType: data.unitType,
+            basePrice: this.collateralDetails.basePrice,
+            pctToBase: this.collateralDetails.pctToBase
+          });
         });
       });
-    });
-    this.clientCollateralForm.controls.quantity.valueChanges.subscribe((quantity: any) => {
-      this.clientCollateralForm.patchValue({
-        totalValue: this.collateralDetails.basePrice * quantity,
-        totalCollateralValue: (this.collateralDetails.basePrice * this.collateralDetails.pctToBase * quantity) / 100
+    this.clientCollateralForm.controls.quantity.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((quantity: any) => {
+        this.clientCollateralForm.patchValue({
+          totalValue: this.collateralDetails.basePrice * quantity,
+          totalCollateralValue: (this.collateralDetails.basePrice * this.collateralDetails.pctToBase * quantity) / 100
+        });
       });
-    });
   }
 
   /**

--- a/src/app/clients/clients-view/client-actions/client-assign-staff/client-assign-staff.component.ts
+++ b/src/app/clients/clients-view/client-actions/client-assign-staff/client-assign-staff.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -29,13 +30,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ClientAssignStaffComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly route = inject(ActivatedRoute);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Client Assign Staff form. */
-  clientAssignStaffForm: UntypedFormGroup;
+  clientAssignStaffForm: FormGroup;
   /** Staff Data */
   staffData: any;
   /** Client Data */
@@ -49,7 +51,7 @@ export class ClientAssignStaffComponent implements OnInit {
    * @param {Router} router Router
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.clientData = data.clientActionData;
     });
   }

--- a/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.ts
+++ b/src/app/clients/clients-view/client-actions/client-screen-reports/client-screen-reports.component.ts
@@ -10,14 +10,16 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
+  ElementRef,
   OnInit,
   Renderer2,
-  ViewChild,
-  ElementRef,
   SecurityContext,
+  ViewChild,
   inject
 } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -40,14 +42,15 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ClientScreenReportsComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private clientsService = inject(ClientsService);
   private route = inject(ActivatedRoute);
   private sanitizer = inject(DomSanitizer);
   private renderer = inject(Renderer2);
+  private destroyRef = inject(DestroyRef);
 
   /** Client Screen Reportform. */
-  clientScreenReportForm: UntypedFormGroup;
+  clientScreenReportForm: FormGroup;
   /** Templates Data */
   templatesData: any;
   /** Client Id */
@@ -67,7 +70,7 @@ export class ClientScreenReportsComponent implements OnInit {
    * @param {Renderer2} renderer Renderer 2
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.templatesData = data.clientActionData;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];

--- a/src/app/clients/clients-view/client-actions/close-client/close-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/close-client/close-client.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -31,19 +32,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CloseClientComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly dateUtils = inject(Dates);
   private readonly route = inject(ActivatedRoute);
   private readonly settingsService = inject(SettingsService);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Close Client form. */
-  closeClientForm: UntypedFormGroup;
+  closeClientForm: FormGroup;
   /** Client Data */
   closureData: any;
   /** Client Id */
@@ -58,7 +60,7 @@ export class CloseClientComponent implements OnInit {
    * @param {SettingsService} settingsService Setting service
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.closureData = data.clientActionData.narrations;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];

--- a/src/app/clients/clients-view/client-actions/reactivate-client/reactivate-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/reactivate-client/reactivate-client.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -31,7 +32,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ReactivateClientComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly dateUtils = inject(Dates);
   private readonly route = inject(ActivatedRoute);
@@ -43,7 +44,7 @@ export class ReactivateClientComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Reactivate client form. */
-  reactivateClientForm: UntypedFormGroup;
+  reactivateClientForm: FormGroup;
   /** Client Account Id */
   clientId: any;
 

--- a/src/app/clients/clients-view/client-actions/reject-client-transfer/reject-client-transfer.component.ts
+++ b/src/app/clients/clients-view/client-actions/reject-client-transfer/reject-client-transfer.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -33,15 +34,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RejectClientTransferComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly settingsService = inject(SettingsService);
   private readonly dateUtils = inject(Dates);
   private readonly route = inject(ActivatedRoute);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Reject Client Transfer form. */
-  rejectClientTransferForm: UntypedFormGroup;
+  rejectClientTransferForm: FormGroup;
   /** Client Id */
   clientId: any;
   /** Transfer Date */
@@ -54,7 +56,7 @@ export class RejectClientTransferComponent implements OnInit {
    * @param {Router} router Router
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.transferDate = data.clientActionData;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];

--- a/src/app/clients/clients-view/client-actions/reject-client/reject-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/reject-client/reject-client.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -31,19 +32,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RejectClientComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly dateUtils = inject(Dates);
   private readonly route = inject(ActivatedRoute);
   private readonly settingsService = inject(SettingsService);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Reject Share Account form. */
-  rejectClientForm: UntypedFormGroup;
+  rejectClientForm: FormGroup;
   /** Client Data */
   rejectionData: any;
   /** Client Id */
@@ -53,7 +55,7 @@ export class RejectClientComponent implements OnInit {
    * constructor
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.rejectionData = data.clientActionData.narrations;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];

--- a/src/app/clients/clients-view/client-actions/take-survey/take-survey.component.ts
+++ b/src/app/clients/clients-view/client-actions/take-survey/take-survey.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -38,6 +39,7 @@ export class TakeSurveyComponent {
   private readonly clientsService = inject(ClientsService);
   private readonly authenticationService = inject(AuthenticationService);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** List of all Survey Data */
   allSurveyData: any;
@@ -67,7 +69,7 @@ export class TakeSurveyComponent {
    * @param {AuthenticationService} authenticationService AuthenticationService
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.allSurveyData = data.clientActionData;
       this.clientId = this.route.parent.snapshot.params['clientId'];
     });

--- a/src/app/clients/clients-view/client-actions/transfer-client/transfer-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/transfer-client/transfer-client.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -33,19 +34,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TransferClientComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly dateUtils = inject(Dates);
   private readonly route = inject(ActivatedRoute);
   private readonly settingsService = inject(SettingsService);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Transfer Client form. */
-  transferClientForm: UntypedFormGroup;
+  transferClientForm: FormGroup;
   /** Client Data */
   officeData: any;
   /** Client Id */
@@ -59,7 +61,7 @@ export class TransferClientComponent implements OnInit {
    * @param {SettingsService} settingsService Setting service
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.officeData = data.clientActionData;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];

--- a/src/app/clients/clients-view/client-actions/undo-client-rejection/undo-client-rejection.component.ts
+++ b/src/app/clients/clients-view/client-actions/undo-client-rejection/undo-client-rejection.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -31,7 +32,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UndoClientRejectionComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly dateUtils = inject(Dates);
   private readonly route = inject(ActivatedRoute);
@@ -43,7 +44,7 @@ export class UndoClientRejectionComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Undo Client Rejection form. */
-  undoClientRejectionForm: UntypedFormGroup;
+  undoClientRejectionForm: FormGroup;
   /** Client Id */
   clientId: any;
 

--- a/src/app/clients/clients-view/client-actions/undo-client-transfer/undo-client-transfer.component.ts
+++ b/src/app/clients/clients-view/client-actions/undo-client-transfer/undo-client-transfer.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -33,15 +34,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UndoClientTransferComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly settingsService = inject(SettingsService);
   private readonly dateUtils = inject(Dates);
   private readonly route = inject(ActivatedRoute);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Undo Client Transfer form. */
-  undoClientTransferForm: UntypedFormGroup;
+  undoClientTransferForm: FormGroup;
   /** Client Id */
   clientId: any;
   /** Transfer Date */
@@ -54,7 +56,7 @@ export class UndoClientTransferComponent implements OnInit {
    * @param {Router} router Router
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.transferDate = data.clientActionData;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];

--- a/src/app/clients/clients-view/client-actions/update-client-savings-account/update-client-savings-account.component.ts
+++ b/src/app/clients/clients-view/client-actions/update-client-savings-account/update-client-savings-account.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -29,13 +30,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UpdateClientSavingsAccountComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly route = inject(ActivatedRoute);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Client Update Savings Account form. */
-  clientSavingsAccountForm: UntypedFormGroup;
+  clientSavingsAccountForm: FormGroup;
   /** Savings Accounts Data */
   savingsAccounts: any;
   /** Client Data */
@@ -49,7 +51,7 @@ export class UpdateClientSavingsAccountComponent implements OnInit {
    * @param {Router} router Router
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.clientData = data.clientActionData;
     });
   }

--- a/src/app/clients/clients-view/client-actions/view-survey/view-survey.component.ts
+++ b/src/app/clients/clients-view/client-actions/view-survey/view-survey.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -59,6 +60,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewSurveyComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Survey Data */
   surveyData: any;
@@ -82,7 +84,7 @@ export class ViewSurveyComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.surveyData = data.clientActionData;
     });
   }

--- a/src/app/clients/clients-view/client-actions/withdraw-client/withdraw-client.component.ts
+++ b/src/app/clients/clients-view/client-actions/withdraw-client/withdraw-client.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -31,19 +32,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class WithdrawClientComponent implements OnInit {
-  private readonly formBuilder = inject(UntypedFormBuilder);
+  private readonly formBuilder = inject(FormBuilder);
   private readonly clientsService = inject(ClientsService);
   private readonly dateUtils = inject(Dates);
   private readonly route = inject(ActivatedRoute);
   private readonly settingsService = inject(SettingsService);
   private readonly notifier = inject(ClientActionNotifierService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Withdraw Client form. */
-  withdrawClientForm: UntypedFormGroup;
+  withdrawClientForm: FormGroup;
   /** Client Data */
   withdrawalData: any;
   /** Client Id */
@@ -53,7 +55,7 @@ export class WithdrawClientComponent implements OnInit {
    * constructor
    */
   constructor() {
-    this.route.data.subscribe((data: { clientActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientActionData: any }) => {
       this.withdrawalData = data.clientActionData.narrations;
     });
     this.clientId = this.route.parent.snapshot.params['clientId'];

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { environment } from '../../../environments/environment';
 import { ActivatedRoute, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -138,6 +139,7 @@ export class ClientsViewComponent implements OnInit {
   private clientsService = inject(ClientsService);
   private _sanitizer = inject(DomSanitizer);
   dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   clientViewData: any;
   clientDatatables: any;
@@ -145,14 +147,16 @@ export class ClientsViewComponent implements OnInit {
   clientTemplateData: any;
 
   constructor() {
-    this.route.data.subscribe((data: { clientViewData: any; clientTemplateData: any; clientDatatables: any }) => {
-      this.clientViewData = data.clientViewData;
-      this.clientDatatables = this.filterDatatablesByClientSubtype(
-        data.clientDatatables,
-        data.clientViewData?.legalForm?.id
-      );
-      this.clientTemplateData = data.clientTemplateData;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { clientViewData: any; clientTemplateData: any; clientDatatables: any }) => {
+        this.clientViewData = data.clientViewData;
+        this.clientDatatables = this.filterDatatablesByClientSubtype(
+          data.clientDatatables,
+          data.clientViewData?.legalForm?.id
+        );
+        this.clientTemplateData = data.clientTemplateData;
+      });
   }
 
   /**

--- a/src/app/clients/clients-view/custom-dialogs/edit-notes-dialog/edit-notes-dialog.component.ts
+++ b/src/app/clients/clients-view/custom-dialogs/edit-notes-dialog/edit-notes-dialog.component.ts
@@ -15,7 +15,7 @@ import {
   MatDialogActions,
   MatDialogClose
 } from '@angular/material/dialog';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
 @Component({
@@ -32,10 +32,10 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class EditNotesDialogComponent implements OnInit {
   dialogRef = inject<MatDialogRef<EditNotesDialogComponent>>(MatDialogRef);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   data = inject(MAT_DIALOG_DATA);
 
-  noteForm: UntypedFormGroup;
+  noteForm: FormGroup;
 
   ngOnInit() {
     this.createNoteForm();

--- a/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.ts
+++ b/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.ts
@@ -14,7 +14,7 @@ import {
   MatDialogActions,
   MatDialogClose
 } from '@angular/material/dialog';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { FileUploadComponent } from '../../../../shared/file-upload/file-upload.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
@@ -33,11 +33,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class UploadDocumentDialogComponent implements OnInit {
   dialogRef = inject<MatDialogRef<UploadDocumentDialogComponent>>(MatDialogRef);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   data = inject(MAT_DIALOG_DATA);
 
   /** Upload Document form. */
-  uploadDocumentForm: UntypedFormGroup;
+  uploadDocumentForm: FormGroup;
   /** Upload Document Data */
   uploadDocumentData: any = [];
   /** Triggers identity fields (documentType, status, documentKey) */

--- a/src/app/clients/clients-view/datatable-tab/datatable-tab.component.ts
+++ b/src/app/clients/clients-view/datatable-tab/datatable-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -23,6 +24,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class DatatableTabComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   entityId: string;
   entityDatatable: any;
@@ -31,7 +33,7 @@ export class DatatableTabComponent {
   constructor() {
     this.entityId = this.route.parent.parent.snapshot.paramMap.get('clientId');
 
-    this.route.data.subscribe((data: { clientDatatable: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientDatatable: any }) => {
       this.entityDatatable = data.clientDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
     });

--- a/src/app/clients/clients-view/documents-tab/documents-tab.component.ts
+++ b/src/app/clients/clients-view/documents-tab/documents-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -29,13 +30,14 @@ export class DocumentsTabComponent {
   private route = inject(ActivatedRoute);
   private clientsService = inject(ClientsService);
   dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   entityDocuments: any;
   entityId: string;
   entityType = 'clients';
 
   constructor() {
-    this.route.data.subscribe((data: { clientDocuments: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientDocuments: any }) => {
       this.entityDocuments = data.clientDocuments;
     });
     this.entityId = this.route.parent.snapshot.paramMap.get('clientId');

--- a/src/app/clients/clients-view/family-members-tab/add-family-member/add-family-member.component.ts
+++ b/src/app/clients/clients-view/family-members-tab/add-family-member/add-family-member.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -32,19 +33,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AddFamilyMemberComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private dateUtils = inject(Dates);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private clientsService = inject(ClientsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Maximum Due Date allowed. */
   maxDate = new Date();
   /** Minimum age allowed is 0. */
   minAge = 0;
   /** Add family member form. */
-  addFamilyMemberForm: UntypedFormGroup;
+  addFamilyMemberForm: FormGroup;
   /** Add family member template. */
   addFamilyMemberTemplate: any;
   /** Client ID */
@@ -59,7 +61,7 @@ export class AddFamilyMemberComponent implements OnInit {
    * @param {SettingsService} settingsService Setting service
    */
   constructor() {
-    this.route.data.subscribe((data: { clientTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientTemplate: any }) => {
       this.addFamilyMemberTemplate = data.clientTemplate.familyMemberOptions;
     });
     this.clientId = this.route.parent.parent.snapshot.params['clientId'];
@@ -68,14 +70,17 @@ export class AddFamilyMemberComponent implements OnInit {
   ngOnInit() {
     this.maxDate = this.settingsService.businessDate;
     this.createAddFamilyMemberForm();
-    this.addFamilyMemberForm.get('dateOfBirth').valueChanges.subscribe((dateOfBirth: any) => {
-      if (dateOfBirth) {
-        const age = this.calculateAge(dateOfBirth);
-        this.addFamilyMemberForm.get('age').setValue(age);
-      } else {
-        this.addFamilyMemberForm.get('age').setValue('');
-      }
-    });
+    this.addFamilyMemberForm
+      .get('dateOfBirth')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((dateOfBirth: any) => {
+        if (dateOfBirth) {
+          const age = this.calculateAge(dateOfBirth);
+          this.addFamilyMemberForm.get('age').setValue(age);
+        } else {
+          this.addFamilyMemberForm.get('age').setValue('');
+        }
+      });
   }
 
   /**

--- a/src/app/clients/clients-view/family-members-tab/edit-family-member/edit-family-member.component.ts
+++ b/src/app/clients/clients-view/family-members-tab/edit-family-member/edit-family-member.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -32,17 +33,18 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditFamilyMemberComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private dateUtils = inject(Dates);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private clientsService = inject(ClientsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Maximum Due Date allowed. */
   maxDate = new Date();
   /** Add family member form. */
-  editFamilyMemberForm: UntypedFormGroup;
+  editFamilyMemberForm: FormGroup;
   /** Add family member template. */
   addFamilyMemberTemplate: any;
   /** Family Members Details */
@@ -57,23 +59,28 @@ export class EditFamilyMemberComponent implements OnInit {
    * @param {SettingsService} settingsService Setting service
    */
   constructor() {
-    this.route.data.subscribe((data: { clientTemplate: any; editFamilyMember: any }) => {
-      this.addFamilyMemberTemplate = data.clientTemplate.familyMemberOptions;
-      this.familyMemberDetails = data.editFamilyMember;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { clientTemplate: any; editFamilyMember: any }) => {
+        this.addFamilyMemberTemplate = data.clientTemplate.familyMemberOptions;
+        this.familyMemberDetails = data.editFamilyMember;
+      });
   }
 
   ngOnInit() {
     this.maxDate = this.settingsService.businessDate;
     this.createEditFamilyMemberForm(this.familyMemberDetails);
-    this.editFamilyMemberForm.get('dateOfBirth').valueChanges.subscribe((dateOfBirth: any) => {
-      if (dateOfBirth) {
-        const age = this.calculateAge(dateOfBirth);
-        this.editFamilyMemberForm.get('age').setValue(age);
-      } else {
-        this.editFamilyMemberForm.get('age').setValue('');
-      }
-    });
+    this.editFamilyMemberForm
+      .get('dateOfBirth')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((dateOfBirth: any) => {
+        if (dateOfBirth) {
+          const age = this.calculateAge(dateOfBirth);
+          this.editFamilyMemberForm.get('age').setValue(age);
+        } else {
+          this.editFamilyMemberForm.get('age').setValue('');
+        }
+      });
   }
 
   /**

--- a/src/app/clients/clients-view/family-members-tab/family-members-tab.component.ts
+++ b/src/app/clients/clients-view/family-members-tab/family-members-tab.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterOutlet, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -55,6 +56,7 @@ export class FamilyMembersTabComponent {
   private route = inject(ActivatedRoute);
   private clientsService = inject(ClientsService);
   dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Client Family Members */
   clientFamilyMembers: any;
@@ -65,7 +67,7 @@ export class FamilyMembersTabComponent {
    * @param {MatDialog }dialog Mat Dialog
    */
   constructor() {
-    this.route.data.subscribe((data: { clientFamilyMembers: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientFamilyMembers: any }) => {
       this.clientFamilyMembers = data.clientFamilyMembers;
     });
   }

--- a/src/app/clients/clients-view/general-tab/general-tab.component.ts
+++ b/src/app/clients/clients-view/general-tab/general-tab.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnDestroy, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnDestroy, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, ActivatedRoute } from '@angular/router';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
@@ -41,8 +42,7 @@ import { CurrencyPipe } from '@angular/common';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { ReportsService } from 'app/reports/reports.service';
 import { SettingsService } from 'app/settings/settings.service';
-import { Subject } from 'rxjs';
-import { takeUntil, catchError } from 'rxjs/operators';
+import { catchError } from 'rxjs/operators';
 import { AlertService } from 'app/core/alert/alert.service';
 import { EMPTY } from 'rxjs';
 import { LoanProductService } from 'app/products/loan-products/services/loan-product.service';
@@ -83,9 +83,9 @@ import { LoanProductService } from 'app/products/loan-products/services/loan-pro
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class GeneralTabComponent implements OnDestroy {
-  private destroy$ = new Subject<void>();
   private alertService = inject(AlertService);
   private sanitizer = inject(DomSanitizer);
+  private destroyRef = inject(DestroyRef);
   pdfUrl: SafeResourceUrl | null = null;
   rawPdfUrl: string | null = null;
   showPdf: boolean = false;
@@ -100,7 +100,6 @@ export class GeneralTabComponent implements OnDestroy {
     this.reportsService
       .getPentahoRunReportData('LoanApplicationReport', formData, tenantIdentifier, locale, dateFormat)
       .pipe(
-        takeUntil(this.destroy$),
         catchError((error): any => {
           this.showPdf = false;
           if (this.rawPdfUrl) {
@@ -113,7 +112,8 @@ export class GeneralTabComponent implements OnDestroy {
             message: 'Failed to load Loan Application PDF report.'
           });
           return EMPTY;
-        })
+        }),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((res: any) => {
         if (this.rawPdfUrl) {
@@ -139,8 +139,6 @@ export class GeneralTabComponent implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
     if (this.rawPdfUrl) {
       URL.revokeObjectURL(this.rawPdfUrl);
       this.rawPdfUrl = null;
@@ -274,26 +272,28 @@ export class GeneralTabComponent implements OnDestroy {
    * @param {Router} router Router
    */
   constructor() {
-    this.route.data.subscribe(
-      (data: { clientAccountsData: any; clientChargesData: any; clientSummary: any; clientCollateralData: any }) => {
-        this.clientAccountData = data.clientAccountsData;
-        this.savingAccounts = data.clientAccountsData?.savingsAccounts ?? [];
-        this.loanAccounts = [];
-        this.processLoanAccounts(data.clientAccountsData?.loanAccounts ?? [], 'loan');
-        this.processLoanAccounts(data.clientAccountsData?.workingCapitalLoanAccounts ?? [], 'working-capital');
-        this.workingCapitalLoanAccounts = data.clientAccountsData?.workingCapitalLoanAccounts ?? [];
-        this.shareAccounts = data.clientAccountsData?.shareAccounts ?? [];
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(
+        (data: { clientAccountsData: any; clientChargesData: any; clientSummary: any; clientCollateralData: any }) => {
+          this.clientAccountData = data.clientAccountsData;
+          this.savingAccounts = data.clientAccountsData?.savingsAccounts ?? [];
+          this.loanAccounts = [];
+          this.processLoanAccounts(data.clientAccountsData?.loanAccounts ?? [], 'loan');
+          this.processLoanAccounts(data.clientAccountsData?.workingCapitalLoanAccounts ?? [], 'working-capital');
+          this.workingCapitalLoanAccounts = data.clientAccountsData?.workingCapitalLoanAccounts ?? [];
+          this.shareAccounts = data.clientAccountsData?.shareAccounts ?? [];
 
-        this.upcomingCharges = data.clientChargesData?.pageItems ?? [];
+          this.upcomingCharges = data.clientChargesData?.pageItems ?? [];
 
-        this.collaterals = data.clientCollateralData ?? [];
+          this.collaterals = data.clientCollateralData ?? [];
 
-        this.clientid = this.route.parent.snapshot.params['clientId'];
+          this.clientid = this.route.parent.snapshot.params['clientId'];
 
-        // Compute performance history from accounts data
-        this.computePerformanceHistory(data.clientAccountsData ?? { loanAccounts: [], savingsAccounts: [] });
-      }
-    );
+          // Compute performance history from accounts data
+          this.computePerformanceHistory(data.clientAccountsData ?? { loanAccounts: [], savingsAccounts: [] });
+        }
+      );
   }
 
   private computePerformanceHistory(accountsData: any) {

--- a/src/app/clients/clients-view/notes-tab/notes-tab.component.ts
+++ b/src/app/clients/clients-view/notes-tab/notes-tab.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Components */
@@ -35,6 +36,7 @@ export class NotesTabComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private clientsService = inject(ClientsService);
   private authenticationService = inject(AuthenticationService);
+  private destroyRef = inject(DestroyRef);
 
   /** Client ID */
   entityId: string;
@@ -58,7 +60,7 @@ export class NotesTabComponent implements OnInit {
   ngOnInit(): void {
     const credentials = this.authenticationService.getCredentials();
     this.username = credentials.username;
-    this.route.data.subscribe((data: { clientNotes: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientNotes: any }) => {
       this.entityNotes = data.clientNotes;
     });
   }

--- a/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.ts
+++ b/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnDestroy, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
@@ -24,8 +24,8 @@ import { ReportsService } from 'app/reports/reports.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { AlertService } from 'app/core/alert/alert.service';
 import { SystemService } from 'app/system/system.service';
-import { Subject, EMPTY } from 'rxjs';
-import { takeUntil, catchError } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import {
   CustomerDataValidation,
   KYC_VALIDATION_DATATABLE,
@@ -91,6 +91,7 @@ export class PersonalDataTabComponent implements OnDestroy {
   private systemService = inject(SystemService);
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Client View Data */
   clientViewData!: ClientViewData;
@@ -98,7 +99,6 @@ export class PersonalDataTabComponent implements OnDestroy {
   showPdf = false;
   pdfUrl: SafeResourceUrl | null = null;
   rawPdfUrl: string | null = null;
-  private destroy$ = new Subject<void>();
 
   /** Whether the KYC validation feature is enabled via global configuration */
   isKycEnabled = false;
@@ -129,14 +129,16 @@ export class PersonalDataTabComponent implements OnDestroy {
         this.loadValidationData();
       });
 
-    this.route.parent.data.pipe(takeUntilDestroyed()).subscribe((data: { clientViewData: ClientViewData }) => {
-      this.clientViewData = data.clientViewData;
-      this.validationData = null;
-      this.hasDatatableEntry = false;
-      if (this.configLoaded) {
-        this.loadValidationData();
-      }
-    });
+    this.route.parent.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { clientViewData: ClientViewData }) => {
+        this.clientViewData = data.clientViewData;
+        this.validationData = null;
+        this.hasDatatableEntry = false;
+        if (this.configLoaded) {
+          this.loadValidationData();
+        }
+      });
   }
 
   /** Returns the correct datatable name based on the client's legal form */
@@ -153,7 +155,7 @@ export class PersonalDataTabComponent implements OnDestroy {
     this.clientsService
       .getClientDatatable(this.clientViewData.id.toString(), datatableName)
       .pipe(
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
         catchError(() => {
           // Datatable may not exist yet — silently ignore
           this.hasDatatableEntry = false;
@@ -239,7 +241,7 @@ export class PersonalDataTabComponent implements OnDestroy {
         : this.clientsService.addClientDatatableEntry(clientId, datatableName, payload);
       save$
         .pipe(
-          takeUntil(this.destroy$),
+          takeUntilDestroyed(this.destroyRef),
           catchError(() => {
             this.alertService.alert({
               type: 'error',
@@ -330,7 +332,7 @@ export class PersonalDataTabComponent implements OnDestroy {
     this.reportsService
       .getPentahoRunReportData(reportName, formData, tenantIdentifier, locale, dateFormat)
       .pipe(
-        takeUntil(this.destroy$),
+        takeUntilDestroyed(this.destroyRef),
         catchError((error): any => {
           this.showPdf = false;
           if (this.rawPdfUrl) {
@@ -384,8 +386,6 @@ export class PersonalDataTabComponent implements OnDestroy {
    * Cleanup on component destroy
    */
   ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
     if (this.rawPdfUrl) {
       URL.revokeObjectURL(this.rawPdfUrl);
       this.rawPdfUrl = null;

--- a/src/app/clients/clients.component.ts
+++ b/src/app/clients/clients.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSort, Sort, MatSortHeader } from '@angular/material/sort';
@@ -29,7 +30,7 @@ import { MatIcon } from '@angular/material/icon';
 
 /** rxjs Imports */
 import { Subject, Subscription } from 'rxjs';
-import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
 /** Custom Services */
 import { environment } from '../../environments/environment';
@@ -77,8 +78,8 @@ export const DEBOUNCE_MS = 500;
 })
 export class ClientsComponent implements OnInit, OnDestroy {
   private clientService = inject(ClientsService);
+  private destroyRef = inject(DestroyRef);
 
-  private destroy$ = new Subject<void>();
   private searchInput$ = new Subject<string>();
   private clientsRequestSub: Subscription | null = null;
   private isComposing = false;
@@ -126,7 +127,7 @@ export class ClientsComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.searchInput$
-      .pipe(debounceTime(DEBOUNCE_MS), distinctUntilChanged(), takeUntil(this.destroy$))
+      .pipe(debounceTime(DEBOUNCE_MS), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
       .subscribe((value) => {
         if (value !== this.filterText) {
           this.search(value);
@@ -140,8 +141,6 @@ export class ClientsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.clientsRequestSub?.unsubscribe();
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   onSearchInput(value: string) {

--- a/src/app/clients/create-client/create-client.component.ts
+++ b/src/app/clients/create-client/create-client.component.ts
@@ -7,7 +7,16 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, QueryList, ViewChild, ViewChildren, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  QueryList,
+  ViewChild,
+  ViewChildren,
+  inject
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -53,6 +62,7 @@ export class CreateClientComponent {
   private router = inject(Router);
   private clientsService = inject(ClientsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Client General Step */
   @ViewChild(ClientGeneralStepComponent, { static: true }) clientGeneralStep: ClientGeneralStepComponent;
@@ -79,11 +89,13 @@ export class CreateClientComponent {
    * @param {SettingsService} settingsService Setting service
    */
   constructor() {
-    this.route.data.subscribe((data: { clientTemplate: any; clientAddressFieldConfig: any }) => {
-      this.clientTemplate = data.clientTemplate;
-      this.clientAddressFieldConfig = data.clientAddressFieldConfig;
-      this.setDatatables();
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { clientTemplate: any; clientAddressFieldConfig: any }) => {
+        this.clientTemplate = data.clientTemplate;
+        this.clientAddressFieldConfig = data.clientAddressFieldConfig;
+        this.setDatatables();
+      });
   }
 
   /**

--- a/src/app/clients/edit-client/edit-client.component.ts
+++ b/src/app/clients/edit-client/edit-client.component.ts
@@ -7,16 +7,11 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { LegalFormId } from 'app/clients/models/legal-form.enum';
-import {
-  UntypedFormBuilder,
-  UntypedFormGroup,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { ClientsService } from '../clients.service';
@@ -45,13 +40,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditClientComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private clientsService = inject(ClientsService);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
   externalNationalIdService = inject(ExternalNationalIdService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -61,7 +57,7 @@ export class EditClientComponent implements OnInit {
   /** Client Data and Template */
   clientDataAndTemplate: any;
   /** Edit Client Form */
-  editClientForm: UntypedFormGroup;
+  editClientForm: FormGroup;
 
   /** Office Options */
   officeOptions: any;
@@ -94,7 +90,7 @@ export class EditClientComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { clientDataAndTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientDataAndTemplate: any }) => {
       this.clientDataAndTemplate = data.clientDataAndTemplate;
     });
   }
@@ -181,49 +177,52 @@ export class EditClientComponent implements OnInit {
    * Adds controls conditionally.
    */
   buildDependencies() {
-    this.editClientForm.get('legalFormId').valueChanges.subscribe((legalFormId: any) => {
-      if (legalFormId === LegalFormId.PERSON) {
-        this.editClientForm.removeControl('fullname');
-        this.editClientForm.removeControl('clientNonPersonDetails');
-        this.editClientForm.addControl(
-          'firstname',
-          new UntypedFormControl(this.clientDataAndTemplate.firstname, Validators.required)
-        );
-        this.editClientForm.addControl('middlename', new UntypedFormControl(this.clientDataAndTemplate.middlename));
-        this.editClientForm.addControl(
-          'lastname',
-          new UntypedFormControl(this.clientDataAndTemplate.lastname, Validators.required)
-        );
-      } else {
-        this.editClientForm.removeControl('firstname');
-        this.editClientForm.removeControl('middlename');
-        this.editClientForm.removeControl('lastname');
-        this.editClientForm.addControl(
-          'fullname',
-          new UntypedFormControl(this.clientDataAndTemplate.fullname, Validators.required)
-        );
-        this.editClientForm.addControl(
-          'clientNonPersonDetails',
-          this.formBuilder.group({
-            constitutionId: [
-              this.clientDataAndTemplate.clientNonPersonDetails.constitution &&
-                this.clientDataAndTemplate.clientNonPersonDetails.constitution.id,
-              Validators.required
-            ],
-            incorpValidityTillDate: [
-              this.clientDataAndTemplate.clientNonPersonDetails.incorpValidityTillDate &&
-                new Date(this.clientDataAndTemplate.clientNonPersonDetails.incorpValidityTillDate)
-            ],
-            incorpNumber: [this.clientDataAndTemplate.clientNonPersonDetails.incorpNumber],
-            mainBusinessLineId: [
-              this.clientDataAndTemplate.clientNonPersonDetails.mainBusinessLine &&
-                this.clientDataAndTemplate.clientNonPersonDetails.mainBusinessLine.id
-            ],
-            remarks: [this.clientDataAndTemplate.clientNonPersonDetails.remarks]
-          })
-        );
-      }
-    });
+    this.editClientForm
+      .get('legalFormId')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((legalFormId: any) => {
+        if (legalFormId === LegalFormId.PERSON) {
+          this.editClientForm.removeControl('fullname');
+          this.editClientForm.removeControl('clientNonPersonDetails');
+          this.editClientForm.addControl(
+            'firstname',
+            new FormControl(this.clientDataAndTemplate.firstname, Validators.required)
+          );
+          this.editClientForm.addControl('middlename', new FormControl(this.clientDataAndTemplate.middlename));
+          this.editClientForm.addControl(
+            'lastname',
+            new FormControl(this.clientDataAndTemplate.lastname, Validators.required)
+          );
+        } else {
+          this.editClientForm.removeControl('firstname');
+          this.editClientForm.removeControl('middlename');
+          this.editClientForm.removeControl('lastname');
+          this.editClientForm.addControl(
+            'fullname',
+            new FormControl(this.clientDataAndTemplate.fullname, Validators.required)
+          );
+          this.editClientForm.addControl(
+            'clientNonPersonDetails',
+            this.formBuilder.group({
+              constitutionId: [
+                this.clientDataAndTemplate.clientNonPersonDetails.constitution &&
+                  this.clientDataAndTemplate.clientNonPersonDetails.constitution.id,
+                Validators.required
+              ],
+              incorpValidityTillDate: [
+                this.clientDataAndTemplate.clientNonPersonDetails.incorpValidityTillDate &&
+                  new Date(this.clientDataAndTemplate.clientNonPersonDetails.incorpValidityTillDate)
+              ],
+              incorpNumber: [this.clientDataAndTemplate.clientNonPersonDetails.incorpNumber],
+              mainBusinessLineId: [
+                this.clientDataAndTemplate.clientNonPersonDetails.mainBusinessLine &&
+                  this.clientDataAndTemplate.clientNonPersonDetails.mainBusinessLine.id
+              ],
+              remarks: [this.clientDataAndTemplate.clientNonPersonDetails.remarks]
+            })
+          );
+        }
+      });
   }
 
   getDateLabel(legalFormId: number, values: string[]): string {

--- a/src/app/clients/services/external-national-id.service.ts
+++ b/src/app/clients/services/external-national-id.service.ts
@@ -6,10 +6,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { inject, Injectable, OnDestroy } from '@angular/core';
-import { UntypedFormGroup } from '@angular/forms';
-import { Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, switchMap, takeUntil, timeout, catchError } from 'rxjs/operators';
+import { DestroyRef, Injectable, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup } from '@angular/forms';
+import { debounceTime, distinctUntilChanged, filter, switchMap, timeout, catchError } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { environment } from 'environments/environment';
 import { ClientsService } from '../clients.service';
@@ -54,7 +54,7 @@ export interface GenderOption {
  * - Disables those fields so users cannot modify API-provided values
  */
 @Injectable()
-export class ExternalNationalIdService implements OnDestroy {
+export class ExternalNationalIdService {
   /** Whether the feature is enabled via env var */
   readonly enabled: boolean;
 
@@ -71,9 +71,8 @@ export class ExternalNationalIdService implements OnDestroy {
   /** Whether a lookup is currently in progress */
   isLoading = false;
 
-  private destroy$ = new Subject<void>();
-
   private clientsService = inject(ClientsService);
+  private destroyRef = inject(DestroyRef);
 
   constructor() {
     this.enabled = environment.enableExternalNationalIdSystem === true;
@@ -110,7 +109,7 @@ export class ExternalNationalIdService implements OnDestroy {
    * @param skipInitialValue If true, skips lookup for the current form value (used in edit mode
    *                         to avoid re-fetching data for an already-saved external ID)
    */
-  watchExternalId(form: UntypedFormGroup, genderOptions: GenderOption[], skipInitialValue = false): void {
+  watchExternalId(form: FormGroup, genderOptions: GenderOption[], skipInitialValue = false): void {
     if (!this.enabled) {
       return;
     }
@@ -163,7 +162,7 @@ export class ExternalNationalIdService implements OnDestroy {
             })
           );
         }),
-        takeUntil(this.destroy$)
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((response: ExternalNationalIdResponse | null) => {
         this.isLoading = false;
@@ -179,7 +178,7 @@ export class ExternalNationalIdService implements OnDestroy {
    * while a lookup is in-flight (e.g. controls removed by buildDependencies).
    */
   private fillFormFromResponse(
-    form: UntypedFormGroup,
+    form: FormGroup,
     response: ExternalNationalIdResponse,
     genderOptions: GenderOption[]
   ): void {
@@ -286,7 +285,7 @@ export class ExternalNationalIdService implements OnDestroy {
   /**
    * Re-enable person fields so they can be edited manually.
    */
-  enablePersonFields(form: UntypedFormGroup): void {
+  enablePersonFields(form: FormGroup): void {
     for (const field of PERSON_FIELD_NAMES) {
       form.get(field)?.enable();
     }
@@ -295,14 +294,9 @@ export class ExternalNationalIdService implements OnDestroy {
   /**
    * Disable person fields (used in edit mode to lock fields for existing external IDs).
    */
-  private disablePersonFields(form: UntypedFormGroup): void {
+  private disablePersonFields(form: FormGroup): void {
     for (const field of PERSON_FIELD_NAMES) {
       form.get(field)?.disable();
     }
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/src/app/savings/create-savings-account/create-savings-account.component.ts
+++ b/src/app/savings/create-savings-account/create-savings-account.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, ActivatedRoute } from '@angular/router';
 
 /** Custom Components */
@@ -51,6 +52,7 @@ export class CreateSavingsAccountComponent {
   private dateUtils = inject(Dates);
   private savingsService = inject(SavingsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Savings Account Template */
   savingsAccountTemplate: any;
@@ -76,7 +78,7 @@ export class CreateSavingsAccountComponent {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountTemplate: any }) => {
       this.savingsAccountTemplate = data.savingsAccountTemplate;
     });
   }

--- a/src/app/savings/edit-savings-account/edit-savings-account.component.ts
+++ b/src/app/savings/edit-savings-account/edit-savings-account.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, ActivatedRoute } from '@angular/router';
 
 /** Custom Components */
@@ -51,6 +52,7 @@ export class EditSavingsAccountComponent {
   private dateUtils = inject(Dates);
   private savingsService = inject(SavingsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Savings Account Template */
   savingsAccountAndTemplate: any;
@@ -76,7 +78,7 @@ export class EditSavingsAccountComponent {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountAndTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountAndTemplate: any }) => {
       this.savingsAccountAndTemplate = data.savingsAccountAndTemplate;
     });
   }

--- a/src/app/savings/gsim-account/create-gsim-account/create-gsim-account.component.ts
+++ b/src/app/savings/gsim-account/create-gsim-account/create-gsim-account.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, ActivatedRoute } from '@angular/router';
 
 /** Custom Components */
@@ -53,6 +54,7 @@ export class CreateGsimAccountComponent {
   private dateUtils = inject(Dates);
   private savingsService = inject(SavingsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Savings Account Template */
   savingsAccountTemplate: any;
@@ -85,10 +87,12 @@ export class CreateGsimAccountComponent {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountTemplate: any; groupsData: any }) => {
-      this.savingsAccountTemplate = data.savingsAccountTemplate;
-      this.dataSource = data.groupsData.activeClientMembers;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { savingsAccountTemplate: any; groupsData: any }) => {
+        this.savingsAccountTemplate = data.savingsAccountTemplate;
+        this.dataSource = data.groupsData.activeClientMembers;
+      });
   }
 
   /**

--- a/src/app/savings/gsim-account/gsim-account.component.ts
+++ b/src/app/savings/gsim-account/gsim-account.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import {
@@ -92,6 +93,7 @@ export class GsimAccountComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Columns to be displayed in charge overview table. */
   displayedColumns: string[] = [
@@ -122,15 +124,17 @@ export class GsimAccountComponent implements OnInit {
    */
   constructor() {
     // Get groupId from route params
-    this.route.parent?.parent?.params.subscribe((params) => {
+    this.route.parent?.parent?.params.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.groupId = params['groupId'];
     });
 
-    this.route.data.subscribe((data: { gsimData: any; savingAccountData: any; groupsData: any }) => {
-      this.gsimOverviewData = data.gsimData[0].childGSIMAccounts;
-      this.savingAccountData = data.savingAccountData;
-      this.groupsData = data.groupsData;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { gsimData: any; savingAccountData: any; groupsData: any }) => {
+        this.gsimOverviewData = data.gsimData[0].childGSIMAccounts;
+        this.savingAccountData = data.savingAccountData;
+        this.groupsData = data.groupsData;
+      });
   }
 
   ngOnInit(): void {

--- a/src/app/savings/saving-account-actions/activate-savings-account/activate-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/activate-savings-account/activate-savings-account.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -30,7 +30,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ActivateSavingsAccountComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
@@ -42,7 +42,7 @@ export class ActivateSavingsAccountComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Activate Savings Account form. */
-  activateSavingsAccountForm: UntypedFormGroup;
+  activateSavingsAccountForm: FormGroup;
   /** Savings Account Id */
   accountId: any;
 

--- a/src/app/savings/saving-account-actions/add-charge-savings-account/add-charge-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/add-charge-savings-account/add-charge-savings-account.component.ts
@@ -7,14 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -36,19 +31,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AddChargeSavingsAccountComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
   private savingsService = inject(SavingsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum Due Date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum Due Date allowed. */
   maxDate = new Date();
   /** Add Savings Charge form. */
-  savingsChargeForm: UntypedFormGroup;
+  savingsChargeForm: FormGroup;
   /** savings charge options. */
   savingsChargeOptions: any;
   /** savings Id of the savings account. */
@@ -66,7 +62,7 @@ export class AddChargeSavingsAccountComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountActionData: any }) => {
       this.savingsChargeOptions = data.savingsAccountActionData.chargeOptions;
     });
     this.savingAccountId = this.route.snapshot.params['savingAccountId'];
@@ -82,41 +78,43 @@ export class AddChargeSavingsAccountComponent implements OnInit {
   }
 
   buildDependencies() {
-    this.savingsChargeForm.controls.chargeId.valueChanges.subscribe((chargeId) => {
-      this.savingsService.getChargeTemplate(chargeId).subscribe((data: any) => {
-        this.chargeDetails = data;
-        const chargeTimeType = data.chargeTimeType.id;
-        if (data.chargeTimeType.value === 'Withdrawal Fee' || data.chargeTimeType.value === 'Saving No Activity Fee') {
-          this.chargeDetails.dueDateNotRequired = true;
-        }
-        if (data.chargeTimeType.value === 'Annual Fee' || data.chargeTimeType.value === 'Monthly Fee') {
-          this.chargeDetails.chargeTimeTypeAnnualOrMonth = true;
-        }
-        if (!this.chargeDetails.dueDateNotRequired && !this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
-          this.savingsChargeForm.addControl('dueDate', new UntypedFormControl('', Validators.required));
-        } else {
-          this.savingsChargeForm.removeControl('dueDate');
-        }
-        if (!this.chargeDetails.dueDateNotRequired && this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
-          this.savingsChargeForm.addControl('feeOnMonthDay', new UntypedFormControl('', Validators.required));
-        } else {
-          this.savingsChargeForm.removeControl('feeOnMonthDay');
-        }
-        if (chargeTimeType.value === 'Monthly Fee') {
-          this.savingsChargeForm.addControl(
-            'feeInterval',
-            new UntypedFormControl(data.feeInterval, Validators.required)
-          );
-        } else {
-          this.savingsChargeForm.removeControl('feeInterval');
-        }
-        this.savingsChargeForm.patchValue({
-          amount: data.amount,
-          chargeCalculationType: data.chargeCalculationType.id,
-          chargeTimeType: data.chargeTimeType.id
+    this.savingsChargeForm.controls.chargeId.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((chargeId) => {
+        this.savingsService.getChargeTemplate(chargeId).subscribe((data: any) => {
+          this.chargeDetails = data;
+          const chargeTimeType = data.chargeTimeType.id;
+          if (
+            data.chargeTimeType.value === 'Withdrawal Fee' ||
+            data.chargeTimeType.value === 'Saving No Activity Fee'
+          ) {
+            this.chargeDetails.dueDateNotRequired = true;
+          }
+          if (data.chargeTimeType.value === 'Annual Fee' || data.chargeTimeType.value === 'Monthly Fee') {
+            this.chargeDetails.chargeTimeTypeAnnualOrMonth = true;
+          }
+          if (!this.chargeDetails.dueDateNotRequired && !this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
+            this.savingsChargeForm.addControl('dueDate', new FormControl('', Validators.required));
+          } else {
+            this.savingsChargeForm.removeControl('dueDate');
+          }
+          if (!this.chargeDetails.dueDateNotRequired && this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
+            this.savingsChargeForm.addControl('feeOnMonthDay', new FormControl('', Validators.required));
+          } else {
+            this.savingsChargeForm.removeControl('feeOnMonthDay');
+          }
+          if (chargeTimeType.value === 'Monthly Fee') {
+            this.savingsChargeForm.addControl('feeInterval', new FormControl(data.feeInterval, Validators.required));
+          } else {
+            this.savingsChargeForm.removeControl('feeInterval');
+          }
+          this.savingsChargeForm.patchValue({
+            amount: data.amount,
+            chargeCalculationType: data.chargeCalculationType.id,
+            chargeTimeType: data.chargeTimeType.id
+          });
         });
       });
-    });
   }
 
   /**

--- a/src/app/savings/saving-account-actions/apply-annual-fees-savings-account/apply-annual-fees-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/apply-annual-fees-savings-account/apply-annual-fees-savings-account.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -30,19 +31,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ApplyAnnualFeesSavingsAccountComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Apply annual fees form. */
-  applyAnnualFeesForm: UntypedFormGroup;
+  applyAnnualFeesForm: FormGroup;
   /** Savings Account Id */
   accountId: any;
   /** Annual Fees charge Id */
@@ -60,7 +62,7 @@ export class ApplyAnnualFeesSavingsAccountComponent implements OnInit {
    */
   constructor() {
     this.accountId = this.route.snapshot.params['savingAccountId'];
-    this.route.data.subscribe((data: { savingsAccountActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountActionData: any }) => {
       this.savingsAccountData = data.savingsAccountActionData;
     });
   }

--- a/src/app/savings/saving-account-actions/approve-savings-account/approve-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/approve-savings-account/approve-savings-account.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -32,7 +32,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ApproveSavingsAccountComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
@@ -44,7 +44,7 @@ export class ApproveSavingsAccountComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Approve Savings Account form. */
-  approveSavingsAccountForm: UntypedFormGroup;
+  approveSavingsAccountForm: FormGroup;
   /** Savings Account Id */
   accountId: any;
 

--- a/src/app/savings/saving-account-actions/close-savings-account/close-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/close-savings-account/close-savings-account.component.ts
@@ -7,14 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -42,19 +37,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CloseSavingsAccountComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Close Savings Account form. */
-  closeSavingsAccountForm: UntypedFormGroup;
+  closeSavingsAccountForm: FormGroup;
   /** Savings Account Id */
   accountId: any;
   /** Flag to enable payment details fields. */
@@ -73,7 +69,7 @@ export class CloseSavingsAccountComponent implements OnInit {
    * @param {SettingsService} settingsService Setting service
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountActionData: any }) => {
       this.paymentTypeOptions = data.savingsAccountActionData[0].paymentTypeOptions;
       this.transactionAmount = data.savingsAccountActionData[1].summary.accountBalance;
     });
@@ -108,18 +104,21 @@ export class CloseSavingsAccountComponent implements OnInit {
    * Subscribe to value changes of withdraw balance checkbox.
    */
   buildDependencies() {
-    this.closeSavingsAccountForm.get('withdrawBalance').valueChanges.subscribe((value: boolean) => {
-      if (value) {
-        this.closeSavingsAccountForm.addControl(
-          'amount',
-          new UntypedFormControl({ value: this.transactionAmount, disabled: true })
-        );
-        this.closeSavingsAccountForm.addControl('paymentTypeId', new UntypedFormControl(''));
-      } else {
-        this.closeSavingsAccountForm.removeControl('amount');
-        this.closeSavingsAccountForm.removeControl('paymentTypeId');
-      }
-    });
+    this.closeSavingsAccountForm
+      .get('withdrawBalance')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value: boolean) => {
+        if (value) {
+          this.closeSavingsAccountForm.addControl(
+            'amount',
+            new FormControl({ value: this.transactionAmount, disabled: true })
+          );
+          this.closeSavingsAccountForm.addControl('paymentTypeId', new FormControl(''));
+        } else {
+          this.closeSavingsAccountForm.removeControl('amount');
+          this.closeSavingsAccountForm.removeControl('paymentTypeId');
+        }
+      });
   }
 
   /**
@@ -128,11 +127,11 @@ export class CloseSavingsAccountComponent implements OnInit {
   addPaymentDetails() {
     this.addPaymentDetailsFlag = !this.addPaymentDetailsFlag;
     if (this.addPaymentDetailsFlag) {
-      this.closeSavingsAccountForm.addControl('accountNumber', new UntypedFormControl(''));
-      this.closeSavingsAccountForm.addControl('checkNumber', new UntypedFormControl(''));
-      this.closeSavingsAccountForm.addControl('routingCode', new UntypedFormControl(''));
-      this.closeSavingsAccountForm.addControl('receiptNumber', new UntypedFormControl(''));
-      this.closeSavingsAccountForm.addControl('bankNumber', new UntypedFormControl(''));
+      this.closeSavingsAccountForm.addControl('accountNumber', new FormControl(''));
+      this.closeSavingsAccountForm.addControl('checkNumber', new FormControl(''));
+      this.closeSavingsAccountForm.addControl('routingCode', new FormControl(''));
+      this.closeSavingsAccountForm.addControl('receiptNumber', new FormControl(''));
+      this.closeSavingsAccountForm.addControl('bankNumber', new FormControl(''));
     } else {
       this.closeSavingsAccountForm.removeControl('accountNumber');
       this.closeSavingsAccountForm.removeControl('checkNumber');

--- a/src/app/savings/saving-account-actions/manage-savings-account/manage-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/manage-savings-account/manage-savings-account.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 import { SavingsService } from 'app/savings/savings.service';
@@ -39,7 +39,7 @@ interface TransactionType {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ManageSavingsAccountComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
@@ -53,7 +53,7 @@ export class ManageSavingsAccountComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Manage Savings Account form. */
-  manageSavingsAccountForm: UntypedFormGroup;
+  manageSavingsAccountForm: FormGroup;
   /** Savings Account Id */
   savingAccountId: string;
   transactionCommand: TransactionCommandType;

--- a/src/app/savings/saving-account-actions/post-interest-as-on-savings-account/post-interest-as-on-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/post-interest-as-on-savings-account/post-interest-as-on-savings-account.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -30,7 +30,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class PostInterestAsOnSavingsAccountComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
@@ -42,7 +42,7 @@ export class PostInterestAsOnSavingsAccountComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Post Interest Savings Account form. */
-  postInterestSavingsAccountForm: UntypedFormGroup;
+  postInterestSavingsAccountForm: FormGroup;
   /** Savings Account Id */
   accountId: any;
 

--- a/src/app/savings/saving-account-actions/reject-savings-account/reject-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/reject-savings-account/reject-savings-account.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -32,7 +32,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RejectSavingsAccountComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
@@ -44,7 +44,7 @@ export class RejectSavingsAccountComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Reject Saving Account form. */
-  rejectSavingsAccountForm: UntypedFormGroup;
+  rejectSavingsAccountForm: FormGroup;
   /** Savings Account Id */
   accountId: any;
 

--- a/src/app/savings/saving-account-actions/saving-account-actions.component.ts
+++ b/src/app/savings/saving-account-actions/saving-account-actions.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { Currency } from 'app/shared/models/general.model';
 import { ApproveSavingsAccountComponent } from './approve-savings-account/approve-savings-account.component';
@@ -52,6 +53,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class SavingAccountActionsComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Flag object to store possible actions and render appropriate UI to the user */
   actions: {
@@ -104,7 +106,7 @@ export class SavingAccountActionsComponent {
    * @param {ActivatedRoute} route Activated Route
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountActionData: any }) => {
       if (data.savingsAccountActionData) {
         this.currency = data.savingsAccountActionData.currency;
       }

--- a/src/app/savings/saving-account-actions/savings-account-assign-staff/savings-account-assign-staff.component.ts
+++ b/src/app/savings/saving-account-actions/savings-account-assign-staff/savings-account-assign-staff.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -30,19 +31,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SavingsAccountAssignStaffComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Savings Account Assign Staff form. */
-  savingsAssignStaffForm: UntypedFormGroup;
+  savingsAssignStaffForm: FormGroup;
   /** Savings Account Id */
   accountId: any;
   /** Field Officer Data */
@@ -60,7 +62,7 @@ export class SavingsAccountAssignStaffComponent implements OnInit {
    */
   constructor() {
     this.accountId = this.route.snapshot.params['savingAccountId'];
-    this.route.data.subscribe((data: { savingsAccountActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountActionData: any }) => {
       this.savingsAccountData = data.savingsAccountActionData;
     });
   }

--- a/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.ts
+++ b/src/app/savings/saving-account-actions/savings-account-transactions/savings-account-transactions.component.ts
@@ -7,14 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject, ViewChild } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import { finalize } from 'rxjs';
@@ -50,19 +45,20 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 export class SavingsAccountTransactionsComponent implements OnInit {
   @ViewChild('stepper') stepper: MatStepper;
 
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
   private savingsService = inject(SavingsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum Due Date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum Due Date allowed. */
   maxDate = new Date();
   /** Savings account transaction form. */
-  savingAccountTransactionForm: UntypedFormGroup;
+  savingAccountTransactionForm: FormGroup;
   /** savings account transaction payment options. */
   paymentTypeOptions: {
     id: number;
@@ -95,7 +91,7 @@ export class SavingsAccountTransactionsComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountActionData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountActionData: any }) => {
       this.paymentTypeOptions = data.savingsAccountActionData.paymentTypeOptions;
       if (data.savingsAccountActionData.currency) {
         this.currency = data.savingsAccountActionData.currency;
@@ -141,11 +137,11 @@ export class SavingsAccountTransactionsComponent implements OnInit {
   addPaymentDetails() {
     this.addPaymentDetailsFlag = !this.addPaymentDetailsFlag;
     if (this.addPaymentDetailsFlag) {
-      this.savingAccountTransactionForm.addControl('accountNumber', new UntypedFormControl(''));
-      this.savingAccountTransactionForm.addControl('checkNumber', new UntypedFormControl(''));
-      this.savingAccountTransactionForm.addControl('routingCode', new UntypedFormControl(''));
-      this.savingAccountTransactionForm.addControl('receiptNumber', new UntypedFormControl(''));
-      this.savingAccountTransactionForm.addControl('bankNumber', new UntypedFormControl(''));
+      this.savingAccountTransactionForm.addControl('accountNumber', new FormControl(''));
+      this.savingAccountTransactionForm.addControl('checkNumber', new FormControl(''));
+      this.savingAccountTransactionForm.addControl('routingCode', new FormControl(''));
+      this.savingAccountTransactionForm.addControl('receiptNumber', new FormControl(''));
+      this.savingAccountTransactionForm.addControl('bankNumber', new FormControl(''));
     } else {
       this.savingAccountTransactionForm.removeControl('accountNumber');
       this.savingAccountTransactionForm.removeControl('checkNumber');

--- a/src/app/savings/saving-account-actions/savings-account-unassign-staff/savings-account-unassign-staff.component.ts
+++ b/src/app/savings/saving-account-actions/savings-account-unassign-staff/savings-account-unassign-staff.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -30,7 +30,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SavingsAccountUnassignStaffComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
@@ -42,7 +42,7 @@ export class SavingsAccountUnassignStaffComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Savings Account Unassign Staff form. */
-  savingsUnassignStaffForm: UntypedFormGroup;
+  savingsUnassignStaffForm: FormGroup;
   /** Savings Account Id */
   accountId: any;
 

--- a/src/app/savings/saving-account-actions/undo-approval-savings-account/undo-approval-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/undo-approval-savings-account/undo-approval-savings-account.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -30,13 +30,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UndoApprovalSavingsAccountComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
   /** Undo Approval Savings Account form. */
-  undoApprovalSavingsAccountForm: UntypedFormGroup;
+  undoApprovalSavingsAccountForm: FormGroup;
   /** Savings Account Id */
   accountId: any;
 

--- a/src/app/savings/saving-account-actions/withdraw-by-client-savings-account/withdraw-by-client-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/withdraw-by-client-savings-account/withdraw-by-client-savings-account.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -32,7 +32,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class WithdrawByClientSavingsAccountComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
@@ -44,7 +44,7 @@ export class WithdrawByClientSavingsAccountComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Withdraw Savings Account form. */
-  withdrawSavingsAccountForm: UntypedFormGroup;
+  withdrawSavingsAccountForm: FormGroup;
   /** Savings Account Id */
   accountId: any;
 

--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
@@ -9,7 +9,7 @@
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, OnChanges, Input, inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { UntypedFormControl } from '@angular/forms';
+import { FormControl } from '@angular/forms';
 
 /** Custom Dialogs */
 import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
@@ -80,7 +80,7 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
   /** Savings Account Template */
   @Input() savingsAccountTemplate: any;
   /** Currency Code */
-  @Input() currencyCode: UntypedFormControl;
+  @Input() currencyCode: FormControl;
   /** active Client Members in case of GSIM Account */
   @Input() activeClientMembers?: any;
 

--- a/src/app/savings/savings-account-stepper/savings-account-details-step/savings-account-details-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-details-step/savings-account-details-step.component.ts
@@ -7,8 +7,18 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, Input, Output, EventEmitter, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  inject
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 
 /** Custom Services */
 import { SavingsService } from 'app/savings/savings.service';
@@ -33,9 +43,10 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SavingsAccountDetailsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private savingsService = inject(SavingsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Savings Account Template */
   @Input() savingsAccountTemplate: any;
@@ -51,7 +62,7 @@ export class SavingsAccountDetailsStepComponent implements OnInit {
   /** For edit savings form */
   isFieldOfficerPatched = false;
   /** Savings Account Details Form */
-  savingsAccountDetailsForm: UntypedFormGroup;
+  savingsAccountDetailsForm: FormGroup;
 
   savingsProductSelected = false;
 
@@ -112,21 +123,26 @@ export class SavingsAccountDetailsStepComponent implements OnInit {
    */
   buildDependencies() {
     const entityId = this.savingsAccountTemplate.groupId || this.savingsAccountTemplate.clientId;
-    this.savingsAccountDetailsForm.get('productId').valueChanges.subscribe((productId: string) => {
-      this.savingsService
-        .getSavingsAccountTemplate(entityId, productId, this.savingsAccountTemplate.groupId ? true : false)
-        .subscribe((response: any) => {
-          this.savingsAccountProductTemplate.emit(response);
-          this.fieldOfficerData = response.fieldOfficerOptions;
-          this.savingsProductSelected = true;
-          if (!this.isFieldOfficerPatched && this.savingsAccountTemplate.fieldOfficerId) {
-            this.savingsAccountDetailsForm.get('fieldOfficerId').patchValue(this.savingsAccountTemplate.fieldOfficerId);
-            this.isFieldOfficerPatched = true;
-          } else {
-            this.savingsAccountDetailsForm.get('fieldOfficerId').patchValue('');
-          }
-        });
-    });
+    this.savingsAccountDetailsForm
+      .get('productId')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((productId: string) => {
+        this.savingsService
+          .getSavingsAccountTemplate(entityId, productId, this.savingsAccountTemplate.groupId ? true : false)
+          .subscribe((response: any) => {
+            this.savingsAccountProductTemplate.emit(response);
+            this.fieldOfficerData = response.fieldOfficerOptions;
+            this.savingsProductSelected = true;
+            if (!this.isFieldOfficerPatched && this.savingsAccountTemplate.fieldOfficerId) {
+              this.savingsAccountDetailsForm
+                .get('fieldOfficerId')
+                .patchValue(this.savingsAccountTemplate.fieldOfficerId);
+              this.isFieldOfficerPatched = true;
+            } else {
+              this.savingsAccountDetailsForm.get('fieldOfficerId').patchValue('');
+            }
+          });
+      });
   }
 
   /**

--- a/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-terms-step/savings-account-terms-step.component.ts
@@ -7,14 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnChanges, OnInit, Input, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnChanges, OnInit, Input, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { SettingsService } from 'app/settings/settings.service';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDivider } from '@angular/material/divider';
@@ -40,8 +35,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Savings Account and Product Template */
   @Input() savingsAccountProductTemplate: any;
@@ -53,7 +49,7 @@ export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
   /** Maximum date allowed. */
   maxDate = new Date();
   /** Savings Account Terms Form */
-  savingsAccountTermsForm: UntypedFormGroup;
+  savingsAccountTermsForm: FormGroup;
   /** Lockin Period Frequency Type Data */
   lockinPeriodFrequencyTypeData: any;
   /** Interest Compounding Period Type Data */
@@ -188,29 +184,32 @@ export class SavingsAccountTermsStepComponent implements OnChanges, OnInit {
   buildDependencies() {
     const nominalInterestControl = this.savingsAccountTermsForm.get('nominalAnnualInterestRate');
     if (nominalInterestControl) {
-      nominalInterestControl.valueChanges.subscribe((value) => {
+      nominalInterestControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => {
         if (typeof value === 'number' && value < 0) {
           nominalInterestControl.setValue(0, { emitEvent: false });
         }
       });
     }
-    this.savingsAccountTermsForm.get('allowOverdraft').valueChanges.subscribe((allowOverdraft: any) => {
-      if (allowOverdraft) {
-        this.savingsAccountTermsForm.addControl(
-          'minOverdraftForInterestCalculation',
-          new UntypedFormControl('', Validators.min(0))
-        );
-        this.savingsAccountTermsForm.addControl(
-          'nominalAnnualInterestRateOverdraft',
-          new UntypedFormControl('', Validators.min(0))
-        );
-        this.savingsAccountTermsForm.addControl('overdraftLimit', new UntypedFormControl('', Validators.min(0)));
-      } else {
-        this.savingsAccountTermsForm.removeControl('minOverdraftForInterestCalculation');
-        this.savingsAccountTermsForm.removeControl('nominalAnnualInterestRateOverdraft');
-        this.savingsAccountTermsForm.removeControl('overdraftLimit');
-      }
-    });
+    this.savingsAccountTermsForm
+      .get('allowOverdraft')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((allowOverdraft: any) => {
+        if (allowOverdraft) {
+          this.savingsAccountTermsForm.addControl(
+            'minOverdraftForInterestCalculation',
+            new FormControl('', Validators.min(0))
+          );
+          this.savingsAccountTermsForm.addControl(
+            'nominalAnnualInterestRateOverdraft',
+            new FormControl('', Validators.min(0))
+          );
+          this.savingsAccountTermsForm.addControl('overdraftLimit', new FormControl('', Validators.min(0)));
+        } else {
+          this.savingsAccountTermsForm.removeControl('minOverdraftForInterestCalculation');
+          this.savingsAccountTermsForm.removeControl('nominalAnnualInterestRateOverdraft');
+          this.savingsAccountTermsForm.removeControl('overdraftLimit');
+        }
+      });
   }
 
   /**

--- a/src/app/savings/savings-account-view/datatable-tabs/datatable-tabs.component.ts
+++ b/src/app/savings/savings-account-view/datatable-tabs/datatable-tabs.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -27,6 +28,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class DatatableTabsComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   entityId: string;
   /** Savings Datatable */
@@ -41,7 +43,7 @@ export class DatatableTabsComponent {
   constructor() {
     this.entityId = this.route.parent.parent.snapshot.paramMap.get('savingAccountId');
 
-    this.route.data.subscribe((data: { savingsDatatable: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsDatatable: any }) => {
       this.entityDatatable = data.savingsDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
     });

--- a/src/app/savings/savings-account-view/notes-tab/notes-tab.component.ts
+++ b/src/app/savings/savings-account-view/notes-tab/notes-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
 import { SavingsService } from 'app/savings/savings.service';
@@ -27,6 +28,7 @@ export class NotesTabComponent {
   private route = inject(ActivatedRoute);
   private savingsService = inject(SavingsService);
   private authenticationService = inject(AuthenticationService);
+  private destroyRef = inject(DestroyRef);
 
   entityId: string;
   username: string;
@@ -36,7 +38,7 @@ export class NotesTabComponent {
     const savedCredentials = this.authenticationService.getCredentials();
     this.username = savedCredentials.username;
     this.entityId = this.route.parent.snapshot.params['savingAccountId'];
-    this.route.data.subscribe((data: { savingAccountNotes: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingAccountNotes: any }) => {
       this.entityNotes = data.savingAccountNotes;
     });
   }

--- a/src/app/savings/savings-account-view/savings-account-view.component.ts
+++ b/src/app/savings/savings-account-view/savings-account-view.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -85,6 +86,7 @@ export class SavingsAccountViewComponent implements OnInit {
   private savingsService = inject(SavingsService);
   private translateService = inject(TranslateService);
   dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Savings Account Data */
   savingsAccountData: any;
@@ -105,11 +107,13 @@ export class SavingsAccountViewComponent implements OnInit {
    * @param {SavingsService} savingsService Savings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountData: any; savingsDatatables: any }) => {
-      this.savingsAccountData = data.savingsAccountData;
-      this.currency = this.savingsAccountData.currency;
-      this.savingsDatatables = data.savingsDatatables;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { savingsAccountData: any; savingsDatatables: any }) => {
+        this.savingsAccountData = data.savingsAccountData;
+        this.currency = this.savingsAccountData.currency;
+        this.savingsDatatables = data.savingsDatatables;
+      });
     if (this.router.url.includes('clients')) {
       this.entityType = 'Client';
     } else if (this.router.url.includes('groups')) {

--- a/src/app/savings/savings-account-view/savings-documents-tab/savings-documents-tab.component.ts
+++ b/src/app/savings/savings-account-view/savings-documents-tab/savings-documents-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { SavingsService } from 'app/savings/savings.service';
@@ -30,6 +31,7 @@ export class SavingsDocumentsTabComponent {
   private savingsService = inject(SavingsService);
   private settingsService = inject(SettingsService);
   dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Stores the resolved savings documents data */
   entityDocuments: any;
@@ -42,7 +44,7 @@ export class SavingsDocumentsTabComponent {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsDocuments: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsDocuments: any }) => {
       this.setSavingsDocumentsData(data.savingsDocuments);
     });
     this.entityId = this.route.parent.snapshot.paramMap.get('savingAccountId');

--- a/src/app/savings/savings-account-view/transactions-tab/export-transactions/export-transactions.component.ts
+++ b/src/app/savings/savings-account-view/transactions-tab/export-transactions/export-transactions.component.ts
@@ -7,9 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DomSanitizer } from '@angular/platform-browser';
-import { UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -35,10 +36,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class ExportTransactionsComponent implements OnInit {
   private sanitizer = inject(DomSanitizer);
   private reportsService = inject(ReportsService);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private dateUtils = inject(Dates);
   private route = inject(ActivatedRoute);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -63,9 +65,11 @@ export class ExportTransactionsComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.parent.parent.data.subscribe((data: { savingsAccountData: any }) => {
-      this.savingsAccountId = data.savingsAccountData.accountNo;
-    });
+    this.route.parent.parent.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { savingsAccountData: any }) => {
+        this.savingsAccountId = data.savingsAccountData.accountNo;
+      });
   }
 
   ngOnInit() {

--- a/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
-import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import { CurrencyPipe, NgClass } from '@angular/common';
@@ -93,6 +94,7 @@ export class TransactionsTabComponent implements OnInit {
   private dateUtils = inject(Dates);
   private accountTransfersService = inject(AccountTransfersService);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Savings Account Status */
   status: any;
@@ -101,8 +103,8 @@ export class TransactionsTabComponent implements OnInit {
   /** Transactions Data */
   transactionsData: SavingsAccountTransaction[] = [];
   /** Form control to handle accural parameter */
-  hideAccrualsParam: UntypedFormControl;
-  hideReversedParam: UntypedFormControl;
+  hideAccrualsParam: FormControl;
+  hideReversedParam: FormControl;
   /** Columns to be displayed in transactions table. */
   displayedColumns: string[] = [
     'row',
@@ -129,17 +131,19 @@ export class TransactionsTabComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.parent.parent.data.subscribe((data: { savingsAccountData: any }) => {
-      this.transactionsData = data.savingsAccountData.transactions;
-      this.status = data.savingsAccountData.status.value;
-      this.currency = data.savingsAccountData.currency || null;
-    });
+    this.route.parent.parent.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { savingsAccountData: any }) => {
+        this.transactionsData = data.savingsAccountData.transactions;
+        this.status = data.savingsAccountData.status.value;
+        this.currency = data.savingsAccountData.currency || null;
+      });
     this.accountId = this.route.parent.parent.snapshot.params['savingAccountId'];
   }
 
   ngOnInit() {
-    this.hideAccrualsParam = new UntypedFormControl(false);
-    this.hideReversedParam = new UntypedFormControl(false);
+    this.hideAccrualsParam = new FormControl(false);
+    this.hideReversedParam = new FormControl(false);
     this.setTransactions();
   }
 

--- a/src/app/savings/savings-account-view/transactions/edit-transaction/edit-transaction.component.ts
+++ b/src/app/savings/savings-account-view/transactions/edit-transaction/edit-transaction.component.ts
@@ -7,14 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -41,19 +36,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditTransactionComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
   private savingsService = inject(SavingsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum Due Date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum Due Date allowed. */
   maxDate = new Date();
   /** Savings account transaction form. */
-  editTransactionForm: UntypedFormGroup;
+  editTransactionForm: FormGroup;
   /** savings account transaction payment options. */
   paymentTypeOptions: {
     id: number;
@@ -80,13 +76,15 @@ export class EditTransactionComponent implements OnInit {
    * @param {SettingsService} settingsService Setting service
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountTransactionTemplate: any }) => {
-      this.transactionTemplateData = data.savingsAccountTransactionTemplate;
-      if (data.savingsAccountTransactionTemplate.currency) {
-        this.currency = data.savingsAccountTransactionTemplate.currency;
-      }
-      this.paymentTypeOptions = this.transactionTemplateData.paymentTypeOptions;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { savingsAccountTransactionTemplate: any }) => {
+        this.transactionTemplateData = data.savingsAccountTransactionTemplate;
+        if (data.savingsAccountTransactionTemplate.currency) {
+          this.currency = data.savingsAccountTransactionTemplate.currency;
+        }
+        this.paymentTypeOptions = this.transactionTemplateData.paymentTypeOptions;
+      });
     this.savingAccountId = this.route.snapshot.params['savingAccountId'];
   }
 
@@ -126,11 +124,11 @@ export class EditTransactionComponent implements OnInit {
   addPaymentDetails() {
     this.showPaymentDetails = !this.showPaymentDetails;
     if (this.showPaymentDetails) {
-      this.editTransactionForm.addControl('accountNumber', new UntypedFormControl(''));
-      this.editTransactionForm.addControl('checkNumber', new UntypedFormControl(''));
-      this.editTransactionForm.addControl('routingCode', new UntypedFormControl(''));
-      this.editTransactionForm.addControl('receiptNumber', new UntypedFormControl(''));
-      this.editTransactionForm.addControl('bankNumber', new UntypedFormControl(''));
+      this.editTransactionForm.addControl('accountNumber', new FormControl(''));
+      this.editTransactionForm.addControl('checkNumber', new FormControl(''));
+      this.editTransactionForm.addControl('routingCode', new FormControl(''));
+      this.editTransactionForm.addControl('receiptNumber', new FormControl(''));
+      this.editTransactionForm.addControl('bankNumber', new FormControl(''));
     } else {
       this.editTransactionForm.removeControl('accountNumber');
       this.editTransactionForm.removeControl('checkNumber');

--- a/src/app/savings/savings-account-view/transactions/view-reciept/view-reciept.component.ts
+++ b/src/app/savings/savings-account-view/transactions/view-reciept/view-reciept.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnDestroy, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -30,6 +31,7 @@ import { HttpResponse } from '@angular/common/http';
 export class ViewRecieptComponent implements OnInit, OnDestroy {
   private sanitizer = inject(DomSanitizer);
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** trusted resource url for pentaho output */
   pentahoUrl: SafeResourceUrl | null = null;
@@ -44,9 +46,11 @@ export class ViewRecieptComponent implements OnInit, OnDestroy {
    * @param {ActivatedRoute} route Activated Route
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsTransactionReciept: HttpResponse<Blob> }) => {
-      this.transactionRecieptData = data.savingsTransactionReciept;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { savingsTransactionReciept: HttpResponse<Blob> }) => {
+        this.transactionRecieptData = data.savingsTransactionReciept;
+      });
   }
 
   ngOnInit() {

--- a/src/app/savings/savings-account-view/transactions/view-transaction/datatable-transaction-tab/datatable-transaction-tab.component.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/datatable-transaction-tab/datatable-transaction-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -23,6 +24,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class DatatableTransactionTabComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Transaction Id */
   entityId: string;
@@ -32,7 +34,7 @@ export class DatatableTransactionTabComponent {
   multiRowDatatableFlag: boolean;
   constructor() {
     this.entityId = this.route.parent.parent.snapshot.paramMap.get('id');
-    this.route.data.subscribe((data: { transactionDatatable: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { transactionDatatable: any }) => {
       this.entityDatatable = data.transactionDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
     });

--- a/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
@@ -41,13 +42,14 @@ export class SavingsTransactionGeneralTabComponent {
   private router = inject(Router);
   dialog = inject(MatDialog);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   accountId: string;
   transactionId: string;
   transactionData: any;
 
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountTransaction: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountTransaction: any }) => {
       this.accountId = this.route.parent.snapshot.params['savingAccountId'];
       this.transactionData = data.savingsAccountTransaction;
     });

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
@@ -30,6 +31,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class ViewTransactionComponent {
   private route = inject(ActivatedRoute);
   dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   /** Transaction data. */
   transactionData: any;
@@ -43,7 +45,7 @@ export class ViewTransactionComponent {
    * @param {MatDialog} dialog Dialog reference.
    */
   constructor() {
-    this.route.data.subscribe((data: { transactionDatatables: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { transactionDatatables: any }) => {
       this.accountId = this.route.snapshot.params['savingAccountId'];
       this.entityDatatables = data.transactionDatatables;
     });

--- a/src/app/savings/savings-account-view/view-charge/view-charge.component.ts
+++ b/src/app/savings/savings-account-view/view-charge/view-charge.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -53,6 +54,7 @@ export class ViewChargeComponent {
   private router = inject(Router);
   dialog = inject(MatDialog);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Charge data. */
   chargeData: any;
@@ -69,10 +71,10 @@ export class ViewChargeComponent {
    * @param {SettingsService} settingsService Setting service
    */
   constructor() {
-    this.route.data.subscribe((data: { savingsAccountCharge: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountCharge: any }) => {
       this.chargeData = data.savingsAccountCharge;
     });
-    this.route.data.subscribe((data: { savingsAccountData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingsAccountData: any }) => {
       this.savingsAccountData = data.savingsAccountData;
     });
   }


### PR DESCRIPTION
## Description

Replace manual subscribe/unsubscribe patterns with DestroyRef + takeUntilDestroyed across clients and savings components and directives. Also replace UntypedFormBuilder/Group/Control/Array with typed Angular equivalents.

## Related issues and discussion

[WEB-954](https://github.com/openMF/web-app/pull/WEB-954)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-954]: https://mifosforge.jira.com/browse/WEB-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal form type safety and subscription lifecycle management across the application for better code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->