### PR TITLE
WEB-1010: Make Copilot config deploy-configurable via runtime env files

### DIFF
--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -98,6 +98,11 @@
   window['env']['mifosRemittanceApiClientHeader'] = '';
   window['env']['mifosRemittanceApiClientKey'] = '';
 
+  // Mifos Copilot AI assistant
+  // Set enableCopilot to 'true' to load the Copilot panel for this deployment (off by default)
+  window['env']['enableCopilot'] = false;
+  window['env']['copilotMcpBaseUrl'] = 'https://ai.mifos.community';
+
   // Enable Role-Based Access Control (RBAC) for menu/button permissions
   // Set to true to enable RBAC, false (default) for backward compatibility
   window['env']['productionModeEnableRBAC'] = false;

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -113,6 +113,11 @@
   window['env']['mifosRemittanceApiClientHeader'] = '$MIFOS_REMITTANCE_API_CLIENT_HEADER';
   window['env']['mifosRemittanceApiClientKey'] = '$MIFOS_REMITTANCE_API_CLIENT_KEY';
 
+  // Mifos Copilot AI assistant
+  // Set MIFOS_ENABLE_COPILOT=true to load the Copilot panel for this deployment (off by default)
+  window['env']['enableCopilot'] = '$MIFOS_ENABLE_COPILOT';
+  window['env']['copilotMcpBaseUrl'] = '$MIFOS_COPILOT_MCP_BASE_URL';
+
   // Enable Role-Based Access Control (RBAC) for menu/button permissions
   // Set to 'true' to enable RBAC, 'false' (default) for backward compatibility
   window['env']['productionModeEnableRBAC'] = '$MIFOS_PRODUCTION_MODE_ENABLE_RBAC';

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -90,11 +90,10 @@ export const environment = {
 
   /**
    * Mifos Copilot AI assistant: deployment master switch (level 1 feature flag).
-   * Off => the panel never renders and its lazy chunk is never downloaded.
-   * Currently DISABLED. To re-enable (default on), restore:
-   *   loadedEnv['enableCopilot'] !== 'false' && loadedEnv['enableCopilot'] !== false
+   * Off by default; set MIFOS_ENABLE_COPILOT=true to load the panel for a deployment.
+   * When off, the panel never renders and its lazy chunk is never downloaded.
    */
-  enableCopilot: false,
+  enableCopilot: loadedEnv['enableCopilot'] === 'true' || loadedEnv['enableCopilot'] === true || false,
   /** Base URL of the Mifos MCP server the Copilot talks to. */
   copilotMcpBaseUrl: loadedEnv['copilotMcpBaseUrl'] || 'https://ai.mifos.community',
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -92,11 +92,10 @@ export const environment = {
 
   /**
    * Mifos Copilot AI assistant: deployment master switch (level 1 feature flag).
-   * Off => the panel never renders and its lazy chunk is never downloaded.
-   * Currently DISABLED. Set back to the line below to re-enable (default on):
-   *   loadedEnv.enableCopilot !== 'false' && loadedEnv.enableCopilot !== false
+   * Off by default; set MIFOS_ENABLE_COPILOT=true to load the panel for a deployment.
+   * When off, the panel never renders and its lazy chunk is never downloaded.
    */
-  enableCopilot: false,
+  enableCopilot: loadedEnv.enableCopilot === 'true' || loadedEnv.enableCopilot === true || false,
   /** Base URL of the Mifos MCP server the Copilot talks to. */
   copilotMcpBaseUrl: loadedEnv.copilotMcpBaseUrl || 'https://ai.mifos.community',
 


### PR DESCRIPTION
The Copilot flags (enableCopilot, copilotMcpBaseUrl) lived only in environment.ts, so they could not be set at deploy time. The system is deployed with Docker, which reads runtime config from env.template.js (substituted into env.js via envsubst on container start), so the variables must be registered there too.

- env.js: add runtime defaults (enableCopilot = false, copilotMcpBaseUrl = https://ai.mifos.community).
- env.template.js: add $MIFOS_ENABLE_COPILOT and $MIFOS_COPILOT_MCP_BASE_URL placeholders for envsubst.
- environment.ts / environment.prod.ts: enableCopilot now reads from window.env (off by default) instead of being hardcoded.

Operators can set MIFOS_ENABLE_COPILOT=true and MIFOS_COPILOT_MCP_BASE_URL per deployment without rebuilding.

[WEB-1010](https://mifosforge.jira.com/browse/WEB-1010)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1010]: https://mifosforge.jira.com/browse/WEB-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added environment configuration support for Copilot AI assistant feature with configurable toggle and service URL. Both values can be set via environment variables at deployment time, with the feature disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->