### PR TITLE
WEB-951 The 'Print' button should be visible 

### DIFF
--- a/src/app/loans/loans-view/loan-account-actions/loan-screen-reports/loan-screen-reports.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/loan-screen-reports/loan-screen-reports.component.html
@@ -45,10 +45,12 @@
 <div #output class="container">
   <mat-card class="layout-column gap-3percent">
     <div class="layout-align-end">
-      <button mat-stroked-button color="primary" [disabled]="!template" (click)="print()">
-        <fa-icon icon="file" class="m-r-10"></fa-icon>
-        {{ 'labels.buttons.Print' | translate }}
-      </button>
+      @if (productionMode) {
+        <button mat-stroked-button color="primary" [disabled]="!template" (click)="print()">
+          <fa-icon icon="file" class="m-r-10"></fa-icon>
+          {{ 'labels.buttons.Print' | translate }}
+        </button>
+      }
     </div>
 
     <div #screenReport class="screen-report">


### PR DESCRIPTION
**Chnages Made :-**

-Restore print button visibility condition when MIFOS_PRODUCTION_MODE is enabled .

[WEB-951](https://mifosforge.jira.com/browse/WEB-951)

[WEB-951]: https://mifosforge.jira.com/browse/WEB-951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the loan screen reports UI so the **Print** button is shown only in **production mode** (while keeping the same disabled/interaction behavior as before).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->