### PR TITLE
WEB-1008: Build AIContextService for Copilot context detection

### DIFF
--- a/src/app/copilot/services/ai-context.service.spec.ts
+++ b/src/app/copilot/services/ai-context.service.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { EMPTY } from 'rxjs';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { AiContextService } from './ai-context.service';
+import { AuthenticationService } from '../../core/authentication/authentication.service';
+
+interface RouteNode {
+  params: Record<string, string>;
+  data: Record<string, unknown>;
+  firstChild: RouteNode | null;
+}
+
+function routeChain(levels: Array<Partial<RouteNode>>): RouteNode {
+  let root: RouteNode | null = null;
+  let prev: RouteNode | null = null;
+  for (const level of levels) {
+    const node: RouteNode = { params: level.params ?? {}, data: level.data ?? {}, firstChild: null };
+    if (!root) {
+      root = node;
+    }
+    if (prev) {
+      prev.firstChild = node;
+    }
+    prev = node;
+  }
+  return root ?? { params: {}, data: {}, firstChild: null };
+}
+
+describe('AiContextService', () => {
+  let service: AiContextService;
+  const routerMock: any = { url: '/', events: EMPTY, routerState: { snapshot: { root: routeChain([]) } } };
+  let credentials: any;
+  const translateMock: any = { currentLang: 'en-US', defaultLang: 'en-US' };
+
+  function setRoute(levels: Array<Partial<RouteNode>>, url: string): void {
+    routerMock.routerState.snapshot.root = routeChain(levels);
+    routerMock.url = url;
+  }
+
+  beforeEach(() => {
+    setRoute([], '/');
+    credentials = { username: 'priya', roles: [{ name: 'Loan Officer' }], permissions: ['READ_CLIENT'] };
+    translateMock.currentLang = 'en-US';
+
+    TestBed.configureTestingModule({
+      providers: [
+        AiContextService,
+        { provide: Router, useValue: routerMock },
+        { provide: AuthenticationService, useValue: { getCredentials: () => credentials } },
+        { provide: TranslateService, useValue: translateMock }
+      ]
+    });
+    service = TestBed.inject(AiContextService);
+  });
+
+  it('reads clientId from nested route params on a client detail page', () => {
+    setRoute(
+      [{ params: { clientId: '42' }, data: { clientViewData: { displayName: 'Rajesh Kumar' } } }],
+      '/clients/42/general'
+    );
+    const ctx = service.getContextSnapshot();
+    expect(ctx.clientId).toBe(42);
+    expect(ctx.clientName).toBe('Rajesh Kumar');
+    expect(ctx.screen).toBe('client-detail');
+  });
+
+  it('reads loanId and reports the loan-detail screen', () => {
+    setRoute(
+      [
+        { params: { clientId: '42' } },
+        { params: { loanId: '107' } }
+      ],
+      '/clients/42/loans-accounts/107/general'
+    );
+    const ctx = service.getContextSnapshot();
+    expect(ctx.clientId).toBe(42);
+    expect(ctx.loanId).toBe(107);
+    expect(ctx.screen).toBe('loan-detail');
+  });
+
+  it('detects a client list view with no specific client', () => {
+    setRoute([{ data: { title: 'Clients' } }], '/clients');
+    const ctx = service.getContextSnapshot();
+    expect(ctx.clientId).toBeNull();
+    expect(ctx.clientName).toBeNull();
+    expect(ctx.screen).toBe('client-list');
+    expect(service.hasSpecificClient()).toBe(false);
+  });
+
+  it('reports the dashboard screen at the root url', () => {
+    setRoute([], '/');
+    expect(service.getContextSnapshot().screen).toBe('dashboard');
+  });
+
+  it('treats an invalid clientId as null', () => {
+    setRoute([{ params: { clientId: 'abc' } }], '/clients/abc');
+    expect(service.getContextSnapshot().clientId).toBeNull();
+  });
+
+  it('reads the logged-in user and role from credentials', () => {
+    const ctx = service.getContextSnapshot();
+    expect(ctx.loggedInUser).toBe('priya');
+    expect(ctx.role).toBe('Loan Officer');
+  });
+
+  it('falls back to empty user/role when not authenticated', () => {
+    credentials = null;
+    const ctx = service.getContextSnapshot();
+    expect(ctx.loggedInUser).toBe('');
+    expect(ctx.role).toBe('');
+  });
+
+  it('exposes a lowercase two-letter language code from the active translation', () => {
+    translateMock.currentLang = 'es-MX';
+    expect(service.getContextSnapshot().language).toBe('es');
+    translateMock.currentLang = 'EN-US';
+    expect(service.getContextSnapshot().language).toBe('en');
+  });
+
+  it('hasSpecificClient and getCurrentClientId reflect the focused client', () => {
+    setRoute([{ params: { clientId: '7' } }], '/clients/7/general');
+    expect(service.hasSpecificClient()).toBe(true);
+    expect(service.getCurrentClientId()).toBe(7);
+  });
+});

--- a/src/app/copilot/services/ai-context.service.ts
+++ b/src/app/copilot/services/ai-context.service.ts
@@ -6,36 +6,106 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-/** Angular Imports */
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter, map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { TranslateService } from '@ngx-translate/core';
 
-/** Models */
+import { AuthenticationService } from '../../core/authentication/authentication.service';
 import { CopilotContext } from '../core/models/copilot-context.model';
 
 /**
- * Builds the CopilotContext automatically from three sources:
- *   1. Angular Router + route params  -> clientId, loanId, screen
- *   2. Client-service observables      -> clientName
- *   3. AuthenticationService (JWT)      -> loggedInUser, role, language
- * The user never types any of this.
+ * Derives the Copilot context (focused client/loan, screen, user, language)
+ * from the router state, auth credentials and active translation, so the user
+ * never has to type which record they are on.
  */
 @Injectable({ providedIn: 'root' })
 export class AiContextService {
-  /** Snapshot of the current context for synchronous reads. */
+  private readonly router = inject(Router);
+  private readonly authenticationService = inject(AuthenticationService);
+  private readonly translateService = inject(TranslateService);
+
+  /** Fresh context after every completed navigation. */
+  readonly context$: Observable<CopilotContext> = this.router.events.pipe(
+    filter((event) => event instanceof NavigationEnd),
+    map(() => this.getContextSnapshot())
+  );
+
+  readonly context = toSignal(this.context$, { initialValue: this.getContextSnapshot() });
+
   getContextSnapshot(): CopilotContext {
-    // TODO: assemble from router + client service + JWT.
-    throw new Error('Not implemented');
+    const { params, data, url } = this.collectRouteState();
+    const credentials = this.authenticationService.getCredentials();
+    const clientId = this.toId(params['clientId']);
+    const loanId = this.toId(params['loanId']);
+
+    return {
+      clientId,
+      clientName: data['clientViewData']?.displayName ?? null,
+      loanId,
+      screen: this.deriveScreen(clientId, loanId, url),
+      loggedInUser: credentials?.username ?? '',
+      role: this.currentRole(credentials?.roles),
+      language: this.currentLanguage()
+    };
   }
 
-  /** True only on single-client detail pages (drives disambiguation). */
+  /** Only true on a single-client detail page; drives prompt disambiguation. */
   hasSpecificClient(): boolean {
-    // TODO: clientId !== null.
-    throw new Error('Not implemented');
+    return this.getContextSnapshot().clientId !== null;
   }
 
-  /** Convenience accessor used by chat.service. */
   getCurrentClientId(): number | null {
-    // TODO: read from snapshot.
-    throw new Error('Not implemented');
+    return this.getContextSnapshot().clientId;
+  }
+
+  // Merge params + resolved data from root down to the deepest route, so nested
+  // ids (clientId/loanId) and the resolved clientViewData are all visible.
+  private collectRouteState(): { params: Record<string, unknown>; data: Record<string, any>; url: string } {
+    const params: Record<string, unknown> = {};
+    const data: Record<string, any> = {};
+    let route = this.router.routerState.snapshot.root;
+    while (route) {
+      Object.assign(params, route.params);
+      Object.assign(data, route.data);
+      route = route.firstChild as typeof route;
+    }
+    return { params, data, url: this.router.url };
+  }
+
+  private toId(value: unknown): number | null {
+    const id = Number(value);
+    return Number.isInteger(id) && id > 0 ? id : null;
+  }
+
+  private deriveScreen(clientId: number | null, loanId: number | null, url: string): string {
+    if (loanId !== null) {
+      return 'loan-detail';
+    }
+    if (clientId !== null) {
+      return 'client-detail';
+    }
+    const path = url.split('?')[0];
+    if (path.startsWith('/clients')) {
+      return 'client-list';
+    }
+    if (path === '/' || path.startsWith('/home') || path.startsWith('/dashboard')) {
+      return 'dashboard';
+    }
+    return path.split('/').filter(Boolean)[0] ?? 'dashboard';
+  }
+
+  private currentRole(roles: unknown): string {
+    if (!Array.isArray(roles) || roles.length === 0) {
+      return '';
+    }
+    return (roles[0] as { name?: string })?.name ?? '';
+  }
+
+  private currentLanguage(): string {
+    const lang = this.translateService.currentLang || this.translateService.defaultLang || 'en';
+    return lang.substring(0, 2).toLowerCase();
   }
 }


### PR DESCRIPTION
Implement the context-detection service so the Copilot knows which client, loan and screen the user is on without the user typing ids. Context is derived from three live sources:

- Angular router state tree for clientId, loanId and a logical screen name.
- Resolved route data (clientViewData) for the client display name, reusing data the client view already loads (no extra HTTP call).
- AuthenticationService credentials for the logged-in user and role, and TranslateService for the active language code.

Exposes getContextSnapshot(), a context$ observable plus a context signal, and hasSpecificClient() / getCurrentClientId() helpers for prompt disambiguation on list views. Includes unit tests covering params, client name, screen derivation, role/user, language and invalid input.


[WEB-1008](https://mifosforge.jira.com/browse/WEB-1008)
## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1008]: https://mifosforge.jira.com/browse/WEB-1008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic Copilot context detection based on the current navigation, including the active screen, client/loan identifiers, logged-in user details (with role handling), and language.
  * Exposed the detected context for both reactive updates and immediate access.

* **Tests**
  * Added comprehensive unit tests covering multiple navigation scenarios, identifier parsing/validation, and language/role population behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->