### PR TITLE
WEB-1006: Move release details from footer to About dialog

### DIFF
--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -234,6 +234,12 @@
     </mat-icon>
     <span>{{ 'labels.menus.Settings' | translate }}</span>
   </button>
+  <button mat-menu-item (click)="openAboutDialog()" tabindex="0">
+    <mat-icon>
+      <fa-icon icon="info-circle" size="sm"></fa-icon>
+    </mat-icon>
+    <span>{{ 'labels.menus.About' | translate }}</span>
+  </button>
   <button mat-menu-item (click)="logout()" id="logout" tabindex="0">
     <mat-icon>
       <fa-icon icon="sign-out-alt" size="sm"></fa-icon>

--- a/src/app/core/shell/toolbar/toolbar.component.ts
+++ b/src/app/core/shell/toolbar/toolbar.component.ts
@@ -41,6 +41,7 @@ import { ConfigurationWizardService } from '../../../configuration-wizard/config
 /** Custom Components */
 import { ConfigurationWizardComponent } from '../../../configuration-wizard/configuration-wizard.component';
 import { NotificationsTrayComponent } from 'app/shared/notifications-tray/notifications-tray.component';
+import { AboutDialogComponent } from 'app/shared/about-dialog/about-dialog.component';
 import { MatToolbar } from '@angular/material/toolbar';
 import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -162,6 +163,15 @@ export class ToolbarComponent implements OnInit, AfterViewInit, AfterContentChec
    */
   help() {
     this.documentationLinks.open('userManual');
+  }
+
+  /**
+   * Opens the About dialog.
+   */
+  openAboutDialog() {
+    this.dialog.open(AboutDialogComponent, {
+      width: '450px'
+    });
   }
   /**
    * Popover function

--- a/src/app/shared/about-dialog/about-dialog.component.html
+++ b/src/app/shared/about-dialog/about-dialog.component.html
@@ -1,0 +1,54 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<h2 mat-dialog-title>{{ 'labels.heading.About' | translate }}</h2>
+
+<mat-dialog-content>
+  <div class="about-content">
+    <table class="about-table">
+      <tr>
+        <td class="info-label">{{ 'labels.version.Mifos WebApp' | translate }}</td>
+        <td class="info-value">
+          {{ mifosVersion }} - <span class="hash">{{ mifosHash }}</span>
+        </td>
+      </tr>
+      <tr>
+        <td class="info-label">{{ 'labels.version.Apache Fineract' | translate }}</td>
+        <td class="info-value">
+          {{ fineractVersion || '...' }}
+        </td>
+      </tr>
+      <tr>
+        <td class="info-label">{{ 'labels.inputs.Server' | translate }}</td>
+        <td class="info-value">{{ server }}</td>
+      </tr>
+      <tr>
+        <td class="info-label">{{ 'labels.version.Tenant' | translate }}</td>
+        <td class="info-value">{{ tenant }}</td>
+      </tr>
+      <tr>
+        <td class="info-label">{{ 'labels.version.Username' | translate }}</td>
+        <td class="info-value">{{ username }}</td>
+      </tr>
+      <tr>
+        <td class="info-label">{{ 'labels.version.Name' | translate }}</td>
+        <td class="info-value">{{ name }}</td>
+      </tr>
+      <tr>
+        <td class="info-label">{{ 'labels.version.Render Time' | translate }}</td>
+        <td class="info-value">{{ renderTime | date: 'dd MMMM yyyy HH:mm:ss' }}</td>
+      </tr>
+    </table>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-raised-button mat-dialog-close color="primary">
+    {{ 'labels.buttons.Close' | translate }}
+  </button>
+</mat-dialog-actions>

--- a/src/app/shared/about-dialog/about-dialog.component.scss
+++ b/src/app/shared/about-dialog/about-dialog.component.scss
@@ -1,0 +1,68 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.about-content {
+  padding: 16px 0;
+  min-width: 350px;
+}
+
+.about-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  tr {
+    border-bottom: 1px solid var(--md-sys-color-outline-variant, #e0e0e0);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  td {
+    padding: 12px 8px;
+  }
+
+  .info-label {
+    font-weight: 500;
+    color: var(--md-sys-color-on-surface-variant, #555);
+    width: 40%;
+  }
+
+  .info-value {
+    font-weight: 600;
+    color: var(--md-sys-color-on-surface, #333);
+    text-align: right;
+
+    .hash {
+      font-weight: 400;
+      font-size: 0.85em;
+      color: var(--md-sys-color-on-surface-variant, #666);
+    }
+  }
+}
+
+// Dark theme support
+:host-context(.dark-theme) {
+  .about-table {
+    tr {
+      border-bottom-color: rgb(255 255 255 / 30%);
+    }
+
+    .info-label {
+      color: rgb(255 255 255 / 70%);
+    }
+
+    .info-value {
+      color: rgb(255 255 255 / 87%);
+
+      .hash {
+        color: rgb(255 255 255 / 60%);
+      }
+    }
+  }
+}

--- a/src/app/shared/about-dialog/about-dialog.component.ts
+++ b/src/app/shared/about-dialog/about-dialog.component.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import {
+  MatDialogRef,
+  MatDialogTitle,
+  MatDialogContent,
+  MatDialogActions,
+  MatDialogClose
+} from '@angular/material/dialog';
+import { MatButton } from '@angular/material/button';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { VersionService } from 'app/system/version.service';
+import { environment } from '../../../environments/environment';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+/**
+ * About Dialog Component.
+ * Displays version information accessible from the profile dropdown menu.
+ */
+@Component({
+  selector: 'mifosx-about-dialog',
+  templateUrl: './about-dialog.component.html',
+  styleUrls: ['./about-dialog.component.scss'],
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatButton
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AboutDialogComponent implements OnInit {
+  private dialogRef = inject<MatDialogRef<AboutDialogComponent>>(MatDialogRef);
+  private authenticationService = inject(AuthenticationService);
+  private settingsService = inject(SettingsService);
+  private versionService = inject(VersionService);
+
+  /** Mifos X version from environment */
+  mifosVersion = environment.version;
+  /** Mifos X hash from environment */
+  mifosHash = environment.hash;
+  /** Apache Fineract version */
+  fineractVersion = '';
+  /** Server URL */
+  server = '';
+  /** Tenant identifier */
+  tenant = '';
+  /** Username */
+  username = '';
+  /** Name */
+  name = '';
+  /** Render time */
+  renderTime = new Date();
+
+  ngOnInit(): void {
+    this.server = this.settingsService.server;
+    this.tenant = this.settingsService.tenantIdentifier || 'default';
+    this.setUserInfo();
+    this.fetchBackendInfo();
+  }
+
+  /**
+   * Sets user info from authentication credentials.
+   */
+  private setUserInfo(): void {
+    const credentials = this.authenticationService.getCredentials();
+    if (credentials) {
+      this.username = credentials.username || '';
+      this.name = credentials.staffDisplayName || credentials.username || '';
+    }
+  }
+
+  /**
+   * Fetches backend version info from the server.
+   */
+  private fetchBackendInfo(): void {
+    this.versionService.getBackendInfo().subscribe({
+      next: (data: any) => {
+        if (data.git && data.git.build && data.git.build.version) {
+          const buildVersion: string = data.git.build.version.split('-');
+          this.fineractVersion = buildVersion[0];
+        }
+      },
+      error: () => {
+        this.fineractVersion = 'N/A';
+      }
+    });
+  }
+}

--- a/src/app/shared/footer/footer.component.ts
+++ b/src/app/shared/footer/footer.component.ts
@@ -75,10 +75,11 @@ export class FooterComponent implements OnInit, OnDestroy {
   alert$: Subscription;
   timer: any;
 
-  displayBackEndInfo = true;
+  displayBackEndInfo = false;
 
   constructor() {
-    this.displayBackEndInfo = environment.displayBackEndInfo === 'true';
+    // Display backend info is now handled by About dialog
+    // Set to false to remove release details from footer
     this.setUserInfo();
     this.renderTime = new Date();
   }

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1123,6 +1123,7 @@
       "NotEqual": "Not equal"
     },
     "heading": {
+      "About": "About",
       "About Us": "About Us",
       "Account Information": "Account Information",
       "Account Linked Financial": "List of accounts linked to different financial activities. To know more click:",
@@ -3156,6 +3157,7 @@
       "Working with Code": "Working with Code"
     },
     "menus": {
+      "About": "About",
       "Unassign Staff": "Unassign Staff",
       "Accounting": "Accounting",
       "Account Overview": "Account Overview",


### PR DESCRIPTION
## Description

This PR improves the user experience by moving release and environment details from the global footer to the About dialog accessible from the profile menu.

Displaying this information in the footer consumed valuable screen space across all pages. By relocating it to the About dialog, the application UI becomes cleaner while still keeping the information easily accessible for debugging and support purposes.

Changes included:

* Added an About option to the profile dropdown menu.
* Displayed release and environment information in the About dialog.
* Removed release details from the global footer.
* Reused the existing services for fetching version and user information.

## Related issues and discussion

#WEB-1006

## Screenshots, if any

### Before

<img width="1431" height="765" alt="image" src="https://github.com/user-attachments/assets/3c977d12-5e9b-42e0-a41e-7819b1a2b3e7" />

### After

https://github.com/user-attachments/assets/14141543-0904-4aba-912c-feb92a3817aa

<img width="696" height="672" alt="image" src="https://github.com/user-attachments/assets/68bfa68a-acd8-403c-8460-796414d87a83" />

## Checklist

* [x] If you have multiple commits please combine them into one commit by squashing them.

* [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
