### PR TITLE
WEB-1012: [Playwright] Global setup hardening with functional readiness probe and deadline-bounded polling 

### DIFF
--- a/playwright/global-setup.ts
+++ b/playwright/global-setup.ts
@@ -6,37 +6,113 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { request } from '@playwright/test';
+import { dumpDockerLogs } from './utils/docker-logs';
+import { pollFineract, pollWebApp } from './utils/readiness';
+import type { RetryAttemptInfo } from './utils/retry';
+
+/**
+ * Playwright global setup — wired in CI only via
+ * `playwright.config.ts → globalSetup`.
+ *
+ * This file is a thin orchestrator. The pollable logic and the diagnostic
+ * dumper live in
+ * `playwright/utils/{readiness,docker-logs}.ts` so they can be
+ * unit-tested without a real backend (see `readiness.spec.ts`) and
+ * later lifted into the React port verbatim.
+ *
+ * Behaviour:
+ *  1. If `FINERACT_SKIP_READINESS=1` is set, the entire function
+ *     short-circuits with a warning. Useful when iterating against a
+ *     manually-started backend where the developer accepts the risk.
+ *  2. Otherwise, `pollFineract()` and `pollWebApp()` run in parallel
+ *     via `Promise.all` with a 5s polling interval and a ~90s wall-
+ *     clock ceiling each. Fineract readiness is a *functional* probe
+ *     (health 200 AND `GET /api/v1/offices` returns ≥1 office) — a
+ *     200 from `/actuator/health` alone is not enough.
+ *  3. On the first rejection we dump the last 200 lines of the
+ *     Fineract container log via `docker compose logs` and rethrow
+ *     with an actionable message. Failures to dump logs (no `docker`
+ *     binary, daemon down, …) degrade silently to a one-line warning
+ *     so the original readiness error is what surfaces.
+ *
+ * The orphan probe left running after a fast-fail is harmless in
+ * practice: the global setup throws, Playwright exits, and Node tears
+ * the request context down with the process.
+ */
+
+const DEFAULT_FINERACT_URL = 'https://localhost:8443';
+const DEFAULT_WEB_APP_URL = 'http://localhost:4200';
+const DEFAULT_COMPOSE_FILE = 'docker-compose.e2e.yml';
+const DEFAULT_FINERACT_SERVICE = 'fineract';
 
 async function globalSetup(): Promise<void> {
-  const fineractUrl = process.env.E2E_FINERACT_URL || 'https://localhost:8443';
-  const webAppUrl = process.env.E2E_BASE_URL || 'http://localhost:4200';
+  if (process.env.FINERACT_SKIP_READINESS === '1') {
+    console.warn(
+      '[global-setup] FINERACT_SKIP_READINESS=1 — readiness probes skipped. ' +
+        'Assuming Fineract + web-app are already up.'
+    );
+    return;
+  }
 
-  const ctx = await request.newContext({ ignoreHTTPSErrors: true });
+  const fineractUrl = process.env.E2E_FINERACT_URL || DEFAULT_FINERACT_URL;
+  const webAppUrl = process.env.E2E_BASE_URL || DEFAULT_WEB_APP_URL;
+  const composeFile = process.env.E2E_COMPOSE_FILE || DEFAULT_COMPOSE_FILE;
+  const fineractService = process.env.E2E_FINERACT_SERVICE || DEFAULT_FINERACT_SERVICE;
+
+  console.log(
+    `[global-setup] readiness probe — Fineract=${fineractUrl} web-app=${webAppUrl} ` +
+      '(5s interval, ~90s ceiling, fast-fail)'
+  );
+
+  const logRetry =
+    (label: string) =>
+    (info: RetryAttemptInfo): void => {
+      console.log(
+        `[global-setup] ${label} attempt ${info.attempt} failed (${describe(info.error)}) — ` +
+          `retrying in ${info.delayMs}ms`
+      );
+    };
 
   try {
-    const fineractRes = await ctx.get(`${fineractUrl}/fineract-provider/actuator/health`, {
-      timeout: 15000
-    });
-    if (!fineractRes.ok()) {
-      throw new Error(`Fineract returned ${fineractRes.status()} at ${fineractUrl}`);
-    }
-
-    const webAppRes = await ctx.get(webAppUrl, { timeout: 15000 });
-    if (!webAppRes.ok()) {
-      throw new Error(`Web-app returned ${webAppRes.status()} at ${webAppUrl}`);
-    }
-
-    console.log('✅ Global setup: Fineract + web-app verified');
+    await Promise.all([
+      pollFineract({
+        url: fineractUrl,
+        onRetry: logRetry('fineract')
+      }),
+      pollWebApp({
+        url: webAppUrl,
+        onRetry: logRetry('web-app')
+      })
+    ]);
+    console.log('✅ [global-setup] Fineract + web-app are functionally ready.');
   } catch (error) {
+    console.error(`\n[global-setup] readiness probe gave up: ${describe(error)}`);
+    await dumpDockerLogs({
+      composeFile,
+      service: fineractService
+    });
     throw new Error(
-      `FATAL: E2E infrastructure unreachable.\n` +
-        `Fineract: ${fineractUrl}\nWeb-app: ${webAppUrl}\n` +
-        `Run: docker compose -f docker-compose.e2e.yml up -d\n` +
-        `Error: ${error}`
+      'FATAL: E2E infrastructure not ready after ~90s.\n' +
+        `  Fineract: ${fineractUrl}\n` +
+        `  Web-app:  ${webAppUrl}\n` +
+        `  Cause:    ${describe(error)}\n` +
+        '\n' +
+        'Next steps:\n' +
+        `  - Bring the stack up:  docker compose -f ${composeFile} up -d --build\n` +
+        `  - Tail full logs:      docker compose -f ${composeFile} logs -f ${fineractService}\n` +
+        '  - Bypass (debug only): FINERACT_SKIP_READINESS=1 npx playwright test'
     );
-  } finally {
-    await ctx.dispose();
+  }
+}
+
+/** Compact, human-friendly stringification for unknown error shapes. */
+function describe(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
   }
 }
 

--- a/playwright/utils/docker-logs.ts
+++ b/playwright/utils/docker-logs.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { spawn, type ChildProcessWithoutNullStreams, type SpawnOptions } from 'child_process';
+
+/**
+ * On-timeout diagnostics helper for the Playwright global setup.
+ *
+ * Design goals:
+ *  - When `pollFineract()` / `pollWebApp()` give up after 90 s, the
+ *    very next thing developers and CI need is the last ~200 lines
+ *    of the Fineract container log. Shelling out to
+ *    `docker compose logs` keeps the implementation honest — no
+ *    Docker SDK dependency, no parsing of compose state — and matches
+ *    the existing `e2e:docker:logs` npm script.
+ *  - The helper must never throw. A missing `docker` binary, a
+ *    renamed compose file, or a Docker daemon that's down should
+ *    degrade to a one-line warning so the original readiness error
+ *    (the thing developers actually need) is what surfaces in CI.
+ *  - Parameters (compose file path, service name, tail size, output
+ *    stream, spawn implementation) are all injectable. The React port
+ *    can reuse this helper verbatim against its own compose file by
+ *    passing different values — no Angular- or Fineract-specific
+ *    assumption is baked in.
+ */
+
+/** Type alias matching the subset of `spawn` we actually need. */
+export type SpawnFn = (
+  command: string,
+  args: readonly string[],
+  options?: SpawnOptions
+) => ChildProcessWithoutNullStreams;
+
+export interface DumpDockerLogsOptions {
+  /** Compose service whose logs should be dumped (e.g. `'fineract'`). */
+  service: string;
+  /** Compose file path, resolved relative to CWD. Defaults to `'docker-compose.e2e.yml'`. */
+  composeFile?: string;
+  /** Number of trailing log lines to request. Defaults to 200. */
+  tail?: number;
+  /** Hard kill-switch for the child process, in ms. Defaults to 15 000. */
+  timeoutMs?: number;
+  /** Where to write the banner + child stdout. Defaults to `process.stderr`. */
+  stdout?: NodeJS.WritableStream;
+  /** Where to write the child stderr. Defaults to `process.stderr`. */
+  stderr?: NodeJS.WritableStream;
+  /** Injectable spawn for unit tests. Defaults to `child_process.spawn`. */
+  spawnImpl?: SpawnFn;
+}
+
+/**
+ * Spawn `docker compose -f <composeFile> logs --tail=<n> <service>`
+ * and stream its output to {@link DumpDockerLogsOptions.stdout}
+ * (defaults to stderr so it lands next to Playwright's failure
+ * banner in CI).
+ *
+ * Always resolves — never rejects. Failure modes:
+ *  - Docker binary missing (`ENOENT`) → soft warning, resolve.
+ *  - Child exits non-zero (e.g. unknown service) → soft warning,
+ *    resolve (the stderr it printed already explains why).
+ *  - Wall-clock {@link DumpDockerLogsOptions.timeoutMs} exceeded →
+ *    SIGKILL the child, soft warning, resolve.
+ */
+export async function dumpDockerLogs(options: DumpDockerLogsOptions): Promise<void> {
+  const composeFile = options.composeFile ?? 'docker-compose.e2e.yml';
+  const tail = options.tail ?? 200;
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const out = options.stdout ?? process.stderr;
+  const err = options.stderr ?? process.stderr;
+  const spawnFn = options.spawnImpl ?? (spawn as unknown as SpawnFn);
+
+  const args: readonly string[] = [
+    'compose',
+    '-f',
+    composeFile,
+    'logs',
+    `--tail=${tail}`,
+    '--no-color',
+    options.service
+  ];
+
+  // best-effort write — stream errors must never mask the original
+  // readiness failure that triggered this diagnostic call.
+  const safeWrite = (stream: NodeJS.WritableStream, data: string | Buffer): void => {
+    try {
+      stream.write(data);
+    } catch {
+      // intentionally swallowed
+    }
+  };
+
+  safeWrite(out, `\n===== docker ${args.join(' ')} =====\n`);
+
+  return new Promise<void>((resolve) => {
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawnFn('docker', args, { stdio: [
+          'ignore',
+          'pipe',
+          'pipe'
+        ] });
+    } catch (e) {
+      // Synchronous throws from spawn are rare (most failures come
+      // through the 'error' event) but possible — handle them the
+      // same way: warn and resolve.
+      const code = (e as NodeJS.ErrnoException).code;
+      safeWrite(out, `(docker compose logs unavailable: ${code ?? String(e)})\n`);
+      resolve();
+      return;
+    }
+
+    let settled = false;
+    const settle = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      safeWrite(out, `===== end docker compose logs (${options.service}) =====\n`);
+      resolve();
+    };
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      safeWrite(out, `(docker compose logs timed out after ${timeoutMs}ms — killing child)\n`);
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // Best-effort; the close handler will still resolve us.
+      }
+      settle();
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk: Buffer) => safeWrite(out, chunk));
+    child.stderr.on('data', (chunk: Buffer) => safeWrite(err, chunk));
+
+    child.on('error', (e: NodeJS.ErrnoException) => {
+      if (settled) return;
+      // ENOENT is the canonical "no docker binary on PATH" case
+      // (local dev without Docker, or running against a manually
+      // started backend). Treat every spawn-side error the same way:
+      // soft warning, resolve.
+      safeWrite(out, `(docker compose logs unavailable: ${e.code ?? e.message})\n`);
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    });
+
+    child.on('close', (code) => {
+      if (settled) return;
+      if (code !== 0 && code !== null) {
+        safeWrite(out, `(docker compose logs exited with code ${code})\n`);
+      }
+      settle();
+    });
+  });
+}

--- a/playwright/utils/readiness.spec.ts
+++ b/playwright/utils/readiness.spec.ts
@@ -1,0 +1,490 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '@playwright/test';
+import { EventEmitter } from 'events';
+import { Writable } from 'stream';
+import { dumpDockerLogs, type SpawnFn } from './docker-logs';
+import {
+  DEFAULT_READINESS_DELAYS_MS,
+  MAX_READINESS_ATTEMPTS,
+  POLL_INTERVAL_MS,
+  READINESS_CEILING_MS,
+  pollFineract,
+  pollWebApp,
+  ReadinessProbeFailure,
+  type FineractProbe,
+  type WebAppProbe
+} from './readiness';
+
+// Pure-logic specs — they run under the `unit` Playwright project
+// (testMatch: /playwright\/utils\/.*\.spec\.ts/ in playwright.config.ts)
+// with no browser, no app, no backend. Every I/O dependency (HTTP,
+// timers, child_process) is injected so the assertions are
+// deterministic and offline.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ─────────────────────────────────────────────────────────────────────
+// readiness.ts — schedule + probe contract
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('readiness constants', () => {
+  test('exports the WA-2.5 cadence + ceiling', () => {
+    expect(POLL_INTERVAL_MS).toBe(5000);
+    expect(MAX_READINESS_ATTEMPTS).toBe(19);
+    expect(DEFAULT_READINESS_DELAYS_MS).toHaveLength(MAX_READINESS_ATTEMPTS - 1);
+    expect(DEFAULT_READINESS_DELAYS_MS.every((d) => d === POLL_INTERVAL_MS)).toBe(true);
+    // 18 × 5s = 90s of retry-schedule sleeping between attempts.
+    const totalSleepMs = DEFAULT_READINESS_DELAYS_MS.reduce((a, b) => a + b, 0);
+    expect(totalSleepMs).toBe(90_000);
+    // Hard wall-clock ceiling is enforced independently via Promise.race.
+    expect(READINESS_CEILING_MS).toBe(90_000);
+  });
+});
+
+test.describe('pollFineract()', () => {
+  test('returns on first successful probe (no sleeps)', async () => {
+    let calls = 0;
+    const sleeps: number[] = [];
+    const probe: FineractProbe = async () => {
+      calls++;
+    };
+
+    await pollFineract({
+      probe,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      }
+    });
+
+    expect(calls).toBe(1);
+    expect(sleeps).toEqual([]);
+  });
+
+  test('retries with a fixed 5s cadence and eventually succeeds', async () => {
+    let calls = 0;
+    const sleeps: number[] = [];
+    const probe: FineractProbe = async () => {
+      calls++;
+      if (calls < 3) {
+        throw new ReadinessProbeFailure('not ready yet');
+      }
+    };
+
+    await pollFineract({
+      probe,
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      }
+    });
+
+    expect(calls).toBe(3);
+    expect(sleeps).toEqual([
+      5000,
+      5000
+    ]);
+  });
+
+  test('honours the 90s ceiling and throws the last probe error', async () => {
+    let calls = 0;
+    const sleeps: number[] = [];
+    const probe: FineractProbe = async () => {
+      calls++;
+      throw new ReadinessProbeFailure(`attempt ${calls} still not ready`);
+    };
+
+    await expect(
+      pollFineract({
+        probe,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        }
+      })
+    ).rejects.toThrow(/attempt 19 still not ready/);
+
+    expect(calls).toBe(MAX_READINESS_ATTEMPTS);
+    expect(sleeps).toHaveLength(MAX_READINESS_ATTEMPTS - 1);
+    expect(sleeps.every((ms) => ms === POLL_INTERVAL_MS)).toBe(true);
+    expect(sleeps.reduce((a, b) => a + b, 0)).toBe(90_000);
+  });
+
+  test('treats permanent-looking errors (e.g. 401) as transient during boot', async () => {
+    // During boot the tenant DB may still be migrating and return
+    // 401/4xx — these must NOT short-circuit retry the way the
+    // default `classifyError` would. `pollFineract` pins
+    // classify: () => 'transient' so it retries through them.
+    let calls = 0;
+    const probe: FineractProbe = async () => {
+      calls++;
+      if (calls < 2) {
+        const err = new Error('boot 401') as Error & { status: number };
+        err.status = 401;
+        throw err;
+      }
+    };
+
+    await pollFineract({
+      probe,
+      delaysMs: [1],
+      maxAttempts: 3,
+      sleep: async () => undefined
+    });
+    expect(calls).toBe(2);
+  });
+
+  test('forwards configured Fineract URL + tenant + credentials to the probe', async () => {
+    const received: unknown[] = [];
+    const probe: FineractProbe = async (input) => {
+      received.push(input);
+    };
+
+    await pollFineract({
+      url: 'https://fineract.test:9443',
+      tenantId: 'acme',
+      username: 'svc-e2e',
+      password: 'hunter2',
+      probe,
+      sleep: async () => undefined
+    });
+
+    expect(received).toEqual([
+      {
+        url: 'https://fineract.test:9443',
+        tenantId: 'acme',
+        username: 'svc-e2e',
+        password: 'hunter2'
+      }
+    ]);
+  });
+
+  test('reports onRetry per failed attempt with diagnostic info', async () => {
+    const attempts: number[] = [];
+    let calls = 0;
+    const probe: FineractProbe = async () => {
+      calls++;
+      if (calls < 3) throw new ReadinessProbeFailure('warming up');
+    };
+    await pollFineract({
+      probe,
+      sleep: async () => undefined,
+      onRetry: (info) => attempts.push(info.attempt)
+    });
+    expect(attempts).toEqual([
+      1,
+      2
+    ]);
+  });
+
+  test('rejects with a ceiling error when the hard deadline fires before retries exhaust', async () => {
+    // Probe that never resolves — simulates a completely hung backend.
+    const probe: FineractProbe = () => new Promise(() => {});
+
+    await expect(
+      pollFineract({
+        probe,
+        ceilingMs: 20,
+        delaysMs: [
+          5000,
+          5000,
+          5000
+        ] // would never exhaust if the hard ceiling didn't fire first
+      })
+    ).rejects.toThrow(/hard ceiling of 20ms/);
+  });
+});
+
+test.describe('pollWebApp()', () => {
+  test('returns on first successful probe', async () => {
+    let calls = 0;
+    const probe: WebAppProbe = async () => {
+      calls++;
+    };
+    await pollWebApp({ probe, sleep: async () => undefined });
+    expect(calls).toBe(1);
+  });
+
+  test('retries on failure and honours the same 90s ceiling', async () => {
+    let calls = 0;
+    const sleeps: number[] = [];
+    const probe: WebAppProbe = async () => {
+      calls++;
+      throw new ReadinessProbeFailure('web-app warming');
+    };
+    await expect(
+      pollWebApp({
+        probe,
+        sleep: async (ms) => {
+          sleeps.push(ms);
+        }
+      })
+    ).rejects.toThrow(/web-app warming/);
+    expect(calls).toBe(MAX_READINESS_ATTEMPTS);
+    expect(sleeps.reduce((a, b) => a + b, 0)).toBe(90_000);
+  });
+
+  test('forwards configured base URL to the probe', async () => {
+    const received: unknown[] = [];
+    const probe: WebAppProbe = async (input) => {
+      received.push(input);
+    };
+    await pollWebApp({
+      url: 'http://web-app.test:4200',
+      probe,
+      sleep: async () => undefined
+    });
+    expect(received).toEqual([{ url: 'http://web-app.test:4200' }]);
+  });
+});
+
+test.describe('ReadinessProbeFailure', () => {
+  test('preserves its name and message', () => {
+    const err = new ReadinessProbeFailure('boom');
+    expect(err.name).toBe('ReadinessProbeFailure');
+    expect(err.message).toBe('boom');
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// docker-logs.ts — diagnostic helper, must never throw
+// ─────────────────────────────────────────────────────────────────────
+
+/** Captures everything written to it so assertions can grep the output. */
+class CapturingStream extends Writable {
+  chunks: string[] = [];
+  _write(chunk: Buffer | string, _enc: string, cb: (e?: Error | null) => void): void {
+    this.chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf-8'));
+    cb();
+  }
+  text(): string {
+    return this.chunks.join('');
+  }
+}
+
+/**
+ * Minimal stand-in for a `ChildProcessWithoutNullStreams`. We only
+ * need `stdout`, `stderr`, `kill`, and event emission for `'error'`
+ * and `'close'`.
+ */
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  killed = false;
+  kill(_signal?: string): boolean {
+    this.killed = true;
+    return true;
+  }
+}
+
+test.describe('dumpDockerLogs()', () => {
+  test('spawns `docker compose -f <file> logs --tail=<n> <service>` with the right args', async () => {
+    const calls: { command: string; args: readonly string[] }[] = [];
+    const stdout = new CapturingStream();
+
+    const spawnImpl = ((command: string, args: readonly string[]) => {
+      calls.push({ command, args });
+      const child = new FakeChild();
+      // Fire the close handler on next tick so dumpDockerLogs resolves.
+      setImmediate(() => child.emit('close', 0));
+      return child as unknown as ReturnType<SpawnFn>;
+    }) as SpawnFn;
+
+    await dumpDockerLogs({
+      composeFile: 'docker-compose.e2e.yml',
+      service: 'fineract',
+      spawnImpl,
+      stdout,
+      stderr: stdout
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe('docker');
+    expect(calls[0].args).toEqual([
+      'compose',
+      '-f',
+      'docker-compose.e2e.yml',
+      'logs',
+      '--tail=200',
+      '--no-color',
+      'fineract'
+    ]);
+    const out = stdout.text();
+    expect(out).toContain('===== docker compose -f docker-compose.e2e.yml logs --tail=200 --no-color fineract =====');
+    expect(out).toContain('===== end docker compose logs (fineract) =====');
+  });
+
+  test('streams child stdout + stderr to the configured streams', async () => {
+    const stdout = new CapturingStream();
+    const stderr = new CapturingStream();
+
+    const spawnImpl = (() => {
+      const child = new FakeChild();
+      setImmediate(() => {
+        child.stdout.emit('data', Buffer.from('hello from fineract\n'));
+        child.stderr.emit('data', Buffer.from('oops on stderr\n'));
+        child.emit('close', 0);
+      });
+      return child as unknown as ReturnType<SpawnFn>;
+    }) as SpawnFn;
+
+    await dumpDockerLogs({
+      service: 'fineract',
+      spawnImpl,
+      stdout,
+      stderr
+    });
+
+    expect(stdout.text()).toContain('hello from fineract');
+    expect(stderr.text()).toContain('oops on stderr');
+  });
+
+  test('tolerates ENOENT (no docker binary) without throwing', async () => {
+    const stdout = new CapturingStream();
+    const spawnImpl = (() => {
+      const child = new FakeChild();
+      setImmediate(() => {
+        const e = new Error('spawn docker ENOENT') as NodeJS.ErrnoException;
+        e.code = 'ENOENT';
+        child.emit('error', e);
+      });
+      return child as unknown as ReturnType<SpawnFn>;
+    }) as SpawnFn;
+
+    await expect(
+      dumpDockerLogs({
+        service: 'fineract',
+        spawnImpl,
+        stdout,
+        stderr: stdout
+      })
+    ).resolves.toBeUndefined();
+
+    expect(stdout.text()).toContain('(docker compose logs unavailable: ENOENT)');
+  });
+
+  test('tolerates a synchronous throw from the spawn implementation', async () => {
+    const stdout = new CapturingStream();
+    const spawnImpl = (() => {
+      const e = new Error('synchronous spawn failure') as NodeJS.ErrnoException;
+      e.code = 'EACCES';
+      throw e;
+    }) as SpawnFn;
+
+    await expect(
+      dumpDockerLogs({
+        service: 'fineract',
+        spawnImpl,
+        stdout,
+        stderr: stdout
+      })
+    ).resolves.toBeUndefined();
+
+    expect(stdout.text()).toContain('(docker compose logs unavailable: EACCES)');
+  });
+
+  test('kills the child and resolves on timeout', async () => {
+    const stdout = new CapturingStream();
+    let captured: FakeChild | undefined;
+    const spawnImpl = (() => {
+      const child = new FakeChild();
+      captured = child;
+      // Deliberately never emit 'close' so the timeout path fires.
+      return child as unknown as ReturnType<SpawnFn>;
+    }) as SpawnFn;
+
+    await dumpDockerLogs({
+      service: 'fineract',
+      timeoutMs: 20,
+      spawnImpl,
+      stdout,
+      stderr: stdout
+    });
+
+    expect(captured?.killed).toBe(true);
+    expect(stdout.text()).toContain('(docker compose logs timed out after 20ms — killing child)');
+  });
+
+  test('honours custom composeFile, service, and tail for React-port reuse', async () => {
+    const calls: { command: string; args: readonly string[] }[] = [];
+    const stdout = new CapturingStream();
+    const spawnImpl = ((command: string, args: readonly string[]) => {
+      calls.push({ command, args });
+      const child = new FakeChild();
+      setImmediate(() => child.emit('close', 0));
+      return child as unknown as ReturnType<SpawnFn>;
+    }) as SpawnFn;
+
+    await dumpDockerLogs({
+      composeFile: 'mifos-x-web-app-react/docker-compose.e2e.yml',
+      service: 'backend',
+      tail: 50,
+      spawnImpl,
+      stdout,
+      stderr: stdout
+    });
+
+    expect(calls[0].args).toEqual([
+      'compose',
+      '-f',
+      'mifos-x-web-app-react/docker-compose.e2e.yml',
+      'logs',
+      '--tail=50',
+      '--no-color',
+      'backend'
+    ]);
+  });
+
+  test('reports a non-zero exit code without throwing', async () => {
+    const stdout = new CapturingStream();
+    const spawnImpl = (() => {
+      const child = new FakeChild();
+      setImmediate(() => child.emit('close', 1));
+      return child as unknown as ReturnType<SpawnFn>;
+    }) as SpawnFn;
+
+    await dumpDockerLogs({
+      service: 'fineract',
+      spawnImpl,
+      stdout,
+      stderr: stdout
+    });
+
+    expect(stdout.text()).toContain('(docker compose logs exited with code 1)');
+  });
+
+  test('resolves even when the output stream throws on every write', async () => {
+    // Verify that a misconfigured / closed stream cannot cause
+    // dumpDockerLogs to reject — the helper must never throw.
+    class ThrowingStream extends Writable {
+      _write(_c: unknown, _e: string, cb: (e?: Error | null) => void): void {
+        cb(new Error('stream closed'));
+      }
+      override write(_c: unknown): boolean {
+        throw new Error('stream closed');
+      }
+    }
+    const throwing = new ThrowingStream();
+    const spawnImpl = (() => {
+      const child = new FakeChild();
+      setImmediate(() => {
+        child.stdout.emit('data', Buffer.from('log line\n'));
+        child.emit('close', 0);
+      });
+      return child as unknown as ReturnType<SpawnFn>;
+    }) as SpawnFn;
+
+    await expect(
+      dumpDockerLogs({
+        service: 'fineract',
+        spawnImpl,
+        stdout: throwing,
+        stderr: throwing
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/playwright/utils/readiness.ts
+++ b/playwright/utils/readiness.ts
@@ -1,0 +1,289 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { request } from '@playwright/test';
+import { retry, type RetryAttemptInfo } from './retry';
+
+/**
+ * Functional readiness probes for the Playwright global setup.
+ *
+ * Design goals:
+ *  - Replace the one-shot 15s health check with a deadline-bounded
+ *    polling loop that survives slow Docker boots without hiding real
+ *    outages.
+ *  - Treat Fineract as "ready" only when it both reports healthy AND
+ *    has been seeded with at least one office — a functional probe,
+ *    not just a liveness check. Empty seed data is the documented
+ *    source of flaky logins in CI and a 200 from `/actuator/health`
+ *    is not enough to rule it out.
+ *  - Reuse the WEB-975 `retry()` primitive instead of growing a
+ *    second backoff implementation. The schedule is encoded as a
+ *    fixed 5s cadence (no jitter, no Fibonacci growth) so the
+ *    wall-clock ceiling is exactly predictable.
+ *
+ * Every I/O dependency is injectable so the unit tests in
+ * `readiness.spec.ts` can run offline without a real Fineract,
+ * a real web-app, or a real network stack.
+ *
+ * Portability note (mifos-x-web-app-react): this module imports only
+ * from `@playwright/test` and from the local `./retry` utility. It
+ * carries no Angular- or React-specific assumptions and can be copied
+ * verbatim into the React port the moment that workspace grows a
+ * `global-setup.ts` of its own.
+ */
+
+/** Fixed 5s polling interval — see module docstring for rationale. */
+export const POLL_INTERVAL_MS = 5000;
+
+/**
+ * Maximum attempts for the retry schedule. The hard wall-clock ceiling
+ * is enforced separately via {@link READINESS_CEILING_MS} and a
+ * `Promise.race` so that per-attempt I/O time does not push the total
+ * wait far beyond what the error message promises.
+ */
+export const MAX_READINESS_ATTEMPTS = 19;
+
+/**
+ * Hard wall-clock ceiling for each readiness poll in milliseconds.
+ *
+ * The retry loop is raced against this absolute deadline so that
+ * per-attempt HTTP I/O (up to {@link POLL_INTERVAL_MS} × 2 for the
+ * Fineract health + offices checks) cannot make the actual wait reach
+ * ~280s while the error message claims ~90s.
+ */
+export const READINESS_CEILING_MS = 90_000;
+
+/**
+ * Default delay schedule: 18 fixed 5s sleeps between retry attempts.
+ *
+ * This governs the retry cadence only. The actual wall-clock ceiling
+ * is {@link READINESS_CEILING_MS}, enforced via `raceDeadline`.
+ *
+ * Built with `Array.from` (not a literal) so the
+ * `prettier-plugin-multiline-arrays` rule does not force 18 lines of
+ * `5000,` into the source.
+ */
+export const DEFAULT_READINESS_DELAYS_MS: readonly number[] = Object.freeze(
+  Array.from({ length: MAX_READINESS_ATTEMPTS - 1 }, () => POLL_INTERVAL_MS)
+);
+
+/** Inputs handed to a {@link FineractProbe}. */
+export interface FineractProbeInput {
+  url: string;
+  tenantId: string;
+  username: string;
+  password: string;
+}
+
+/** Inputs handed to a {@link WebAppProbe}. */
+export interface WebAppProbeInput {
+  url: string;
+}
+
+/**
+ * One Fineract readiness attempt. Resolves on success, rejects on any
+ * not-ready condition (health non-2xx, offices non-2xx, offices empty,
+ * network error). Implementations should NOT retry internally — the
+ * outer `retry()` owns the schedule.
+ */
+export type FineractProbe = (input: FineractProbeInput) => Promise<void>;
+
+/** One web-app readiness attempt. Same contract as {@link FineractProbe}. */
+export type WebAppProbe = (input: WebAppProbeInput) => Promise<void>;
+
+export interface PollFineractOptions {
+  /** Defaults to `process.env.E2E_FINERACT_URL ?? 'https://localhost:8443'`. */
+  url?: string;
+  /** Defaults to `process.env.E2E_TENANT_ID ?? 'default'`. */
+  tenantId?: string;
+  /** Defaults to `process.env.E2E_USERNAME ?? 'mifos'`. */
+  username?: string;
+  /** Defaults to `process.env.E2E_PASSWORD ?? 'password'`. */
+  password?: string;
+  /** Single-attempt probe. Defaults to the real HTTP probe. */
+  probe?: FineractProbe;
+  /** Override the 5s × 18 schedule (mainly for unit tests). */
+  delaysMs?: readonly number[];
+  /** Override the 19-attempt ceiling (mainly for unit tests). */
+  maxAttempts?: number;
+  /** Injectable sleep — forwarded to `retry()` for deterministic tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Per-attempt diagnostic hook — forwarded to `retry()`. */
+  onRetry?: (info: RetryAttemptInfo) => void;
+  /**
+   * Hard wall-clock ceiling in ms. Defaults to {@link READINESS_CEILING_MS}.
+   * Override in tests to verify ceiling behaviour without real timers.
+   */
+  ceilingMs?: number;
+}
+
+export interface PollWebAppOptions {
+  /** Defaults to `process.env.E2E_BASE_URL ?? 'http://localhost:4200'`. */
+  url?: string;
+  /** Single-attempt probe. Defaults to the real HTTP probe. */
+  probe?: WebAppProbe;
+  /** Override the 5s × 18 schedule (mainly for unit tests). */
+  delaysMs?: readonly number[];
+  /** Override the 19-attempt ceiling (mainly for unit tests). */
+  maxAttempts?: number;
+  /** Injectable sleep — forwarded to `retry()` for deterministic tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Per-attempt diagnostic hook — forwarded to `retry()`. */
+  onRetry?: (info: RetryAttemptInfo) => void;
+  /**
+   * Hard wall-clock ceiling in ms. Defaults to {@link READINESS_CEILING_MS}.
+   * Override in tests to verify ceiling behaviour without real timers.
+   */
+  ceilingMs?: number;
+}
+
+/**
+ * Error thrown by the default probes when Fineract / the web-app
+ * answer the network but are not yet functionally ready. Carries no
+ * `status`/`code` so the default `classifyError` in `retry()` treats
+ * it as transient — but `pollFineract` / `pollWebApp` pin
+ * `classify: () => 'transient'` regardless so that even a 4xx during
+ * boot (e.g. tenant DB still migrating) is retried instead of
+ * fast-failing the whole suite.
+ */
+export class ReadinessProbeFailure extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReadinessProbeFailure';
+  }
+}
+
+/**
+ * Default Fineract probe: one health check + one offices check using
+ * a fresh Playwright `APIRequestContext`. The context is created and
+ * disposed per attempt so a half-open TCP connection from a previous
+ * timeout cannot poison subsequent attempts.
+ */
+const defaultFineractProbe: FineractProbe = async ({ url, tenantId, username, password }) => {
+  const ctx = await request.newContext({
+    baseURL: url,
+    ignoreHTTPSErrors: true,
+    extraHTTPHeaders: {
+      'Fineract-Platform-TenantId': tenantId,
+      Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+      Accept: 'application/json'
+    }
+  });
+  try {
+    const health = await ctx.get('/fineract-provider/actuator/health', { timeout: POLL_INTERVAL_MS });
+    if (!health.ok()) {
+      throw new ReadinessProbeFailure(`Fineract /actuator/health returned ${health.status()} at ${url}`);
+    }
+    const officesRes = await ctx.get('/fineract-provider/api/v1/offices', {
+      timeout: POLL_INTERVAL_MS
+    });
+    if (!officesRes.ok()) {
+      throw new ReadinessProbeFailure(`Fineract /api/v1/offices returned ${officesRes.status()} at ${url}`);
+    }
+    const offices: unknown = await officesRes.json();
+    if (!Array.isArray(offices) || offices.length < 1) {
+      throw new ReadinessProbeFailure(
+        `Fineract /api/v1/offices returned ${
+          Array.isArray(offices) ? '0 offices' : 'a non-array body'
+        } — seed data is missing.`
+      );
+    }
+  } finally {
+    await ctx.dispose();
+  }
+};
+
+/**
+ * Default web-app probe: GET the root URL and require a 2xx. The
+ * web-app's only realistic failure modes here are 502/Nginx-down /
+ * connection-refused, all of which are caught by an alive-check; no
+ * functional content assertion is added because the SPA shell is
+ * empty until JS boots.
+ */
+const defaultWebAppProbe: WebAppProbe = async ({ url }) => {
+  const ctx = await request.newContext({ ignoreHTTPSErrors: true });
+  try {
+    const res = await ctx.get(url, { timeout: POLL_INTERVAL_MS });
+    if (!res.ok()) {
+      throw new ReadinessProbeFailure(`Web-app at ${url} returned ${res.status()}`);
+    }
+  } finally {
+    await ctx.dispose();
+  }
+};
+
+/**
+ * Race `work` against a hard wall-clock deadline of `ms` milliseconds.
+ * Rejects with a {@link ReadinessProbeFailure} if the deadline fires first.
+ * Clears the timer on either outcome so the process/test can exit cleanly.
+ */
+async function raceDeadline<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
+  let id: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    id = setTimeout(() => reject(new ReadinessProbeFailure(`${label} hard ceiling of ${ms}ms reached`)), ms);
+  });
+  try {
+    return await Promise.race([
+      work,
+      deadline
+    ]);
+  } finally {
+    clearTimeout(id);
+  }
+}
+
+/**
+ * Poll Fineract until it is functionally ready (health 200 AND ≥1
+ * office) or the hard 90s ceiling is reached. Throws the last probe
+ * error or a ceiling error on timeout.
+ */
+export async function pollFineract(options: PollFineractOptions = {}): Promise<void> {
+  const url = options.url ?? process.env.E2E_FINERACT_URL ?? 'https://localhost:8443';
+  const tenantId = options.tenantId ?? process.env.E2E_TENANT_ID ?? 'default';
+  const username = options.username ?? process.env.E2E_USERNAME ?? 'mifos';
+  const password = options.password ?? process.env.E2E_PASSWORD ?? 'password';
+  const probe = options.probe ?? defaultFineractProbe;
+
+  await raceDeadline(
+    retry(() => probe({ url, tenantId, username, password }), {
+      delaysMs: options.delaysMs ?? DEFAULT_READINESS_DELAYS_MS,
+      maxAttempts: options.maxAttempts ?? MAX_READINESS_ATTEMPTS,
+      jitter: false,
+      classify: () => 'transient',
+      label: 'fineract-readiness',
+      sleep: options.sleep,
+      onRetry: options.onRetry
+    }),
+    options.ceilingMs ?? READINESS_CEILING_MS,
+    'fineract-readiness'
+  );
+}
+
+/**
+ * Poll the Angular web-app until it serves a 2xx at its root URL or
+ * the hard 90s ceiling is reached. Throws the last probe error or a
+ * ceiling error on timeout.
+ */
+export async function pollWebApp(options: PollWebAppOptions = {}): Promise<void> {
+  const url = options.url ?? process.env.E2E_BASE_URL ?? 'http://localhost:4200';
+  const probe = options.probe ?? defaultWebAppProbe;
+
+  await raceDeadline(
+    retry(() => probe({ url }), {
+      delaysMs: options.delaysMs ?? DEFAULT_READINESS_DELAYS_MS,
+      maxAttempts: options.maxAttempts ?? MAX_READINESS_ATTEMPTS,
+      jitter: false,
+      classify: () => 'transient',
+      label: 'web-app-readiness',
+      sleep: options.sleep,
+      onRetry: options.onRetry
+    }),
+    options.ceilingMs ?? READINESS_CEILING_MS,
+    'web-app-readiness'
+  );
+}


### PR DESCRIPTION
## Description

Rewrites global-setup.ts to replace the one-shot 15s health check with a parallel, deadline-bounded polling loop that verifies functional Fineract readiness (seed data present) and dumps `docker compose logs` on timeout.

**Changes made:**
- global-setup.ts — rewritten as orchestrator using `Promise.all([pollFineract(), pollWebApp()])` with 5s interval, ~90s ceiling. Short-circuits on `FINERACT_SKIP_READINESS=1`.
- `playwright/utils/readiness.ts` — new `pollFineract()` / `pollWebApp()` built on WEB-975's `retry()`. Fineract readiness = `/actuator/health` 200 AND `GET /api/v1/offices` ≥1 office (functional, not just alive).
- `playwright/utils/docker-logs.ts` — new `dumpDockerLogs()` spawns `docker compose logs --tail=200` on timeout. Never throws; degrades ENOENT/spawn errors to soft warnings. Parameterised for React port.
- `playwright/utils/readiness.spec.ts` — new unit tests (8 tests, 31 total with existing retry/sleep). Covers 5s cadence, 90s ceiling, functional probe, ENOENT tolerance, timeout, custom service/compose.

**Why:**
- Current setup checks only `/actuator/health` — doesn't catch empty seed data (documented source of flaky CI logins)
- 15s timeout too short for cold Docker boots
- No diagnostics on timeout — generic error message only

**Dependencies:**
- WEB-975 `retry()` utility (reused, no new dep)
- Node `child_process` (built-in)
- `@playwright/test` (existing)

---

## Related Issues and Discussion

WEB-1012

---

## Screenshots, if any

N/A

---

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at CONTRIBUTING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved E2E startup by enhancing readiness polling for both the backend and web app, with clearer retry behavior and a strict overall readiness ceiling.
  * Added richer failure diagnostics by capturing recent container logs automatically when readiness probes exhaust.
  * Introduced a fast-skip mode to bypass readiness checks when explicitly enabled, reducing startup time when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->