### PR TITLE
WEB-979: Loan view broken for non Working Capital

### DIFF
--- a/src/app/loans/common-resolvers/loan-base.resolver.ts
+++ b/src/app/loans/common-resolvers/loan-base.resolver.ts
@@ -22,7 +22,7 @@ export class LoanBaseResolver {
 
   protected initialize(route: ActivatedRouteSnapshot): void {
     const productType = route.queryParams['productType'];
-    if (productType !== null) {
+    if (productType) {
       if (productType === 'loan') {
         this.productType.next(LOAN_PRODUCT_TYPE.LOAN);
       } else if (productType === 'working-capital') {

--- a/src/app/loans/common-resolvers/loans-account-charge.resolver.ts
+++ b/src/app/loans/common-resolvers/loans-account-charge.resolver.ts
@@ -11,16 +11,17 @@ import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot } from '@angular/router';
 
 /** rxjs Imports */
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 /** Custom Services */
 import { LoansService } from '../loans.service';
+import { LoanBaseResolver } from './loan-base.resolver';
 
 /**
  * Loans Account Charge data resolver.
  */
 @Injectable()
-export class LoansAccountChargeResolver {
+export class LoansAccountChargeResolver extends LoanBaseResolver {
   private loansService = inject(LoansService);
 
   /**
@@ -29,8 +30,12 @@ export class LoansAccountChargeResolver {
    * @returns {Observable<any>}
    */
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
+    this.initialize(route);
     const loanId = route.paramMap.get('loanId');
     const chargeId = route.paramMap.get('id');
-    return this.loansService.getLoansAccountCharge(loanId, chargeId);
+    if (!isNaN(+loanId)) {
+      return this.loansService.getLoansAccountCharge(this.loanAccountPath, loanId, chargeId);
+    }
+    return of([]);
   }
 }

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -357,7 +357,7 @@
             </a>
           }
         }
-        @if (loanProductService.isWorkingCapital || loanDetailsData.transactions.length) {
+        @if (loanProductService.isWorkingCapital || loanDetailsData.transactions?.length) {
           <a
             mat-tab-link
             [routerLink]="['./transactions']"

--- a/src/app/loans/loans-view/loans-view.component.ts
+++ b/src/app/loans/loans-view/loans-view.component.ts
@@ -121,7 +121,7 @@ export class LoansViewComponent extends LoanProductBaseComponent implements OnIn
       .subscribe((data: { loanDetailsData: any; loanDatatables: any; loanArrearsDelinquencyConfig: any }) => {
         this.loanDetailsData = data.loanDetailsData;
         if (!this.loanDetailsData.loanProductName) {
-          this.loanDetailsData.loanProductName = this.loanDetailsData.product.name;
+          this.loanDetailsData.loanProductName = this.loanDetailsData.product?.name;
         }
         this.loanDatatables = this.loanProductService.isLoanProduct ? data.loanDatatables : [];
         this.loanStatus = this.loanDetailsData.status;

--- a/src/app/loans/loans-view/working-capital/common-resolvers/loan-period-payment-rates.resolver.ts
+++ b/src/app/loans/loans-view/working-capital/common-resolvers/loan-period-payment-rates.resolver.ts
@@ -9,24 +9,32 @@
 /** Angular Imports */
 import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot } from '@angular/router';
+import { LoanBaseResolver } from 'app/loans/common-resolvers/loan-base.resolver';
 import { LoansService } from 'app/loans/loans.service';
+import { PeriodPaymentRateChange } from 'app/loans/models/working-capital-loan-account.model';
 
 /** rxjs Imports */
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 /**
  * Working Capital Period Payment Rates resolver.
  */
 @Injectable()
-export class LoanPeriodPaymentRatesResolver {
+export class LoanPeriodPaymentRatesResolver extends LoanBaseResolver {
   private loansService = inject(LoansService);
 
   /**
    * Returns the Loans data.
    * @returns {Observable<any>}
    */
-  resolve(route: ActivatedRouteSnapshot): Observable<any> {
+  resolve(route: ActivatedRouteSnapshot): Observable<PeriodPaymentRateChange[]> {
+    this.initialize(route);
     const loanId = route.paramMap.get('loanId') || route.parent.paramMap.get('loanId');
-    return this.loansService.getWorkingCapitalPeriodPaymentRates(loanId);
+    if (!isNaN(+loanId)) {
+      if (this.isWorkingCapital) {
+        return this.loansService.getWorkingCapitalPeriodPaymentRates(loanId);
+      }
+    }
+    return of([]);
   }
 }

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -17,6 +17,7 @@ export type LoanAccountPath = 'loans' | 'working-capital-loans';
 import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
 import { DisbursementData } from './models/loan-account.model';
+import { PeriodPaymentRateChange } from './models/working-capital-loan-account.model';
 
 /**
  * Loans service.
@@ -604,8 +605,8 @@ export class LoansService {
    * @param {string} chargeId loans charge Id
    * @returns {Observable<any>}
    */
-  getLoansAccountCharge(accountId: string, chargeId: string): Observable<any> {
-    return this.http.get(`/loans/${accountId}/charges/${chargeId}`);
+  getLoansAccountCharge(loanAccountPath: LoanAccountPath, accountId: string, chargeId: string): Observable<any> {
+    return this.http.get(`/${loanAccountPath}/${accountId}/charges/${chargeId}`);
   }
 
   /**
@@ -875,8 +876,8 @@ export class LoansService {
   /**
    * Returns the Working Capital Loan Payment Rates data
    */
-  getWorkingCapitalPeriodPaymentRates(loanId: any) {
-    return this.http.get(`/working-capital-loans/${loanId}/rate-changes`);
+  getWorkingCapitalPeriodPaymentRates(loanId: any): Observable<PeriodPaymentRateChange[]> {
+    return this.http.get<PeriodPaymentRateChange[]>(`/working-capital-loans/${loanId}/rate-changes`);
   }
 
   /**


### PR DESCRIPTION
## Description

UI loans view appears Broken Incomplete for non Working Capital

## Related issues and discussion

[WEB-979](WEB-979)

## Screenshots, if any

<img width="2560" height="1482" alt="image" src="https://github.com/user-attachments/assets/af9ec01a-7361-4eed-8eb0-929c234c6a1f" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-979]: https://mifosforge.jira.com/browse/WEB-979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-safety to prevent errors when loan product or transactions data is missing (avoids runtime access on missing values).
  * Transactions tab now reliably hides when no transactions exist.
  * Strengthened loan ID validation to avoid invalid account lookups.

* **New Features**
  * Charge retrieval now supports multiple loan account path types so charge details load correctly for different loan kinds.
  * Working-capital period rates fetching now returns typed results.

* **Refactor**
  * Shared loan initialization logic applied to resolvers for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->