### PR TITLE
WEB-954: Migrate Subscription management : products

### DIFF
--- a/src/app/products/charges/charges.component.ts
+++ b/src/app/products/charges/charges.component.ts
@@ -15,8 +15,10 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
+  DestroyRef,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -82,6 +84,7 @@ export class ChargesComponent implements OnInit, AfterViewInit {
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
   private charges = inject(Charges);
+  private destroyRef = inject(DestroyRef);
 
   /** Charge data. */
   chargeData: Charge[] = [];
@@ -122,7 +125,7 @@ export class ChargesComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { charges: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { charges: any }) => {
       this.chargeData = data.charges;
     });
     this.chargeAppliesToOptions = this.charges.getChargeAppliesToOptions();

--- a/src/app/products/charges/create-charge/create-charge.component.ts
+++ b/src/app/products/charges/create-charge/create-charge.component.ts
@@ -7,15 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
-import { Router, ActivatedRoute, RouterLink } from '@angular/router';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, FormControl, Validators } from '@angular/forms';
+import { Router, ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
 import { ProductsService } from '../../products.service';
@@ -46,15 +41,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateChargeComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Charge form. */
-  chargeForm: UntypedFormGroup;
+  chargeForm: FormGroup;
   /** Charges template data. */
   chargesTemplateData: any;
   /** Charge time type data. */
@@ -84,7 +80,7 @@ export class CreateChargeComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { chargesTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { chargesTemplate: any }) => {
       this.chargesTemplateData = data.chargesTemplate;
       this.chargePaymentModeData = this.chargesTemplateData.chargePaymetModeOptions;
       const incomeOptions = data.chargesTemplate.incomeOrLiabilityAccountOptions.incomeAccountOptions || [];
@@ -156,35 +152,42 @@ export class CreateChargeComponent implements OnInit {
    * Sets the charge calculation type and charge time type data
    */
   setChargeForm() {
-    this.chargeForm.get('chargeAppliesTo').valueChanges.subscribe((chargeAppliesTo) => {
-      switch (chargeAppliesTo) {
-        case 1:
-          this.chargeCalculationTypeData = this.chargesTemplateData.loanChargeCalculationTypeOptions;
-          this.chargeTimeTypeData = this.chargesTemplateData.loanChargeTimeTypeOptions;
-          break;
-        case 2:
-          this.chargeCalculationTypeData = this.chargesTemplateData.savingsChargeCalculationTypeOptions;
-          this.chargeTimeTypeData = this.chargesTemplateData.savingsChargeTimeTypeOptions;
-          break;
-        case 3:
-          this.chargeCalculationTypeData = this.chargesTemplateData.clientChargeCalculationTypeOptions;
-          this.chargeTimeTypeData = this.chargesTemplateData.clientChargeTimeTypeOptions;
-          break;
-        case 4:
-          this.chargeCalculationTypeData = this.chargesTemplateData.shareChargeCalculationTypeOptions;
-          this.chargeTimeTypeData = this.chargesTemplateData.shareChargeTimeTypeOptions;
-          break;
-        case 5:
-          this.chargeCalculationTypeData = this.chargesTemplateData.loanChargeCalculationTypeOptions;
-          this.chargeTimeTypeData = this.chargesTemplateData.loanChargeTimeTypeOptions.filter((chargeTimeType: any) => {
-            return [2].includes(chargeTimeType.id); // Only Specific Due Date
-          });
-          this.chargePaymentModeData = this.chargePaymentModeData.filter((chargePaymentMode: any) => {
-            return chargePaymentMode.id === 0;
-          });
-          break;
-      }
-    });
+    this.chargeForm
+      .get('chargeAppliesTo')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((chargeAppliesTo) => {
+        const allPaymentModes = this.chargesTemplateData.chargePaymetModeOptions || [];
+        this.chargePaymentModeData = allPaymentModes;
+        switch (chargeAppliesTo) {
+          case 1:
+            this.chargeCalculationTypeData = this.chargesTemplateData.loanChargeCalculationTypeOptions;
+            this.chargeTimeTypeData = this.chargesTemplateData.loanChargeTimeTypeOptions;
+            break;
+          case 2:
+            this.chargeCalculationTypeData = this.chargesTemplateData.savingsChargeCalculationTypeOptions;
+            this.chargeTimeTypeData = this.chargesTemplateData.savingsChargeTimeTypeOptions;
+            break;
+          case 3:
+            this.chargeCalculationTypeData = this.chargesTemplateData.clientChargeCalculationTypeOptions;
+            this.chargeTimeTypeData = this.chargesTemplateData.clientChargeTimeTypeOptions;
+            break;
+          case 4:
+            this.chargeCalculationTypeData = this.chargesTemplateData.shareChargeCalculationTypeOptions;
+            this.chargeTimeTypeData = this.chargesTemplateData.shareChargeTimeTypeOptions;
+            break;
+          case 5:
+            this.chargeCalculationTypeData = this.chargesTemplateData.loanChargeCalculationTypeOptions;
+            this.chargeTimeTypeData = this.chargesTemplateData.loanChargeTimeTypeOptions.filter(
+              (chargeTimeType: any) => {
+                return [2].includes(chargeTimeType.id); // Only Specific Due Date
+              }
+            );
+            this.chargePaymentModeData = allPaymentModes.filter((chargePaymentMode: any) => {
+              return chargePaymentMode.id === 0;
+            });
+            break;
+        }
+      });
   }
 
   /**
@@ -245,95 +248,102 @@ export class CreateChargeComponent implements OnInit {
    * Sets the conditional controls of the user form
    */
   setConditionalControls() {
-    this.chargeForm.get('chargeAppliesTo').valueChanges.subscribe((chargeAppliesTo) => {
-      this.chargeForm.get('penalty').enable();
-      switch (chargeAppliesTo) {
-        case 1: // Loan
-          this.chargeForm.addControl('chargePaymentMode', new UntypedFormControl('', Validators.required));
-          this.chargeForm.removeControl('incomeAccountId');
-          break;
-        case 2: // Savings
-          this.chargeForm.removeControl('chargePaymentMode');
-          this.chargeForm.removeControl('incomeAccountId');
-          break;
-        case 3: // Client
-          this.chargeForm.removeControl('chargePaymentMode');
-          this.chargeForm.addControl('incomeAccountId', new UntypedFormControl(''));
-          break;
-        case 4: // Shares
-          this.chargeForm.removeControl('chargePaymentMode');
-          this.chargeForm.removeControl('incomeAccountId');
-          this.chargeForm.get('penalty').setValue(false);
-          break;
-        case 5: // Working Capital Loans
-          this.chargeForm.addControl('chargePaymentMode', new UntypedFormControl('', Validators.required));
-          this.chargeForm.removeControl('incomeAccountId');
-          break;
-      }
-      this.chargeForm.get('chargeCalculationType').reset();
-      this.chargeForm.get('chargeTimeType').reset();
-    });
-    this.chargeForm.get('chargeTimeType').valueChanges.subscribe((chargeTimeType) => {
-      this.chargeForm.removeControl('feeFrequency');
-      this.chargeForm.removeControl('feeInterval');
-      this.chargeForm.removeControl('feeOnMonthDay');
-      this.chargeForm.removeControl('addFeeFrequency');
-      if (this.chargeForm.get('chargeAppliesTo').value !== 4) {
+    this.chargeForm
+      .get('chargeAppliesTo')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((chargeAppliesTo) => {
         this.chargeForm.get('penalty').enable();
-      }
-      switch (chargeTimeType) {
-        case 6: // Annual Fee
-          this.chargeForm.addControl('feeOnMonthDay', new UntypedFormControl('', Validators.required));
-          break;
-        case 7: // Monthly Fee
-          this.chargeForm.addControl('feeOnMonthDay', new UntypedFormControl(''));
-          this.chargeForm.addControl(
-            'feeInterval',
-            new UntypedFormControl('', [
-              Validators.required,
-              Validators.min(1),
-              Validators.max(12),
-              Validators.pattern('^[1-9]\\d*$')
-            ])
-          );
-          this.repeatEveryLabel = 'Months';
-          break;
-        case 9: // Overdue Fee
-          this.chargeForm.get('penalty').setValue(true);
-          this.chargeForm.addControl('addFeeFrequency', new UntypedFormControl(false));
-          this.chargeForm.get('addFeeFrequency').valueChanges.subscribe((addFeeFrequency) => {
-            if (addFeeFrequency) {
-              this.chargeForm.addControl('feeFrequency', new UntypedFormControl('', Validators.required));
-              this.chargeForm.addControl(
-                'feeInterval',
-                new UntypedFormControl('', [
-                  Validators.required,
-                  Validators.pattern('^[1-9]\\d*$')
-                ])
-              );
-            } else {
-              this.chargeForm.removeControl('feeFrequency');
-              this.chargeForm.removeControl('feeInterval');
-            }
-          });
-          break;
-        case 11: // Weekly Fee
-          this.chargeForm.addControl(
-            'feeInterval',
-            new UntypedFormControl('', [
-              Validators.required,
-              Validators.pattern('^[1-9]\\d*$')
-            ])
-          );
-          this.repeatEveryLabel = 'Weeks';
-          break;
-      }
-    });
-    this.chargeForm.get('currencyCode').valueChanges.subscribe((currencyCode) => {
-      this.currencyDecimalPlaces = this.chargesTemplateData.currencyOptions.find(
-        (currency: any) => currency.code === currencyCode
-      ).decimalPlaces;
-    });
+        this.chargeForm.removeControl('chargePaymentMode');
+        this.chargeForm.removeControl('incomeAccountId');
+        switch (chargeAppliesTo) {
+          case 1: // Loan
+            this.chargeForm.addControl('chargePaymentMode', new FormControl('', Validators.required));
+            break;
+          case 2: // Savings
+            break;
+          case 3: // Client
+            this.chargeForm.addControl('incomeAccountId', new FormControl(''));
+            break;
+          case 4: // Shares
+            this.chargeForm.get('penalty').setValue(false);
+            break;
+          case 5: // Working Capital Loans
+            this.chargeForm.addControl('chargePaymentMode', new FormControl('', Validators.required));
+            break;
+        }
+        this.chargeForm.get('chargeCalculationType').reset();
+        this.chargeForm.get('chargeTimeType').reset();
+      });
+    this.chargeForm
+      .get('chargeTimeType')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((chargeTimeType) => {
+        this.chargeForm.removeControl('feeFrequency');
+        this.chargeForm.removeControl('feeInterval');
+        this.chargeForm.removeControl('feeOnMonthDay');
+        this.chargeForm.removeControl('addFeeFrequency');
+        if (this.chargeForm.get('chargeAppliesTo').value !== 4) {
+          this.chargeForm.get('penalty').enable();
+        }
+        switch (chargeTimeType) {
+          case 6: // Annual Fee
+            this.chargeForm.addControl('feeOnMonthDay', new FormControl('', Validators.required));
+            break;
+          case 7: // Monthly Fee
+            this.chargeForm.addControl('feeOnMonthDay', new FormControl(''));
+            this.chargeForm.addControl(
+              'feeInterval',
+              new FormControl('', [
+                Validators.required,
+                Validators.min(1),
+                Validators.max(12),
+                Validators.pattern('^[1-9]\\d*$')
+              ])
+            );
+            this.repeatEveryLabel = 'Months';
+            break;
+          case 9: // Overdue Fee
+            this.chargeForm.get('penalty').setValue(true);
+            this.chargeForm.addControl('addFeeFrequency', new FormControl(false));
+            this.chargeForm
+              .get('addFeeFrequency')
+              .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+              .subscribe((addFeeFrequency) => {
+                if (addFeeFrequency) {
+                  this.chargeForm.addControl('feeFrequency', new FormControl('', Validators.required));
+                  this.chargeForm.addControl(
+                    'feeInterval',
+                    new FormControl('', [
+                      Validators.required,
+                      Validators.pattern('^[1-9]\\d*$')
+                    ])
+                  );
+                } else {
+                  this.chargeForm.removeControl('feeFrequency');
+                  this.chargeForm.removeControl('feeInterval');
+                }
+              });
+            break;
+          case 11: // Weekly Fee
+            this.chargeForm.addControl(
+              'feeInterval',
+              new FormControl('', [
+                Validators.required,
+                Validators.pattern('^[1-9]\\d*$')
+              ])
+            );
+            this.repeatEveryLabel = 'Weeks';
+            break;
+        }
+      });
+    this.chargeForm
+      .get('currencyCode')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((currencyCode) => {
+        this.currencyDecimalPlaces = this.chargesTemplateData.currencyOptions.find(
+          (currency: any) => currency.code === currencyCode
+        ).decimalPlaces;
+      });
   }
 
   /**

--- a/src/app/products/charges/edit-charge/edit-charge.component.ts
+++ b/src/app/products/charges/edit-charge/edit-charge.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
 /** Custom Services */
@@ -38,15 +39,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class EditChargeComponent implements OnInit {
   private productsService = inject(ProductsService);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Selected Data. */
   chargeData: any;
   /** Charge form. */
-  chargeForm: UntypedFormGroup;
+  chargeForm: FormGroup;
   /** Select Income. */
   selectedIncome: any;
   /** Select Time Type. */
@@ -79,7 +81,7 @@ export class EditChargeComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { chargesTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { chargesTemplate: any }) => {
       this.chargeData = data.chargesTemplate;
     });
   }
@@ -200,7 +202,7 @@ export class EditChargeComponent implements OnInit {
         this.formBuilder.control({ value: this.chargeData.taxGroup.id, disabled: true })
       );
     } else {
-      this.chargeForm.addControl('taxGroupId', this.formBuilder.control({ value: '' }));
+      this.chargeForm.addControl('taxGroupId', this.formBuilder.control(''));
     }
   }
 
@@ -224,7 +226,7 @@ export class EditChargeComponent implements OnInit {
   submit() {
     const charges = this.chargeForm.getRawValue();
     charges.locale = this.settingsService.language.code;
-    if (charges.taxGroupId.value === '') {
+    if (!charges.taxGroupId) {
       delete charges.taxGroupId;
     }
     if (!charges.minCap) {

--- a/src/app/products/charges/view-charge/view-charge.component.ts
+++ b/src/app/products/charges/view-charge/view-charge.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
@@ -43,6 +44,7 @@ export class ViewChargeComponent {
   private router = inject(Router);
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Charge data. */
   chargeData: any;
@@ -58,7 +60,7 @@ export class ViewChargeComponent {
    * @param {TranslateService} translateService Translate Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { charge: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { charge: any }) => {
       this.chargeData = data.charge;
       if (this.chargeData.minCap) {
         this.minCap = true;

--- a/src/app/products/collaterals/collaterals.component.ts
+++ b/src/app/products/collaterals/collaterals.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ViewChild, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -52,6 +53,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class CollateralsComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Collateral Data */
   collateralData: any;
@@ -76,7 +78,7 @@ export class CollateralsComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { collaterals: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { collaterals: any }) => {
       this.collateralData = data.collaterals;
     });
   }

--- a/src/app/products/collaterals/create-collateral/create-collateral.component.ts
+++ b/src/app/products/collaterals/create-collateral/create-collateral.component.ts
@@ -7,9 +7,10 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { OrganizationService } from 'app/organization/organization.service';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -30,15 +31,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateCollateralComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private organizationService = inject(OrganizationService);
+  private destroyRef = inject(DestroyRef);
 
   /** Collateral form */
-  collateralForm: UntypedFormGroup;
+  collateralForm: FormGroup;
   /** Charges Template data */
   collateralTemplateData: any;
 
@@ -51,7 +53,7 @@ export class CreateCollateralComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { collateralTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { collateralTemplate: any }) => {
       this.organizationService.getCurrencies().subscribe((orgCurrencies: any) => {
         let orgCurrencyList = Array.isArray(orgCurrencies.selectedCurrencyOptions)
           ? orgCurrencies.selectedCurrencyOptions

--- a/src/app/products/collaterals/edit-collateral/edit-collateral.component.ts
+++ b/src/app/products/collaterals/edit-collateral/edit-collateral.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -27,17 +28,18 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class EditCollateralComponent implements OnInit {
   private productsService = inject(ProductsService);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Colalteral Data */
   collateralData: any;
   /** Collateral Template */
   collateralTemplateData: any;
   /** Collateral Form */
-  collateralForm: UntypedFormGroup;
+  collateralForm: FormGroup;
 
   /**
    * Retrieves the Collateral Data from `resolve`
@@ -48,10 +50,12 @@ export class EditCollateralComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { collateral: any; collateralTemplate: any }) => {
-      this.collateralData = data.collateral;
-      this.collateralTemplateData = data.collateralTemplate;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { collateral: any; collateralTemplate: any }) => {
+        this.collateralData = data.collateral;
+        this.collateralTemplateData = data.collateralTemplate;
+      });
   }
 
   ngOnInit(): void {

--- a/src/app/products/collaterals/view-collateral/view-collateral.component.ts
+++ b/src/app/products/collaterals/view-collateral/view-collateral.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
@@ -38,6 +39,7 @@ export class ViewCollateralComponent {
   private router = inject(Router);
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Collateral Data */
   collateralData: any;
@@ -51,7 +53,7 @@ export class ViewCollateralComponent {
    * @param {TranslateService} translateService Translate Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { collateral: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { collateral: any }) => {
       this.collateralData = data.collateral;
     });
   }

--- a/src/app/products/deposit-product-incentive-form-dialog/deposit-product-incentive-form-dialog.component.ts
+++ b/src/app/products/deposit-product-incentive-form-dialog/deposit-product-incentive-form-dialog.component.ts
@@ -15,7 +15,7 @@ import {
   MatDialogActions,
   MatDialogClose
 } from '@angular/material/dialog';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { TranslateService } from '@ngx-translate/core';
 
@@ -43,7 +43,7 @@ export class DepositProductIncentiveFormDialogComponent implements OnInit {
 
   data = inject(MAT_DIALOG_DATA);
 
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
 
   protected conditionLabelService = inject(ConditionLabelService);
 
@@ -53,7 +53,7 @@ export class DepositProductIncentiveFormDialogComponent implements OnInit {
     addButtonText: 'Add'
   };
 
-  depositProductIncentiveForm!: UntypedFormGroup;
+  depositProductIncentiveForm!: FormGroup;
   title!: string;
 
   entityTypeData: any;

--- a/src/app/products/fixed-deposit-products/create-fixed-deposit-product/create-fixed-deposit-product.component.ts
+++ b/src/app/products/fixed-deposit-products/create-fixed-deposit-product/create-fixed-deposit-product.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 
 /** Custom Components */
@@ -56,6 +57,7 @@ export class CreateFixedDepositProductComponent {
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private accounting = inject(Accounting);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild(FixedDepositProductDetailsStepComponent, { static: true })
   fixedDepositProductDetailsStep: FixedDepositProductDetailsStepComponent;
@@ -83,9 +85,11 @@ export class CreateFixedDepositProductComponent {
    */
 
   constructor() {
-    this.route.data.subscribe((data: { fixedDepositProductsTemplate: any }) => {
-      this.fixedDepositProductsTemplate = data.fixedDepositProductsTemplate;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { fixedDepositProductsTemplate: any }) => {
+        this.fixedDepositProductsTemplate = data.fixedDepositProductsTemplate;
+      });
     this.accountingRuleData = this.accounting.getAccountingRulesForSavings();
   }
 

--- a/src/app/products/fixed-deposit-products/edit-fixed-deposit-product/edit-fixed-deposit-product.component.ts
+++ b/src/app/products/fixed-deposit-products/edit-fixed-deposit-product/edit-fixed-deposit-product.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 
 /** Custom Components */
@@ -56,6 +57,7 @@ export class EditFixedDepositProductComponent {
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private accounting = inject(Accounting);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild(FixedDepositProductDetailsStepComponent, { static: true })
   fixedDepositProductDetailsStep: FixedDepositProductDetailsStepComponent;
@@ -83,9 +85,11 @@ export class EditFixedDepositProductComponent {
    */
 
   constructor() {
-    this.route.data.subscribe((data: { fixedDepositProductAndTemplate: any }) => {
-      this.fixedDepositProductsTemplate = data.fixedDepositProductAndTemplate;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { fixedDepositProductAndTemplate: any }) => {
+        this.fixedDepositProductsTemplate = data.fixedDepositProductAndTemplate;
+      });
     this.accountingRuleData = this.accounting.getAccountingRulesForSavings();
   }
 

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-accounting-step/fixed-deposit-product-accounting-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-accounting-step/fixed-deposit-product-accounting-step.component.ts
@@ -6,15 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormArray,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  UntypedFormGroup,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, Input, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
@@ -28,7 +22,7 @@ import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 import { MatDivider } from '@angular/material/divider';
 import { GlAccountSelectorComponent } from '../../../../shared/accounting/gl-account-selector/gl-account-selector.component';
 import { MatCheckbox } from '@angular/material/checkbox';
-import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatIconButton } from '@angular/material/button';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import {
   MatTable,
@@ -76,16 +70,17 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FixedDepositProductAccountingStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   dialog = inject(MatDialog);
   private accounting = inject(Accounting);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() fixedDepositProductsTemplate: any;
   @Input() accountingRuleData: any;
   @Input() fixedDepositProductFormValid: boolean;
 
-  fixedDepositProductAccountingForm: UntypedFormGroup;
+  fixedDepositProductAccountingForm: FormGroup;
 
   chargeData: any;
   penaltyData: any;
@@ -173,7 +168,7 @@ export class FixedDepositProductAccountingStepComponent implements OnInit {
             });
             const formArray = this.fixedDepositProductAccountingForm.controls[
               'paymentChannelToFundSourceMappings'
-            ] as UntypedFormArray;
+            ] as FormArray;
             formArray.push(paymentChannelToFundSourceMappingData);
           }
         );
@@ -190,9 +185,7 @@ export class FixedDepositProductAccountingStepComponent implements OnInit {
               Validators.required
             ]
           });
-          const formArray = this.fixedDepositProductAccountingForm.controls[
-            'feeToIncomeAccountMappings'
-          ] as UntypedFormArray;
+          const formArray = this.fixedDepositProductAccountingForm.controls['feeToIncomeAccountMappings'] as FormArray;
           formArray.push(feeToIncomeAccountMappingData);
         });
       }
@@ -211,7 +204,7 @@ export class FixedDepositProductAccountingStepComponent implements OnInit {
             });
             const formArray = this.fixedDepositProductAccountingForm.controls[
               'penaltyToIncomeAccountMappings'
-            ] as UntypedFormArray;
+            ] as FormArray;
             formArray.push(penaltyToIncomeAccountMappingData);
           }
         );
@@ -230,103 +223,80 @@ export class FixedDepositProductAccountingStepComponent implements OnInit {
   }
 
   setConditionalControls() {
-    this.fixedDepositProductAccountingForm.get('accountingRule').valueChanges.subscribe((accountingRule: any) => {
-      if (accountingRule === 2 || accountingRule === 3) {
-        this.fixedDepositProductAccountingForm.addControl(
-          'savingsReferenceAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.fixedDepositProductAccountingForm.addControl(
-          'savingsControlAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.fixedDepositProductAccountingForm.addControl(
-          'transfersInSuspenseAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.fixedDepositProductAccountingForm.addControl(
-          'interestOnSavingsAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.fixedDepositProductAccountingForm.addControl(
-          'incomeFromFeeAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.fixedDepositProductAccountingForm.addControl(
-          'incomeFromPenaltyAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.fixedDepositProductAccountingForm.addControl('advancedAccountingRules', new UntypedFormControl(false));
+    this.fixedDepositProductAccountingForm
+      .get('accountingRule')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((accountingRule: any) => {
+        if (accountingRule === 2 || accountingRule === 3) {
+          this.ensureControl('savingsReferenceAccountId', new FormControl('', Validators.required));
+          this.ensureControl('savingsControlAccountId', new FormControl('', Validators.required));
+          this.ensureControl('transfersInSuspenseAccountId', new FormControl('', Validators.required));
+          this.ensureControl('interestOnSavingsAccountId', new FormControl('', Validators.required));
+          this.ensureControl('incomeFromFeeAccountId', new FormControl('', Validators.required));
+          this.ensureControl('incomeFromPenaltyAccountId', new FormControl('', Validators.required));
+          this.ensureControl('advancedAccountingRules', new FormControl(false));
 
-        if (accountingRule === 3) {
-          this.fixedDepositProductAccountingForm.addControl(
-            'feesReceivableAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.fixedDepositProductAccountingForm.addControl(
-            'penaltiesReceivableAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.fixedDepositProductAccountingForm.addControl(
-            'interestPayableAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
+          if (accountingRule === 3) {
+            this.ensureControl('feesReceivableAccountId', new FormControl('', Validators.required));
+            this.ensureControl('penaltiesReceivableAccountId', new FormControl('', Validators.required));
+            this.ensureControl('interestPayableAccountId', new FormControl('', Validators.required));
+          }
+
+          this.fixedDepositProductAccountingForm
+            .get('advancedAccountingRules')
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((advancedAccountingRules: boolean) => {
+              if (advancedAccountingRules) {
+                this.fixedDepositProductAccountingForm.addControl(
+                  'paymentChannelToFundSourceMappings',
+                  this.formBuilder.array([])
+                );
+                this.fixedDepositProductAccountingForm.addControl(
+                  'feeToIncomeAccountMappings',
+                  this.formBuilder.array([])
+                );
+                this.fixedDepositProductAccountingForm.addControl(
+                  'penaltyToIncomeAccountMappings',
+                  this.formBuilder.array([])
+                );
+              } else {
+                this.fixedDepositProductAccountingForm.removeControl('paymentChannelToFundSourceMappings');
+                this.fixedDepositProductAccountingForm.removeControl('feeToIncomeAccountMappings');
+                this.fixedDepositProductAccountingForm.removeControl('penaltyToIncomeAccountMappings');
+              }
+            });
+        } else {
+          this.fixedDepositProductAccountingForm.removeControl('savingsReferenceAccountId');
+          this.fixedDepositProductAccountingForm.removeControl('overdraftPortfolioControlId');
+          this.fixedDepositProductAccountingForm.removeControl('savingsControlAccountId');
+          this.fixedDepositProductAccountingForm.removeControl('transfersInSuspenseAccountId');
+          this.fixedDepositProductAccountingForm.removeControl('interestOnSavingsAccountId');
+          this.fixedDepositProductAccountingForm.removeControl('writeOffAccountId');
+          this.fixedDepositProductAccountingForm.removeControl('incomeFromFeeAccountId');
+          this.fixedDepositProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
+          this.fixedDepositProductAccountingForm.removeControl('incomeFromInterestId');
+          this.fixedDepositProductAccountingForm.removeControl('advancedAccountingRules');
+          this.fixedDepositProductAccountingForm.removeControl('escheatLiabilityId');
+          this.fixedDepositProductAccountingForm.removeControl('feesReceivableAccountId');
+          this.fixedDepositProductAccountingForm.removeControl('penaltiesReceivableAccountId');
+          this.fixedDepositProductAccountingForm.removeControl('interestPayableAccountId');
         }
-
-        this.fixedDepositProductAccountingForm
-          .get('advancedAccountingRules')
-          .valueChanges.subscribe((advancedAccountingRules: boolean) => {
-            if (advancedAccountingRules) {
-              this.fixedDepositProductAccountingForm.addControl(
-                'paymentChannelToFundSourceMappings',
-                this.formBuilder.array([])
-              );
-              this.fixedDepositProductAccountingForm.addControl(
-                'feeToIncomeAccountMappings',
-                this.formBuilder.array([])
-              );
-              this.fixedDepositProductAccountingForm.addControl(
-                'penaltyToIncomeAccountMappings',
-                this.formBuilder.array([])
-              );
-            } else {
-              this.fixedDepositProductAccountingForm.removeControl('paymentChannelToFundSourceMappings');
-              this.fixedDepositProductAccountingForm.removeControl('feeToIncomeAccountMappings');
-              this.fixedDepositProductAccountingForm.removeControl('penaltyToIncomeAccountMappings');
-            }
-          });
-      } else {
-        this.fixedDepositProductAccountingForm.removeControl('savingsReferenceAccountId');
-        this.fixedDepositProductAccountingForm.removeControl('overdraftPortfolioControlId');
-        this.fixedDepositProductAccountingForm.removeControl('savingsControlAccountId');
-        this.fixedDepositProductAccountingForm.removeControl('transfersInSuspenseAccountId');
-        this.fixedDepositProductAccountingForm.removeControl('interestOnSavingsAccountId');
-        this.fixedDepositProductAccountingForm.removeControl('writeOffAccountId');
-        this.fixedDepositProductAccountingForm.removeControl('incomeFromFeeAccountId');
-        this.fixedDepositProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
-        this.fixedDepositProductAccountingForm.removeControl('incomeFromInterestId');
-        this.fixedDepositProductAccountingForm.removeControl('advancedAccountingRules');
-        this.fixedDepositProductAccountingForm.removeControl('escheatLiabilityId');
-        this.fixedDepositProductAccountingForm.removeControl('feesReceivableAccountId');
-        this.fixedDepositProductAccountingForm.removeControl('penaltiesReceivableAccountId');
-        this.fixedDepositProductAccountingForm.removeControl('interestPayableAccountId');
-      }
-    });
+      });
   }
 
-  get paymentChannelToFundSourceMappings(): UntypedFormArray {
-    return this.fixedDepositProductAccountingForm.get('paymentChannelToFundSourceMappings') as UntypedFormArray;
+  get paymentChannelToFundSourceMappings(): FormArray {
+    return this.fixedDepositProductAccountingForm.get('paymentChannelToFundSourceMappings') as FormArray;
   }
 
-  get feeToIncomeAccountMappings(): UntypedFormArray {
-    return this.fixedDepositProductAccountingForm.get('feeToIncomeAccountMappings') as UntypedFormArray;
+  get feeToIncomeAccountMappings(): FormArray {
+    return this.fixedDepositProductAccountingForm.get('feeToIncomeAccountMappings') as FormArray;
   }
 
-  get penaltyToIncomeAccountMappings(): UntypedFormArray {
-    return this.fixedDepositProductAccountingForm.get('penaltyToIncomeAccountMappings') as UntypedFormArray;
+  get penaltyToIncomeAccountMappings(): FormArray {
+    return this.fixedDepositProductAccountingForm.get('penaltyToIncomeAccountMappings') as FormArray;
   }
 
-  add(formType: string, formArray: UntypedFormArray) {
+  add(formType: string, formArray: FormArray) {
     const data = { ...this.getData(formType), pristine: false };
     const dialogRef = this.dialog.open(FormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -336,7 +306,7 @@ export class FixedDepositProductAccountingStepComponent implements OnInit {
     });
   }
 
-  edit(formType: string, formArray: UntypedFormArray, index: number) {
+  edit(formType: string, formArray: FormArray, index: number) {
     const data = { ...this.getData(formType, formArray.at(index).value), layout: { addButtonText: 'Edit' } };
     const dialogRef = this.dialog.open(FormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -346,7 +316,7 @@ export class FixedDepositProductAccountingStepComponent implements OnInit {
     });
   }
 
-  delete(formArray: UntypedFormArray, index: number) {
+  delete(formArray: FormArray, index: number) {
     const dialogRef = this.dialog.open(DeleteDialogComponent, {
       data: { deleteContext: this.translateService.instant('labels.text.this') }
     });
@@ -450,5 +420,11 @@ export class FixedDepositProductAccountingStepComponent implements OnInit {
 
   isAccrualAccounting(): boolean {
     return this.accounting.isAccrualAccountingRuleId(this.fixedDepositProductAccountingForm.value.accountingRule);
+  }
+
+  private ensureControl(name: string, control: FormControl | FormArray) {
+    if (!this.fixedDepositProductAccountingForm.contains(name)) {
+      this.fixedDepositProductAccountingForm.addControl(name, control);
+    }
   }
 }

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-charges-step/fixed-deposit-product-charges-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-charges-step/fixed-deposit-product-charges-step.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, Input, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { TranslateService } from '@ngx-translate/core';
@@ -59,9 +60,10 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class FixedDepositProductChargesStepComponent implements OnInit {
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() fixedDepositProductsTemplate: any;
-  @Input() currencyCode: UntypedFormControl;
+  @Input() currencyCode: FormControl;
 
   chargeData: any;
 
@@ -81,7 +83,9 @@ export class FixedDepositProductChargesStepComponent implements OnInit {
     } else {
       this.chargesDataSource = [];
     }
-    this.currencyCode.valueChanges.subscribe(() => (this.chargesDataSource = []));
+    this.currencyCode.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => (this.chargesDataSource = []));
   }
 
   addCharge(charge: any) {

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-currency-step/fixed-deposit-product-currency-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-currency-step/fixed-deposit-product-currency-step.component.ts
@@ -9,7 +9,7 @@
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { startWith } from 'rxjs/operators';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -31,12 +31,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FixedDepositProductCurrencyStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
 
   @Input() fixedDepositProductsTemplate: any;
 
-  fixedDepositProductCurrencyForm: UntypedFormGroup;
+  fixedDepositProductCurrencyForm: FormGroup;
 
   currencyData: any;
 

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-details-step/fixed-deposit-product-details-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-details-step/fixed-deposit-product-details-step.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -25,11 +25,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FixedDepositProductDetailsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
 
   @Input() fixedDepositProductsTemplate: any;
 
-  fixedDepositProductDetailsForm: UntypedFormGroup;
+  fixedDepositProductDetailsForm: FormGroup;
 
   constructor() {
     this.createFixedDepositProductDetailsForm();

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.ts
@@ -8,14 +8,9 @@
 
 /** Angular Imports */
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormArray,
-  UntypedFormBuilder,
-  UntypedFormGroup,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, Input, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormArray, FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 /** Custom Components */
@@ -89,15 +84,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FixedDepositProductInterestRateChartStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   dialog = inject(MatDialog);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() fixedDepositProductsTemplate: any;
 
-  fixedDepositProductInterestRateChartForm: UntypedFormGroup;
+  fixedDepositProductInterestRateChartForm: FormGroup;
 
   periodTypeData: any;
   entityTypeData: any;
@@ -168,7 +164,7 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
     this.getChartsDetailsData();
 
     // Iterates for every chart in charts
-    this.charts.controls.forEach((chartDetailControl: UntypedFormGroup, i: number) => {
+    this.charts.controls.forEach((chartDetailControl: FormGroup, i: number) => {
       if (!this.chartsDetail[i]) {
         return;
       }
@@ -198,11 +194,11 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
           ],
           incentives: this.formBuilder.array([])
         });
-        const formArray = chartDetailControl.controls['chartSlabs'] as UntypedFormArray;
+        const formArray = chartDetailControl.controls['chartSlabs'] as FormArray;
         formArray.push(chartSlabInfo);
 
         // Iterate for every slab in chartSlab
-        const chartIncentiveControl = (chartDetailControl.controls['chartSlabs'] as UntypedFormArray).controls[j];
+        const chartIncentiveControl = (chartDetailControl.controls['chartSlabs'] as FormArray).controls[j];
 
         // Iterate to input all the incentive for particular chart slab
         this.chartsDetail[i].chartSlabs[j].incentives.forEach((chartIncentiveDetail: any) => {
@@ -232,7 +228,7 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
               Validators.required
             ]
           });
-          const newFormArray = (chartIncentiveControl as UntypedFormGroup).controls['incentives'] as UntypedFormArray;
+          const newFormArray = (chartIncentiveControl as FormGroup).controls['incentives'] as FormArray;
           newFormArray.push(incentiveInfo);
         });
       });
@@ -329,11 +325,11 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
     });
   }
 
-  get charts(): UntypedFormArray {
-    return this.fixedDepositProductInterestRateChartForm.get('charts') as UntypedFormArray;
+  get charts(): FormArray {
+    return this.fixedDepositProductInterestRateChartForm.get('charts') as FormArray;
   }
 
-  createChartForm(): UntypedFormGroup {
+  createChartForm(): FormGroup {
     return this.formBuilder.group({
       id: [null],
       name: [''],
@@ -364,7 +360,8 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
     this.charts
       .at(chartIndex)
       .get('isPrimaryGroupingByAmount')
-      .valueChanges.subscribe((isPrimaryGroupingByAmount: boolean) => {
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((isPrimaryGroupingByAmount: boolean) => {
         this.chartSlabsDisplayedColumns[chartIndex] = isPrimaryGroupingByAmount ? [
               'amountRange',
               'period'
@@ -376,11 +373,11 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
       });
   }
 
-  getIncentives(chartSlabs: UntypedFormArray, chartSlabIndex: number): UntypedFormArray {
-    return chartSlabs.at(chartSlabIndex).get('incentives') as UntypedFormArray;
+  getIncentives(chartSlabs: FormArray, chartSlabIndex: number): FormArray {
+    return chartSlabs.at(chartSlabIndex).get('incentives') as FormArray;
   }
 
-  addChartSlab(chartSlabs: UntypedFormArray) {
+  addChartSlab(chartSlabs: FormArray) {
     const data = { ...this.getData('Range') };
     const dialogRef = this.dialog.open(FormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -391,7 +388,7 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
     });
   }
 
-  addIncentive(incentives: UntypedFormArray) {
+  addIncentive(incentives: FormArray) {
     const data = { ...this.getData('Incentive'), entityType: this.entityTypeData[0].id };
     const dialogRef = this.dialog.open(DepositProductIncentiveFormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -401,7 +398,7 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
     });
   }
 
-  editChartSlab(chartSlabs: UntypedFormArray, chartSlabIndex: number) {
+  editChartSlab(chartSlabs: FormArray, chartSlabIndex: number) {
     const data = {
       ...this.getData('Range', chartSlabs.at(chartSlabIndex).value),
       layout: { addButtonText: 'Submit' }
@@ -414,7 +411,7 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
     });
   }
 
-  editIncentive(incentives: UntypedFormArray, incentiveIndex: number) {
+  editIncentive(incentives: FormArray, incentiveIndex: number) {
     const data = {
       ...this.getData('Incentive', incentives.at(incentiveIndex).value),
       layout: { addButtonText: 'Submit' }
@@ -427,7 +424,7 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
     });
   }
 
-  delete(formArray: UntypedFormArray, index: number) {
+  delete(formArray: FormArray, index: number) {
     const dialogRef = this.dialog.open(DeleteDialogComponent, {
       data: { deleteContext: this.translateService.instant('labels.text.this') }
     });

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-settings-step/fixed-deposit-product-settings-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-settings-step/fixed-deposit-product-settings-step.component.ts
@@ -6,14 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, Input, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatDivider } from '@angular/material/divider';
 import { MatCheckbox } from '@angular/material/checkbox';
@@ -37,11 +32,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FixedDepositProductSettingsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
 
   @Input() fixedDepositProductsTemplate: any;
 
-  fixedDepositProductSettingsForm: UntypedFormGroup;
+  fixedDepositProductSettingsForm: FormGroup;
 
   lockinPeriodFrequencyTypeData: any;
   periodFrequencyTypeData: any;
@@ -135,13 +131,16 @@ export class FixedDepositProductSettingsStepComponent implements OnInit {
   }
 
   setConditionalControls() {
-    this.fixedDepositProductSettingsForm.get('withHoldTax').valueChanges.subscribe((withHoldTax: any) => {
-      if (withHoldTax) {
-        this.fixedDepositProductSettingsForm.addControl('taxGroupId', new UntypedFormControl('', Validators.required));
-      } else {
-        this.fixedDepositProductSettingsForm.removeControl('taxGroupId');
-      }
-    });
+    this.fixedDepositProductSettingsForm
+      .get('withHoldTax')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((withHoldTax: any) => {
+        if (withHoldTax) {
+          this.fixedDepositProductSettingsForm.addControl('taxGroupId', new FormControl('', Validators.required));
+        } else {
+          this.fixedDepositProductSettingsForm.removeControl('taxGroupId');
+        }
+      });
   }
 
   get fixedDepositProductSettings() {

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-terms-step/fixed-deposit-product-terms-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-terms-step/fixed-deposit-product-terms-step.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatDivider } from '@angular/material/divider';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
@@ -29,11 +29,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FixedDepositProductTermsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
 
   @Input() fixedDepositProductsTemplate: any;
 
-  fixedDepositProductTermsForm: UntypedFormGroup;
+  fixedDepositProductTermsForm: FormGroup;
 
   interestCompoundingPeriodTypeData: any;
   interestPostingPeriodTypeData: any;

--- a/src/app/products/fixed-deposit-products/fixed-deposit-products.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-products.component.ts
@@ -10,6 +10,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   OnInit,
   TemplateRef,
   ElementRef,
@@ -17,6 +18,7 @@ import {
   AfterViewInit,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -32,10 +34,7 @@ import {
   MatRowDef,
   MatRow
 } from '@angular/material/table';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-
-/** rxjs Imports */
-import { of } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
 
 /* Custom Services */
 import { PopoverService } from '../../configuration-wizard/popover/popover.service';
@@ -74,6 +73,7 @@ export class FixedDepositProductsComponent implements OnInit, AfterViewInit {
   private router = inject(Router);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private destroyRef = inject(DestroyRef);
 
   /** Fixed deposit products data. */
   fixedDepositProductData: any;
@@ -107,7 +107,7 @@ export class FixedDepositProductsComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { fixedDepositProducts: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { fixedDepositProducts: any }) => {
       this.fixedDepositProductData = data.fixedDepositProducts;
     });
   }

--- a/src/app/products/fixed-deposit-products/view-fixed-deposit-product/fixed-deposit-datatable-tab/fixed-deposit-datatable-tab.component.ts
+++ b/src/app/products/fixed-deposit-products/view-fixed-deposit-product/fixed-deposit-datatable-tab/fixed-deposit-datatable-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -23,6 +24,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class FixedDepositDatatableTabComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   entityId: string;
   entityDatatable: any;
@@ -31,7 +33,7 @@ export class FixedDepositDatatableTabComponent {
   constructor() {
     this.entityId = this.route.parent.parent.snapshot.paramMap.get('productId');
 
-    this.route.data.subscribe((data: { fixedDepositDatatable: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { fixedDepositDatatable: any }) => {
       this.entityDatatable = data.fixedDepositDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
     });

--- a/src/app/products/fixed-deposit-products/view-fixed-deposit-product/fixed-deposit-general-tab/fixed-deposit-general-tab.component.ts
+++ b/src/app/products/fixed-deposit-products/view-fixed-deposit-product/fixed-deposit-general-tab/fixed-deposit-general-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { trigger, state, transition, animate, style } from '@angular/animations';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -66,6 +67,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class FixedDepositGeneralTabComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Fixed Deposit Product data. */
   fixedDepositProductData: any;
@@ -107,9 +109,11 @@ export class FixedDepositGeneralTabComponent {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { fixedDepositProduct: any; fixedDepositProductsTemplate: any }) => {
-      this.fixedDepositProductData = data.fixedDepositProduct;
-      this.fixedDepositProductsTemplate = data.fixedDepositProductsTemplate;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { fixedDepositProduct: any; fixedDepositProductsTemplate: any }) => {
+        this.fixedDepositProductData = data.fixedDepositProduct;
+        this.fixedDepositProductsTemplate = data.fixedDepositProductsTemplate;
+      });
   }
 }

--- a/src/app/products/fixed-deposit-products/view-fixed-deposit-product/view-fixed-deposit-product.component.ts
+++ b/src/app/products/fixed-deposit-products/view-fixed-deposit-product/view-fixed-deposit-product.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -31,11 +32,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewFixedDepositProductComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   fixedDepositDatatables: any = [];
 
   constructor() {
-    this.route.data.subscribe((data: { fixedDepositDatatables: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { fixedDepositDatatables: any }) => {
       this.fixedDepositDatatables = [];
       data.fixedDepositDatatables.forEach((datatable: any) => {
         if (datatable.entitySubType === 'Fixed Deposit') {

--- a/src/app/products/floating-rates/create-floating-rate/create-floating-rate.component.ts
+++ b/src/app/products/floating-rates/create-floating-rate/create-floating-rate.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -80,7 +80,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class CreateFloatingRateComponent implements OnInit {
   private router = inject(Router);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private dateUtils = inject(Dates);
@@ -91,7 +91,7 @@ export class CreateFloatingRateComponent implements OnInit {
   /** Floating Rate Period Data. */
   floatingRatePeriodsData: any[] = [];
   /** Floating Rate Form. */
-  floatingRateForm: UntypedFormGroup;
+  floatingRateForm: FormGroup;
   /** Columns to be displayed in floating rate periods table. */
   displayedColumns: string[] = [
     'fromDate',
@@ -144,7 +144,7 @@ export class CreateFloatingRateComponent implements OnInit {
    * Creates the Floating Rate Periods Form.
    * @returns {FormGroup} Floating Rate Period Form.
    */
-  createFloatingRatePeriodsForm(): UntypedFormGroup {
+  createFloatingRatePeriodsForm(): FormGroup {
     return this.formBuilder.group({
       fromDate: [
         '',

--- a/src/app/products/floating-rates/edit-floating-rate/edit-floating-rate.component.ts
+++ b/src/app/products/floating-rates/edit-floating-rate/edit-floating-rate.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -78,16 +79,17 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class EditFloatingRateComponent implements OnInit {
   private router = inject(Router);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private dateUtils = inject(Dates);
   private dialog = inject(MatDialog);
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Floating Rate Form. */
-  floatingRateForm: UntypedFormGroup;
+  floatingRateForm: FormGroup;
   /** Floating Rate Data. */
   floatingRateData: any;
   /** Form Pristine Status. */
@@ -123,7 +125,7 @@ export class EditFloatingRateComponent implements OnInit {
    * @param {TranslateService} translateService Translate Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { floatingRate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { floatingRate: any }) => {
       this.floatingRateData = data.floatingRate;
       this.floatingRatePeriodsData = data.floatingRate.ratePeriods ? data.floatingRate.ratePeriods : [];
     });

--- a/src/app/products/floating-rates/floating-rate-period-dialog/floating-rate-period-dialog.component.ts
+++ b/src/app/products/floating-rates/floating-rate-period-dialog/floating-rate-period-dialog.component.ts
@@ -16,7 +16,7 @@ import {
   MatDialogActions,
   MatDialogClose
 } from '@angular/material/dialog';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { SettingsService } from 'app/settings/settings.service';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { MatCheckbox } from '@angular/material/checkbox';
@@ -42,12 +42,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class FloatingRatePeriodDialogComponent implements OnInit {
   dialogRef = inject<MatDialogRef<FloatingRatePeriodDialogComponent>>(MatDialogRef);
-  formBuilder = inject(UntypedFormBuilder);
+  formBuilder = inject(FormBuilder);
   private settingsService = inject(SettingsService);
   data = inject(MAT_DIALOG_DATA);
 
   /** Floating Rate Period Form. */
-  floatingRatePeriodForm: UntypedFormGroup;
+  floatingRatePeriodForm: FormGroup;
   /** Minimum floating rate period date allowed. */
   minDate = new Date();
 

--- a/src/app/products/floating-rates/floating-rates.component.ts
+++ b/src/app/products/floating-rates/floating-rates.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -57,6 +58,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class FloatingRatesComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Floating Rates data. */
   floatingRatesData: any;
@@ -80,7 +82,7 @@ export class FloatingRatesComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { floatingrates: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { floatingrates: any }) => {
       this.floatingRatesData = data.floatingrates;
     });
   }

--- a/src/app/products/floating-rates/view-floating-rate/view-floating-rate.component.ts
+++ b/src/app/products/floating-rates/view-floating-rate/view-floating-rate.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -65,6 +66,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewFloatingRateComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Floating Rate Data. */
   floatingRateData: any;
@@ -87,7 +89,7 @@ export class ViewFloatingRateComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { floatingRate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { floatingRate: any }) => {
       this.floatingRateData = data.floatingRate;
     });
   }

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
@@ -12,10 +12,12 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   OnInit,
   ViewChild,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Components */
@@ -41,7 +43,7 @@ import {
 import { Accounting } from 'app/core/utils/accounting';
 import { StringEnumOptionData } from '../../../shared/models/option-data.model';
 import { LoanProductDeferredIncomeRecognitionStepComponent } from '../loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component';
-import { UntypedFormGroup } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
 import { MatStepper, MatStepperIcon, MatStep, MatStepLabel } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { LoanProductPaymentStrategyStepComponent } from '../loan-product-stepper/loan-product-payment-strategy-step/loan-product-payment-strategy-step.component';
@@ -82,6 +84,7 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
   private accounting = inject(Accounting);
   private advancedPaymentStrategy = inject(AdvancedPaymentStrategy);
   private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild(LoanProductDetailsStepComponent, { static: true }) loanProductDetailsStep: LoanProductDetailsStepComponent;
   @ViewChild(LoanProductCurrencyStepComponent, { static: true })
@@ -110,7 +113,7 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
   advancedCreditAllocations: AdvancedPaymentAllocation[] = [];
 
   deferredIncomeRecognition: DeferredIncomeRecognition | null = null;
-  loanIncomeCapitalizationForm: UntypedFormGroup | null = null;
+  loanIncomeCapitalizationForm: FormGroup | null = null;
 
   constructor() {
     super();
@@ -119,20 +122,22 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
     const productType = this.route.snapshot.queryParamMap.get('productType') || 'loan';
     this.loanProductService.initialize(productType);
 
-    this.route.data.subscribe((data: { loanProductsTemplate: any; configurations: any }) => {
-      this.loanProductsTemplate = data.loanProductsTemplate;
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { loanProductsTemplate: any; configurations: any }) => {
+        this.loanProductsTemplate = data.loanProductsTemplate;
 
-      if (this.loanProductService.isLoanProduct) {
-        const assetAccountData = this.loanProductsTemplate.accountingMappingOptions.assetAccountOptions || [];
-        const liabilityAccountData = this.loanProductsTemplate.accountingMappingOptions.liabilityAccountOptions || [];
-        this.loanProductsTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions =
-          assetAccountData.concat(liabilityAccountData);
-      }
+        if (this.loanProductService.isLoanProduct) {
+          const assetAccountData = this.loanProductsTemplate.accountingMappingOptions.assetAccountOptions || [];
+          const liabilityAccountData = this.loanProductsTemplate.accountingMappingOptions.liabilityAccountOptions || [];
+          this.loanProductsTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions =
+            assetAccountData.concat(liabilityAccountData);
+        }
 
-      this.itemsByDefault = loanProducts.setItemsByDefault(data.configurations);
-      this.loanProductsTemplate['itemsByDefault'] = this.itemsByDefault;
-      this.loanProductsTemplate = loanProducts.updateLoanProductDefaults(this.loanProductsTemplate, false);
-    });
+        this.itemsByDefault = loanProducts.setItemsByDefault(data.configurations);
+        this.loanProductsTemplate['itemsByDefault'] = this.itemsByDefault;
+        this.loanProductsTemplate = loanProducts.updateLoanProductDefaults(this.loanProductsTemplate, false);
+      });
   }
 
   ngOnInit() {
@@ -226,7 +231,7 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
     }
   }
 
-  setViewChildForm(viewChildForm: UntypedFormGroup): void {
+  setViewChildForm(viewChildForm: FormGroup): void {
     const formValues: any = viewChildForm.getRawValue();
     this.loanIncomeCapitalizationForm = viewChildForm;
     const capitalizedIncome: CapitalizedIncome = formValues.enableIncomeCapitalization

--- a/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
+++ b/src/app/products/loan-products/edit-loan-product/edit-loan-product.component.ts
@@ -12,10 +12,12 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   OnInit,
   ViewChild,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Components */
@@ -44,7 +46,7 @@ import { Accounting } from 'app/core/utils/accounting';
 import { LoanProductInterestRefundStepComponent } from '../loan-product-stepper/loan-product-interest-refund-step/loan-product-interest-refund-step.component';
 import { StringEnumOptionData } from '../../../shared/models/option-data.model';
 import { LoanProductDeferredIncomeRecognitionStepComponent } from '../loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component';
-import { UntypedFormGroup } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
 import { MatStepper, MatStepperIcon, MatStep, MatStepLabel } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { StepperButtonsComponent } from '../../../shared/steppers/stepper-buttons/stepper-buttons.component';
@@ -85,6 +87,7 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
   private accounting = inject(Accounting);
   private advancedPaymentStrategy = inject(AdvancedPaymentStrategy);
   private cdr = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild(LoanProductDetailsStepComponent, { static: true }) loanProductDetailsStep: LoanProductDetailsStepComponent;
   @ViewChild(LoanProductCurrencyStepComponent, { static: true })
@@ -114,7 +117,7 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
   supportedInterestRefundTypes: StringEnumOptionData[] = [];
 
   deferredIncomeRecognition: DeferredIncomeRecognition | null = null;
-  loanIncomeCapitalizationForm: UntypedFormGroup | null = null;
+  loanIncomeCapitalizationForm: FormGroup | null = null;
 
   constructor() {
     super();
@@ -123,18 +126,21 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
     const productType = this.route.snapshot.queryParamMap.get('productType') || 'loan';
     this.loanProductService.initialize(productType);
 
-    this.route.data.subscribe((data: { loanProductAndTemplate: any; configurations: any }) => {
-      this.loanProductAndTemplate = data.loanProductAndTemplate;
-      if (this.loanProductService.isLoanProduct) {
-        const assetAccountData = this.loanProductAndTemplate.accountingMappingOptions.assetAccountOptions || [];
-        const liabilityAccountData = this.loanProductAndTemplate.accountingMappingOptions.liabilityAccountOptions || [];
-        this.loanProductAndTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions =
-          assetAccountData.concat(liabilityAccountData);
-      }
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { loanProductAndTemplate: any; configurations: any }) => {
+        this.loanProductAndTemplate = data.loanProductAndTemplate;
+        if (this.loanProductService.isLoanProduct) {
+          const assetAccountData = this.loanProductAndTemplate.accountingMappingOptions.assetAccountOptions || [];
+          const liabilityAccountData =
+            this.loanProductAndTemplate.accountingMappingOptions.liabilityAccountOptions || [];
+          this.loanProductAndTemplate.accountingMappingOptions.assetAndLiabilityAccountOptions =
+            assetAccountData.concat(liabilityAccountData);
+        }
 
-      this.itemsByDefault = loanProducts.setItemsByDefault(data.configurations);
-      this.loanProductAndTemplate['itemsByDefault'] = this.itemsByDefault;
-    });
+        this.itemsByDefault = loanProducts.setItemsByDefault(data.configurations);
+        this.loanProductAndTemplate['itemsByDefault'] = this.itemsByDefault;
+      });
   }
 
   ngOnInit() {
@@ -204,7 +210,7 @@ export class EditLoanProductComponent extends LoanProductBaseComponent implement
     }
   }
 
-  setViewChildForm(viewChildForm: UntypedFormGroup): void {
+  setViewChildForm(viewChildForm: FormGroup): void {
     this.loanIncomeCapitalizationForm = viewChildForm;
     const formValues: any = this.loanIncomeCapitalizationForm.getRawValue();
     const capitalizedIncome: CapitalizedIncome = formValues.enableIncomeCapitalization

--- a/src/app/products/loan-products/import-loan-product-dialog/import-loan-product-dialog.component.ts
+++ b/src/app/products/loan-products/import-loan-product-dialog/import-loan-product-dialog.component.ts
@@ -14,7 +14,7 @@ import {
   MatDialogClose,
   MatDialogContent
 } from '@angular/material/dialog';
-import { UntypedFormGroup, UntypedFormBuilder, Validators } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { FileUploadComponent } from '../../../shared/file-upload/file-upload.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
@@ -34,11 +34,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ImportLoanProductDialogComponent implements OnInit {
   dialogRef = inject<MatDialogRef<ImportLoanProductDialogComponent>>(MatDialogRef);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   data = inject(MAT_DIALOG_DATA);
 
   /** Import Loan Product form. */
-  importLoanProductForm: UntypedFormGroup;
+  importLoanProductForm: FormGroup;
 
   ngOnInit() {
     this.createImportLoanProductForm();

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
-import { UntypedFormArray } from '@angular/forms';
+import { FormArray } from '@angular/forms';
 import { MatIconButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import {
@@ -58,7 +58,7 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
   translateService = inject(TranslateService);
 
   @Input() formType: string;
-  @Input() formArray: UntypedFormArray;
+  @Input() formArray: FormArray;
   @Input() textHeading: string;
   @Input() textField: string;
   @Input() allowAddAccountingMapping: boolean = true;

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -6,8 +6,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnChanges, OnInit, SimpleChanges, inject } from '@angular/core';
-import { UntypedFormArray, UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  inject
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
@@ -51,16 +61,17 @@ import { LoanProductBaseComponent } from '../../common/loan-product-base.compone
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LoanProductAccountingStepComponent extends LoanProductBaseComponent implements OnInit, OnChanges {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() loanProductsTemplate: any;
   @Input() accountingRuleData: any;
   @Input() loanProductFormValid: boolean;
   @Input() deferredIncomeRecognition: DeferredIncomeRecognition;
 
-  loanProductAccountingForm: UntypedFormGroup;
+  loanProductAccountingForm: FormGroup;
 
   chargeData: any;
   penaltyData: any;
@@ -408,310 +419,304 @@ export class LoanProductAccountingStepComponent extends LoanProductBaseComponent
 
   setConditionalControls() {
     if (this.loanProductService.isLoanProduct) {
-      this.loanProductAccountingForm.get('accountingRule').valueChanges.subscribe((accountingRule: any) => {
-        if (accountingRule >= 2 && accountingRule <= 4) {
-          this.loanProductAccountingForm.addControl(
-            'fundSourceAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'loanPortfolioAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'transfersInSuspenseAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'interestOnLoanAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromFeeAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromPenaltyAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromRecoveryAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'writeOffAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'goodwillCreditAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'overpaymentLiabilityAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl('advancedAccountingRules', new UntypedFormControl(false));
-          this.loanProductAccountingForm.addControl(
-            'chargeOffFraudExpenseAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'chargeOffExpenseAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromChargeOffPenaltyAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromChargeOffFeesAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromChargeOffInterestAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromGoodwillCreditInterestAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromGoodwillCreditFeesAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromGoodwillCreditPenaltyAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
+      this.loanProductAccountingForm
+        .get('accountingRule')
+        .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((accountingRule: any) => {
+          if (accountingRule >= 2 && accountingRule <= 4) {
+            this.loanProductAccountingForm.addControl('fundSourceAccountId', new FormControl('', Validators.required));
+            this.loanProductAccountingForm.addControl(
+              'loanPortfolioAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'transfersInSuspenseAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'interestOnLoanAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromFeeAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromPenaltyAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromRecoveryAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl('writeOffAccountId', new FormControl('', Validators.required));
+            this.loanProductAccountingForm.addControl(
+              'goodwillCreditAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'overpaymentLiabilityAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl('advancedAccountingRules', new FormControl(false));
+            this.loanProductAccountingForm.addControl(
+              'chargeOffFraudExpenseAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'chargeOffExpenseAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromChargeOffPenaltyAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromChargeOffFeesAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromChargeOffInterestAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromGoodwillCreditInterestAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromGoodwillCreditFeesAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromGoodwillCreditPenaltyAccountId',
+              new FormControl('', Validators.required)
+            );
 
-          this.loanProductAccountingForm
-            .get('advancedAccountingRules')
-            .valueChanges.subscribe((advancedAccountingRules: boolean) => {
-              if (advancedAccountingRules) {
-                this.loanProductAccountingForm.addControl(
-                  'paymentChannelToFundSourceMappings',
-                  this.formBuilder.array([])
-                );
-                this.loanProductAccountingForm.addControl('feeToIncomeAccountMappings', this.formBuilder.array([]));
-                this.loanProductAccountingForm.addControl('penaltyToIncomeAccountMappings', this.formBuilder.array([]));
-                this.loanProductAccountingForm.addControl(
-                  'chargeOffReasonToExpenseAccountMappings',
-                  this.formBuilder.array([])
-                );
-                this.loanProductAccountingForm.addControl(
-                  'buydownfeeClassificationToIncomeAccountMappings',
-                  this.formBuilder.array([])
-                );
-                this.loanProductAccountingForm.addControl(
-                  'capitalizedIncomeClassificationToIncomeAccountMappings',
-                  this.formBuilder.array([])
-                );
-                this.loanProductAccountingForm.addControl(
-                  'writeOffReasonsToExpenseMappings',
-                  this.formBuilder.array([])
-                );
-              } else {
-                this.loanProductAccountingForm.setControl(
-                  'paymentChannelToFundSourceMappings',
-                  this.formBuilder.array([])
-                );
-                this.loanProductAccountingForm.setControl('feeToIncomeAccountMappings', this.formBuilder.array([]));
-                this.loanProductAccountingForm.setControl('penaltyToIncomeAccountMappings', this.formBuilder.array([]));
-                this.loanProductAccountingForm.setControl(
-                  'chargeOffReasonToExpenseAccountMappings',
-                  this.formBuilder.array([])
-                );
-                this.loanProductAccountingForm.setControl(
-                  'buydownfeeClassificationToIncomeAccountMappings',
-                  this.formBuilder.array([])
-                );
-                this.loanProductAccountingForm.setControl(
-                  'capitalizedIncomeClassificationToIncomeAccountMappings',
-                  this.formBuilder.array([])
-                );
-                this.loanProductAccountingForm.setControl(
-                  'writeOffReasonsToExpenseMappings',
-                  this.formBuilder.array([])
-                );
-              }
-            });
-        } else {
-          this.loanProductAccountingForm.removeControl('fundSourceAccountId');
-          this.loanProductAccountingForm.removeControl('loanPortfolioAccountId');
-          this.loanProductAccountingForm.removeControl('transfersInSuspenseAccountId');
-          this.loanProductAccountingForm.removeControl('interestOnLoanAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromFeeAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromRecoveryAccountId');
-          this.loanProductAccountingForm.removeControl('writeOffAccountId');
-          this.loanProductAccountingForm.removeControl('goodwillCreditAccountId');
-          this.loanProductAccountingForm.removeControl('overpaymentLiabilityAccountId');
-          this.loanProductAccountingForm.removeControl('advancedAccountingRules');
-          this.loanProductAccountingForm.removeControl('chargeOffExpenseAccountId');
-          this.loanProductAccountingForm.removeControl('chargeOffFraudExpenseAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromChargeOffPenaltyAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromChargeOffFeesAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromChargeOffInterestAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditInterestAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditFeesAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditPenaltyAccountId');
-        }
+            this.loanProductAccountingForm
+              .get('advancedAccountingRules')
+              .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+              .subscribe((advancedAccountingRules: boolean) => {
+                if (advancedAccountingRules) {
+                  this.loanProductAccountingForm.addControl(
+                    'paymentChannelToFundSourceMappings',
+                    this.formBuilder.array([])
+                  );
+                  this.loanProductAccountingForm.addControl('feeToIncomeAccountMappings', this.formBuilder.array([]));
+                  this.loanProductAccountingForm.addControl(
+                    'penaltyToIncomeAccountMappings',
+                    this.formBuilder.array([])
+                  );
+                  this.loanProductAccountingForm.addControl(
+                    'chargeOffReasonToExpenseAccountMappings',
+                    this.formBuilder.array([])
+                  );
+                  this.loanProductAccountingForm.addControl(
+                    'buydownfeeClassificationToIncomeAccountMappings',
+                    this.formBuilder.array([])
+                  );
+                  this.loanProductAccountingForm.addControl(
+                    'capitalizedIncomeClassificationToIncomeAccountMappings',
+                    this.formBuilder.array([])
+                  );
+                  this.loanProductAccountingForm.addControl(
+                    'writeOffReasonsToExpenseMappings',
+                    this.formBuilder.array([])
+                  );
+                } else {
+                  this.loanProductAccountingForm.setControl(
+                    'paymentChannelToFundSourceMappings',
+                    this.formBuilder.array([])
+                  );
+                  this.loanProductAccountingForm.setControl('feeToIncomeAccountMappings', this.formBuilder.array([]));
+                  this.loanProductAccountingForm.setControl(
+                    'penaltyToIncomeAccountMappings',
+                    this.formBuilder.array([])
+                  );
+                  this.loanProductAccountingForm.setControl(
+                    'chargeOffReasonToExpenseAccountMappings',
+                    this.formBuilder.array([])
+                  );
+                  this.loanProductAccountingForm.setControl(
+                    'buydownfeeClassificationToIncomeAccountMappings',
+                    this.formBuilder.array([])
+                  );
+                  this.loanProductAccountingForm.setControl(
+                    'capitalizedIncomeClassificationToIncomeAccountMappings',
+                    this.formBuilder.array([])
+                  );
+                  this.loanProductAccountingForm.setControl(
+                    'writeOffReasonsToExpenseMappings',
+                    this.formBuilder.array([])
+                  );
+                }
+              });
+          } else {
+            this.loanProductAccountingForm.removeControl('fundSourceAccountId');
+            this.loanProductAccountingForm.removeControl('loanPortfolioAccountId');
+            this.loanProductAccountingForm.removeControl('transfersInSuspenseAccountId');
+            this.loanProductAccountingForm.removeControl('interestOnLoanAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromFeeAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromRecoveryAccountId');
+            this.loanProductAccountingForm.removeControl('writeOffAccountId');
+            this.loanProductAccountingForm.removeControl('goodwillCreditAccountId');
+            this.loanProductAccountingForm.removeControl('overpaymentLiabilityAccountId');
+            this.loanProductAccountingForm.removeControl('advancedAccountingRules');
+            this.loanProductAccountingForm.removeControl('chargeOffExpenseAccountId');
+            this.loanProductAccountingForm.removeControl('chargeOffFraudExpenseAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromChargeOffPenaltyAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromChargeOffFeesAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromChargeOffInterestAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditInterestAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditFeesAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditPenaltyAccountId');
+          }
 
-        if (accountingRule === 3 || accountingRule === 4) {
-          this.loanProductAccountingForm.addControl(
-            'receivableInterestAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'receivableFeeAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'receivablePenaltyAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl('enableAccrualActivityPosting', new UntypedFormControl(false));
-        } else {
-          this.loanProductAccountingForm.removeControl('receivableInterestAccountId');
-          this.loanProductAccountingForm.removeControl('receivableFeeAccountId');
-          this.loanProductAccountingForm.removeControl('receivablePenaltyAccountId');
-          this.loanProductAccountingForm.removeControl('enableAccrualActivityPosting');
-        }
-      });
+          if (accountingRule === 3 || accountingRule === 4) {
+            this.loanProductAccountingForm.addControl(
+              'receivableInterestAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'receivableFeeAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'receivablePenaltyAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl('enableAccrualActivityPosting', new FormControl(false));
+          } else {
+            this.loanProductAccountingForm.removeControl('receivableInterestAccountId');
+            this.loanProductAccountingForm.removeControl('receivableFeeAccountId');
+            this.loanProductAccountingForm.removeControl('receivablePenaltyAccountId');
+            this.loanProductAccountingForm.removeControl('enableAccrualActivityPosting');
+          }
+        });
     } else if (this.loanProductService.isWorkingCapital) {
-      this.loanProductAccountingForm.get('accountingRule').valueChanges.subscribe((accountingRule: any) => {
-        if (accountingRule === 'NONE') {
-          this.loanProductAccountingForm.removeControl('fundSourceAccountId');
-          this.loanProductAccountingForm.removeControl('loanPortfolioAccountId');
-          this.loanProductAccountingForm.removeControl('transfersInSuspenseAccountId');
+      this.loanProductAccountingForm
+        .get('accountingRule')
+        .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((accountingRule: any) => {
+          if (accountingRule === 'NONE') {
+            this.loanProductAccountingForm.removeControl('fundSourceAccountId');
+            this.loanProductAccountingForm.removeControl('loanPortfolioAccountId');
+            this.loanProductAccountingForm.removeControl('transfersInSuspenseAccountId');
 
-          this.loanProductAccountingForm.removeControl('incomeFromDiscountFeeAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromFeeAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromRecoveryAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromDiscountFeeAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromFeeAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromRecoveryAccountId');
 
-          this.loanProductAccountingForm.removeControl('incomeFromChargeOffFeesAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromChargeOffPenaltyAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditFeesAccountId');
-          this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditPenaltyAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromChargeOffFeesAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromChargeOffPenaltyAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditFeesAccountId');
+            this.loanProductAccountingForm.removeControl('incomeFromGoodwillCreditPenaltyAccountId');
 
-          this.loanProductAccountingForm.removeControl('writeOffAccountId');
-          this.loanProductAccountingForm.removeControl('goodwillCreditAccountId');
-          this.loanProductAccountingForm.removeControl('chargeOffExpenseAccountId');
-          this.loanProductAccountingForm.removeControl('chargeOffFraudExpenseAccountId');
+            this.loanProductAccountingForm.removeControl('writeOffAccountId');
+            this.loanProductAccountingForm.removeControl('goodwillCreditAccountId');
+            this.loanProductAccountingForm.removeControl('chargeOffExpenseAccountId');
+            this.loanProductAccountingForm.removeControl('chargeOffFraudExpenseAccountId');
 
-          this.loanProductAccountingForm.removeControl('overpaymentLiabilityAccountId');
-          this.loanProductAccountingForm.removeControl('deferredIncomeLiabilityAccountId');
-          this.loanProductAccountingForm.removeControl('receivableFeeAccountId');
-          this.loanProductAccountingForm.removeControl('receivablePenaltyAccountId');
+            this.loanProductAccountingForm.removeControl('overpaymentLiabilityAccountId');
+            this.loanProductAccountingForm.removeControl('deferredIncomeLiabilityAccountId');
+            this.loanProductAccountingForm.removeControl('receivableFeeAccountId');
+            this.loanProductAccountingForm.removeControl('receivablePenaltyAccountId');
 
-          this.loanProductAccountingForm.removeControl('advancedAccountingRules');
-        } else if (accountingRule === 'CASH_BASED') {
-          this.loanProductAccountingForm.addControl(
-            'fundSourceAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'loanPortfolioAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'transfersInSuspenseAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromDiscountFeeAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromFeeAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromPenaltyAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromRecoveryAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl('incomeFromChargeOffFeesAccountId', new UntypedFormControl(''));
-          this.loanProductAccountingForm.addControl('incomeFromChargeOffPenaltyAccountId', new UntypedFormControl(''));
-          this.loanProductAccountingForm.addControl(
-            'incomeFromGoodwillCreditFeesAccountId',
-            new UntypedFormControl('')
-          );
-          this.loanProductAccountingForm.addControl(
-            'incomeFromGoodwillCreditPenaltyAccountId',
-            new UntypedFormControl('')
-          );
+            this.loanProductAccountingForm.removeControl('advancedAccountingRules');
+          } else if (accountingRule === 'CASH_BASED') {
+            this.loanProductAccountingForm.addControl('fundSourceAccountId', new FormControl('', Validators.required));
+            this.loanProductAccountingForm.addControl(
+              'loanPortfolioAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'transfersInSuspenseAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromDiscountFeeAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromFeeAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromPenaltyAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'incomeFromRecoveryAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl('incomeFromChargeOffFeesAccountId', new FormControl(''));
+            this.loanProductAccountingForm.addControl('incomeFromChargeOffPenaltyAccountId', new FormControl(''));
+            this.loanProductAccountingForm.addControl('incomeFromGoodwillCreditFeesAccountId', new FormControl(''));
+            this.loanProductAccountingForm.addControl('incomeFromGoodwillCreditPenaltyAccountId', new FormControl(''));
 
-          this.loanProductAccountingForm.addControl(
-            'writeOffAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl('goodwillCreditAccountId', new UntypedFormControl(''));
-          this.loanProductAccountingForm.addControl('chargeOffFraudExpenseAccountId', new UntypedFormControl(''));
-          this.loanProductAccountingForm.addControl('chargeOffExpenseAccountId', new UntypedFormControl(''));
+            this.loanProductAccountingForm.addControl('writeOffAccountId', new FormControl('', Validators.required));
+            this.loanProductAccountingForm.addControl('goodwillCreditAccountId', new FormControl(''));
+            this.loanProductAccountingForm.addControl('chargeOffFraudExpenseAccountId', new FormControl(''));
+            this.loanProductAccountingForm.addControl('chargeOffExpenseAccountId', new FormControl(''));
 
-          this.loanProductAccountingForm.addControl(
-            'overpaymentLiabilityAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'deferredIncomeLiabilityAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'receivableFeeAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl(
-            'receivablePenaltyAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.loanProductAccountingForm.addControl('advancedAccountingRules', new UntypedFormControl(false));
+            this.loanProductAccountingForm.addControl(
+              'overpaymentLiabilityAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'deferredIncomeLiabilityAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'receivableFeeAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl(
+              'receivablePenaltyAccountId',
+              new FormControl('', Validators.required)
+            );
+            this.loanProductAccountingForm.addControl('advancedAccountingRules', new FormControl(false));
 
-          this.loanProductAccountingForm
-            .get('advancedAccountingRules')
-            .valueChanges.subscribe((advancedAccountingRules: boolean) => {
-              if (advancedAccountingRules) {
-              } else {
-              }
-            });
-        }
-      });
+            this.loanProductAccountingForm
+              .get('advancedAccountingRules')
+              .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+              .subscribe((advancedAccountingRules: boolean) => {
+                if (advancedAccountingRules) {
+                } else {
+                }
+              });
+          }
+        });
     }
   }
 
-  get paymentChannelToFundSourceMappings(): UntypedFormArray {
-    return this.loanProductAccountingForm.get('paymentChannelToFundSourceMappings') as UntypedFormArray;
+  get paymentChannelToFundSourceMappings(): FormArray {
+    return this.loanProductAccountingForm.get('paymentChannelToFundSourceMappings') as FormArray;
   }
 
-  get feeToIncomeAccountMappings(): UntypedFormArray {
-    return this.loanProductAccountingForm.get('feeToIncomeAccountMappings') as UntypedFormArray;
+  get feeToIncomeAccountMappings(): FormArray {
+    return this.loanProductAccountingForm.get('feeToIncomeAccountMappings') as FormArray;
   }
 
-  get penaltyToIncomeAccountMappings(): UntypedFormArray {
-    return this.loanProductAccountingForm.get('penaltyToIncomeAccountMappings') as UntypedFormArray;
+  get penaltyToIncomeAccountMappings(): FormArray {
+    return this.loanProductAccountingForm.get('penaltyToIncomeAccountMappings') as FormArray;
   }
 
-  get chargeOffReasonToExpenseAccountMappings(): UntypedFormArray {
-    return this.loanProductAccountingForm.get('chargeOffReasonToExpenseAccountMappings') as UntypedFormArray;
+  get chargeOffReasonToExpenseAccountMappings(): FormArray {
+    return this.loanProductAccountingForm.get('chargeOffReasonToExpenseAccountMappings') as FormArray;
   }
 
-  get buydownfeeClassificationToIncomeAccountMappings(): UntypedFormArray {
-    return this.loanProductAccountingForm.get('buydownfeeClassificationToIncomeAccountMappings') as UntypedFormArray;
+  get buydownfeeClassificationToIncomeAccountMappings(): FormArray {
+    return this.loanProductAccountingForm.get('buydownfeeClassificationToIncomeAccountMappings') as FormArray;
   }
 
-  get capitalizedIncomeClassificationToIncomeAccountMappings(): UntypedFormArray {
-    return this.loanProductAccountingForm.get(
-      'capitalizedIncomeClassificationToIncomeAccountMappings'
-    ) as UntypedFormArray;
+  get capitalizedIncomeClassificationToIncomeAccountMappings(): FormArray {
+    return this.loanProductAccountingForm.get('capitalizedIncomeClassificationToIncomeAccountMappings') as FormArray;
   }
 
-  get writeOffReasonsToExpenseMappings(): UntypedFormArray {
-    return this.loanProductAccountingForm.get('writeOffReasonsToExpenseMappings') as UntypedFormArray;
+  get writeOffReasonsToExpenseMappings(): FormArray {
+    return this.loanProductAccountingForm.get('writeOffReasonsToExpenseMappings') as FormArray;
   }
 
   setLoanProductAccountingFormDirty() {
@@ -720,7 +725,7 @@ export class LoanProductAccountingStepComponent extends LoanProductBaseComponent
     }
   }
 
-  add(formType: string, formArray: UntypedFormArray) {
+  add(formType: string, formArray: FormArray) {
     this.currentFormValues = [];
     if (formType == 'ChargeOffReasonExpense') {
       this.allowAddChargeOffReasonExpense = true;
@@ -744,7 +749,7 @@ export class LoanProductAccountingStepComponent extends LoanProductBaseComponent
     });
   }
 
-  edit(formType: string, formArray: UntypedFormArray, index: number) {
+  edit(formType: string, formArray: FormArray, index: number) {
     const data = { ...this.getData(formType, formArray.at(index).value), layout: { addButtonText: 'Edit' } };
     const dialogRef = this.dialog.open(FormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -755,7 +760,7 @@ export class LoanProductAccountingStepComponent extends LoanProductBaseComponent
     });
   }
 
-  delete(formType: string, formArray: UntypedFormArray, index: number) {
+  delete(formType: string, formArray: FormArray, index: number) {
     const dialogRef = this.dialog.open(DeleteDialogComponent, {
       data: { deleteContext: this.translateService.instant('labels.text.this') }
     });
@@ -902,7 +907,7 @@ export class LoanProductAccountingStepComponent extends LoanProductBaseComponent
         ) {
           this.loanProductAccountingForm.addControl(
             'deferredIncomeLiabilityAccountId',
-            new UntypedFormControl('', Validators.required)
+            new FormControl('', Validators.required)
           );
         } else {
           this.loanProductAccountingForm.removeControl('deferredIncomeLiabilityAccountId');
@@ -910,7 +915,7 @@ export class LoanProductAccountingStepComponent extends LoanProductBaseComponent
         if (this.deferredIncomeRecognition.capitalizedIncome?.enableIncomeCapitalization) {
           this.loanProductAccountingForm.addControl(
             'incomeFromCapitalizationAccountId',
-            new UntypedFormControl('', Validators.required)
+            new FormControl('', Validators.required)
           );
         } else {
           this.loanProductAccountingForm.removeControl('incomeFromCapitalizationAccountId');
@@ -919,12 +924,12 @@ export class LoanProductAccountingStepComponent extends LoanProductBaseComponent
           if (this.deferredIncomeRecognition.buyDownFee?.merchantBuyDownFee) {
             this.loanProductAccountingForm.addControl(
               'buyDownExpenseAccountId',
-              new UntypedFormControl('', Validators.required)
+              new FormControl('', Validators.required)
             );
           }
           this.loanProductAccountingForm.addControl(
             'incomeFromBuyDownAccountId',
-            new UntypedFormControl('', Validators.required)
+            new FormControl('', Validators.required)
           );
         } else {
           this.loanProductAccountingForm.removeControl('buyDownExpenseAccountId');

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component.ts
@@ -6,8 +6,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  inject
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { DeferredIncomeRecognition } from '../loan-product-payment-strategy-step/payment-allocation-model';
 import { StringEnumOptionData } from 'app/shared/models/option-data.model';
 import { MatCheckbox } from '@angular/material/checkbox';
@@ -24,7 +34,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LoanProductDeferredIncomeRecognitionStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
 
   @Input() deferredIncomeRecognition: DeferredIncomeRecognition;
   @Input() capitalizedIncomeCalculationTypeOptions: StringEnumOptionData[];
@@ -34,12 +45,12 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnInit
   @Input() buyDownFeeStrategyOptions: StringEnumOptionData[];
   @Input() buyDownFeeIncomeTypeOptions: StringEnumOptionData[];
 
-  loanDeferredIncomeRecognitionForm: UntypedFormGroup;
+  loanDeferredIncomeRecognitionForm: FormGroup;
 
   enableIncomeCapitalization: boolean;
   enableBuyDownFee: boolean;
 
-  @Output() setViewChildForm = new EventEmitter<UntypedFormGroup>();
+  @Output() setViewChildForm = new EventEmitter<FormGroup>();
 
   constructor() {
     this.enableIncomeCapitalization =
@@ -121,7 +132,8 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnInit
   setConditionalControls() {
     this.loanDeferredIncomeRecognitionForm
       .get('enableIncomeCapitalization')
-      .valueChanges.subscribe((enabled: boolean) => {
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((enabled: boolean) => {
         this.enableIncomeCapitalization = enabled;
         if (this.enableIncomeCapitalization) {
           const capitalizedIncomeCalculationType =
@@ -133,7 +145,7 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnInit
               : this.deferredIncomeRecognition.capitalizedIncome.capitalizedIncomeCalculationType;
           this.loanDeferredIncomeRecognitionForm.addControl(
             'capitalizedIncomeCalculationType',
-            new UntypedFormControl(capitalizedIncomeCalculationType, Validators.required)
+            new FormControl(capitalizedIncomeCalculationType, Validators.required)
           );
           const capitalizedIncomeStrategy =
             !this.deferredIncomeRecognition.capitalizedIncome.capitalizedIncomeStrategy ||
@@ -142,7 +154,7 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnInit
               : this.deferredIncomeRecognition.capitalizedIncome.capitalizedIncomeStrategy;
           this.loanDeferredIncomeRecognitionForm.addControl(
             'capitalizedIncomeStrategy',
-            new UntypedFormControl(capitalizedIncomeStrategy, Validators.required)
+            new FormControl(capitalizedIncomeStrategy, Validators.required)
           );
           const capitalizedIncomeType =
             !this.deferredIncomeRecognition.capitalizedIncome.capitalizedIncomeType ||
@@ -151,22 +163,25 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnInit
               : this.deferredIncomeRecognition.capitalizedIncome.capitalizedIncomeType;
           this.loanDeferredIncomeRecognitionForm.addControl(
             'capitalizedIncomeType',
-            new UntypedFormControl(capitalizedIncomeType, Validators.required)
+            new FormControl(capitalizedIncomeType, Validators.required)
           );
 
           this.loanDeferredIncomeRecognitionForm
             .get('capitalizedIncomeCalculationType')
-            .valueChanges.subscribe((newValue: string) => {
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((newValue: string) => {
               this.emitValuesChange();
             });
           this.loanDeferredIncomeRecognitionForm
             .get('capitalizedIncomeStrategy')
-            .valueChanges.subscribe((newValue: string) => {
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((newValue: string) => {
               this.emitValuesChange();
             });
           this.loanDeferredIncomeRecognitionForm
             .get('capitalizedIncomeType')
-            .valueChanges.subscribe((newValue: string) => {
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((newValue: string) => {
               this.emitValuesChange();
             });
         } else {
@@ -179,66 +194,77 @@ export class LoanProductDeferredIncomeRecognitionStepComponent implements OnInit
         this.setViewChildForm.emit(this.loanDeferredIncomeRecognitionForm);
       });
 
-    this.loanDeferredIncomeRecognitionForm.get('enableBuyDownFee').valueChanges.subscribe((enabled: boolean) => {
-      this.enableBuyDownFee = enabled;
-      if (this.enableBuyDownFee) {
-        const buyDownFeeCalculationType =
-          !this.deferredIncomeRecognition.buyDownFee.buyDownFeeCalculationType ||
-          this.deferredIncomeRecognition.buyDownFee.buyDownFeeCalculationType == ''
-            ? this.buyDownFeeCalculationTypeOptions[0].id
-            : this.deferredIncomeRecognition.buyDownFee.buyDownFeeCalculationType;
-        this.loanDeferredIncomeRecognitionForm.addControl(
-          'buyDownFeeCalculationType',
-          new UntypedFormControl(buyDownFeeCalculationType, Validators.required)
-        );
-        const buyDownFeeStrategy =
-          !this.deferredIncomeRecognition.buyDownFee.buyDownFeeStrategy ||
-          this.deferredIncomeRecognition.buyDownFee.buyDownFeeStrategy == ''
-            ? this.buyDownFeeStrategyOptions[0].id
-            : this.deferredIncomeRecognition.buyDownFee.buyDownFeeStrategy;
-        this.loanDeferredIncomeRecognitionForm.addControl(
-          'buyDownFeeStrategy',
-          new UntypedFormControl(buyDownFeeStrategy, Validators.required)
-        );
-        const buyDownFeeIncomeType =
-          !this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType ||
-          this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType == ''
-            ? this.buyDownFeeIncomeTypeOptions[0].id
-            : this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType;
-        this.loanDeferredIncomeRecognitionForm.addControl(
-          'buyDownFeeIncomeType',
-          new UntypedFormControl(buyDownFeeIncomeType, Validators.required)
-        );
-        this.loanDeferredIncomeRecognitionForm.addControl(
-          'merchantBuyDownFee',
-          new UntypedFormControl(this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee)
-        );
+    this.loanDeferredIncomeRecognitionForm
+      .get('enableBuyDownFee')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((enabled: boolean) => {
+        this.enableBuyDownFee = enabled;
+        if (this.enableBuyDownFee) {
+          const buyDownFeeCalculationType =
+            !this.deferredIncomeRecognition.buyDownFee.buyDownFeeCalculationType ||
+            this.deferredIncomeRecognition.buyDownFee.buyDownFeeCalculationType == ''
+              ? this.buyDownFeeCalculationTypeOptions[0].id
+              : this.deferredIncomeRecognition.buyDownFee.buyDownFeeCalculationType;
+          this.loanDeferredIncomeRecognitionForm.addControl(
+            'buyDownFeeCalculationType',
+            new FormControl(buyDownFeeCalculationType, Validators.required)
+          );
+          const buyDownFeeStrategy =
+            !this.deferredIncomeRecognition.buyDownFee.buyDownFeeStrategy ||
+            this.deferredIncomeRecognition.buyDownFee.buyDownFeeStrategy == ''
+              ? this.buyDownFeeStrategyOptions[0].id
+              : this.deferredIncomeRecognition.buyDownFee.buyDownFeeStrategy;
+          this.loanDeferredIncomeRecognitionForm.addControl(
+            'buyDownFeeStrategy',
+            new FormControl(buyDownFeeStrategy, Validators.required)
+          );
+          const buyDownFeeIncomeType =
+            !this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType ||
+            this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType == ''
+              ? this.buyDownFeeIncomeTypeOptions[0].id
+              : this.deferredIncomeRecognition.buyDownFee.buyDownFeeIncomeType;
+          this.loanDeferredIncomeRecognitionForm.addControl(
+            'buyDownFeeIncomeType',
+            new FormControl(buyDownFeeIncomeType, Validators.required)
+          );
+          this.loanDeferredIncomeRecognitionForm.addControl(
+            'merchantBuyDownFee',
+            new FormControl(this.deferredIncomeRecognition.buyDownFee.merchantBuyDownFee)
+          );
 
-        this.loanDeferredIncomeRecognitionForm
-          .get('buyDownFeeCalculationType')
-          .valueChanges.subscribe((newValue: string) => {
-            this.emitValuesChange();
-          });
-        this.loanDeferredIncomeRecognitionForm.get('buyDownFeeStrategy').valueChanges.subscribe((newValue: string) => {
-          this.emitValuesChange();
-        });
-        this.loanDeferredIncomeRecognitionForm
-          .get('buyDownFeeIncomeType')
-          .valueChanges.subscribe((newValue: string) => {
-            this.emitValuesChange();
-          });
-        this.loanDeferredIncomeRecognitionForm.get('merchantBuyDownFee').valueChanges.subscribe((newValue: boolean) => {
-          this.emitValuesChange();
-        });
-      } else {
-        this.loanDeferredIncomeRecognitionForm.removeControl('buyDownFeeCalculationType');
-        this.loanDeferredIncomeRecognitionForm.removeControl('buyDownFeeStrategy');
-        this.loanDeferredIncomeRecognitionForm.removeControl('buyDownFeeIncomeType');
-        this.loanDeferredIncomeRecognitionForm.removeControl('merchantBuyDownFee');
-      }
+          this.loanDeferredIncomeRecognitionForm
+            .get('buyDownFeeCalculationType')
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((newValue: string) => {
+              this.emitValuesChange();
+            });
+          this.loanDeferredIncomeRecognitionForm
+            .get('buyDownFeeStrategy')
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((newValue: string) => {
+              this.emitValuesChange();
+            });
+          this.loanDeferredIncomeRecognitionForm
+            .get('buyDownFeeIncomeType')
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((newValue: string) => {
+              this.emitValuesChange();
+            });
+          this.loanDeferredIncomeRecognitionForm
+            .get('merchantBuyDownFee')
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((newValue: boolean) => {
+              this.emitValuesChange();
+            });
+        } else {
+          this.loanDeferredIncomeRecognitionForm.removeControl('buyDownFeeCalculationType');
+          this.loanDeferredIncomeRecognitionForm.removeControl('buyDownFeeStrategy');
+          this.loanDeferredIncomeRecognitionForm.removeControl('buyDownFeeIncomeType');
+          this.loanDeferredIncomeRecognitionForm.removeControl('merchantBuyDownFee');
+        }
 
-      this.emitValuesChange();
-    });
+        this.emitValuesChange();
+      });
   }
 
   emitValuesChange(): void {

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-charges-step/loan-product-charges-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-charges-step/loan-product-charges-step.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, Input, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { TranslateService } from '@ngx-translate/core';
@@ -64,10 +65,11 @@ import { LoanProductBaseComponent } from '../../common/loan-product-base.compone
 export class LoanProductChargesStepComponent extends LoanProductBaseComponent implements OnInit {
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() loanProductsTemplate: any;
-  @Input() currencyCode: UntypedFormControl;
-  @Input() multiDisburseLoan: UntypedFormControl | null;
+  @Input() currencyCode: FormControl;
+  @Input() multiDisburseLoan: FormControl | null;
 
   chargeData: any;
   overdueChargeData: any;
@@ -98,9 +100,13 @@ export class LoanProductChargesStepComponent extends LoanProductBaseComponent im
     this.chargesDataSource = this.loanProductsTemplate.charges || [];
     this.pristine = true;
 
-    this.currencyCode.valueChanges.subscribe(() => (this.chargesDataSource = []));
+    this.currencyCode.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => (this.chargesDataSource = []));
     if (this.loanProductService.isLoanProduct && this.multiDisburseLoan) {
-      this.multiDisburseLoan.valueChanges.subscribe(() => (this.chargesDataSource = []));
+      this.multiDisburseLoan.valueChanges
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => (this.chargesDataSource = []));
     }
   }
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject, DestroyRef } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, UntypedFormControl } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, FormControl } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -28,13 +28,13 @@ import { LoanProductService } from '../../services/loan-product.service';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LoanProductCurrencyStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   protected loanProductService = inject(LoanProductService);
   private destroyRef = inject(DestroyRef);
 
   @Input() loanProductsTemplate: any;
 
-  loanProductCurrencyForm!: UntypedFormGroup;
+  loanProductCurrencyForm!: FormGroup;
 
   currencyData: any;
 
@@ -97,7 +97,7 @@ export class LoanProductCurrencyStepComponent implements OnInit {
     });
 
     if (this.loanProductService.isLoanProduct) {
-      this.loanProductCurrencyForm.addControl('installmentAmountInMultiplesOf', new UntypedFormControl(''));
+      this.loanProductCurrencyForm.addControl('installmentAmountInMultiplesOf', new FormControl(''));
     }
   }
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-details-step/loan-product-details-step.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, UntypedFormControl } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, FormControl } from '@angular/forms';
 import { Dates } from 'app/core/utils/dates';
 
 /** Custom Services */
@@ -37,13 +37,13 @@ import { LoanProductBaseComponent } from '../../common/loan-product-base.compone
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LoanProductDetailsStepComponent extends LoanProductBaseComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
 
   @Input() loanProductsTemplate: any;
 
-  loanProductDetailsForm: UntypedFormGroup;
+  loanProductDetailsForm: FormGroup;
 
   fundData: any;
 
@@ -97,7 +97,7 @@ export class LoanProductDetailsStepComponent extends LoanProductBaseComponent im
     });
 
     if (this.loanProductService.isLoanProduct) {
-      this.loanProductDetailsForm.addControl('includeInBorrowerCycle', new UntypedFormControl(false));
+      this.loanProductDetailsForm.addControl('includeInBorrowerCycle', new FormControl(false));
     }
   }
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-interest-refund-step/loan-product-interest-refund-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-interest-refund-step/loan-product-interest-refund-step.component.ts
@@ -6,8 +6,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, ReactiveFormsModule } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  inject
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { StringEnumOptionData } from '../../../../shared/models/option-data.model';
 import { MatTooltip } from '@angular/material/tooltip';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -23,12 +33,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LoanProductInterestRefundStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
 
   @Input() loanProductsTemplate: any;
   @Output() supportedInterestRefundTypes = new EventEmitter<StringEnumOptionData[]>();
 
-  loanProductInterestRefundForm: UntypedFormGroup;
+  loanProductInterestRefundForm: FormGroup;
 
   supportedInterestRefundTypesOptions: StringEnumOptionData[];
 
@@ -54,11 +65,14 @@ export class LoanProductInterestRefundStepComponent implements OnInit {
   }
 
   setConditionalControls() {
-    this.loanProductInterestRefundForm.get('supportedInterestRefundTypes').valueChanges.subscribe((value) => {
-      this.supportedInterestRefundTypes.emit(
-        this.mapIdToStringEnumOptionList(value, this.loanProductsTemplate.supportedInterestRefundTypesOptions)
-      );
-    });
+    this.loanProductInterestRefundForm
+      .get('supportedInterestRefundTypes')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value) => {
+        this.supportedInterestRefundTypes.emit(
+          this.mapIdToStringEnumOptionList(value, this.loanProductsTemplate.supportedInterestRefundTypesOptions)
+        );
+      });
   }
 
   mapStringEnumOptionToIdList(incomingValues: StringEnumOptionData[]): string[] {

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-payment-strategy-step/advance-payment-allocation-tab/advance-payment-allocation-tab.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-payment-strategy-step/advance-payment-allocation-tab/advance-payment-allocation-tab.component.ts
@@ -10,6 +10,7 @@ import { CdkDragDrop, moveItemInArray, CdkDropList, CdkDrag } from '@angular/cdk
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   EventEmitter,
   Input,
   OnInit,
@@ -17,7 +18,8 @@ import {
   ViewChild,
   inject
 } from '@angular/core';
-import { UntypedFormControl, Validators } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import {
   MatTable,
@@ -73,6 +75,7 @@ export class AdvancePaymentAllocationTabComponent implements OnInit {
   private advancedPaymentStrategy = inject(AdvancedPaymentStrategy);
   private translateService = inject(TranslateService);
   protected loanProductService = inject(LoanProductService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() advancedPaymentAllocation: AdvancedPaymentAllocation;
   @Input() advancedCreditAllocation: AdvancedCreditAllocation;
@@ -90,7 +93,7 @@ export class AdvancePaymentAllocationTabComponent implements OnInit {
     'allocationRule'
   ];
 
-  futureInstallmentAllocationRule = new UntypedFormControl('', Validators.required);
+  futureInstallmentAllocationRule = new FormControl('', Validators.required);
 
   @ViewChild('table') table: MatTable<any>;
 
@@ -107,16 +110,18 @@ export class AdvancePaymentAllocationTabComponent implements OnInit {
           this.advancedPaymentAllocation.futureInstallmentAllocationRule.code
         );
       }
-      this.futureInstallmentAllocationRule.valueChanges.subscribe((value: any) => {
-        this.advancedPaymentAllocation.futureInstallmentAllocationRules.forEach(
-          (item: FutureInstallmentAllocationRule) => {
-            if (value === item.code) {
-              this.advancedPaymentAllocation.futureInstallmentAllocationRule = item;
-              this.allocationChanged.emit(true);
+      this.futureInstallmentAllocationRule.valueChanges
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((value: any) => {
+          this.advancedPaymentAllocation.futureInstallmentAllocationRules.forEach(
+            (item: FutureInstallmentAllocationRule) => {
+              if (value === item.code) {
+                this.advancedPaymentAllocation.futureInstallmentAllocationRule = item;
+                this.allocationChanged.emit(true);
+              }
             }
-          }
-        );
-      });
+          );
+        });
     }
   }
 

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component.ts
@@ -6,8 +6,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, Input, Output, EventEmitter, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, UntypedFormControl } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  Input,
+  Output,
+  EventEmitter,
+  inject
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl } from '@angular/forms';
 import { LoanProducts } from '../../loan-products';
 import { rangeValidator } from 'app/shared/validators/percentage.validator';
 import { GlobalConfiguration } from 'app/system/configurations/global-configurations-tab/configuration.model';
@@ -46,18 +56,19 @@ import { InputPositiveIntegerComponent } from 'app/shared/input-positive-integer
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LoanProductSettingsStepComponent extends LoanProductBaseComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private processingStrategyService = inject(ProcessingStrategyService);
+  private destroyRef = inject(DestroyRef);
 
   DAYS_BEFORE_REPAYMENT_IS_DUE = LoanProducts.DAYS_BEFORE_REPAYMENT_IS_DUE;
   DAYS_AFTER_REPAYMENT_IS_OVERDUE = LoanProducts.DAYS_AFTER_REPAYMENT_IS_OVERDUE;
 
   @Input() toEdit: boolean;
   @Input() loanProductsTemplate: any;
-  @Input() isLinkedToFloatingInterestRates: UntypedFormControl | null;
+  @Input() isLinkedToFloatingInterestRates: FormControl | null;
   @Output() advancePaymentStrategy = new EventEmitter<string>();
 
-  loanProductSettingsForm: UntypedFormGroup;
+  loanProductSettingsForm: FormGroup;
 
   amortizationTypeData: any;
   interestTypeData: any;
@@ -512,7 +523,7 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
               : this.daysInYearCustomStrategyOptions[0].id;
             this.loanProductSettingsForm.addControl(
               'daysInYearCustomStrategy',
-              new UntypedFormControl(daysInYearCustomStrategy, Validators.required)
+              new FormControl(daysInYearCustomStrategy, Validators.required)
             );
           } else {
             this.loanProductSettingsForm.removeControl('daysInYearCustomStrategy');
@@ -534,14 +545,14 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
           if (allowVariableInstallments) {
             this.loanProductSettingsForm.addControl(
               'minimumGap',
-              new UntypedFormControl('', [
+              new FormControl('', [
                 Validators.required,
                 Validators.min(0)
               ])
             );
             this.loanProductSettingsForm.addControl(
               'maximumGap',
-              new UntypedFormControl('', [
+              new FormControl('', [
                 Validators.required,
                 Validators.min(0)
               ])
@@ -557,21 +568,21 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
           if (isInterestRecalculationEnabled) {
             this.loanProductSettingsForm.addControl(
               'preClosureInterestCalculationStrategy',
-              new UntypedFormControl(this.preClosureInterestCalculationStrategyData[0].id, Validators.required)
+              new FormControl(this.preClosureInterestCalculationStrategyData[0].id, Validators.required)
             );
             this.loanProductSettingsForm.addControl(
               'rescheduleStrategyMethod',
-              new UntypedFormControl(this.rescheduleStrategyTypeData[0].id, Validators.required)
+              new FormControl(this.rescheduleStrategyTypeData[0].id, Validators.required)
             );
             this.loanProductSettingsForm.addControl(
               'interestRecalculationCompoundingMethod',
-              new UntypedFormControl(this.interestRecalculationCompoundingTypeData[0].id, Validators.required)
+              new FormControl(this.interestRecalculationCompoundingTypeData[0].id, Validators.required)
             );
             this.loanProductSettingsForm.addControl(
               'recalculationRestFrequencyType',
-              new UntypedFormControl(this.interestRecalculationFrequencyTypeData[0].id, Validators.required)
+              new FormControl(this.interestRecalculationFrequencyTypeData[0].id, Validators.required)
             );
-            this.loanProductSettingsForm.addControl('isArrearsBasedOnOriginalSchedule', new UntypedFormControl(''));
+            this.loanProductSettingsForm.addControl('isArrearsBasedOnOriginalSchedule', new FormControl(''));
             if (this.loanProductSettingsForm.value.isInterestRecalculationEnabled) {
               this.setRescheduleStrategies();
             }
@@ -581,7 +592,7 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
                 if (interestRecalculationCompoundingMethod !== 0) {
                   this.loanProductSettingsForm.addControl(
                     'recalculationCompoundingFrequencyType',
-                    new UntypedFormControl(this.interestRecalculationFrequencyTypeData[0].id, Validators.required)
+                    new FormControl(this.interestRecalculationFrequencyTypeData[0].id, Validators.required)
                   );
 
                   this.loanProductSettingsForm
@@ -590,7 +601,7 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
                       if (recalculationCompoundingFrequencyType !== 1) {
                         this.loanProductSettingsForm.addControl(
                           'recalculationCompoundingFrequencyInterval',
-                          new UntypedFormControl('', Validators.required)
+                          new FormControl('', Validators.required)
                         );
                       } else {
                         this.loanProductSettingsForm.removeControl('recalculationCompoundingFrequencyInterval');
@@ -599,18 +610,18 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
                       if (recalculationCompoundingFrequencyType === 3) {
                         this.loanProductSettingsForm.addControl(
                           'recalculationCompoundingFrequencyDayOfWeekType',
-                          new UntypedFormControl('')
+                          new FormControl('')
                         );
                         this.loanProductSettingsForm.removeControl('recalculationCompoundingFrequencyNthDayType');
                         this.loanProductSettingsForm.removeControl('recalculationCompoundingFrequencyOnDayType');
                       } else if (recalculationCompoundingFrequencyType === 4) {
                         this.loanProductSettingsForm.addControl(
                           'recalculationCompoundingFrequencyNthDayType',
-                          new UntypedFormControl('')
+                          new FormControl('')
                         );
                         this.loanProductSettingsForm.addControl(
                           'recalculationCompoundingFrequencyDayOfWeekType',
-                          new UntypedFormControl('')
+                          new FormControl('')
                         );
 
                         this.loanProductSettingsForm
@@ -619,7 +630,7 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
                             if (recalculationCompoundingFrequencyNthDayType === -2) {
                               this.loanProductSettingsForm.addControl(
                                 'recalculationCompoundingFrequencyOnDayType',
-                                new UntypedFormControl('')
+                                new FormControl('')
                               );
                               this.loanProductSettingsForm.removeControl(
                                 'recalculationCompoundingFrequencyDayOfWeekType'
@@ -627,7 +638,7 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
                             } else {
                               this.loanProductSettingsForm.addControl(
                                 'recalculationCompoundingFrequencyDayOfWeekType',
-                                new UntypedFormControl('')
+                                new FormControl('')
                               );
                               this.loanProductSettingsForm.removeControl('recalculationCompoundingFrequencyOnDayType');
                             }
@@ -649,7 +660,7 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
                 if (recalculationRestFrequencyType !== 1) {
                   this.loanProductSettingsForm.addControl(
                     'recalculationRestFrequencyInterval',
-                    new UntypedFormControl('', Validators.required)
+                    new FormControl('', Validators.required)
                   );
                 } else {
                   this.loanProductSettingsForm.removeControl('recalculationRestFrequencyInterval');
@@ -658,18 +669,15 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
                 if (recalculationRestFrequencyType === 3) {
                   this.loanProductSettingsForm.addControl(
                     'recalculationRestFrequencyDayOfWeekType',
-                    new UntypedFormControl('')
+                    new FormControl('')
                   );
                   this.loanProductSettingsForm.removeControl('recalculationRestFrequencyNthDayType');
                   this.loanProductSettingsForm.removeControl('recalculationRestFrequencyOnDayType');
                 } else if (recalculationRestFrequencyType === 4) {
-                  this.loanProductSettingsForm.addControl(
-                    'recalculationRestFrequencyNthDayType',
-                    new UntypedFormControl('')
-                  );
+                  this.loanProductSettingsForm.addControl('recalculationRestFrequencyNthDayType', new FormControl(''));
                   this.loanProductSettingsForm.addControl(
                     'recalculationRestFrequencyDayOfWeekType',
-                    new UntypedFormControl('')
+                    new FormControl('')
                   );
 
                   this.loanProductSettingsForm
@@ -678,13 +686,13 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
                       if (recalculationRestFrequencyNthDayType === -2) {
                         this.loanProductSettingsForm.addControl(
                           'recalculationRestFrequencyOnDayType',
-                          new UntypedFormControl('')
+                          new FormControl('')
                         );
                         this.loanProductSettingsForm.removeControl('recalculationRestFrequencyDayOfWeekType');
                       } else {
                         this.loanProductSettingsForm.addControl(
                           'recalculationRestFrequencyDayOfWeekType',
-                          new UntypedFormControl('')
+                          new FormControl('')
                         );
                         this.loanProductSettingsForm.removeControl('recalculationRestFrequencyOnDayType');
                       }
@@ -709,18 +717,18 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
         if (holdGuaranteeFunds) {
           this.loanProductSettingsForm.addControl(
             'mandatoryGuarantee',
-            new UntypedFormControl('', [
+            new FormControl('', [
               Validators.required,
               Validators.min(0)
             ])
           );
           this.loanProductSettingsForm.addControl(
             'minimumGuaranteeFromOwnFunds',
-            new UntypedFormControl('', [Validators.min(0)])
+            new FormControl('', [Validators.min(0)])
           );
           this.loanProductSettingsForm.addControl(
             'minimumGuaranteeFromGuarantor',
-            new UntypedFormControl('', [Validators.min(0)])
+            new FormControl('', [Validators.min(0)])
           );
         } else {
           this.loanProductSettingsForm.removeControl('mandatoryGuarantee');
@@ -733,15 +741,12 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
         if (multiDisburseLoan) {
           this.loanProductSettingsForm.addControl(
             'maxTrancheCount',
-            new UntypedFormControl('', [
+            new FormControl('', [
               Validators.required,
               Validators.min(0)
             ])
           );
-          this.loanProductSettingsForm.addControl(
-            'outstandingLoanBalance',
-            new UntypedFormControl('', [Validators.min(0)])
-          );
+          this.loanProductSettingsForm.addControl('outstandingLoanBalance', new FormControl('', [Validators.min(0)]));
         } else {
           this.loanProductSettingsForm.removeControl('maxTrancheCount');
           this.loanProductSettingsForm.removeControl('outstandingLoanBalance');
@@ -756,15 +761,12 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
         if (enableDownPayment) {
           this.loanProductSettingsForm.addControl(
             'disbursedAmountPercentageForDownPayment',
-            new UntypedFormControl(0, [
+            new FormControl(0, [
               Validators.required,
               rangeValidator(0, 100)
             ])
           );
-          this.loanProductSettingsForm.addControl(
-            'enableAutoRepaymentForDownPayment',
-            new UntypedFormControl(false, [])
-          );
+          this.loanProductSettingsForm.addControl('enableAutoRepaymentForDownPayment', new FormControl(false, []));
         } else {
           this.loanProductSettingsForm.removeControl('disbursedAmountPercentageForDownPayment');
           this.loanProductSettingsForm.removeControl('enableAutoRepaymentForDownPayment');
@@ -832,7 +834,7 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
           this.isAdvancedTransactionProcessingStrategy = true;
           this.loanProductSettingsForm.addControl(
             'chargeOffBehaviour',
-            new UntypedFormControl(this.loanProductsTemplate.chargeOffBehaviour.id)
+            new FormControl(this.loanProductsTemplate.chargeOffBehaviour.id)
           );
           this.validateAdvancedPaymentStrategyControls();
         }
@@ -879,7 +881,7 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
     const isControlExists = this.loanProductSettingsForm.contains('disallowInterestCalculationOnPastDue');
 
     if (shouldControlExists && !isControlExists) {
-      this.loanProductSettingsForm.addControl('disallowInterestCalculationOnPastDue', new UntypedFormControl(''));
+      this.loanProductSettingsForm.addControl('disallowInterestCalculationOnPastDue', new FormControl(''));
       this.loanProductSettingsForm.patchValue({
         disallowInterestCalculationOnPastDue:
           this.loanProductsTemplate.interestRecalculationData?.disallowInterestCalculationOnPastDue ?? false
@@ -969,7 +971,7 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
       const daysInYearType: any = this.loanProductSettingsForm.get('daysInYearType').value;
       this.loanProductSettingsForm.addControl(
         'loanScheduleProcessingType',
-        new UntypedFormControl(
+        new FormControl(
           this.loanProductsTemplate.loanScheduleProcessingType.code ||
             LoanProducts.LOAN_SCHEDULE_PROCESSING_TYPE_HORIZONTAL,
           [Validators.required]
@@ -982,7 +984,7 @@ export class LoanProductSettingsStepComponent extends LoanProductBaseComponent i
           : this.daysInYearCustomStrategyOptions[0].id;
         this.loanProductSettingsForm.addControl(
           'daysInYearCustomStrategy',
-          new UntypedFormControl(daysInYearCustomStrategy, Validators.required)
+          new FormControl(daysInYearCustomStrategy, Validators.required)
         );
       }
     } else {

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -6,8 +6,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, UntypedFormArray, UntypedFormControl } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  inject,
+  DestroyRef
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormArray, FormControl } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
@@ -69,17 +79,18 @@ import { LoanProductBaseComponent } from '../../common/loan-product-base.compone
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class LoanProductTermsStepComponent extends LoanProductBaseComponent implements OnInit, OnChanges {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private processingStrategyService = inject(ProcessingStrategyService);
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() loanProductsTemplate: any;
 
-  loanProductTermsForm!: UntypedFormGroup;
+  loanProductTermsForm!: FormGroup;
 
   /** Zero Interest control. */
-  zeroInterest = new UntypedFormControl(false);
+  zeroInterest = new FormControl(false);
 
   valueConditionTypeData: any;
   floatingRateData: any;
@@ -187,9 +198,11 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
           this.loanProductsTemplate.maxInterestRatePerPeriod === 0
       );
 
-      this.processingStrategyService.advancedTransactionProcessingStrategy.subscribe((value: boolean) => {
-        this.isAdvancedTransactionProcessingStrategy = value;
-      });
+      this.processingStrategyService.advancedTransactionProcessingStrategy
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((value: boolean) => {
+          this.isAdvancedTransactionProcessingStrategy = value;
+        });
       this.validateAdvancedPaymentStrategyControls();
     }
 
@@ -372,12 +385,13 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
     if (this.loanProductService.isLoanProduct) {
       this.loanProductTermsForm
         .get('allowApprovedDisbursedAmountsOverApplied')!
-        .valueChanges.subscribe((allowApprovedDisbursedAmountsOverApplied) => {
+        .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((allowApprovedDisbursedAmountsOverApplied) => {
           if (allowApprovedDisbursedAmountsOverApplied) {
             this.loanProductTermsForm.get('overAppliedCalculationType')!.enable();
             this.loanProductTermsForm.get('overAppliedNumber')!.enable();
             if (this.loanProductService.isLoanProduct) {
-              this.loanProductTermsForm.addControl('disallowExpectedDisbursements', new UntypedFormControl(true));
+              this.loanProductTermsForm.addControl('disallowExpectedDisbursements', new FormControl(true));
             }
           } else {
             this.loanProductTermsForm.get('overAppliedCalculationType')!.disable();
@@ -392,44 +406,39 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
 
       this.loanProductTermsForm
         .get('isLinkedToFloatingInterestRates')!
-        .valueChanges.subscribe((isLinkedToFloatingInterestRates) => {
+        .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((isLinkedToFloatingInterestRates) => {
           if (isLinkedToFloatingInterestRates) {
             this.loanProductTermsForm.removeControl('minInterestRatePerPeriod');
             this.loanProductTermsForm.removeControl('interestRatePerPeriod');
             this.loanProductTermsForm.removeControl('maxInterestRatePerPeriod');
             this.loanProductTermsForm.removeControl('interestRateFrequencyType');
-            this.loanProductTermsForm.addControl('floatingRatesId', new UntypedFormControl('', Validators.required));
-            this.loanProductTermsForm.addControl(
-              'interestRateDifferential',
-              new UntypedFormControl('', Validators.required)
-            );
-            this.loanProductTermsForm.addControl(
-              'isFloatingInterestRateCalculationAllowed',
-              new UntypedFormControl(false)
-            );
+            this.loanProductTermsForm.addControl('floatingRatesId', new FormControl('', Validators.required));
+            this.loanProductTermsForm.addControl('interestRateDifferential', new FormControl('', Validators.required));
+            this.loanProductTermsForm.addControl('isFloatingInterestRateCalculationAllowed', new FormControl(false));
             this.loanProductTermsForm.addControl(
               'minDifferentialLendingRate',
-              new UntypedFormControl('', Validators.required)
+              new FormControl('', Validators.required)
             );
             this.loanProductTermsForm.addControl(
               'defaultDifferentialLendingRate',
-              new UntypedFormControl('', Validators.required)
+              new FormControl('', Validators.required)
             );
             this.loanProductTermsForm.addControl(
               'maxDifferentialLendingRate',
-              new UntypedFormControl('', Validators.required)
+              new FormControl('', Validators.required)
             );
           } else {
             this.loanProductTermsForm.addControl(
               'minInterestRatePerPeriod',
-              new UntypedFormControl('', [
+              new FormControl('', [
                 Validators.min(0),
                 Validators.pattern(/^\d+([.,]\d{1,6})?$/)
               ])
             );
             this.loanProductTermsForm.addControl(
               'interestRatePerPeriod',
-              new UntypedFormControl('', [
+              new FormControl('', [
                 Validators.required,
                 Validators.min(0),
                 Validators.pattern(/^\d+([.,]\d{1,6})?$/)
@@ -437,14 +446,14 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
             );
             this.loanProductTermsForm.addControl(
               'maxInterestRatePerPeriod',
-              new UntypedFormControl('', [
+              new FormControl('', [
                 Validators.min(0),
                 Validators.pattern(/^\d+([.,]\d{1,6})?$/)
               ])
             );
             this.loanProductTermsForm.addControl(
               'interestRateFrequencyType',
-              new UntypedFormControl(
+              new FormControl(
                 this.loanProductsTemplate.interestRateFrequencyType?.id ?? +this.interestRateFrequencyTypeData[0]?.id,
                 Validators.required
               )
@@ -458,22 +467,25 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
           }
         });
 
-      this.loanProductTermsForm.get('useBorrowerCycle')!.valueChanges.subscribe((useBorrowerCycle) => {
-        if (useBorrowerCycle) {
-          this.loanProductTermsForm.addControl('principalVariationsForBorrowerCycle', this.formBuilder.array([]));
-          this.loanProductTermsForm.addControl(
-            'numberOfRepaymentVariationsForBorrowerCycle',
-            this.formBuilder.array([])
-          );
-          this.loanProductTermsForm.addControl('interestRateVariationsForBorrowerCycle', this.formBuilder.array([]));
-        } else {
-          this.loanProductTermsForm.removeControl('principalVariationsForBorrowerCycle');
-          this.loanProductTermsForm.removeControl('numberOfRepaymentVariationsForBorrowerCycle');
-          this.loanProductTermsForm.removeControl('interestRateVariationsForBorrowerCycle');
-        }
-      });
+      this.loanProductTermsForm
+        .get('useBorrowerCycle')!
+        .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((useBorrowerCycle) => {
+          if (useBorrowerCycle) {
+            this.loanProductTermsForm.addControl('principalVariationsForBorrowerCycle', this.formBuilder.array([]));
+            this.loanProductTermsForm.addControl(
+              'numberOfRepaymentVariationsForBorrowerCycle',
+              this.formBuilder.array([])
+            );
+            this.loanProductTermsForm.addControl('interestRateVariationsForBorrowerCycle', this.formBuilder.array([]));
+          } else {
+            this.loanProductTermsForm.removeControl('principalVariationsForBorrowerCycle');
+            this.loanProductTermsForm.removeControl('numberOfRepaymentVariationsForBorrowerCycle');
+            this.loanProductTermsForm.removeControl('interestRateVariationsForBorrowerCycle');
+          }
+        });
 
-      this.zeroInterest.valueChanges.subscribe((zeroInterest) => {
+      this.zeroInterest.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((zeroInterest) => {
         if (zeroInterest) {
           this.loanProductTermsForm.get('minInterestRatePerPeriod')!.patchValue(0);
           this.loanProductTermsForm.get('minInterestRatePerPeriod')!.disable();
@@ -500,16 +512,16 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
     }
   }
 
-  get principalVariationsForBorrowerCycle(): UntypedFormArray {
-    return this.loanProductTermsForm.get('principalVariationsForBorrowerCycle')! as UntypedFormArray;
+  get principalVariationsForBorrowerCycle(): FormArray {
+    return this.loanProductTermsForm.get('principalVariationsForBorrowerCycle')! as FormArray;
   }
 
-  get numberOfRepaymentVariationsForBorrowerCycle(): UntypedFormArray {
-    return this.loanProductTermsForm.get('numberOfRepaymentVariationsForBorrowerCycle')! as UntypedFormArray;
+  get numberOfRepaymentVariationsForBorrowerCycle(): FormArray {
+    return this.loanProductTermsForm.get('numberOfRepaymentVariationsForBorrowerCycle')! as FormArray;
   }
 
-  get interestRateVariationsForBorrowerCycle(): UntypedFormArray {
-    return this.loanProductTermsForm.get('interestRateVariationsForBorrowerCycle')! as UntypedFormArray;
+  get interestRateVariationsForBorrowerCycle(): FormArray {
+    return this.loanProductTermsForm.get('interestRateVariationsForBorrowerCycle')! as FormArray;
   }
 
   setLoanProductTermsFormDirty() {
@@ -518,7 +530,7 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
     }
   }
 
-  addVariationsForBorrowerCycle(formType: string, variationsForBorrowerCycleFormArray: UntypedFormArray) {
+  addVariationsForBorrowerCycle(formType: string, variationsForBorrowerCycleFormArray: FormArray) {
     const data = this.getData(formType);
     const addVariationsForBorrowerCycleDialogRef = this.dialog.open(FormDialogComponent, { data });
     addVariationsForBorrowerCycleDialogRef.afterClosed().subscribe((response: any) => {
@@ -529,11 +541,7 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
     });
   }
 
-  editVariationsForBorrowerCycle(
-    formType: string,
-    variationsForBorrowerCycleFormArray: UntypedFormArray,
-    index: number
-  ) {
+  editVariationsForBorrowerCycle(formType: string, variationsForBorrowerCycleFormArray: FormArray, index: number) {
     const data = {
       ...this.getData(formType, variationsForBorrowerCycleFormArray.at(index).value),
       layout: { addButtonText: 'Edit' }
@@ -547,7 +555,7 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
     });
   }
 
-  deleteVariationsForBorrowerCycle(variationsForBorrowerCycleFormArray: UntypedFormArray, index: number) {
+  deleteVariationsForBorrowerCycle(variationsForBorrowerCycleFormArray: FormArray, index: number) {
     const deleteVariationsForBorrowerCycleDialogRef = this.dialog.open(DeleteDialogComponent, {
       data: { deleteContext: `this` }
     });

--- a/src/app/products/loan-products/loan-products.component.ts
+++ b/src/app/products/loan-products/loan-products.component.ts
@@ -15,8 +15,10 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import { MatDialog } from '@angular/material/dialog';
@@ -51,7 +53,7 @@ import { MatMenu, MatMenuTrigger, MatMenuItem } from '@angular/material/menu';
 import { StatusLookupPipe } from '../../pipes/status-lookup.pipe';
 import { DateFormatPipe } from '../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
-import { UntypedFormControl } from '@angular/forms';
+import { FormControl } from '@angular/forms';
 import { LOAN_PRODUCT_TYPE, PRODUCT_TYPES } from './models/loan-product.model';
 import { LoanProductBaseComponent } from './common/loan-product-base.component';
 
@@ -92,8 +94,9 @@ export class LoanProductsComponent extends LoanProductBaseComponent implements O
   private productsService = inject(ProductsService);
   private settingsService = inject(SettingsService);
   private errorHandler = inject(ErrorHandlerService);
+  private destroyRef = inject(DestroyRef);
 
-  loanProductSelector = new UntypedFormControl();
+  loanProductSelector = new FormControl();
 
   loanProductsData: any;
   displayedColumns: string[] = [
@@ -129,7 +132,7 @@ export class LoanProductsComponent extends LoanProductBaseComponent implements O
     const productType = this.route.snapshot.queryParamMap.get('productType') || 'loan';
     this.loanProductService.initialize(productType);
 
-    this.route.data.subscribe((data: { loanProducts: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanProducts: any }) => {
       this.loanProductsData = data.loanProducts;
     });
   }

--- a/src/app/products/loan-products/view-loan-product/datatable-tab/datatable-tab.component.ts
+++ b/src/app/products/loan-products/view-loan-product/datatable-tab/datatable-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -23,6 +24,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class DatatableTabComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   entityId: string;
   entityDatatable: any;
@@ -31,7 +33,7 @@ export class DatatableTabComponent {
   constructor() {
     this.entityId = this.route.parent.parent.snapshot.paramMap.get('productId');
 
-    this.route.data.subscribe((data: { loanProductDatatable: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanProductDatatable: any }) => {
       this.entityDatatable = data.loanProductDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
     });

--- a/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.ts
+++ b/src/app/products/loan-products/view-loan-product/general-tab/general-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { LoanProduct } from '../../models/loan-product.model';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -27,13 +28,14 @@ import { LoanProductBaseComponent } from '../../common/loan-product-base.compone
 })
 export class GeneralTabComponent extends LoanProductBaseComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   loanProduct: LoanProduct;
   useDueForRepaymentsConfigurations = false;
 
   constructor() {
     super();
-    this.route.data.subscribe((data: { loanProduct: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanProduct: any }) => {
       this.loanProduct = data.loanProduct;
       this.useDueForRepaymentsConfigurations =
         !this.loanProduct.dueDaysForRepaymentEvent && !this.loanProduct.overDueDaysForRepaymentEvent;

--- a/src/app/products/loan-products/view-loan-product/view-loan-product.component.ts
+++ b/src/app/products/loan-products/view-loan-product/view-loan-product.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -28,6 +29,7 @@ import { LoanProductBaseComponent } from '../common/loan-product-base.component'
 })
 export class ViewLoanProductComponent extends LoanProductBaseComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   loanProductDatatables: any = [];
 
@@ -38,7 +40,7 @@ export class ViewLoanProductComponent extends LoanProductBaseComponent {
       this.loanProductService.initialize(productType);
     }
 
-    this.route.data.subscribe((data: { loanProductDatatables: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanProductDatatables: any }) => {
       this.loanProductDatatables = data.loanProductDatatables;
     });
   }

--- a/src/app/products/loan-products/working-capital/breach-configuration/breach-configuration.component.ts
+++ b/src/app/products/loan-products/working-capital/breach-configuration/breach-configuration.component.ts
@@ -5,7 +5,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { ChangeDetectionStrategy, Component, inject, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -60,6 +61,7 @@ export class BreachConfigurationComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private productsService = inject(ProductsService);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   breachesData: Breach[] = [];
   /** Columns to be displayed in breaches table. */
@@ -79,7 +81,7 @@ export class BreachConfigurationComponent implements OnInit {
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 
   constructor() {
-    this.route.data.subscribe((data: { breaches: Breach[] }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { breaches: Breach[] }) => {
       this.breachesData = data.breaches ?? [];
     });
   }

--- a/src/app/products/loan-products/working-capital/breach-configuration/create-breach-configuration/create-breach-configuration.component.ts
+++ b/src/app/products/loan-products/working-capital/breach-configuration/create-breach-configuration/create-breach-configuration.component.ts
@@ -5,8 +5,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { ProductsService } from 'app/products/products.service';
 import { StringEnumOptionData } from 'app/shared/models/option-data.model';
@@ -16,6 +17,7 @@ import { Router } from '@angular/router';
 import { InputPositiveIntegerComponent } from 'app/shared/input-positive-integer/input-positive-integer.component';
 import { ErrorHandlerService } from 'app/core/error-handler/error-handler.service';
 import { catchError } from 'rxjs';
+import { WorkingCapitalBreachRequest, WorkingCapitalBreachTemplate } from '../../working-capital-product.model';
 
 @Component({
   selector: 'mifosx-create-breach-configuration',
@@ -31,21 +33,23 @@ import { catchError } from 'rxjs';
 export class CreateBreachConfigurationComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private errorHandler = inject(ErrorHandlerService);
+  private destroyRef = inject(DestroyRef);
 
-  breachForm: UntypedFormGroup;
+  breachForm: FormGroup;
 
   breachFrequencyTypeOptions: StringEnumOptionData[] = [];
   breachAmountCalculationTypeOptions: StringEnumOptionData[] = [];
 
   constructor() {
-    this.route.data.subscribe((data: { breachTemplate?: any }) => {
-      const breachTemplate = data.breachTemplate ?? {};
-      this.breachFrequencyTypeOptions = breachTemplate.breachFrequencyTypeOptions || [];
-      this.breachAmountCalculationTypeOptions = breachTemplate.breachAmountCalculationTypeOptions || [];
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { breachTemplate: WorkingCapitalBreachTemplate }) => {
+        this.breachFrequencyTypeOptions = data.breachTemplate.breachFrequencyTypeOptions || [];
+        this.breachAmountCalculationTypeOptions = data.breachTemplate.breachAmountCalculationTypeOptions || [];
+      });
   }
 
   ngOnInit(): void {
@@ -81,7 +85,7 @@ export class CreateBreachConfigurationComponent implements OnInit {
   }
 
   submit(): void {
-    const payload = this.breachForm.getRawValue();
+    const payload: WorkingCapitalBreachRequest = this.breachForm.getRawValue();
     this.productsService
       .createWrokingCapitalBreach(payload)
       .pipe(catchError((error) => this.errorHandler.handleError(error, 'Breach Configuration Creation')))

--- a/src/app/products/loan-products/working-capital/breach-configuration/edit-breach-configuration/edit-breach-configuration.component.ts
+++ b/src/app/products/loan-products/working-capital/breach-configuration/edit-breach-configuration/edit-breach-configuration.component.ts
@@ -5,8 +5,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { ProductsService } from 'app/products/products.service';
 import { StringEnumOptionData } from 'app/shared/models/option-data.model';
@@ -15,6 +16,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { Router } from '@angular/router';
 import { Breach } from 'app/products/loan-products/models/loan-product.model';
 import { InputPositiveIntegerComponent } from 'app/shared/input-positive-integer/input-positive-integer.component';
+import { WorkingCapitalBreachRequest, WorkingCapitalBreachTemplate } from '../../working-capital-product.model';
 
 @Component({
   selector: 'mifosx-edit-breach-configuration',
@@ -29,22 +31,25 @@ import { InputPositiveIntegerComponent } from 'app/shared/input-positive-integer
 export class EditBreachConfigurationComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
+  private destroyRef = inject(DestroyRef);
 
-  breachForm: UntypedFormGroup;
+  breachForm: FormGroup;
 
   breachData: Breach | null = null;
   breachFrequencyTypeOptions: StringEnumOptionData[] = [];
   breachAmountCalculationTypeOptions: StringEnumOptionData[] = [];
 
   ngOnInit(): void {
-    this.route.data.subscribe((data: { breachData: Breach; breachTemplate: any }) => {
-      this.breachData = data.breachData;
-      this.breachFrequencyTypeOptions = data.breachTemplate.breachFrequencyTypeOptions || [];
-      this.breachAmountCalculationTypeOptions = data.breachTemplate.breachAmountCalculationTypeOptions || [];
-      this.initForm();
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { breachData: Breach; breachTemplate: WorkingCapitalBreachTemplate }) => {
+        this.breachData = data.breachData;
+        this.breachFrequencyTypeOptions = data.breachTemplate.breachFrequencyTypeOptions || [];
+        this.breachAmountCalculationTypeOptions = data.breachTemplate.breachAmountCalculationTypeOptions || [];
+        this.initForm();
+      });
   }
 
   private initForm(): void {
@@ -80,7 +85,7 @@ export class EditBreachConfigurationComponent implements OnInit {
   }
 
   submit(): void {
-    const payload = this.breachForm.getRawValue();
+    const payload: WorkingCapitalBreachRequest = this.breachForm.getRawValue();
     this.productsService.updateWrokingCapitalBreach(this.breachData.id, payload).subscribe({
       next: () => {
         this.router.navigate(['../'], { relativeTo: this.route });

--- a/src/app/products/loan-products/working-capital/breach-configuration/view-breach-configuration/view-breach-configuration.component.ts
+++ b/src/app/products/loan-products/working-capital/breach-configuration/view-breach-configuration/view-breach-configuration.component.ts
@@ -5,7 +5,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { FormatNumberPipe } from '@pipes/format-number.pipe';
@@ -26,11 +27,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewBreachConfigurationComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   breachData: Breach | null = null;
 
   constructor() {
-    this.route.data.subscribe((data: { breachData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { breachData: any }) => {
       this.breachData = data.breachData;
     });
   }

--- a/src/app/products/loan-products/working-capital/near-breach-configuration/create-near-breach-configuration/create-near-breach-configuration.component.ts
+++ b/src/app/products/loan-products/working-capital/near-breach-configuration/create-near-breach-configuration/create-near-breach-configuration.component.ts
@@ -5,8 +5,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { ProductsService } from 'app/products/products.service';
 import { StringEnumOptionData } from 'app/shared/models/option-data.model';
@@ -31,16 +32,17 @@ import { catchError } from 'rxjs';
 export class CreateNearBreachConfigurationComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private errorHandler = inject(ErrorHandlerService);
+  private destroyRef = inject(DestroyRef);
 
-  nearBreachForm: UntypedFormGroup;
+  nearBreachForm: FormGroup;
   frequencyTypeOptions: StringEnumOptionData[] = [];
   maxThreshold: number = 100.0;
 
   constructor() {
-    this.route.data.subscribe((data: { breachTemplate?: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { breachTemplate?: any }) => {
       const breachTemplate = data.breachTemplate ?? {};
       this.frequencyTypeOptions = breachTemplate.breachFrequencyTypeOptions || [];
     });

--- a/src/app/products/loan-products/working-capital/near-breach-configuration/edit-near-breach-configuration/edit-near-breach-configuration.component.ts
+++ b/src/app/products/loan-products/working-capital/near-breach-configuration/edit-near-breach-configuration/edit-near-breach-configuration.component.ts
@@ -5,8 +5,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { ProductsService } from 'app/products/products.service';
 import { StringEnumOptionData } from 'app/shared/models/option-data.model';
@@ -29,21 +30,24 @@ import { InputPositiveIntegerComponent } from 'app/shared/input-positive-integer
 export class EditNearBreachConfigurationComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
+  private destroyRef = inject(DestroyRef);
 
-  nearBreachForm: UntypedFormGroup;
+  nearBreachForm: FormGroup;
 
   nearBreachData: NearBreach | null = null;
   frequencyTypeOptions: StringEnumOptionData[] = [];
   maxThreshold: number = 100.0;
 
   ngOnInit(): void {
-    this.route.data.subscribe((data: { nearBreachData: NearBreach; breachTemplate: any }) => {
-      this.nearBreachData = data.nearBreachData;
-      this.frequencyTypeOptions = data.breachTemplate.breachFrequencyTypeOptions || [];
-      this.initForm();
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { nearBreachData: NearBreach; breachTemplate: any }) => {
+        this.nearBreachData = data.nearBreachData;
+        this.frequencyTypeOptions = data.breachTemplate.breachFrequencyTypeOptions || [];
+        this.initForm();
+      });
   }
 
   private initForm(): void {

--- a/src/app/products/loan-products/working-capital/near-breach-configuration/near-breach-configuration.component.ts
+++ b/src/app/products/loan-products/working-capital/near-breach-configuration/near-breach-configuration.component.ts
@@ -5,7 +5,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { ChangeDetectionStrategy, Component, inject, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit, ViewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -60,6 +61,7 @@ export class NearBreachConfigurationComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private productsService = inject(ProductsService);
   private dialog = inject(MatDialog);
+  private destroyRef = inject(DestroyRef);
 
   nearBreachesData: NearBreach[] = [];
   /** Columns to be displayed in near breaches table. */
@@ -78,7 +80,7 @@ export class NearBreachConfigurationComponent implements OnInit {
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 
   constructor() {
-    this.route.data.subscribe((data: { nearBreaches: NearBreach[] }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { nearBreaches: NearBreach[] }) => {
       this.nearBreachesData = data.nearBreaches ?? [];
     });
   }

--- a/src/app/products/loan-products/working-capital/near-breach-configuration/view-near-breach-configuration/view-near-breach-configuration.component.ts
+++ b/src/app/products/loan-products/working-capital/near-breach-configuration/view-near-breach-configuration/view-near-breach-configuration.component.ts
@@ -5,7 +5,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { FormatNumberPipe } from '@pipes/format-number.pipe';
@@ -26,13 +27,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewNearBreachConfigurationComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   nearBreachData: NearBreach | null = null;
 
   constructor() {}
 
   ngOnInit(): void {
-    this.route.data.subscribe((data: { nearBreachData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { nearBreachData: any }) => {
       this.nearBreachData = data.nearBreachData;
     });
   }

--- a/src/app/products/loan-products/working-capital/working-capital-product.model.ts
+++ b/src/app/products/loan-products/working-capital/working-capital-product.model.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { StringEnumOptionData } from 'app/shared/models/option-data.model';
+
+export interface WorkingCapitalBreachTemplate {
+  breachFrequencyTypeOptions: StringEnumOptionData[];
+  breachAmountCalculationTypeOptions: StringEnumOptionData[];
+}
+
+export interface WorkingCapitalBreachRequest {
+  name: string;
+  breachFrequency: number;
+  breachFrequencyType: string;
+  breachAmountCalculationType: string;
+  breachAmount: number;
+}

--- a/src/app/products/manage-delinquency-buckets/delinquency-bucket/create-bucket/create-bucket.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-bucket/create-bucket/create-bucket.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -60,14 +61,15 @@ import { EnumOptionData, StringEnumOptionData } from 'app/shared/models/option-d
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateBucketComponent extends DelinquencyBucketBaseComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private router = inject(Router);
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Delinquency Bucket form. */
-  bucketForm: UntypedFormGroup;
+  bucketForm: FormGroup;
   /** Delinquency Bucket template data. */
   bucketTemplateData: any;
   /** Delinquency Range Data Source */
@@ -89,23 +91,25 @@ export class CreateBucketComponent extends DelinquencyBucketBaseComponent implem
 
   constructor() {
     super();
-    this.route.data.subscribe((data: { delinquencyBucketsTemplateData: any }) => {
-      if (this.isRegularBucket) {
-        this.delinquencyRangesData = data.delinquencyBucketsTemplateData;
-        this.delinquencyRangesData = this.delinquencyRangesData.sort(
-          (objA: { minimumAgeDays: number }, objB: { minimumAgeDays: number }) =>
-            objA.minimumAgeDays - objB.minimumAgeDays
-        );
-      } else if (this.isWorkingCapitalBucket) {
-        this.delinquencyRangesData = data.delinquencyBucketsTemplateData.rangesOptions;
-        this.delinquencyRangesData = this.delinquencyRangesData.sort(
-          (objA: { minimumAgeDays: number }, objB: { minimumAgeDays: number }) =>
-            objA.minimumAgeDays - objB.minimumAgeDays
-        );
-        this.frequencyTypeOptions = data.delinquencyBucketsTemplateData.frequencyTypeOptions;
-        this.minimumPaymentOptions = data.delinquencyBucketsTemplateData.minimumPaymentOptions;
-      }
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { delinquencyBucketsTemplateData: any }) => {
+        if (this.isRegularBucket) {
+          this.delinquencyRangesData = data.delinquencyBucketsTemplateData;
+          this.delinquencyRangesData = this.delinquencyRangesData.sort(
+            (objA: { minimumAgeDays: number }, objB: { minimumAgeDays: number }) =>
+              objA.minimumAgeDays - objB.minimumAgeDays
+          );
+        } else if (this.isWorkingCapitalBucket) {
+          this.delinquencyRangesData = data.delinquencyBucketsTemplateData.rangesOptions;
+          this.delinquencyRangesData = this.delinquencyRangesData.sort(
+            (objA: { minimumAgeDays: number }, objB: { minimumAgeDays: number }) =>
+              objA.minimumAgeDays - objB.minimumAgeDays
+          );
+          this.frequencyTypeOptions = data.delinquencyBucketsTemplateData.frequencyTypeOptions;
+          this.minimumPaymentOptions = data.delinquencyBucketsTemplateData.minimumPaymentOptions;
+        }
+      });
   }
 
   ngOnInit(): void {

--- a/src/app/products/manage-delinquency-buckets/delinquency-bucket/delinquency-bucket.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-bucket/delinquency-bucket.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -54,6 +55,8 @@ import { DelinquencyBucketBaseComponent } from '../delinquency-base.component';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DelinquencyBucketComponent extends DelinquencyBucketBaseComponent implements OnInit {
+  private destroyRef = inject(DestroyRef);
+
   delinquencyBucketData: any;
   /** Columns to be displayed in delinquency bucket table. */
   displayedColumns: string[] = [
@@ -70,7 +73,7 @@ export class DelinquencyBucketComponent extends DelinquencyBucketBaseComponent i
 
   constructor() {
     super();
-    this.route.data.subscribe((data: { delinquencyBuckets: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { delinquencyBuckets: any }) => {
       this.delinquencyBucketData = data.delinquencyBuckets;
     });
   }

--- a/src/app/products/manage-delinquency-buckets/delinquency-bucket/edit-bucket/edit-bucket.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-bucket/edit-bucket/edit-bucket.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
@@ -60,14 +61,15 @@ import { EnumOptionData, StringEnumOptionData } from 'app/shared/models/option-d
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditBucketComponent extends DelinquencyBucketBaseComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private router = inject(Router);
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Delinquency Bucket form. */
-  bucketForm: UntypedFormGroup;
+  bucketForm: FormGroup;
   /** Delinquency Bucket template data. */
   bucketTemplateData: any;
   /** Delinquency Range Data Source */
@@ -95,32 +97,34 @@ export class EditBucketComponent extends DelinquencyBucketBaseComponent implemen
 
   constructor() {
     super();
-    this.route.data.subscribe((data: { delinquencyBucket: any; delinquencyBucketsTemplateData: any }) => {
-      this.delinquencyRangesData = data.delinquencyBucketsTemplateData;
-      this.delinquencyBucketData = data.delinquencyBucket;
-      this.delinquencyBucketId = data.delinquencyBucket.id;
-      this.rangesDataSource = [];
-      this.delinquencyRangesIds = [];
-      if (this.isRegularBucket) {
-        this.delinquencyRangesData = this.delinquencyRangesData.sort(
-          (objA: { minimumAgeDays: number }, objB: { minimumAgeDays: number }) =>
-            objA.minimumAgeDays - objB.minimumAgeDays
-        );
-        this.rangesDataSource = this.delinquencyBucketData.ranges;
-      } else if (this.isWorkingCapitalBucket) {
-        this.delinquencyRangesData = data.delinquencyBucketsTemplateData.rangesOptions;
-        this.delinquencyRangesData = this.delinquencyRangesData.sort(
-          (objA: { minimumAgeDays: number }, objB: { minimumAgeDays: number }) =>
-            objA.minimumAgeDays - objB.minimumAgeDays
-        );
-        this.rangesDataSource = data.delinquencyBucket.ranges;
-        this.frequencyTypeOptions = data.delinquencyBucketsTemplateData.frequencyTypeOptions;
-        this.minimumPaymentOptions = data.delinquencyBucketsTemplateData.minimumPaymentOptions;
-      }
-      this.rangesDataSource.forEach((item: any) => {
-        this.delinquencyRangesIds.push(item.id);
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { delinquencyBucket: any; delinquencyBucketsTemplateData: any }) => {
+        this.delinquencyRangesData = data.delinquencyBucketsTemplateData;
+        this.delinquencyBucketData = data.delinquencyBucket;
+        this.delinquencyBucketId = data.delinquencyBucket.id;
+        this.rangesDataSource = [];
+        this.delinquencyRangesIds = [];
+        if (this.isRegularBucket) {
+          this.delinquencyRangesData = this.delinquencyRangesData.sort(
+            (objA: { minimumAgeDays: number }, objB: { minimumAgeDays: number }) =>
+              objA.minimumAgeDays - objB.minimumAgeDays
+          );
+          this.rangesDataSource = this.delinquencyBucketData.ranges;
+        } else if (this.isWorkingCapitalBucket) {
+          this.delinquencyRangesData = data.delinquencyBucketsTemplateData.rangesOptions;
+          this.delinquencyRangesData = this.delinquencyRangesData.sort(
+            (objA: { minimumAgeDays: number }, objB: { minimumAgeDays: number }) =>
+              objA.minimumAgeDays - objB.minimumAgeDays
+          );
+          this.rangesDataSource = data.delinquencyBucket.ranges;
+          this.frequencyTypeOptions = data.delinquencyBucketsTemplateData.frequencyTypeOptions;
+          this.minimumPaymentOptions = data.delinquencyBucketsTemplateData.minimumPaymentOptions;
+        }
+        this.rangesDataSource.forEach((item: any) => {
+          this.delinquencyRangesIds.push(item.id);
+        });
       });
-    });
   }
 
   ngOnInit(): void {

--- a/src/app/products/manage-delinquency-buckets/delinquency-bucket/view-bucket/view-bucket.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-bucket/view-bucket/view-bucket.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { ProductsService } from 'app/products/products.service';
@@ -31,13 +32,14 @@ export class ViewBucketComponent extends DelinquencyBucketBaseComponent {
   private router = inject(Router);
   private dialog = inject(MatDialog);
   private productsService = inject(ProductsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Delinquency Bucket Data. */
   delinquencyBucketData: any;
 
   constructor() {
     super();
-    this.route.data.subscribe((data: { delinquencyBucket: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { delinquencyBucket: any }) => {
       this.delinquencyBucketData = data.delinquencyBucket;
       if (this.isRegularBucket) {
         this.delinquencyBucketData.ranges = this.delinquencyBucketData.ranges.sort(

--- a/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/create-range/create-range.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ProductsService } from 'app/products/products.service';
 import { SettingsService } from 'app/settings/settings.service';
@@ -23,14 +23,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateRangeComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
 
   /** Delinquency Range form. */
-  delinquencyRangeForm: UntypedFormGroup;
+  delinquencyRangeForm: FormGroup;
 
   ngOnInit(): void {
     this.setInputForm();

--- a/src/app/products/manage-delinquency-buckets/delinquency-range/delinquency-range.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/delinquency-range.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -51,6 +52,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class DelinquencyRangeComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   delinquencyRangeData: any;
   /** Columns to be displayed in delinquency range table. */
@@ -68,7 +70,7 @@ export class DelinquencyRangeComponent implements OnInit {
   @ViewChild(MatSort, { static: true }) sort: MatSort;
 
   constructor() {
-    this.route.data.subscribe((data: { delinquencyRanges: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { delinquencyRanges: any }) => {
       this.delinquencyRangeData = data.delinquencyRanges;
     });
   }

--- a/src/app/products/manage-delinquency-buckets/delinquency-range/edit-range/edit-range.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/edit-range/edit-range.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ProductsService } from 'app/products/products.service';
 import { SettingsService } from 'app/settings/settings.service';
@@ -23,19 +24,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditRangeComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Delinquency Range Data. */
   delinquencyRangeData: any;
   /** Delinquency Range form. */
-  delinquencyRangeForm: UntypedFormGroup;
+  delinquencyRangeForm: FormGroup;
 
   constructor() {
-    this.route.data.subscribe((data: { delinquencyRange: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { delinquencyRange: any }) => {
       this.delinquencyRangeData = data.delinquencyRange;
     });
   }

--- a/src/app/products/manage-delinquency-buckets/delinquency-range/view-range/view-range.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-range/view-range/view-range.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ProductsService } from 'app/products/products.service';
@@ -29,12 +30,13 @@ export class ViewRangeComponent {
   private router = inject(Router);
   private dialog = inject(MatDialog);
   private productsService = inject(ProductsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Delinquency Range Data. */
   delinquencyRangeData: any;
 
   constructor() {
-    this.route.data.subscribe((data: { delinquencyRange: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { delinquencyRange: any }) => {
       this.delinquencyRangeData = data.delinquencyRange;
     });
   }

--- a/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.ts
+++ b/src/app/products/manage-tax-components/create-tax-component/create-tax-component.component.ts
@@ -7,14 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -38,19 +33,20 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateTaxComponentComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum start date allowed. */
   minDate = new Date();
   /** Maximum start date allowed. */
   maxDate = new Date();
   /** Tax Component form. */
-  taxComponentForm: UntypedFormGroup;
+  taxComponentForm: FormGroup;
   /** Tax Component template data. */
   taxComponentTemplateData: any;
   /** Credit Account Type data. */
@@ -72,7 +68,7 @@ export class CreateTaxComponentComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { taxComponentTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { taxComponentTemplate: any }) => {
       this.taxComponentTemplateData = data.taxComponentTemplate;
     });
   }
@@ -118,14 +114,28 @@ export class CreateTaxComponentComponent implements OnInit {
    * Sets the conditional controls of the tax Component form
    */
   setConditionalControls() {
-    this.taxComponentForm.get('debitAccountType').valueChanges.subscribe((debitAccountTypeId) => {
-      this.debitAccountData = this.getAccountsData(debitAccountTypeId);
-      this.taxComponentForm.addControl('debitAccountId', new UntypedFormControl('', Validators.required));
-    });
-    this.taxComponentForm.get('creditAccountType').valueChanges.subscribe((creditAccountTypeId) => {
-      this.creditAccountData = this.getAccountsData(creditAccountTypeId);
-      this.taxComponentForm.addControl('creditAccountId', new UntypedFormControl('', Validators.required));
-    });
+    this.taxComponentForm
+      .get('debitAccountType')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((debitAccountTypeId) => {
+        this.debitAccountData = this.getAccountsData(debitAccountTypeId);
+        if (debitAccountTypeId) {
+          this.taxComponentForm.setControl('debitAccountId', new FormControl('', Validators.required));
+        } else {
+          this.taxComponentForm.removeControl('debitAccountId');
+        }
+      });
+    this.taxComponentForm
+      .get('creditAccountType')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((creditAccountTypeId) => {
+        this.creditAccountData = this.getAccountsData(creditAccountTypeId);
+        if (creditAccountTypeId) {
+          this.taxComponentForm.setControl('creditAccountId', new FormControl('', Validators.required));
+        } else {
+          this.taxComponentForm.removeControl('creditAccountId');
+        }
+      });
   }
 
   /**

--- a/src/app/products/manage-tax-components/edit-tax-component/edit-tax-component.component.ts
+++ b/src/app/products/manage-tax-components/edit-tax-component/edit-tax-component.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -31,20 +32,21 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditTaxComponentComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum start date allowed. */
   maxDate = new Date();
   /** Tax Component form. */
-  taxComponentForm: UntypedFormGroup;
+  taxComponentForm: FormGroup;
   /** Tax Component data. */
   taxComponentData: any;
 
@@ -58,7 +60,7 @@ export class EditTaxComponentComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { taxComponent: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { taxComponent: any }) => {
       this.taxComponentData = data.taxComponent;
     });
   }

--- a/src/app/products/manage-tax-components/manage-tax-components.component.ts
+++ b/src/app/products/manage-tax-components/manage-tax-components.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -62,6 +63,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ManageTaxComponentsComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Tax Components data. */
   taxComponentData: any;
@@ -85,7 +87,7 @@ export class ManageTaxComponentsComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { taxComponents: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { taxComponents: any }) => {
       this.taxComponentData = data.taxComponents;
     });
   }

--- a/src/app/products/manage-tax-components/view-tax-component/view-tax-component.component.ts
+++ b/src/app/products/manage-tax-components/view-tax-component/view-tax-component.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
@@ -31,6 +32,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewTaxComponentComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** tax Component Data. */
   taxComponentData: any;
@@ -40,7 +42,7 @@ export class ViewTaxComponentComponent {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { taxComponent: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { taxComponent: any }) => {
       this.taxComponentData = data.taxComponent;
     });
   }

--- a/src/app/products/manage-tax-groups/create-tax-group/create-tax-group.component.ts
+++ b/src/app/products/manage-tax-groups/create-tax-group/create-tax-group.component.ts
@@ -7,15 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  FormControl,
-  FormArray,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, FormArray, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
@@ -76,7 +70,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateTaxGroupComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
@@ -84,13 +78,14 @@ export class CreateTaxGroupComponent implements OnInit {
   private dialog = inject(MatDialog);
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum start date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum start date allowed. */
   maxDate = new Date(2100, 0, 1);
   /** Tax Group form. */
-  taxGroupForm: UntypedFormGroup;
+  taxGroupForm: FormGroup;
   /** Tax Group template data. */
   taxGroupTemplateData: any;
   /** Tax Component Data Source */
@@ -116,7 +111,7 @@ export class CreateTaxGroupComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { taxGroupTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { taxGroupTemplate: any }) => {
       this.taxGroupTemplateData = data.taxGroupTemplate;
       this.taxComponentOptions = this.taxGroupTemplateData.taxComponents;
     });

--- a/src/app/products/manage-tax-groups/edit-tax-group/edit-tax-group.component.ts
+++ b/src/app/products/manage-tax-groups/edit-tax-group/edit-tax-group.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormBuilder, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
@@ -71,7 +72,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditTaxGroupComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
@@ -79,13 +80,14 @@ export class EditTaxGroupComponent implements OnInit {
   dialog = inject(MatDialog);
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum start date allowed. */
   minDate = new Date(2000, 0, 1);
   /** Maximum start date allowed. */
   maxDate = new Date(2100, 0, 1);
   /** Tax Group form. */
-  taxGroupForm: UntypedFormGroup;
+  taxGroupForm: FormGroup;
   /** Tax Group template data. */
   taxGroupData: any;
   /** Tax Component Data Source */
@@ -112,7 +114,7 @@ export class EditTaxGroupComponent implements OnInit {
    * @param {TranslateService} translateService translate Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { taxGroup: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { taxGroup: any }) => {
       this.taxGroupData = data.taxGroup;
       this.taxComponentOptions = this.taxGroupData.taxComponents;
     });

--- a/src/app/products/manage-tax-groups/manage-tax-groups.component.ts
+++ b/src/app/products/manage-tax-groups/manage-tax-groups.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -58,6 +59,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ManageTaxGroupsComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** Tax Groups data. */
   taxGroupsData: any;
@@ -76,7 +78,7 @@ export class ManageTaxGroupsComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { taxGroups: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { taxGroups: any }) => {
       this.taxGroupsData = data.taxGroups;
     });
   }

--- a/src/app/products/manage-tax-groups/view-tax-group/view-tax-group.component.ts
+++ b/src/app/products/manage-tax-groups/view-tax-group/view-tax-group.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
@@ -29,6 +30,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewTaxGroupComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** tax Group Data. */
   taxGroupData: any;
@@ -38,7 +40,7 @@ export class ViewTaxGroupComponent {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { taxGroup: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { taxGroup: any }) => {
       this.taxGroupData = data.taxGroup;
     });
   }

--- a/src/app/products/products-mix/create-product-mix/create-product-mix.component.ts
+++ b/src/app/products/products-mix/create-product-mix/create-product-mix.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -28,13 +29,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateProductMixComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   /** Product mix form. */
-  productMixForm: UntypedFormGroup;
+  productMixForm: FormGroup;
   /** Products mix template data. */
   productsMixTemplateData: any;
   /** Product option data. */
@@ -50,7 +52,7 @@ export class CreateProductMixComponent implements OnInit {
    * @param {Router} router Router for navigation.
    */
   constructor() {
-    this.route.data.subscribe((data: { productsMixTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { productsMixTemplate: any }) => {
       this.productsMixTemplateData = data.productsMixTemplate;
     });
   }
@@ -84,20 +86,23 @@ export class CreateProductMixComponent implements OnInit {
    * Sets the conditional controls of the product mix form.
    */
   setConditionalControls() {
-    this.productMixForm.get('productId').valueChanges.subscribe((productId) => {
-      this.productData = undefined;
-      this.productMixForm.get('restrictedProducts').reset();
-      this.productsService.getProductMixTemplate(productId).subscribe((productMixTemplateData: any) => {
-        const restrictedProductsData = productMixTemplateData.restrictedProducts;
-        this.productData = [
-          ...restrictedProductsData,
-          ...productMixTemplateData.allowedProducts
-        ];
-        this.productMixForm
-          .get('restrictedProducts')
-          .setValue([...restrictedProductsData.map((restrictedProduct: any) => restrictedProduct.id)]);
+    this.productMixForm
+      .get('productId')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((productId) => {
+        this.productData = undefined;
+        this.productMixForm.get('restrictedProducts').reset();
+        this.productsService.getProductMixTemplate(productId).subscribe((productMixTemplateData: any) => {
+          const restrictedProductsData = productMixTemplateData.restrictedProducts;
+          this.productData = [
+            ...restrictedProductsData,
+            ...productMixTemplateData.allowedProducts
+          ];
+          this.productMixForm
+            .get('restrictedProducts')
+            .setValue([...restrictedProductsData.map((restrictedProduct: any) => restrictedProduct.id)]);
+        });
       });
-    });
   }
 
   /**

--- a/src/app/products/products-mix/edit-product-mix/edit-product-mix.component.ts
+++ b/src/app/products/products-mix/edit-product-mix/edit-product-mix.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
 
 /** Custom Services */
@@ -28,13 +29,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EditProductMixComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private productsService = inject(ProductsService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   /** Product mix form. */
-  productMixForm: UntypedFormGroup;
+  productMixForm: FormGroup;
   /** Products mix template data. */
   productMixData: any;
   /** Product option data. */
@@ -50,7 +52,7 @@ export class EditProductMixComponent implements OnInit {
    * @param {Router} router Router for navigation.
    */
   constructor() {
-    this.route.data.subscribe((data: { productMix: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { productMix: any }) => {
       this.productMixData = data.productMix;
     });
   }

--- a/src/app/products/products-mix/products-mix.component.ts
+++ b/src/app/products/products-mix/products-mix.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -58,6 +59,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ProductsMixComponent implements OnInit {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   /** productMix data. */
   productMixData: any;
@@ -75,7 +77,7 @@ export class ProductsMixComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { products: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { products: any }) => {
       this.productMixData = data.products;
     });
   }

--- a/src/app/products/products-mix/view-product-mix/view-product-mix.component.ts
+++ b/src/app/products/products-mix/view-product-mix/view-product-mix.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -66,6 +67,7 @@ export class ViewProductMixComponent implements OnInit {
   private productsService = inject(ProductsService);
   private router = inject(Router);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   /** Product mix data. */
   productMixData: any;
@@ -93,7 +95,7 @@ export class ViewProductMixComponent implements OnInit {
    * @param {TranslateService} translateService Translate Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { productMix: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { productMix: any }) => {
       this.productMixData = data.productMix;
     });
   }

--- a/src/app/products/products.service.ts
+++ b/src/app/products/products.service.ts
@@ -15,6 +15,7 @@ import { Observable } from 'rxjs';
 
 /** Custom Services */
 import { SettingsService } from 'app/settings/settings.service';
+import { WorkingCapitalBreachRequest } from './loan-products/working-capital/working-capital-product.model';
 
 /**
  * Products service.
@@ -633,14 +634,14 @@ export class ProductsService {
   /**
    * @returns {Observable<any>} Working Capital Breach creation.
    */
-  createWrokingCapitalBreach(payload: any): Observable<any> {
+  createWrokingCapitalBreach(payload: WorkingCapitalBreachRequest): Observable<any> {
     return this.http.post(`/working-capital/breach/breaches`, payload);
   }
 
   /**
    * @returns {Observable<any>} Working Capital Breach update.
    */
-  updateWrokingCapitalBreach(breachId: number, payload: any): Observable<any> {
+  updateWrokingCapitalBreach(breachId: number, payload: WorkingCapitalBreachRequest): Observable<any> {
     return this.http.put(`/working-capital/breach/breaches/${breachId}`, payload);
   }
 

--- a/src/app/products/recurring-deposit-products/create-recurring-deposit-product/create-recurring-deposit-product.component.ts
+++ b/src/app/products/recurring-deposit-products/create-recurring-deposit-product/create-recurring-deposit-product.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 
 /** Custom Components */
@@ -56,6 +57,7 @@ export class CreateRecurringDepositProductComponent {
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private accounting = inject(Accounting);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild(RecurringDepositProductDetailsStepComponent, { static: true })
   recurringDepositProductDetailsStep: RecurringDepositProductDetailsStepComponent;
@@ -83,9 +85,11 @@ export class CreateRecurringDepositProductComponent {
    */
 
   constructor() {
-    this.route.data.subscribe((data: { recurringDepositProductsTemplate: any }) => {
-      this.recurringDepositProductsTemplate = data.recurringDepositProductsTemplate;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { recurringDepositProductsTemplate: any }) => {
+        this.recurringDepositProductsTemplate = data.recurringDepositProductsTemplate;
+      });
     this.accountingRuleData = this.accounting.getAccountingRulesForSavings();
   }
 

--- a/src/app/products/recurring-deposit-products/edit-recurring-deposit-product/edit-recurring-deposit-product.component.ts
+++ b/src/app/products/recurring-deposit-products/edit-recurring-deposit-product/edit-recurring-deposit-product.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 
 /** Custom Components */
@@ -56,6 +57,7 @@ export class EditRecurringDepositProductComponent {
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private accounting = inject(Accounting);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild(RecurringDepositProductDetailsStepComponent, { static: true })
   recurringDepositProductDetailsStep: RecurringDepositProductDetailsStepComponent;
@@ -83,9 +85,11 @@ export class EditRecurringDepositProductComponent {
    */
 
   constructor() {
-    this.route.data.subscribe((data: { recurringDepositProductAndTemplate: any }) => {
-      this.recurringDepositProductsTemplate = data.recurringDepositProductAndTemplate;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { recurringDepositProductAndTemplate: any }) => {
+        this.recurringDepositProductsTemplate = data.recurringDepositProductAndTemplate;
+      });
     this.accountingRuleData = this.accounting.getAccountingRulesForSavings();
   }
 

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-accounting-step/recurring-deposit-product-accounting-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-accounting-step/recurring-deposit-product-accounting-step.component.ts
@@ -6,15 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  UntypedFormArray,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, Input, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, FormArray, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
@@ -76,16 +70,17 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RecurringDepositProductAccountingStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private dialog = inject(MatDialog);
   private accounting = inject(Accounting);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() recurringDepositProductsTemplate: any;
   @Input() accountingRuleData: any;
   @Input() recurringDepositProductFormValid: boolean;
 
-  recurringDepositProductAccountingForm: UntypedFormGroup;
+  recurringDepositProductAccountingForm: FormGroup;
 
   chargeData: any;
   penaltyData: any;
@@ -175,7 +170,7 @@ export class RecurringDepositProductAccountingStepComponent implements OnInit {
             });
             const formArray = this.recurringDepositProductAccountingForm.controls[
               'paymentChannelToFundSourceMappings'
-            ] as UntypedFormArray;
+            ] as FormArray;
             formArray.push(paymentChannelToFundSourceMappingData);
           }
         );
@@ -194,7 +189,7 @@ export class RecurringDepositProductAccountingStepComponent implements OnInit {
           });
           const formArray = this.recurringDepositProductAccountingForm.controls[
             'feeToIncomeAccountMappings'
-          ] as UntypedFormArray;
+          ] as FormArray;
           formArray.push(feeToIncomeAccountMappingData);
         });
       }
@@ -213,7 +208,7 @@ export class RecurringDepositProductAccountingStepComponent implements OnInit {
             });
             const formArray = this.recurringDepositProductAccountingForm.controls[
               'penaltyToIncomeAccountMappings'
-            ] as UntypedFormArray;
+            ] as FormArray;
             formArray.push(penaltyToIncomeAccountMappingData);
           }
         );
@@ -232,103 +227,80 @@ export class RecurringDepositProductAccountingStepComponent implements OnInit {
   }
 
   setConditionalControls() {
-    this.recurringDepositProductAccountingForm.get('accountingRule').valueChanges.subscribe((accountingRule: any) => {
-      if (accountingRule === 2 || accountingRule === 3) {
-        this.recurringDepositProductAccountingForm.addControl(
-          'savingsReferenceAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.recurringDepositProductAccountingForm.addControl(
-          'savingsControlAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.recurringDepositProductAccountingForm.addControl(
-          'transfersInSuspenseAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.recurringDepositProductAccountingForm.addControl(
-          'interestOnSavingsAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.recurringDepositProductAccountingForm.addControl(
-          'incomeFromFeeAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.recurringDepositProductAccountingForm.addControl(
-          'incomeFromPenaltyAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.recurringDepositProductAccountingForm.addControl('advancedAccountingRules', new UntypedFormControl(false));
+    this.recurringDepositProductAccountingForm
+      .get('accountingRule')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((accountingRule: any) => {
+        if (accountingRule === 2 || accountingRule === 3) {
+          this.ensureControl('savingsReferenceAccountId', new FormControl('', Validators.required));
+          this.ensureControl('savingsControlAccountId', new FormControl('', Validators.required));
+          this.ensureControl('transfersInSuspenseAccountId', new FormControl('', Validators.required));
+          this.ensureControl('interestOnSavingsAccountId', new FormControl('', Validators.required));
+          this.ensureControl('incomeFromFeeAccountId', new FormControl('', Validators.required));
+          this.ensureControl('incomeFromPenaltyAccountId', new FormControl('', Validators.required));
+          this.ensureControl('advancedAccountingRules', new FormControl(false));
 
-        if (accountingRule === 3) {
-          this.recurringDepositProductAccountingForm.addControl(
-            'feesReceivableAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.recurringDepositProductAccountingForm.addControl(
-            'penaltiesReceivableAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.recurringDepositProductAccountingForm.addControl(
-            'interestPayableAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
+          if (accountingRule === 3) {
+            this.ensureControl('feesReceivableAccountId', new FormControl('', Validators.required));
+            this.ensureControl('penaltiesReceivableAccountId', new FormControl('', Validators.required));
+            this.ensureControl('interestPayableAccountId', new FormControl('', Validators.required));
+          }
+
+          this.recurringDepositProductAccountingForm
+            .get('advancedAccountingRules')
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((advancedAccountingRules: boolean) => {
+              if (advancedAccountingRules) {
+                this.recurringDepositProductAccountingForm.addControl(
+                  'paymentChannelToFundSourceMappings',
+                  this.formBuilder.array([])
+                );
+                this.recurringDepositProductAccountingForm.addControl(
+                  'feeToIncomeAccountMappings',
+                  this.formBuilder.array([])
+                );
+                this.recurringDepositProductAccountingForm.addControl(
+                  'penaltyToIncomeAccountMappings',
+                  this.formBuilder.array([])
+                );
+              } else {
+                this.recurringDepositProductAccountingForm.removeControl('paymentChannelToFundSourceMappings');
+                this.recurringDepositProductAccountingForm.removeControl('feeToIncomeAccountMappings');
+                this.recurringDepositProductAccountingForm.removeControl('penaltyToIncomeAccountMappings');
+              }
+            });
+        } else {
+          this.recurringDepositProductAccountingForm.removeControl('savingsReferenceAccountId');
+          this.recurringDepositProductAccountingForm.removeControl('overdraftPortfolioControlId');
+          this.recurringDepositProductAccountingForm.removeControl('savingsControlAccountId');
+          this.recurringDepositProductAccountingForm.removeControl('transfersInSuspenseAccountId');
+          this.recurringDepositProductAccountingForm.removeControl('interestOnSavingsAccountId');
+          this.recurringDepositProductAccountingForm.removeControl('writeOffAccountId');
+          this.recurringDepositProductAccountingForm.removeControl('incomeFromFeeAccountId');
+          this.recurringDepositProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
+          this.recurringDepositProductAccountingForm.removeControl('incomeFromInterestId');
+          this.recurringDepositProductAccountingForm.removeControl('advancedAccountingRules');
+          this.recurringDepositProductAccountingForm.removeControl('escheatLiabilityId');
+          this.recurringDepositProductAccountingForm.removeControl('feesReceivableAccountId');
+          this.recurringDepositProductAccountingForm.removeControl('penaltiesReceivableAccountId');
+          this.recurringDepositProductAccountingForm.removeControl('interestPayableAccountId');
         }
-
-        this.recurringDepositProductAccountingForm
-          .get('advancedAccountingRules')
-          .valueChanges.subscribe((advancedAccountingRules: boolean) => {
-            if (advancedAccountingRules) {
-              this.recurringDepositProductAccountingForm.addControl(
-                'paymentChannelToFundSourceMappings',
-                this.formBuilder.array([])
-              );
-              this.recurringDepositProductAccountingForm.addControl(
-                'feeToIncomeAccountMappings',
-                this.formBuilder.array([])
-              );
-              this.recurringDepositProductAccountingForm.addControl(
-                'penaltyToIncomeAccountMappings',
-                this.formBuilder.array([])
-              );
-            } else {
-              this.recurringDepositProductAccountingForm.removeControl('paymentChannelToFundSourceMappings');
-              this.recurringDepositProductAccountingForm.removeControl('feeToIncomeAccountMappings');
-              this.recurringDepositProductAccountingForm.removeControl('penaltyToIncomeAccountMappings');
-            }
-          });
-      } else {
-        this.recurringDepositProductAccountingForm.removeControl('savingsReferenceAccountId');
-        this.recurringDepositProductAccountingForm.removeControl('overdraftPortfolioControlId');
-        this.recurringDepositProductAccountingForm.removeControl('savingsControlAccountId');
-        this.recurringDepositProductAccountingForm.removeControl('transfersInSuspenseAccountId');
-        this.recurringDepositProductAccountingForm.removeControl('interestOnSavingsAccountId');
-        this.recurringDepositProductAccountingForm.removeControl('writeOffAccountId');
-        this.recurringDepositProductAccountingForm.removeControl('incomeFromFeeAccountId');
-        this.recurringDepositProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
-        this.recurringDepositProductAccountingForm.removeControl('incomeFromInterestId');
-        this.recurringDepositProductAccountingForm.removeControl('advancedAccountingRules');
-        this.recurringDepositProductAccountingForm.removeControl('escheatLiabilityId');
-        this.recurringDepositProductAccountingForm.removeControl('feesReceivableAccountId');
-        this.recurringDepositProductAccountingForm.removeControl('penaltiesReceivableAccountId');
-        this.recurringDepositProductAccountingForm.removeControl('interestPayableAccountId');
-      }
-    });
+      });
   }
 
-  get paymentChannelToFundSourceMappings(): UntypedFormArray {
-    return this.recurringDepositProductAccountingForm.get('paymentChannelToFundSourceMappings') as UntypedFormArray;
+  get paymentChannelToFundSourceMappings(): FormArray {
+    return this.recurringDepositProductAccountingForm.get('paymentChannelToFundSourceMappings') as FormArray;
   }
 
-  get feeToIncomeAccountMappings(): UntypedFormArray {
-    return this.recurringDepositProductAccountingForm.get('feeToIncomeAccountMappings') as UntypedFormArray;
+  get feeToIncomeAccountMappings(): FormArray {
+    return this.recurringDepositProductAccountingForm.get('feeToIncomeAccountMappings') as FormArray;
   }
 
-  get penaltyToIncomeAccountMappings(): UntypedFormArray {
-    return this.recurringDepositProductAccountingForm.get('penaltyToIncomeAccountMappings') as UntypedFormArray;
+  get penaltyToIncomeAccountMappings(): FormArray {
+    return this.recurringDepositProductAccountingForm.get('penaltyToIncomeAccountMappings') as FormArray;
   }
 
-  add(formType: string, formArray: UntypedFormArray) {
+  add(formType: string, formArray: FormArray) {
     const data = { ...this.getData(formType), pristine: false };
     const dialogRef = this.dialog.open(FormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -338,7 +310,7 @@ export class RecurringDepositProductAccountingStepComponent implements OnInit {
     });
   }
 
-  edit(formType: string, formArray: UntypedFormArray, index: number) {
+  edit(formType: string, formArray: FormArray, index: number) {
     const data = { ...this.getData(formType, formArray.at(index).value), layout: { addButtonText: 'Edit' } };
     const dialogRef = this.dialog.open(FormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -348,7 +320,7 @@ export class RecurringDepositProductAccountingStepComponent implements OnInit {
     });
   }
 
-  delete(formArray: UntypedFormArray, index: number) {
+  delete(formArray: FormArray, index: number) {
     const dialogRef = this.dialog.open(DeleteDialogComponent, {
       data: { deleteContext: `this` }
     });
@@ -457,5 +429,11 @@ export class RecurringDepositProductAccountingStepComponent implements OnInit {
 
   isAccrualAccounting(): boolean {
     return this.accounting.isAccrualAccountingRuleId(this.recurringDepositProductAccountingForm.value.accountingRule);
+  }
+
+  private ensureControl(name: string, control: FormControl | FormArray) {
+    if (!this.recurringDepositProductAccountingForm.contains(name)) {
+      this.recurringDepositProductAccountingForm.addControl(name, control);
+    }
   }
 }

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-charges-step/recurring-deposit-product-charges-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-charges-step/recurring-deposit-product-charges-step.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, Input, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { TranslateService } from '@ngx-translate/core';
@@ -57,9 +58,10 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class RecurringDepositProductChargesStepComponent implements OnInit {
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() recurringDepositProductsTemplate: any;
-  @Input() currencyCode: UntypedFormControl;
+  @Input() currencyCode: FormControl;
 
   chargeData: any;
 
@@ -79,7 +81,9 @@ export class RecurringDepositProductChargesStepComponent implements OnInit {
     } else {
       this.chargesDataSource = [];
     }
-    this.currencyCode.valueChanges.subscribe(() => (this.chargesDataSource = []));
+    this.currencyCode.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => (this.chargesDataSource = []));
   }
 
   addCharge(charge: any) {

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-currency-step/recurring-deposit-product-currency-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-currency-step/recurring-deposit-product-currency-step.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject, DestroyRef } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { MatCheckbox } from '@angular/material/checkbox';
@@ -30,12 +30,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RecurringDepositProductCurrencyStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
 
   @Input() recurringDepositProductsTemplate: any;
 
-  recurringDepositProductCurrencyForm: UntypedFormGroup;
+  recurringDepositProductCurrencyForm: FormGroup;
 
   currencyData: any;
 

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-details-step/recurring-deposit-product-details-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-details-step/recurring-deposit-product-details-step.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
@@ -29,11 +29,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RecurringDepositProductDetailsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
 
   @Input() recurringDepositProductsTemplate: any;
 
-  recurringDepositProductDetailsForm: UntypedFormGroup;
+  recurringDepositProductDetailsForm: FormGroup;
 
   constructor() {
     this.createrecurringDepositProductDetailsForm();

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-interest-rate-chart-step/recurring-deposit-product-interest-rate-chart-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-interest-rate-chart-step/recurring-deposit-product-interest-rate-chart-step.component.ts
@@ -7,14 +7,9 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormArray,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, Input, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormArray, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { animate, state, style, transition, trigger } from '@angular/animations';
 
@@ -88,15 +83,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RecurringDepositProductInterestRateChartStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   dialog = inject(MatDialog);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() recurringDepositProductsTemplate: any;
 
-  recurringDepositProductInterestRateChartForm: UntypedFormGroup;
+  recurringDepositProductInterestRateChartForm: FormGroup;
 
   periodTypeData: any;
   entityTypeData: any;
@@ -168,7 +164,7 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
     this.getChartsDetailsData();
 
     // Iterates for every chart in charts
-    this.charts.controls.forEach((chartDetailControl: UntypedFormGroup, i: number) => {
+    this.charts.controls.forEach((chartDetailControl: FormGroup, i: number) => {
       if (!this.chartsDetail[i]) {
         return;
       }
@@ -198,11 +194,11 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
           ],
           incentives: this.formBuilder.array([])
         });
-        const formArray = chartDetailControl.controls['chartSlabs'] as UntypedFormArray;
+        const formArray = chartDetailControl.controls['chartSlabs'] as FormArray;
         formArray.push(chartSlabInfo);
 
         // Iterate for every slab in chartSlab
-        const chartIncentiveControl = (chartDetailControl.controls['chartSlabs'] as UntypedFormArray).controls[j];
+        const chartIncentiveControl = (chartDetailControl.controls['chartSlabs'] as FormArray).controls[j];
 
         // Iterate to input all the incentive for particular chart slab
         this.chartsDetail[i].chartSlabs[j].incentives.forEach((chartIncentiveDetail: any) => {
@@ -232,7 +228,7 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
               Validators.required
             ]
           });
-          const newFormArray = (chartIncentiveControl as UntypedFormGroup).controls['incentives'] as UntypedFormArray;
+          const newFormArray = (chartIncentiveControl as FormGroup).controls['incentives'] as FormArray;
           newFormArray.push(incentiveInfo);
         });
       });
@@ -335,11 +331,11 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
     });
   }
 
-  get charts(): UntypedFormArray {
-    return this.recurringDepositProductInterestRateChartForm.get('charts') as UntypedFormArray;
+  get charts(): FormArray {
+    return this.recurringDepositProductInterestRateChartForm.get('charts') as FormArray;
   }
 
-  createChartForm(): UntypedFormGroup {
+  createChartForm(): FormGroup {
     return this.formBuilder.group({
       id: [null],
       name: [''],
@@ -370,7 +366,8 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
     this.charts
       .at(chartIndex)
       .get('isPrimaryGroupingByAmount')
-      .valueChanges.subscribe((isPrimaryGroupingByAmount: boolean) => {
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((isPrimaryGroupingByAmount: boolean) => {
         this.chartSlabsDisplayedColumns[chartIndex] = isPrimaryGroupingByAmount ? [
               'amountRange',
               'period'
@@ -382,11 +379,11 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
       });
   }
 
-  getIncentives(chartSlabs: UntypedFormArray, chartSlabIndex: number): UntypedFormArray {
-    return chartSlabs.at(chartSlabIndex).get('incentives') as UntypedFormArray;
+  getIncentives(chartSlabs: FormArray, chartSlabIndex: number): FormArray {
+    return chartSlabs.at(chartSlabIndex).get('incentives') as FormArray;
   }
 
-  addChartSlab(chartSlabs: UntypedFormArray) {
+  addChartSlab(chartSlabs: FormArray) {
     const data = { ...this.getData('Slab') };
     const dialogRef = this.dialog.open(FormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -397,7 +394,7 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
     });
   }
 
-  addIncentive(incentives: UntypedFormArray) {
+  addIncentive(incentives: FormArray) {
     const data = { ...this.getData('Incentive'), entityType: this.entityTypeData[0].id };
     const dialogRef = this.dialog.open(DepositProductIncentiveFormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -407,7 +404,7 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
     });
   }
 
-  editChartSlab(chartSlabs: UntypedFormArray, chartSlabIndex: number) {
+  editChartSlab(chartSlabs: FormArray, chartSlabIndex: number) {
     const data = { ...this.getData('Slab', chartSlabs.at(chartSlabIndex).value), layout: { addButtonText: 'Edit' } };
     const dialogRef = this.dialog.open(FormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -417,7 +414,7 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
     });
   }
 
-  editIncentive(incentives: UntypedFormArray, incentiveIndex: number) {
+  editIncentive(incentives: FormArray, incentiveIndex: number) {
     const data = {
       ...this.getData('Incentive', incentives.at(incentiveIndex).value),
       layout: { addButtonText: 'Edit' }
@@ -430,7 +427,7 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
     });
   }
 
-  delete(formArray: UntypedFormArray, index: number) {
+  delete(formArray: FormArray, index: number) {
     const dialogRef = this.dialog.open(DeleteDialogComponent, {
       data: { deleteContext: `this` }
     });

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-settings-step/recurring-deposit-product-settings-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-settings-step/recurring-deposit-product-settings-step.component.ts
@@ -6,14 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, Input, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatDivider } from '@angular/material/divider';
@@ -37,11 +32,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RecurringDepositProductSettingsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
 
   @Input() recurringDepositProductsTemplate: any;
 
-  recurringDepositProductSettingsForm: UntypedFormGroup;
+  recurringDepositProductSettingsForm: FormGroup;
 
   lockinPeriodFrequencyTypeData: any;
   periodFrequencyTypeData: any;
@@ -140,16 +136,16 @@ export class RecurringDepositProductSettingsStepComponent implements OnInit {
   }
 
   setConditionalControls() {
-    this.recurringDepositProductSettingsForm.get('withHoldTax').valueChanges.subscribe((withHoldTax: any) => {
-      if (withHoldTax) {
-        this.recurringDepositProductSettingsForm.addControl(
-          'taxGroupId',
-          new UntypedFormControl('', Validators.required)
-        );
-      } else {
-        this.recurringDepositProductSettingsForm.removeControl('taxGroupId');
-      }
-    });
+    this.recurringDepositProductSettingsForm
+      .get('withHoldTax')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((withHoldTax: any) => {
+        if (withHoldTax) {
+          this.recurringDepositProductSettingsForm.addControl('taxGroupId', new FormControl('', Validators.required));
+        } else {
+          this.recurringDepositProductSettingsForm.removeControl('taxGroupId');
+        }
+      });
   }
 
   get recurringDepositProductSettings() {

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-terms-step/recurring-deposit-product-terms-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-terms-step/recurring-deposit-product-terms-step.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatDivider } from '@angular/material/divider';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -27,11 +27,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RecurringDepositProductTermsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
 
   @Input() recurringDepositProductsTemplate: any;
 
-  recurringDepositProductTermsForm: UntypedFormGroup;
+  recurringDepositProductTermsForm: FormGroup;
 
   interestCompoundingPeriodTypeData: any;
   interestPostingPeriodTypeData: any;

--- a/src/app/products/recurring-deposit-products/recurring-deposit-products.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-products.component.ts
@@ -10,6 +10,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   OnInit,
   TemplateRef,
   ElementRef,
@@ -17,6 +18,7 @@ import {
   AfterViewInit,
   inject
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -81,6 +83,7 @@ export class RecurringDepositProductsComponent implements OnInit, AfterViewInit 
   private dialog = inject(MatDialog);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private destroyRef = inject(DestroyRef);
 
   /** Data table data. */
   recurringDepositProductData: any;
@@ -114,7 +117,7 @@ export class RecurringDepositProductsComponent implements OnInit, AfterViewInit 
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { recurringDepositProducts: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { recurringDepositProducts: any }) => {
       this.recurringDepositProductData = data.recurringDepositProducts;
     });
   }

--- a/src/app/products/recurring-deposit-products/view-recurring-deposit-product/recurring-deposit-datatable-tab/recurring-deposit-datatable-tab.component.ts
+++ b/src/app/products/recurring-deposit-products/view-recurring-deposit-product/recurring-deposit-datatable-tab/recurring-deposit-datatable-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -23,6 +24,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class RecurringDepositDatatableTabComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   entityId: string;
   entityDatatable: any;
@@ -31,7 +33,7 @@ export class RecurringDepositDatatableTabComponent {
   constructor() {
     this.entityId = this.route.parent.parent.snapshot.paramMap.get('productId');
 
-    this.route.data.subscribe((data: { recurringDepositDatatable: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { recurringDepositDatatable: any }) => {
       this.entityDatatable = data.recurringDepositDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
     });

--- a/src/app/products/recurring-deposit-products/view-recurring-deposit-product/recurring-deposit-general-tab/recurring-deposit-general-tab.component.ts
+++ b/src/app/products/recurring-deposit-products/view-recurring-deposit-product/recurring-deposit-general-tab/recurring-deposit-general-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { trigger, state, transition, animate, style } from '@angular/animations';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -66,6 +67,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class RecurringDepositGeneralTabComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   recurringDepositProduct: any;
   recurringDepositProductTemplate: any;
@@ -102,9 +104,11 @@ export class RecurringDepositGeneralTabComponent {
   ];
 
   constructor() {
-    this.route.data.subscribe((data: { recurringDepositProduct: any; recurringDepositProductsTemplate: any }) => {
-      this.recurringDepositProduct = data.recurringDepositProduct;
-      this.recurringDepositProductTemplate = data.recurringDepositProductsTemplate;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { recurringDepositProduct: any; recurringDepositProductsTemplate: any }) => {
+        this.recurringDepositProduct = data.recurringDepositProduct;
+        this.recurringDepositProductTemplate = data.recurringDepositProductsTemplate;
+      });
   }
 }

--- a/src/app/products/recurring-deposit-products/view-recurring-deposit-product/view-recurring-deposit-product.component.ts
+++ b/src/app/products/recurring-deposit-products/view-recurring-deposit-product/view-recurring-deposit-product.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -27,11 +28,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewRecurringDepositProductComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   recurringDepositDatatables: any = [];
 
   constructor() {
-    this.route.data.subscribe((data: { recurringDepositDatatables: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { recurringDepositDatatables: any }) => {
       this.recurringDepositDatatables = [];
       data.recurringDepositDatatables.forEach((datatable: any) => {
         if (datatable.entitySubType === 'Recurring Deposit') {

--- a/src/app/products/saving-products/create-saving-product/create-saving-product.component.ts
+++ b/src/app/products/saving-products/create-saving-product/create-saving-product.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 
 /** Custom Components */
@@ -54,6 +55,7 @@ export class CreateSavingProductComponent {
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private accounting = inject(Accounting);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild(SavingProductDetailsStepComponent, { static: true })
   savingProductDetailsStep: SavingProductDetailsStepComponent;
@@ -78,7 +80,7 @@ export class CreateSavingProductComponent {
    */
 
   constructor() {
-    this.route.data.subscribe((data: { savingProductsTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingProductsTemplate: any }) => {
       this.savingProductsTemplate = data.savingProductsTemplate;
     });
     this.accountingRuleData = this.accounting.getAccountingRulesForSavings();

--- a/src/app/products/saving-products/edit-saving-product/edit-saving-product.component.ts
+++ b/src/app/products/saving-products/edit-saving-product/edit-saving-product.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 
 /** Custom Components */
@@ -54,6 +55,7 @@ export class EditSavingProductComponent {
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private accounting = inject(Accounting);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild(SavingProductDetailsStepComponent, { static: true })
   savingProductDetailsStep: SavingProductDetailsStepComponent;
@@ -78,7 +80,7 @@ export class EditSavingProductComponent {
    */
 
   constructor() {
-    this.route.data.subscribe((data: { savingProductAndTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingProductAndTemplate: any }) => {
       this.savingProductAndTemplate = data.savingProductAndTemplate;
     });
     this.accountingRuleData = this.accounting.getAccountingRulesForSavings();

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-accounting-step/saving-product-accounting-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-accounting-step/saving-product-accounting-step.component.ts
@@ -6,15 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  UntypedFormArray,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, Input, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, FormArray, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
@@ -75,17 +69,18 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SavingProductAccountingStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() savingProductsTemplate: any;
   @Input() accountingRuleData: any;
-  @Input() isDormancyTrackingActive: UntypedFormControl;
+  @Input() isDormancyTrackingActive: FormControl;
   @Input() savingProductFormValid: boolean;
-  @Input() allowOverdraft: UntypedFormControl;
+  @Input() allowOverdraft: FormControl;
 
-  savingProductAccountingForm: UntypedFormGroup;
+  savingProductAccountingForm: FormGroup;
 
   chargeData: any;
   penaltyData: any;
@@ -217,140 +212,116 @@ export class SavingProductAccountingStepComponent implements OnInit {
   }
 
   setConditionalControls() {
-    this.savingProductAccountingForm.get('accountingRule').valueChanges.subscribe((accountingRule: any) => {
-      if (accountingRule === 2 || accountingRule === 3) {
-        this.savingProductAccountingForm.addControl(
-          'savingsReferenceAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.savingProductAccountingForm.addControl(
-          'overdraftPortfolioControlId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.savingProductAccountingForm.addControl(
-          'savingsControlAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.savingProductAccountingForm.addControl(
-          'transfersInSuspenseAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.savingProductAccountingForm.addControl(
-          'interestOnSavingsAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.savingProductAccountingForm.addControl(
-          'writeOffAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.savingProductAccountingForm.addControl(
-          'incomeFromFeeAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.savingProductAccountingForm.addControl(
-          'incomeFromPenaltyAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.savingProductAccountingForm.addControl(
-          'incomeFromInterestId',
-          new UntypedFormControl('', Validators.required)
-        );
-        this.savingProductAccountingForm.addControl('advancedAccountingRules', new UntypedFormControl(false));
+    this.savingProductAccountingForm
+      .get('accountingRule')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((accountingRule: any) => {
+        if (accountingRule === 2 || accountingRule === 3) {
+          this.ensureControl('savingsReferenceAccountId', new FormControl('', Validators.required));
+          this.ensureControl('overdraftPortfolioControlId', new FormControl('', Validators.required));
+          this.ensureControl('savingsControlAccountId', new FormControl('', Validators.required));
+          this.ensureControl('transfersInSuspenseAccountId', new FormControl('', Validators.required));
+          this.ensureControl('interestOnSavingsAccountId', new FormControl('', Validators.required));
+          this.ensureControl('writeOffAccountId', new FormControl('', Validators.required));
+          this.ensureControl('incomeFromFeeAccountId', new FormControl('', Validators.required));
+          this.ensureControl('incomeFromPenaltyAccountId', new FormControl('', Validators.required));
+          this.ensureControl('incomeFromInterestId', new FormControl('', Validators.required));
+          this.ensureControl('advancedAccountingRules', new FormControl(false));
 
-        if (accountingRule === 3) {
-          this.savingProductAccountingForm.addControl(
-            'feesReceivableAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          this.savingProductAccountingForm.addControl(
-            'penaltiesReceivableAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-          if (this.allowOverdraft.value) {
-            this.savingProductAccountingForm.addControl('interestReceivableAccountId', new UntypedFormControl(''));
-          }
-          this.allowOverdraft.valueChanges.subscribe((allowOverdraft: boolean) => {
-            if (allowOverdraft) {
-              this.savingProductAccountingForm.addControl('interestReceivableAccountId', new UntypedFormControl(''));
-            } else {
-              this.savingProductAccountingForm.removeControl('interestReceivableAccountId');
+          if (accountingRule === 3) {
+            this.ensureControl('feesReceivableAccountId', new FormControl('', Validators.required));
+            this.ensureControl('penaltiesReceivableAccountId', new FormControl('', Validators.required));
+
+            if (this.allowOverdraft.value) {
+              this.ensureControl('interestReceivableAccountId', new FormControl('', Validators.required));
             }
-          });
-          this.savingProductAccountingForm.addControl(
-            'interestPayableAccountId',
-            new UntypedFormControl('', Validators.required)
-          );
-        }
-        if (accountingRule === 2) {
+            this.allowOverdraft.valueChanges
+              .pipe(takeUntilDestroyed(this.destroyRef))
+              .subscribe((allowOverdraft: boolean) => {
+                if (allowOverdraft) {
+                  this.savingProductAccountingForm.addControl('interestReceivableAccountId', new FormControl(''));
+                } else {
+                  this.savingProductAccountingForm.removeControl('interestReceivableAccountId');
+                }
+              });
+            this.savingProductAccountingForm.addControl(
+              'interestPayableAccountId',
+              new FormControl('', Validators.required)
+            );
+          }
+          if (accountingRule === 2) {
+            this.savingProductAccountingForm.removeControl('feesReceivableAccountId');
+            this.savingProductAccountingForm.removeControl('penaltiesReceivableAccountId');
+            this.savingProductAccountingForm.removeControl('interestPayableAccountId');
+          }
+
+          if (this.isDormancyTrackingActive.value) {
+            this.savingProductAccountingForm.addControl('escheatLiabilityId', new FormControl('', Validators.required));
+          }
+
+          this.isDormancyTrackingActive.valueChanges
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((isDormancyTrackingActive: boolean) => {
+              if (isDormancyTrackingActive) {
+                this.savingProductAccountingForm.addControl(
+                  'escheatLiabilityId',
+                  new FormControl('', Validators.required)
+                );
+              } else {
+                this.savingProductAccountingForm.removeControl('escheatLiabilityId');
+              }
+            });
+
+          this.savingProductAccountingForm
+            .get('advancedAccountingRules')
+            .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe((advancedAccountingRules: boolean) => {
+              if (advancedAccountingRules) {
+                this.savingProductAccountingForm.addControl(
+                  'paymentChannelToFundSourceMappings',
+                  this.formBuilder.array([])
+                );
+                this.savingProductAccountingForm.addControl('feeToIncomeAccountMappings', this.formBuilder.array([]));
+                this.savingProductAccountingForm.addControl(
+                  'penaltyToIncomeAccountMappings',
+                  this.formBuilder.array([])
+                );
+              } else {
+                this.savingProductAccountingForm.removeControl('paymentChannelToFundSourceMappings');
+                this.savingProductAccountingForm.removeControl('feeToIncomeAccountMappings');
+                this.savingProductAccountingForm.removeControl('penaltyToIncomeAccountMappings');
+              }
+            });
+        } else {
+          this.savingProductAccountingForm.removeControl('savingsReferenceAccountId');
+          this.savingProductAccountingForm.removeControl('overdraftPortfolioControlId');
+          this.savingProductAccountingForm.removeControl('savingsControlAccountId');
+          this.savingProductAccountingForm.removeControl('transfersInSuspenseAccountId');
+          this.savingProductAccountingForm.removeControl('interestOnSavingsAccountId');
+          this.savingProductAccountingForm.removeControl('writeOffAccountId');
+          this.savingProductAccountingForm.removeControl('incomeFromFeeAccountId');
+          this.savingProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
+          this.savingProductAccountingForm.removeControl('incomeFromInterestId');
+          this.savingProductAccountingForm.removeControl('advancedAccountingRules');
+          this.savingProductAccountingForm.removeControl('escheatLiabilityId');
           this.savingProductAccountingForm.removeControl('feesReceivableAccountId');
           this.savingProductAccountingForm.removeControl('penaltiesReceivableAccountId');
+          this.savingProductAccountingForm.removeControl('interestReceivableAccountId');
           this.savingProductAccountingForm.removeControl('interestPayableAccountId');
         }
-
-        if (this.isDormancyTrackingActive.value) {
-          this.savingProductAccountingForm.addControl(
-            'escheatLiabilityId',
-            new UntypedFormControl('', Validators.required)
-          );
-        }
-
-        this.isDormancyTrackingActive.valueChanges.subscribe((isDormancyTrackingActive: boolean) => {
-          if (isDormancyTrackingActive) {
-            this.savingProductAccountingForm.addControl(
-              'escheatLiabilityId',
-              new UntypedFormControl('', Validators.required)
-            );
-          } else {
-            this.savingProductAccountingForm.removeControl('escheatLiabilityId');
-          }
-        });
-
-        this.savingProductAccountingForm
-          .get('advancedAccountingRules')
-          .valueChanges.subscribe((advancedAccountingRules: boolean) => {
-            if (advancedAccountingRules) {
-              this.savingProductAccountingForm.addControl(
-                'paymentChannelToFundSourceMappings',
-                this.formBuilder.array([])
-              );
-              this.savingProductAccountingForm.addControl('feeToIncomeAccountMappings', this.formBuilder.array([]));
-              this.savingProductAccountingForm.addControl('penaltyToIncomeAccountMappings', this.formBuilder.array([]));
-            } else {
-              this.savingProductAccountingForm.removeControl('paymentChannelToFundSourceMappings');
-              this.savingProductAccountingForm.removeControl('feeToIncomeAccountMappings');
-              this.savingProductAccountingForm.removeControl('penaltyToIncomeAccountMappings');
-            }
-          });
-      } else {
-        this.savingProductAccountingForm.removeControl('savingsReferenceAccountId');
-        this.savingProductAccountingForm.removeControl('overdraftPortfolioControlId');
-        this.savingProductAccountingForm.removeControl('savingsControlAccountId');
-        this.savingProductAccountingForm.removeControl('transfersInSuspenseAccountId');
-        this.savingProductAccountingForm.removeControl('interestOnSavingsAccountId');
-        this.savingProductAccountingForm.removeControl('writeOffAccountId');
-        this.savingProductAccountingForm.removeControl('incomeFromFeeAccountId');
-        this.savingProductAccountingForm.removeControl('incomeFromPenaltyAccountId');
-        this.savingProductAccountingForm.removeControl('incomeFromInterestId');
-        this.savingProductAccountingForm.removeControl('advancedAccountingRules');
-        this.savingProductAccountingForm.removeControl('escheatLiabilityId');
-        this.savingProductAccountingForm.removeControl('feesReceivableAccountId');
-        this.savingProductAccountingForm.removeControl('penaltiesReceivableAccountId');
-        this.savingProductAccountingForm.removeControl('interestReceivableAccountId');
-        this.savingProductAccountingForm.removeControl('interestPayableAccountId');
-      }
-    });
+      });
   }
 
-  get paymentChannelToFundSourceMappings(): UntypedFormArray {
-    return this.savingProductAccountingForm.get('paymentChannelToFundSourceMappings') as UntypedFormArray;
+  get paymentChannelToFundSourceMappings(): FormArray {
+    return this.savingProductAccountingForm.get('paymentChannelToFundSourceMappings') as FormArray;
   }
 
-  get feeToIncomeAccountMappings(): UntypedFormArray {
-    return this.savingProductAccountingForm.get('feeToIncomeAccountMappings') as UntypedFormArray;
+  get feeToIncomeAccountMappings(): FormArray {
+    return this.savingProductAccountingForm.get('feeToIncomeAccountMappings') as FormArray;
   }
 
-  get penaltyToIncomeAccountMappings(): UntypedFormArray {
-    return this.savingProductAccountingForm.get('penaltyToIncomeAccountMappings') as UntypedFormArray;
+  get penaltyToIncomeAccountMappings(): FormArray {
+    return this.savingProductAccountingForm.get('penaltyToIncomeAccountMappings') as FormArray;
   }
 
   setSavingProductAccountingFormDirty() {
@@ -363,7 +334,7 @@ export class SavingProductAccountingStepComponent implements OnInit {
     return this.chargeData.length > 0;
   }
 
-  add(formType: string, formArray: UntypedFormArray) {
+  add(formType: string, formArray: FormArray) {
     const data = { ...this.getData(formType), pristine: false };
     const dialogRef = this.dialog.open(FormDialogComponent, { data, width: '20rem' });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -374,7 +345,7 @@ export class SavingProductAccountingStepComponent implements OnInit {
     });
   }
 
-  edit(formType: string, formArray: UntypedFormArray, index: number) {
+  edit(formType: string, formArray: FormArray, index: number) {
     const data = { ...this.getData(formType, formArray.at(index).value), layout: { addButtonText: 'Edit' } };
     const dialogRef = this.dialog.open(FormDialogComponent, { data });
     dialogRef.afterClosed().subscribe((response: any) => {
@@ -385,7 +356,7 @@ export class SavingProductAccountingStepComponent implements OnInit {
     });
   }
 
-  delete(formArray: UntypedFormArray, index: number) {
+  delete(formArray: FormArray, index: number) {
     const dialogRef = this.dialog.open(DeleteDialogComponent, {
       data: { deleteContext: `this` }
     });
@@ -496,5 +467,11 @@ export class SavingProductAccountingStepComponent implements OnInit {
 
   isAccrualAccounting(): boolean {
     return this.savingProductAccountingForm.value.accountingRule === 3;
+  }
+
+  private ensureControl(name: string, control: FormControl | FormArray) {
+    if (!this.savingProductAccountingForm.contains(name)) {
+      this.savingProductAccountingForm.addControl(name, control);
+    }
   }
 }

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-charges-step/saving-product-charges-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-charges-step/saving-product-charges-step.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { TranslateService } from '@ngx-translate/core';
@@ -59,9 +60,10 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class SavingProductChargesStepComponent implements OnInit {
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() savingProductsTemplate: any;
-  @Input() currencyCode: UntypedFormControl;
+  @Input() currencyCode: FormControl;
 
   chargeData: any;
 
@@ -82,7 +84,9 @@ export class SavingProductChargesStepComponent implements OnInit {
     this.chargesDataSource = this.savingProductsTemplate.charges || [];
     this.pristine = true;
 
-    this.currencyCode.valueChanges.subscribe(() => (this.chargesDataSource = []));
+    this.currencyCode.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => (this.chargesDataSource = []));
   }
 
   addCharge(charge: any) {

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-currency-step/saving-product-currency-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-currency-step/saving-product-currency-step.component.ts
@@ -8,7 +8,7 @@
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { MatCheckbox } from '@angular/material/checkbox';
@@ -30,12 +30,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SavingProductCurrencyStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
 
   @Input() savingProductsTemplate: any;
 
-  savingProductCurrencyForm: UntypedFormGroup;
+  savingProductCurrencyForm: FormGroup;
 
   currencyData: any;
 

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-details-step/saving-product-details-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-details-step/saving-product-details-step.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
@@ -29,11 +29,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SavingProductDetailsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
 
   @Input() savingProductsTemplate: any;
 
-  savingProductDetailsForm: UntypedFormGroup;
+  savingProductDetailsForm: FormGroup;
 
   constructor() {
     this.createSavingProductDetailsForm();

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-settings-step/saving-product-settings-step.component.ts
@@ -6,14 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  UntypedFormControl,
-  Validators,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, Input, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatDivider } from '@angular/material/divider';
@@ -37,11 +32,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SavingProductSettingsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
 
   @Input() savingProductsTemplate: any;
 
-  savingProductSettingsForm: UntypedFormGroup;
+  savingProductSettingsForm: FormGroup;
 
   lockinPeriodFrequencyTypeData: any;
   taxGroupData: any;
@@ -111,73 +107,83 @@ export class SavingProductSettingsStepComponent implements OnInit {
   }
 
   setConditionalControls() {
-    this.savingProductSettingsForm.get('enableLockinPeriod').valueChanges.subscribe((enableLockinPeriod: any) => {
-      if (enableLockinPeriod) {
-        this.savingProductSettingsForm.addControl(
-          'lockinPeriodFrequency',
-          new UntypedFormControl('', [
-            Validators.required,
-            Validators.min(1),
-            Validators.pattern('^[1-9]\\d*$')
-          ])
-        );
-        this.savingProductSettingsForm.addControl(
-          'lockinPeriodFrequencyType',
-          new UntypedFormControl('', Validators.required)
-        );
-      } else {
-        this.savingProductSettingsForm.removeControl('lockinPeriodFrequency');
-        this.savingProductSettingsForm.removeControl('lockinPeriodFrequencyType');
-      }
-    });
+    this.savingProductSettingsForm
+      .get('enableLockinPeriod')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((enableLockinPeriod: any) => {
+        if (enableLockinPeriod) {
+          this.savingProductSettingsForm.addControl(
+            'lockinPeriodFrequency',
+            new FormControl('', [
+              Validators.required,
+              Validators.min(1),
+              Validators.pattern('^[1-9]\\d*$')
+            ])
+          );
+          this.savingProductSettingsForm.addControl(
+            'lockinPeriodFrequencyType',
+            new FormControl('', Validators.required)
+          );
+        } else {
+          this.savingProductSettingsForm.removeControl('lockinPeriodFrequency');
+          this.savingProductSettingsForm.removeControl('lockinPeriodFrequencyType');
+        }
+      });
 
-    this.savingProductSettingsForm.get('allowOverdraft').valueChanges.subscribe((allowOverdraft: any) => {
-      if (allowOverdraft) {
-        this.savingProductSettingsForm.addControl(
-          'minOverdraftForInterestCalculation',
-          new UntypedFormControl('', [Validators.min(0)])
-        );
-        this.savingProductSettingsForm.addControl(
-          'nominalAnnualInterestRateOverdraft',
-          new UntypedFormControl('', [Validators.min(0)])
-        );
-        this.savingProductSettingsForm.addControl('overdraftLimit', new UntypedFormControl('', [Validators.min(0)]));
-      } else {
-        this.savingProductSettingsForm.removeControl('minOverdraftForInterestCalculation');
-        this.savingProductSettingsForm.removeControl('nominalAnnualInterestRateOverdraft');
-        this.savingProductSettingsForm.removeControl('overdraftLimit');
-      }
-    });
+    this.savingProductSettingsForm
+      .get('allowOverdraft')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((allowOverdraft: any) => {
+        if (allowOverdraft) {
+          this.savingProductSettingsForm.addControl(
+            'minOverdraftForInterestCalculation',
+            new FormControl('', [Validators.min(0)])
+          );
+          this.savingProductSettingsForm.addControl(
+            'nominalAnnualInterestRateOverdraft',
+            new FormControl('', [Validators.min(0)])
+          );
+          this.savingProductSettingsForm.addControl('overdraftLimit', new FormControl('', [Validators.min(0)]));
+        } else {
+          this.savingProductSettingsForm.removeControl('minOverdraftForInterestCalculation');
+          this.savingProductSettingsForm.removeControl('nominalAnnualInterestRateOverdraft');
+          this.savingProductSettingsForm.removeControl('overdraftLimit');
+        }
+      });
 
-    this.savingProductSettingsForm.get('withHoldTax').valueChanges.subscribe((withHoldTax: any) => {
-      if (withHoldTax) {
-        this.savingProductSettingsForm.addControl('taxGroupId', new UntypedFormControl('', Validators.required));
-      } else {
-        this.savingProductSettingsForm.removeControl('taxGroupId');
-      }
-    });
+    this.savingProductSettingsForm
+      .get('withHoldTax')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((withHoldTax: any) => {
+        if (withHoldTax) {
+          this.savingProductSettingsForm.addControl('taxGroupId', new FormControl('', Validators.required));
+        } else {
+          this.savingProductSettingsForm.removeControl('taxGroupId');
+        }
+      });
 
     this.savingProductSettingsForm
       .get('isDormancyTrackingActive')
-      .valueChanges.subscribe((isDormancyTrackingActive: any) => {
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((isDormancyTrackingActive: any) => {
         if (isDormancyTrackingActive) {
           this.savingProductSettingsForm.addControl(
             'daysToInactive',
-            new UntypedFormControl('', [
+            new FormControl('', [
               Validators.required,
               Validators.min(0)
             ])
           );
           this.savingProductSettingsForm.addControl(
             'daysToDormancy',
-            new UntypedFormControl('', [
+            new FormControl('', [
               Validators.required,
               Validators.min(0)
             ])
           );
           this.savingProductSettingsForm.addControl(
             'daysToEscheat',
-            new UntypedFormControl('', [
+            new FormControl('', [
               Validators.required,
               Validators.min(0)
             ])

--- a/src/app/products/saving-products/saving-product-stepper/saving-product-terms-step/saving-product-terms-step.component.ts
+++ b/src/app/products/saving-products/saving-product-stepper/saving-product-terms-step/saving-product-terms-step.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -27,11 +27,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SavingProductTermsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
 
   @Input() savingProductsTemplate: any;
 
-  savingProductTermsForm: UntypedFormGroup;
+  savingProductTermsForm: FormGroup;
 
   interestCompoundingPeriodTypeData: any;
   interestPostingPeriodTypeData: any;

--- a/src/app/products/saving-products/saving-products.component.ts
+++ b/src/app/products/saving-products/saving-products.component.ts
@@ -15,8 +15,10 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -68,6 +70,7 @@ export class SavingProductsComponent implements OnInit, AfterViewInit {
   private router = inject(Router);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private destroyRef = inject(DestroyRef);
 
   savingProductsData: any;
   displayedColumns: string[] = [
@@ -95,7 +98,7 @@ export class SavingProductsComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { savingProducts: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingProducts: any }) => {
       this.savingProductsData = data.savingProducts;
     });
   }

--- a/src/app/products/saving-products/view-saving-product/saving-product-datatable-tab/saving-product-datatable-tab.component.ts
+++ b/src/app/products/saving-products/view-saving-product/saving-product-datatable-tab/saving-product-datatable-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -23,6 +24,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class SavingProductDatatableTabComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   entityId: string;
   entityDatatable: any;
@@ -31,7 +33,7 @@ export class SavingProductDatatableTabComponent {
   constructor() {
     this.entityId = this.route.parent.parent.snapshot.paramMap.get('productId');
 
-    this.route.data.subscribe((data: { savingProductDatatable: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingProductDatatable: any }) => {
       this.entityDatatable = data.savingProductDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
     });

--- a/src/app/products/saving-products/view-saving-product/saving-product-general-tab/saving-product-general-tab.component.ts
+++ b/src/app/products/saving-products/view-saving-product/saving-product-general-tab/saving-product-general-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { Accounting } from 'app/core/utils/accounting';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -55,6 +56,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class SavingProductGeneralTabComponent {
   private route = inject(ActivatedRoute);
   private accounting = inject(Accounting);
+  private destroyRef = inject(DestroyRef);
 
   savingProduct: any;
 
@@ -74,7 +76,7 @@ export class SavingProductGeneralTabComponent {
   ];
 
   constructor() {
-    this.route.data.subscribe((data: { savingProduct: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingProduct: any }) => {
       this.savingProduct = data.savingProduct;
     });
   }

--- a/src/app/products/saving-products/view-saving-product/view-saving-product.component.ts
+++ b/src/app/products/saving-products/view-saving-product/view-saving-product.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -27,11 +28,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewSavingProductComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   savingProductDatatables: any = [];
 
   constructor() {
-    this.route.data.subscribe((data: { savingProductDatatables: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingProductDatatables: any }) => {
       this.savingProductDatatables = [];
       data.savingProductDatatables.forEach((datatable: any) => {
         if (datatable.entitySubType === 'Savings Product') {

--- a/src/app/products/share-products/create-dividend/create-dividend.component.ts
+++ b/src/app/products/share-products/create-dividend/create-dividend.component.ts
@@ -7,8 +7,9 @@
  */
 
 /** Angular Imports. */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { Dates } from 'app/core/utils/dates';
 
@@ -30,15 +31,16 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CreateDividendComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private dateUtils = inject(Dates);
   private productService = inject(ProductsService);
   private router = inject(Router);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Create Dividend Form. */
-  createDividendForm: UntypedFormGroup;
+  createDividendForm: FormGroup;
   /** Share Product data. */
   shareProductData: any;
   /** Minimum Date allowed. */
@@ -56,7 +58,7 @@ export class CreateDividendComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service.
    */
   constructor() {
-    this.route.data.subscribe((data: { shareProduct: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { shareProduct: any }) => {
       this.shareProductData = data.shareProduct;
     });
   }

--- a/src/app/products/share-products/create-share-product/create-share-product.component.ts
+++ b/src/app/products/share-products/create-share-product/create-share-product.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 
 /** Custom Components */
@@ -56,6 +57,7 @@ export class CreateShareProductComponent {
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private accounting = inject(Accounting);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild(ShareProductDetailsStepComponent, { static: true })
   shareProductDetailsStep: ShareProductDetailsStepComponent;
@@ -82,7 +84,7 @@ export class CreateShareProductComponent {
    */
 
   constructor() {
-    this.route.data.subscribe((data: { shareProductsTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { shareProductsTemplate: any }) => {
       this.shareProductsTemplate = data.shareProductsTemplate;
     });
     this.accountingRuleData = this.accounting.getAccountingRulesForShares();

--- a/src/app/products/share-products/dividends-share-product/dividends.components.ts
+++ b/src/app/products/share-products/dividends-share-product/dividends.components.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { Component, OnInit, ViewChild, inject } from '@angular/core';
+import { Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -67,6 +68,7 @@ import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 export class ShareProductsDividendsComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   /** Dividends data. */
   dividendData: any;
@@ -91,7 +93,7 @@ export class ShareProductsDividendsComponent implements OnInit {
    * @param {ActivatedRoute} route Activated Route.
    */
   constructor() {
-    this.route.data.subscribe((data: { dividends: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { dividends: any }) => {
       this.dividendData = data.dividends.pageItems;
     });
   }

--- a/src/app/products/share-products/edit-share-product/edit-share-product.component.ts
+++ b/src/app/products/share-products/edit-share-product/edit-share-product.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 
 /** Custom Components */
@@ -56,6 +57,7 @@ export class EditShareProductComponent {
   private router = inject(Router);
   private settingsService = inject(SettingsService);
   private accounting = inject(Accounting);
+  private destroyRef = inject(DestroyRef);
 
   @ViewChild(ShareProductDetailsStepComponent, { static: true })
   shareProductDetailsStep: ShareProductDetailsStepComponent;
@@ -82,7 +84,7 @@ export class EditShareProductComponent {
    */
 
   constructor() {
-    this.route.data.subscribe((data: { shareProductAndTemplate: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { shareProductAndTemplate: any }) => {
       this.shareProductAndTemplate = data.shareProductAndTemplate;
     });
     this.accountingRuleData = this.accounting.getAccountingRulesForShares();

--- a/src/app/products/share-products/share-product-stepper/share-product-accounting-step/share-product-accounting-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-accounting-step/share-product-accounting-step.component.ts
@@ -6,14 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import {
-  UntypedFormGroup,
-  UntypedFormBuilder,
-  Validators,
-  UntypedFormControl,
-  ReactiveFormsModule
-} from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, Input, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 import { MatDivider } from '@angular/material/divider';
 import { GlAccountSelectorComponent } from '../../../../shared/accounting/gl-account-selector/gl-account-selector.component';
@@ -38,13 +33,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ShareProductAccountingStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
 
   @Input() shareProductsTemplate: any;
   @Input() accountingRuleData: any;
   @Input() shareProductFormValid: boolean;
 
-  shareProductAccountingForm: UntypedFormGroup;
+  shareProductAccountingForm: FormGroup;
 
   assetAccountData: any;
   incomeAccountData: any;
@@ -85,22 +81,25 @@ export class ShareProductAccountingStepComponent implements OnInit {
   }
 
   setConditionalControls() {
-    this.shareProductAccountingForm.get('accountingRule').valueChanges.subscribe((accountingRule: any) => {
-      if (accountingRule === 2) {
-        this.shareProductAccountingForm.addControl('shareReferenceId', new UntypedFormControl('', Validators.required));
-        this.shareProductAccountingForm.addControl('shareSuspenseId', new UntypedFormControl('', Validators.required));
-        this.shareProductAccountingForm.addControl('shareEquityId', new UntypedFormControl('', Validators.required));
-        this.shareProductAccountingForm.addControl(
-          'incomeFromFeeAccountId',
-          new UntypedFormControl('', Validators.required)
-        );
-      } else {
-        this.shareProductAccountingForm.removeControl('shareReferenceId');
-        this.shareProductAccountingForm.removeControl('shareSuspenseId');
-        this.shareProductAccountingForm.removeControl('shareEquityId');
-        this.shareProductAccountingForm.removeControl('incomeFromFeeAccountId');
-      }
-    });
+    this.shareProductAccountingForm
+      .get('accountingRule')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((accountingRule: any) => {
+        if (accountingRule === 2) {
+          this.shareProductAccountingForm.addControl('shareReferenceId', new FormControl('', Validators.required));
+          this.shareProductAccountingForm.addControl('shareSuspenseId', new FormControl('', Validators.required));
+          this.shareProductAccountingForm.addControl('shareEquityId', new FormControl('', Validators.required));
+          this.shareProductAccountingForm.addControl(
+            'incomeFromFeeAccountId',
+            new FormControl('', Validators.required)
+          );
+        } else {
+          this.shareProductAccountingForm.removeControl('shareReferenceId');
+          this.shareProductAccountingForm.removeControl('shareSuspenseId');
+          this.shareProductAccountingForm.removeControl('shareEquityId');
+          this.shareProductAccountingForm.removeControl('incomeFromFeeAccountId');
+        }
+      });
   }
 
   get shareProductAccounting() {

--- a/src/app/products/share-products/share-product-stepper/share-product-charges-step/share-product-charges-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-charges-step/share-product-charges-step.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
-import { UntypedFormControl } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, Input, OnInit, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 import { TranslateService } from '@ngx-translate/core';
@@ -59,9 +60,10 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class ShareProductChargesStepComponent implements OnInit {
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
 
   @Input() shareProductsTemplate: any;
-  @Input() currencyCode: UntypedFormControl;
+  @Input() currencyCode: FormControl;
 
   chargeData: any;
 
@@ -82,7 +84,9 @@ export class ShareProductChargesStepComponent implements OnInit {
     this.chargesDataSource = this.shareProductsTemplate.charges || [];
     this.pristine = true;
 
-    this.currencyCode.valueChanges.subscribe(() => (this.chargesDataSource = []));
+    this.currencyCode.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => (this.chargesDataSource = []));
   }
 
   addCharge(charge: any) {

--- a/src/app/products/share-products/share-product-stepper/share-product-currency-step/share-product-currency-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-currency-step/share-product-currency-step.component.ts
@@ -8,7 +8,7 @@
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { MatCheckbox } from '@angular/material/checkbox';
@@ -30,12 +30,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ShareProductCurrencyStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
 
   @Input() shareProductsTemplate: any;
 
-  shareProductCurrencyForm: UntypedFormGroup;
+  shareProductCurrencyForm: FormGroup;
 
   currencyData: any;
 

--- a/src/app/products/share-products/share-product-stepper/share-product-details-step/share-product-details-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-details-step/share-product-details-step.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -27,11 +27,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ShareProductDetailsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
 
   @Input() shareProductsTemplate: any;
 
-  shareProductDetailsForm: UntypedFormGroup;
+  shareProductDetailsForm: FormGroup;
 
   constructor() {
     this.createShareProductDetailsForm();

--- a/src/app/products/share-products/share-product-stepper/share-product-market-price-step/share-product-market-price-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-market-price-step/share-product-market-price-step.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, UntypedFormArray } from '@angular/forms';
+import { FormGroup, FormBuilder, FormArray } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 
 /** Dialog Components */
@@ -67,7 +67,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ShareProductMarketPriceStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
   dialog = inject(MatDialog);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
@@ -75,7 +75,7 @@ export class ShareProductMarketPriceStepComponent implements OnInit {
 
   @Input() shareProductsTemplate: any;
 
-  shareProductMarketPriceForm: UntypedFormGroup;
+  shareProductMarketPriceForm: FormGroup;
 
   /** For displaying required columns */
   displayedColumns: string[] = [
@@ -109,8 +109,8 @@ export class ShareProductMarketPriceStepComponent implements OnInit {
     });
   }
 
-  get marketPricePeriods(): UntypedFormArray {
-    return this.shareProductMarketPriceForm.get('marketPricePeriods') as UntypedFormArray;
+  get marketPricePeriods(): FormArray {
+    return this.shareProductMarketPriceForm.get('marketPricePeriods') as FormArray;
   }
 
   setShareProductMarketPriceFormDirty() {

--- a/src/app/products/share-products/share-product-stepper/share-product-settings-step/share-product-settings-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-settings-step/share-product-settings-step.component.ts
@@ -7,7 +7,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, FormControl, Validators, ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
@@ -29,11 +29,11 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ShareProductSettingsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
 
   @Input() shareProductsTemplate: any;
 
-  shareProductSettingsForm: UntypedFormGroup;
+  shareProductSettingsForm: FormGroup;
 
   minimumActivePeriodFrequencyTypeData: any;
   lockinPeriodFrequencyTypeData: any;
@@ -107,7 +107,7 @@ export class ShareProductSettingsStepComponent implements OnInit {
     );
   }
 
-  private validateSharesOrder(group: UntypedFormGroup): { [key: string]: any } | null {
+  private validateSharesOrder(group: FormGroup): { [key: string]: any } | null {
     const min = Number(group.get('minimumShares')?.value);
     const nominal = Number(group.get('nominalShares')?.value);
     const max = Number(group.get('maximumShares')?.value);

--- a/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.ts
+++ b/src/app/products/share-products/share-product-stepper/share-product-terms-step/share-product-terms-step.component.ts
@@ -6,8 +6,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, Input, inject } from '@angular/core';
-import { UntypedFormGroup, UntypedFormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, OnInit, Input, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, FormBuilder, Validators, ReactiveFormsModule } from '@angular/forms';
 import { combineLatest } from 'rxjs';
 import { MatFormField, MatLabel, MatError, MatHint } from '@angular/material/form-field';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -30,11 +31,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ShareProductTermsStepComponent implements OnInit {
-  private formBuilder = inject(UntypedFormBuilder);
+  private formBuilder = inject(FormBuilder);
+  private destroyRef = inject(DestroyRef);
 
   @Input() shareProductsTemplate: any;
 
-  shareProductTermsForm: UntypedFormGroup;
+  shareProductTermsForm: FormGroup;
 
   constructor() {
     this.createShareProductTermsForm();

--- a/src/app/products/share-products/share-products.component.ts
+++ b/src/app/products/share-products/share-products.component.ts
@@ -15,8 +15,10 @@ import {
   ElementRef,
   ViewChild,
   AfterViewInit,
-  inject
+  inject,
+  DestroyRef
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import {
@@ -68,6 +70,7 @@ export class ShareProductsComponent implements OnInit, AfterViewInit {
   private router = inject(Router);
   private configurationWizardService = inject(ConfigurationWizardService);
   private popoverService = inject(PopoverService);
+  private destroyRef = inject(DestroyRef);
 
   shareProductsData: any;
   displayedColumns: string[] = [
@@ -96,7 +99,7 @@ export class ShareProductsComponent implements OnInit, AfterViewInit {
    * @param {PopoverService} popoverService PopoverService.
    */
   constructor() {
-    this.route.data.subscribe((data: { shareProducts: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { shareProducts: any }) => {
       this.shareProductsData = data.shareProducts.pageItems;
     });
   }

--- a/src/app/products/share-products/view-dividend/view-dividend.component.ts
+++ b/src/app/products/share-products/view-dividend/view-dividend.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, ViewChild, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
@@ -54,6 +55,7 @@ export class ViewDividendComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private productsService = inject(ProductsService);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   dividendData: any;
   status: any;
@@ -70,7 +72,7 @@ export class ViewDividendComponent implements OnInit {
   dataSource: MatTableDataSource<any>;
 
   constructor() {
-    this.route.data.subscribe((data: { dividendData: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { dividendData: any }) => {
       this.dividendData = data.dividendData;
     });
     this.status = this.route.snapshot.queryParams['status'];

--- a/src/app/products/share-products/view-share-product/share-product-datatable-tab/share-product-datatable-tab.component.ts
+++ b/src/app/products/share-products/view-share-product/share-product-datatable-tab/share-product-datatable-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -23,6 +24,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ShareProductDatatableTabComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   entityId: string;
   entityDatatable: any;
@@ -31,7 +33,7 @@ export class ShareProductDatatableTabComponent {
   constructor() {
     this.entityId = this.route.parent.parent.snapshot.paramMap.get('productId');
 
-    this.route.data.subscribe((data: { shareProductDatatable: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { shareProductDatatable: any }) => {
       this.entityDatatable = data.shareProductDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
     });

--- a/src/app/products/share-products/view-share-product/share-product-general-tab/share-product-general-tab.component.ts
+++ b/src/app/products/share-products/view-share-product/share-product-general-tab/share-product-general-tab.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { Accounting } from 'app/core/utils/accounting';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -57,6 +58,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class ShareProductGeneralTabComponent {
   private route = inject(ActivatedRoute);
   private accounting = inject(Accounting);
+  private destroyRef = inject(DestroyRef);
 
   shareProduct: any;
 
@@ -72,7 +74,7 @@ export class ShareProductGeneralTabComponent {
   ];
 
   constructor() {
-    this.route.data.subscribe((data: { shareProduct: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { shareProduct: any }) => {
       this.shareProduct = data.shareProduct;
     });
   }

--- a/src/app/products/share-products/view-share-product/view-share-product.component.ts
+++ b/src/app/products/share-products/view-share-product/view-share-product.component.ts
@@ -6,7 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -27,11 +28,12 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewShareProductComponent {
   private route = inject(ActivatedRoute);
+  private destroyRef = inject(DestroyRef);
 
   shareProductDatatables: any = [];
 
   constructor() {
-    this.route.data.subscribe((data: { shareProductDatatables: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { shareProductDatatables: any }) => {
       this.shareProductDatatables = [];
       data.shareProductDatatables.forEach((datatable: any) => {
         this.shareProductDatatables.push(datatable);


### PR DESCRIPTION
## Description

Replace manual subscribe/unsubscribe patterns with DestroyRef + takeUntilDestroyed across products components and directives. Also replace UntypedFormBuilder/Group/Control/Array with typed Angular equivalents.

## Related issues and discussion

[WEB-954](https://github.com/openMF/web-app/pull/WEB-954)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-954]: https://mifosforge.jira.com/browse/WEB-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated reactive forms to stronger typing across product management screens for more reliable form behavior and validation.
  * Introduced lifecycle-aware subscription cleanup throughout components to prevent lingering listeners, improving stability and reducing memory leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->