### PR TITLE
WEB-1013 Add ApiSetupManager, test-data type interfaces, and E2E nami…

### DIFF
--- a/playwright/types/test-data.types.ts
+++ b/playwright/types/test-data.types.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Portable test-data type surface for Playwright E2E factories.
+ *
+ * Design goals (per GSoC 2026 proposal WA-2.8):
+ *  - Capture the minimum shape every test factory and page object
+ *    needs from a freshly-created Fineract entity — `resourceId` to
+ *    address it in subsequent API calls, `displayName` to assert it
+ *    appears in the UI, and the narrow status/timeline projection
+ *    actually inspected by E2E specs.
+ *  - Stay deliberately narrower than the full Fineract REST payload.
+ *    The platform response carries dozens of fields tests never read;
+ *    typing them here would tie this file to a Fineract version and
+ *    defeat the portability goal.
+ *  - Zero imports. The file is intentionally dependency-free so the
+ *    React port (`mifos-x-web-app-react`) can copy it verbatim — same
+ *    shapes everywhere means factory output is interchangeable across
+ *    the Angular and React Playwright suites.
+ *
+ * Field-naming convention follows the Fineract create-* response
+ * envelope (`resourceId`, `officeId`, ...). The optional `timeline`
+ * sub-shapes match the Fineract `ClientTimeline` / `LoanTimeline`
+ * projections, with every field optional because not every test path
+ * activates / approves / disburses the entity.
+ *
+ * Note: `getLoanTemplate()` and other domain-specific helpers on
+ * `ApiSetupManager` land in PR-3 alongside the factory functions
+ * that consume them. The `TestLoan` shape is included here because
+ * the naming utility in this PR already needs a place for loan
+ * factories in PR-3 to project into without churn.
+ */
+
+/** Identifier projection shared by every freshly-created Fineract entity. */
+export interface TestEntityIdentity {
+  /** Numeric primary key returned by the create-* endpoint. */
+  resourceId: number;
+  /** Human-readable label shown in the UI. */
+  displayName: string;
+}
+
+/** Two-field status projection used in UI assertions. */
+export interface TestStatus {
+  id: number;
+  code: string;
+  value: string;
+}
+
+/** Narrow client-timeline projection — every field optional. */
+export interface TestClientTimeline {
+  submittedOnDate?: readonly number[];
+  activatedOnDate?: readonly number[];
+  closedOnDate?: readonly number[];
+}
+
+/** Narrow loan-timeline projection — every field optional. */
+export interface TestLoanTimeline {
+  submittedOnDate?: readonly number[];
+  approvedOnDate?: readonly number[];
+  disbursedOnDate?: readonly number[];
+  closedOnDate?: readonly number[];
+}
+
+/** Created Fineract client as seen by E2E specs. */
+export interface TestClient extends TestEntityIdentity {
+  officeId: number;
+  status?: TestStatus;
+  timeline?: TestClientTimeline;
+}
+
+/** Created Fineract group as seen by E2E specs. */
+export interface TestGroup extends TestEntityIdentity {
+  officeId: number;
+  status?: TestStatus;
+  /** Member client `resourceId`s, if the group was created with members. */
+  members?: readonly number[];
+}
+
+/** Created Fineract user as seen by E2E specs. */
+export interface TestUser {
+  resourceId: number;
+  username: string;
+  /** Optional — not every test path exercises an email-bearing user. */
+  email?: string;
+  /** Role names assigned at creation time. */
+  roles?: readonly string[];
+  officeId: number;
+}
+
+/** Created Fineract loan as seen by E2E specs. */
+export interface TestLoan extends TestEntityIdentity {
+  clientId: number;
+  loanProductId: number;
+  /** Principal in the loan's minor currency unit. */
+  principal: number;
+  status?: TestStatus;
+  timeline?: TestLoanTimeline;
+}

--- a/playwright/utils/api-setup-manager.spec.ts
+++ b/playwright/utils/api-setup-manager.spec.ts
@@ -1,0 +1,370 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '@playwright/test';
+import type { FineractApiClient } from '../fixtures/fineract-api';
+import { ApiSetupManager, ApiSetupManagerError } from './api-setup-manager';
+
+// Pure-logic specs — they run under the `unit` Playwright project
+// (testMatch: /playwright\/utils\/.*\.spec\.ts/ in playwright.config.ts)
+// with no browser, no app, no backend. The `FineractApiClient` is a
+// stand-in: `ApiSetupManager` never calls any of its methods today,
+// it only holds the reference for PR-3 factory wiring.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+/**
+ * Build a fresh manager with an isolated cache so each `test()` is
+ * independent of every other (the production cache is module-level
+ * and would leak state across cases).
+ */
+function freshManager(): ApiSetupManager {
+  const stubClient = {} as unknown as FineractApiClient;
+  return new ApiSetupManager(stubClient, { cache: new Map() });
+}
+
+/**
+ * Deferred promise helper — lets a test control exactly when an
+ * in-flight `dedupe()` call settles. Mirrors the
+ * Promise-with-resolvers idiom without depending on the Node 22
+ * built-in.
+ */
+function defer<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// dedupe() — input validation
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('ApiSetupManager.dedupe() input contract', () => {
+  test('throws ApiSetupManagerError on an empty key', () => {
+    const manager = freshManager();
+    expect(() => manager.dedupe('', async () => 1)).toThrow(ApiSetupManagerError);
+    expect(() => manager.dedupe('', async () => 1)).toThrow(/non-empty/);
+  });
+
+  test('exposes the api client read-only for PR-3 closure access', () => {
+    const stubClient = {} as unknown as FineractApiClient;
+    const manager = new ApiSetupManager(stubClient, { cache: new Map() });
+    expect(manager.api).toBe(stubClient);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// dedupe() — in-flight sharing + cache hit
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('ApiSetupManager.dedupe() in-flight sharing', () => {
+  test('two concurrent callers receive the same Promise instance', async () => {
+    const manager = freshManager();
+    let calls = 0;
+    const fn = async (): Promise<number> => {
+      calls++;
+      // Stay pending — we are asserting reference equality, not value.
+      return new Promise<number>(() => {});
+    };
+    const p1 = manager.dedupe('k', fn);
+    const p2 = manager.dedupe('k', fn);
+    // Reference equality — the second caller attaches to the first
+    // caller's in-flight promise rather than creating a new one.
+    expect(p2).toBe(p1);
+    // Drain microtasks so the `Promise.resolve().then(fn)` chain
+    // inside `dedupe` actually invokes `fn` — only then can we
+    // assert the call count.
+    await Promise.resolve();
+    expect(calls).toBe(1);
+  });
+
+  test('the work function runs exactly once across concurrent and serial callers', async () => {
+    const manager = freshManager();
+    let calls = 0;
+    const fn = async (): Promise<string> => {
+      calls++;
+      return 'value';
+    };
+
+    const [
+      a,
+      b
+    ] = await Promise.all([
+      manager.dedupe('k', fn),
+      manager.dedupe('k', fn)
+    ]);
+    const c = await manager.dedupe('k', fn);
+
+    expect(a).toBe('value');
+    expect(b).toBe('value');
+    expect(c).toBe('value');
+    expect(calls).toBe(1);
+  });
+
+  test('different keys each fire their own work function', async () => {
+    const manager = freshManager();
+    const calls: string[] = [];
+    const make = (id: string) => async (): Promise<string> => {
+      calls.push(id);
+      return id;
+    };
+
+    const [
+      a,
+      b
+    ] = await Promise.all([
+      manager.dedupe('alpha', make('alpha')),
+      manager.dedupe('beta', make('beta'))
+    ]);
+    expect(a).toBe('alpha');
+    expect(b).toBe('beta');
+    expect(calls.sort()).toEqual([
+      'alpha',
+      'beta'
+    ]);
+  });
+
+  test('serial callers after resolution receive the cached value without rerunning fn', async () => {
+    const manager = freshManager();
+    let calls = 0;
+    const fn = async (): Promise<number> => {
+      calls++;
+      return 42;
+    };
+
+    expect(await manager.dedupe('k', fn)).toBe(42);
+    expect(await manager.dedupe('k', fn)).toBe(42);
+    expect(await manager.dedupe('k', fn)).toBe(42);
+    expect(calls).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// dedupe() — reject eviction (default) + retainErrors opt-in
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('ApiSetupManager.dedupe() reject handling', () => {
+  test('evicts a rejected promise so the next caller fires fresh fn()', async () => {
+    const manager = freshManager();
+    let calls = 0;
+    const flakyThenStable = async (): Promise<string> => {
+      calls++;
+      if (calls === 1) throw new Error('transient blip');
+      return 'recovered';
+    };
+
+    await expect(manager.dedupe('k', flakyThenStable)).rejects.toThrow(/transient blip/);
+    // Second call must execute a fresh attempt because the cache
+    // entry for the rejected promise was evicted.
+    expect(await manager.dedupe('k', flakyThenStable)).toBe('recovered');
+    expect(calls).toBe(2);
+  });
+
+  test('concurrent callers all observe the same rejection from a single fn() invocation', async () => {
+    const manager = freshManager();
+    let calls = 0;
+    const failing = async (): Promise<number> => {
+      calls++;
+      throw new Error('boom');
+    };
+
+    const results = await Promise.allSettled([
+      manager.dedupe('k', failing),
+      manager.dedupe('k', failing),
+      manager.dedupe('k', failing)
+    ]);
+
+    expect(calls).toBe(1);
+    expect(results.every((r) => r.status === 'rejected')).toBe(true);
+    expect(results.every((r) => r.status === 'rejected' && /boom/.test((r.reason as Error).message))).toBe(true);
+  });
+
+  test('retainErrors: true pins the rejection so subsequent callers fast-fail', async () => {
+    const manager = freshManager();
+    let calls = 0;
+    const failing = async (): Promise<number> => {
+      calls++;
+      throw new Error('permanent: template 999 not found');
+    };
+
+    await expect(manager.dedupe('k', failing, { retainErrors: true })).rejects.toThrow(/template 999/);
+    await expect(manager.dedupe('k', failing, { retainErrors: true })).rejects.toThrow(/template 999/);
+    expect(calls).toBe(1);
+  });
+
+  test('does not overwrite a later successful retry that filled the same key', async () => {
+    // Regression guard for the eviction race: the catch handler on
+    // a rejected promise must only evict if the slot still holds
+    // *that* promise — a successful retry filling the slot first
+    // must survive.
+    const manager = freshManager();
+    const failing = defer<number>();
+    const succeeding = defer<number>();
+
+    const callsLog: string[] = [];
+    const p1 = manager.dedupe('k', () => {
+      callsLog.push('first');
+      return failing.promise;
+    });
+
+    // Reject the first promise; its `.catch` handler will run
+    // microtask-asynchronously and try to evict.
+    failing.reject(new Error('first-failed'));
+    await p1.catch((): void => undefined);
+
+    // Now a retry fills the slot. If the eviction logic were
+    // unguarded, this entry would be nuked by the lingering
+    // `.catch` of the *first* call — assert the opposite.
+    const p2 = manager.dedupe('k', () => {
+      callsLog.push('second');
+      return succeeding.promise;
+    });
+    succeeding.resolve(7);
+    expect(await p2).toBe(7);
+
+    // Third call should hit the cache — no third fn invocation.
+    expect(
+      await manager.dedupe('k', () => {
+        callsLog.push('third');
+        return Promise.resolve(99);
+      })
+    ).toBe(7);
+
+    expect(callsLog).toEqual([
+      'first',
+      'second'
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// dedupe() — error-shape handling
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('ApiSetupManager.dedupe() fn error shapes', () => {
+  test('converts a synchronously-thrown fn into a rejected promise', async () => {
+    const manager = freshManager();
+    const fn = (): Promise<number> => {
+      throw new Error('sync boom');
+    };
+
+    await expect(manager.dedupe('k', fn)).rejects.toThrow(/sync boom/);
+    // And eviction still works for sync throws.
+    let secondCalls = 0;
+    const fn2 = async (): Promise<number> => {
+      secondCalls++;
+      return 1;
+    };
+    expect(await manager.dedupe('k', fn2)).toBe(1);
+    expect(secondCalls).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// clearCache() — escape hatch
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('ApiSetupManager.clearCache()', () => {
+  test('forces the next caller to fire a fresh fn() invocation', async () => {
+    const manager = freshManager();
+    let calls = 0;
+    const fn = async (): Promise<number> => {
+      calls++;
+      return calls;
+    };
+
+    expect(await manager.dedupe('k', fn)).toBe(1);
+    expect(await manager.dedupe('k', fn)).toBe(1); // cache hit
+    manager.clearCache();
+    expect(await manager.dedupe('k', fn)).toBe(2); // fresh invocation
+    expect(calls).toBe(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Cache-key convention example — sorted URLSearchParams stability
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('Cache-key convention (sorted URLSearchParams)', () => {
+  test('callers using sorted URLSearchParams hit the same cache entry regardless of insert order', async () => {
+    // This test does NOT call into FineractApiClient — it asserts the
+    // recommended keying convention from the api-setup-manager.ts
+    // docstring: callers that serialise their params via sorted
+    // `URLSearchParams.toString()` produce identical keys even if
+    // they appended the params in different orders.
+    const manager = freshManager();
+    let calls = 0;
+    const fn = async (): Promise<string> => {
+      calls++;
+      return 'template';
+    };
+
+    const buildKey = (entries: ReadonlyArray<[
+          string,
+          string
+        ]>): string => {
+      const params = new URLSearchParams();
+      for (const [
+        k,
+        v
+      ] of entries) {
+        params.set(k, v);
+      }
+      params.sort();
+      return `loanTemplate:${params.toString()}`;
+    };
+
+    const key1 = buildKey([
+      [
+        'clientId',
+        '1'
+      ],
+      [
+        'productId',
+        '2'
+      ],
+      [
+        'activeOnly',
+        'true'
+      ]
+    ]);
+    const key2 = buildKey([
+      [
+        'activeOnly',
+        'true'
+      ],
+      [
+        'productId',
+        '2'
+      ],
+      [
+        'clientId',
+        '1'
+      ]
+    ]);
+    expect(key1).toBe(key2);
+
+    const [
+      a,
+      b
+    ] = await Promise.all([
+      manager.dedupe(key1, fn),
+      manager.dedupe(key2, fn)
+    ]);
+    expect(a).toBe('template');
+    expect(b).toBe('template');
+    expect(calls).toBe(1);
+  });
+});

--- a/playwright/utils/api-setup-manager.ts
+++ b/playwright/utils/api-setup-manager.ts
@@ -1,0 +1,193 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import type { FineractApiClient } from '../fixtures/fineract-api';
+
+/**
+ * In-flight de-duplication + process-lifetime cache for shared
+ * Fineract setup calls (loan-product templates, code-value lookups,
+ * office lists, …).
+ *
+ * Design goals (per GSoC 2026 proposal WA-2.7):
+ *  - When two parallel tests both call `getOrLoadLoanTemplate(1)`
+ *    within the same process, the second caller MUST attach to the
+ *    in-flight `Promise` from the first caller instead of firing a
+ *    duplicate HTTP request. Once that promise resolves, every
+ *    subsequent caller for the same key gets the cached value
+ *    synchronously for the lifetime of the process.
+ *  - The cache is keyed by an opaque string so callers pick the
+ *    granularity (e.g. `loanTemplate:clientId=1&productId=2`). The
+ *    convention is to use a stable serialisation — sorted
+ *    `URLSearchParams.toString()` is recommended for endpoints that
+ *    already build one — so parameter-order changes do not produce
+ *    cache misses.
+ *  - Rejected promises are evicted from the cache by default. A
+ *    transient CI failure (network blip, half-open TCP) must not
+ *    poison the whole suite by pinning a rejection on the key.
+ *    Strict callers can opt out via `{ retainErrors: true }` when the
+ *    failure is genuinely permanent (e.g. requested template id
+ *    does not exist).
+ *
+ * Scope note: this PR ships only the generic `dedupe<T>` primitive.
+ * Domain-specific wrappers (`getLoanTemplate`, `getClientTemplate`,
+ * `getCodeValues`, …) land in PR-3 alongside the factory functions
+ * that call them. The `FineractApiClient` reference is held now so
+ * those PR-3 wrappers can be added without touching the constructor
+ * signature or the fixture wiring.
+ *
+ * Portability note: the module imports nothing from `@playwright/test`
+ * and the cache is a plain `Map`. The React port can adopt this file
+ * verbatim once it has its own `FineractApiClient` (or a structural
+ * equivalent — `FineractApiClient` is only referenced as a type here).
+ */
+
+/**
+ * Module-level cache. Lives for the lifetime of the Node process so
+ * it outlives every per-test `FineractApiClient` instance created by
+ * `playwright/fixtures/test-fixtures.ts`. Exported only via the
+ * {@link clearApiSetupCache} helper — direct access from outside the
+ * module is intentionally not supported.
+ */
+const TEMPLATE_CACHE: Map<string, Promise<unknown>> = new Map();
+
+/** Options passed to {@link ApiSetupManager.dedupe}. */
+export interface DedupeOptions {
+  /**
+   * When `true`, a rejected `fn()` promise is left in the cache so
+   * subsequent callers fast-fail with the same error. Defaults to
+   * `false` — the standard CI-friendly behaviour, matching the
+   * retry mindset of `playwright/utils/retry.ts`.
+   */
+  retainErrors?: boolean;
+}
+
+/** Constructor options for {@link ApiSetupManager}. */
+export interface ApiSetupManagerOptions {
+  /**
+   * Override the module-level cache. Mainly used by the unit specs
+   * to keep per-test state isolated; production callers should never
+   * pass this and instead rely on the singleton.
+   */
+  cache?: Map<string, Promise<unknown>>;
+}
+
+/**
+ * Error thrown when {@link ApiSetupManager.dedupe} is called with an
+ * input that cannot be honoured (e.g. empty cache key). Carries no
+ * extra fields — the message is the contract, mirroring the style of
+ * `ReadinessProbeFailure` in `playwright/utils/readiness.ts`.
+ */
+export class ApiSetupManagerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ApiSetupManagerError';
+  }
+}
+
+/**
+ * Wraps a per-test `FineractApiClient` with a shared cache so
+ * concurrent tests requesting the same template share one in-flight
+ * HTTP call. See module docstring for the design rationale.
+ *
+ * Usage (factory functions in PR-3 will look like this):
+ *
+ * ```ts
+ * const setup = new ApiSetupManager(fineractApi);
+ * const template = await setup.dedupe(
+ *   `loanTemplate:${sortedParams}`,
+ *   () => setup.api.getLoanTemplate(clientId, productId)
+ * );
+ * ```
+ */
+export class ApiSetupManager {
+  /**
+   * Public so PR-3 factory functions can call any
+   * `FineractApiClient` method inside their `dedupe(...)` closure
+   * without re-plumbing the client through every helper.
+   */
+  public readonly api: FineractApiClient;
+
+  private readonly cache: Map<string, Promise<unknown>>;
+
+  constructor(api: FineractApiClient, options: ApiSetupManagerOptions = {}) {
+    this.api = api;
+    this.cache = options.cache ?? TEMPLATE_CACHE;
+  }
+
+  /**
+   * Run `fn()` at most once per `key` for the lifetime of the cache.
+   *
+   * Concurrent callers with the same key share the in-flight
+   * promise. Once that promise settles successfully, every later
+   * caller receives the same resolved value synchronously.
+   *
+   * Rejected promises are evicted by default — the next caller will
+   * fire a fresh `fn()`. Pass `{ retainErrors: true }` to keep the
+   * rejection cached and let subsequent callers fast-fail.
+   *
+   * @param key   Opaque cache key. Choose a stable serialisation
+   *              (e.g. sorted `URLSearchParams.toString()`) so
+   *              callers with equivalent parameters hit the cache.
+   * @param fn    Zero-argument factory that performs the work. Only
+   *              invoked when there is no entry under `key`.
+   * @param opts  See {@link DedupeOptions}.
+   * @throws {@link ApiSetupManagerError} when `key` is empty.
+   */
+  dedupe<T>(key: string, fn: () => Promise<T>, opts: DedupeOptions = {}): Promise<T> {
+    if (typeof key !== 'string' || key.length === 0) {
+      throw new ApiSetupManagerError('dedupe(key, fn): key must be a non-empty string');
+    }
+
+    const existing = this.cache.get(key);
+    if (existing !== undefined) {
+      return existing as Promise<T>;
+    }
+
+    const retainErrors = opts.retainErrors === true;
+    // Wrap `fn()` in a synchronous Promise constructor so a `fn` that
+    // throws synchronously is still converted into a rejected promise
+    // — same observable behaviour as if it had returned `Promise.reject`.
+    const pending = Promise.resolve().then(fn);
+
+    if (!retainErrors) {
+      // Eviction must use the captured `pending` reference, not a
+      // fresh `this.cache.get(key)` lookup — a later caller could
+      // have replaced the entry with a successful retry, and we
+      // must not nuke that.
+      pending.catch(() => {
+        if (this.cache.get(key) === pending) {
+          this.cache.delete(key);
+        }
+      });
+    }
+
+    this.cache.set(key, pending);
+    return pending;
+  }
+
+  /**
+   * Test-only escape hatch. Clears the cache backing this instance —
+   * useful for unit specs that want a clean slate per `test()`
+   * without recreating the manager. Production code should never
+   * need to call this.
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+}
+
+/**
+ * Reset the module-level cache. Intended for the unit specs in
+ * `api-setup-manager.spec.ts` and for any future helper that needs
+ * to nuke shared state between test files. Production callers should
+ * use `ApiSetupManager#clearCache` on an instance that owns its own
+ * injected cache instead.
+ */
+export function clearApiSetupCache(): void {
+  TEMPLATE_CACHE.clear();
+}

--- a/playwright/utils/naming.spec.ts
+++ b/playwright/utils/naming.spec.ts
@@ -1,0 +1,240 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  E2E_NAME_PATTERN,
+  E2E_NAME_PREFIX,
+  E2E_RANDOM_TOKEN_LENGTH,
+  E2ENameGenerationError,
+  generateE2EName
+} from './naming';
+
+// Pure-logic specs — they run under the `unit` Playwright project
+// (testMatch: /playwright\/utils\/.*\.spec\.ts/ in playwright.config.ts)
+// with no browser, no app, no backend. Every dynamic dependency
+// (clock, RNG, shard) is injected so assertions are deterministic.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ─────────────────────────────────────────────────────────────────────
+// naming.ts — exported constants
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('naming constants', () => {
+  test('exports the documented prefix and token length', () => {
+    expect(E2E_NAME_PREFIX).toBe('E2E');
+    expect(E2E_RANDOM_TOKEN_LENGTH).toBe(6);
+  });
+
+  test('E2E_NAME_PATTERN matches the documented format', () => {
+    expect('E2E_S0_1750000000000_abc123').toMatch(E2E_NAME_PATTERN);
+    expect('E2E_client_S3_1750000000000_zz9999').toMatch(E2E_NAME_PATTERN);
+    // Non-matches: missing prefix, uppercase token, missing shard, …
+    expect('S0_1750000000000_abc123').not.toMatch(E2E_NAME_PATTERN);
+    expect('E2E_S0_1750000000000_ABCDEF').not.toMatch(E2E_NAME_PATTERN);
+    expect('E2E_1750000000000_abc123').not.toMatch(E2E_NAME_PATTERN);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// generateE2EName() — format and injection contract
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('generateE2EName() format', () => {
+  test('produces a name that matches E2E_NAME_PATTERN with all defaults', () => {
+    const name = generateE2EName();
+    expect(name).toMatch(E2E_NAME_PATTERN);
+    expect(name.startsWith(`${E2E_NAME_PREFIX}_S`)).toBe(true);
+  });
+
+  test('embeds the injected shard, timestamp, and random token verbatim', () => {
+    const name = generateE2EName(undefined, {
+      shard: 3,
+      now: () => 1_750_000_000_000,
+      random: () => 0.123456789
+    });
+    // (0.123456789).toString(36) === '0.4fzzzxjylrx' — first 6 chars after '0.'
+    expect(name).toBe('E2E_S3_1750000000000_4fzzzx');
+  });
+
+  test('prepends the sanitised prefix between E2E_ and S{shard}', () => {
+    const name = generateE2EName('client', {
+      shard: 0,
+      now: () => 1_750_000_000_000,
+      random: () => 0.5
+    });
+    expect(name.startsWith('E2E_client_S0_1750000000000_')).toBe(true);
+    expect(name).toMatch(E2E_NAME_PATTERN);
+  });
+
+  test('strips disallowed characters from the prefix', () => {
+    const name = generateE2EName('loan-product!@#', {
+      shard: 0,
+      now: () => 1,
+      random: () => 0.5
+    });
+    expect(name.startsWith('E2E_loanproduct_S0_1_')).toBe(true);
+  });
+
+  test('treats an all-symbol prefix the same as no prefix', () => {
+    const name = generateE2EName('!@#$', {
+      shard: 0,
+      now: () => 1,
+      random: () => 0.5
+    });
+    expect(name.startsWith('E2E_S0_1_')).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// generateE2EName() — shard resolution
+// ─────────────────────────────────────────────────────────────────────
+
+// Serial mode is required here because three tests mutate the shared
+// process.env.TEST_PARALLEL_INDEX.  Even though fullyParallel is not
+// currently enabled, being explicit prevents a future config change
+// from introducing a hard-to-diagnose race on process.env.
+test.describe.serial('generateE2EName() shard resolution', () => {
+  test('falls back to TEST_PARALLEL_INDEX when no shard option is passed', () => {
+    const original = process.env.TEST_PARALLEL_INDEX;
+    process.env.TEST_PARALLEL_INDEX = '7';
+    try {
+      const name = generateE2EName(undefined, {
+        now: () => 1,
+        random: () => 0.5
+      });
+      expect(name.startsWith('E2E_S7_1_')).toBe(true);
+    } finally {
+      if (original === undefined) {
+        delete process.env.TEST_PARALLEL_INDEX;
+      } else {
+        process.env.TEST_PARALLEL_INDEX = original;
+      }
+    }
+  });
+
+  test('falls back to "0" when neither option nor env var is set', () => {
+    const original = process.env.TEST_PARALLEL_INDEX;
+    delete process.env.TEST_PARALLEL_INDEX;
+    try {
+      const name = generateE2EName(undefined, {
+        now: () => 1,
+        random: () => 0.5
+      });
+      expect(name.startsWith('E2E_S0_1_')).toBe(true);
+    } finally {
+      if (original !== undefined) {
+        process.env.TEST_PARALLEL_INDEX = original;
+      }
+    }
+  });
+
+  test('sanitises a malformed env value to digits-only', () => {
+    const original = process.env.TEST_PARALLEL_INDEX;
+    process.env.TEST_PARALLEL_INDEX = 'w-12';
+    try {
+      const name = generateE2EName(undefined, {
+        now: () => 1,
+        random: () => 0.5
+      });
+      expect(name.startsWith('E2E_S12_1_')).toBe(true);
+    } finally {
+      if (original === undefined) {
+        delete process.env.TEST_PARALLEL_INDEX;
+      } else {
+        process.env.TEST_PARALLEL_INDEX = original;
+      }
+    }
+  });
+
+  test('accepts a numeric shard option and truncates fractional values', () => {
+    const name = generateE2EName(undefined, {
+      shard: 2.9,
+      now: () => 1,
+      random: () => 0.5
+    });
+    expect(name.startsWith('E2E_S2_1_')).toBe(true);
+  });
+
+  test('floors a negative shard to 0 rather than embedding the minus sign', () => {
+    const name = generateE2EName(undefined, {
+      shard: -4,
+      now: () => 1,
+      random: () => 0.5
+    });
+    expect(name.startsWith('E2E_S0_1_')).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// generateE2EName() — uniqueness + edge cases
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('generateE2EName() uniqueness', () => {
+  test('produces 100 unique names with a fixed clock when RNG varies', () => {
+    const fixedNow = (): number => 1_750_000_000_000;
+    const seen = new Set<string>();
+    let counter = 0;
+    const rng = (): number => {
+      counter++;
+      return counter / 1000; // 0.001, 0.002, … 0.100 — all distinct
+    };
+
+    for (let i = 0; i < 100; i++) {
+      seen.add(generateE2EName(undefined, { now: fixedNow, random: rng }));
+    }
+
+    expect(seen.size).toBe(100);
+  });
+
+  test('always emits a token of exactly E2E_RANDOM_TOKEN_LENGTH characters', () => {
+    // Worst-case input: random() returns a value so small that
+    // `.toString(36)` produces almost nothing — the sanitiser must
+    // still pad to the configured length.
+    const name = generateE2EName(undefined, {
+      shard: 0,
+      now: () => 1,
+      random: () => 0
+    });
+    const token = name.split('_').slice(-1)[0];
+    expect(token).toHaveLength(E2E_RANDOM_TOKEN_LENGTH);
+  });
+
+  test('honours a custom randomTokenLength', () => {
+    const name = generateE2EName(undefined, {
+      shard: 0,
+      now: () => 1,
+      random: () => 0.5,
+      randomTokenLength: 3
+    });
+    const token = name.split('_').slice(-1)[0];
+    expect(token).toHaveLength(3);
+  });
+
+  test('throws E2ENameGenerationError on an invalid randomTokenLength', () => {
+    expect(() =>
+      generateE2EName(undefined, {
+        randomTokenLength: 0
+      })
+    ).toThrow(E2ENameGenerationError);
+    expect(() =>
+      generateE2EName(undefined, {
+        randomTokenLength: 99
+      })
+    ).toThrow(/randomTokenLength/);
+  });
+
+  test('clamps a fractional timestamp to an integer ms', () => {
+    const name = generateE2EName(undefined, {
+      shard: 0,
+      now: () => 1_750_000_000_000.9,
+      random: () => 0.5
+    });
+    expect(name.startsWith('E2E_S0_1750000000000_')).toBe(true);
+  });
+});

--- a/playwright/utils/naming.ts
+++ b/playwright/utils/naming.ts
@@ -1,0 +1,174 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Shard-aware unique-name generator for Playwright E2E test data.
+ *
+ * Design goals (per GSoC 2026 proposal WA-2.8):
+ *  - Every entity a test creates in Fineract (client, group, user,
+ *    loan, …) must carry a name that is unique across a single CI
+ *    run AND visibly recognisable as test data, so a stuck cleanup
+ *    job never confuses production data with leftover E2E records.
+ *  - Encode the worker/shard index in the name itself so logs from
+ *    a flaky parallel run can be traced back to a specific worker
+ *    without cross-referencing a separate report.
+ *  - Be deterministic-under-injection. Every dynamic input — the
+ *    clock, the RNG, the shard — is overridable via options so the
+ *    unit specs can assert the exact output string without relying
+ *    on `Date.now()` advancing or `Math.random()` cooperating.
+ *
+ * Output format: `E2E_S{shard}_{ts}_{rand}` where
+ *   - `E2E_`  is a fixed prefix used by cleanup grep patterns.
+ *   - `S{shard}` is the Playwright worker index (or override).
+ *   - `{ts}` is `Date.now()` (ms since epoch) for monotonicity.
+ *   - `{rand}` is a 6-char base36 token from `Math.random()`,
+ *      enough to defeat collisions within the same millisecond
+ *      for the realistic worker counts Playwright supports.
+ *
+ * The optional `prefix` argument is sanitised and prepended *after*
+ * the `E2E_` marker so factory callers can pass a domain hint
+ * (`'client'`, `'group'`) without losing the cleanup grep anchor.
+ *
+ * Portability note: this module imports nothing. The React port can
+ * adopt it verbatim — `process.env.TEST_PARALLEL_INDEX` is set by
+ * the `@playwright/test` runtime regardless of host framework.
+ */
+
+/** Fixed prefix used by cleanup tooling to identify E2E-owned data. */
+export const E2E_NAME_PREFIX = 'E2E';
+
+/** Length of the random base36 token appended to each name. */
+export const E2E_RANDOM_TOKEN_LENGTH = 6;
+
+/**
+ * Regex describing the exact shape `generateE2EName` emits. Exported
+ * for the unit specs and for any future cleanup script that needs to
+ * match the full name surface — keep this in sync with the format
+ * documented at the top of the file.
+ */
+export const E2E_NAME_PATTERN = /^E2E(?:_[A-Za-z0-9]+)?_S\d+_\d+_[a-z0-9]+$/;
+
+/** Tuning knobs for {@link generateE2EName}. All fields optional. */
+export interface GenerateE2ENameOptions {
+  /**
+   * Override the shard / worker slot. Defaults to
+   * `process.env.TEST_PARALLEL_INDEX ?? '0'`. Non-numeric values are
+   * sanitised to digits-only so a malformed env var cannot produce a
+   * name that fails {@link E2E_NAME_PATTERN}.
+   */
+  shard?: string | number;
+  /**
+   * Injectable wall-clock for tests. Defaults to `Date.now`. The
+   * returned value is rounded down to an integer ms so the formatted
+   * name is always digits-only.
+   */
+  now?: () => number;
+  /**
+   * Injectable RNG returning a value in `[0, 1)`. Defaults to
+   * `Math.random`. The returned value is folded into a base36 token
+   * of {@link E2E_RANDOM_TOKEN_LENGTH} characters.
+   */
+  random?: () => number;
+  /**
+   * Override the random-token length (max 11 — the practical ceiling
+   * of `Math.random().toString(36).slice(2)`). Mainly for tests.
+   */
+  randomTokenLength?: number;
+}
+
+/**
+ * Error thrown when {@link generateE2EName} cannot produce a valid
+ * name from its inputs (e.g. a negative `randomTokenLength`). Carries
+ * no extra fields — the message is the contract.
+ */
+export class E2ENameGenerationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'E2ENameGenerationError';
+  }
+}
+
+/**
+ * Build a unique, shard-tagged test-data name of the form
+ * `E2E_S{shard}_{ts}_{rand}` (or `E2E_{prefix}_S{shard}_{ts}_{rand}`
+ * when `prefix` is supplied).
+ *
+ * The function performs no I/O and never throws for the default
+ * argument shape. It throws {@link E2ENameGenerationError} only when
+ * the caller passes an invalid override (e.g. negative length).
+ *
+ * @param prefix Optional alphanumeric domain hint, e.g. `'client'`.
+ *               Stripped to `[A-Za-z0-9]+`; an empty result is
+ *               treated the same as omitting the prefix entirely.
+ * @param options Injectable inputs — see {@link GenerateE2ENameOptions}.
+ */
+export function generateE2EName(prefix?: string, options: GenerateE2ENameOptions = {}): string {
+  const randomTokenLength = options.randomTokenLength ?? E2E_RANDOM_TOKEN_LENGTH;
+  if (!Number.isInteger(randomTokenLength) || randomTokenLength < 1 || randomTokenLength > 11) {
+    throw new E2ENameGenerationError(`randomTokenLength must be an integer in [1, 11], got ${randomTokenLength}`);
+  }
+
+  const now = options.now ?? Date.now;
+  const random = options.random ?? Math.random;
+  const ts = Math.max(0, Math.trunc(now()));
+  const shard = sanitiseShard(options.shard);
+  const rand = sanitiseRandomToken(random(), randomTokenLength);
+  const cleanedPrefix = sanitisePrefix(prefix);
+
+  const segments: string[] = cleanedPrefix.length > 0 ? [
+          E2E_NAME_PREFIX,
+          cleanedPrefix,
+          `S${shard}`,
+          String(ts),
+          rand
+        ] : [
+          E2E_NAME_PREFIX,
+          `S${shard}`,
+          String(ts),
+          rand
+        ];
+
+  return segments.join('_');
+}
+
+/**
+ * Resolve the shard / worker slot. Precedence:
+ *   1. Explicit option (numbers stringified, strings digit-filtered).
+ *   2. `process.env.TEST_PARALLEL_INDEX` (set by Playwright runtime).
+ *   3. `'0'` as a safe fallback for unit specs and ad-hoc invocation.
+ */
+function sanitiseShard(input: GenerateE2ENameOptions['shard']): string {
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    return String(Math.max(0, Math.trunc(input)));
+  }
+  const raw = typeof input === 'string' ? input : (process.env.TEST_PARALLEL_INDEX ?? '0');
+  const digits = raw.replace(/[^0-9]/g, '');
+  return digits.length > 0 ? digits : '0';
+}
+
+/**
+ * Fold a `[0, 1)` RNG draw into a fixed-length lower-case base36 token.
+ * `Math.random().toString(36).slice(2)` can occasionally yield a token
+ * shorter than expected (when the value is very small), so this helper
+ * pads with the next draw rather than emitting a name shorter than the
+ * pattern documents.
+ */
+function sanitiseRandomToken(value: number, length: number): string {
+  const normalised = Number.isFinite(value) && value >= 0 && value < 1 ? value : 0;
+  let token = normalised.toString(36).replace('0.', '');
+  while (token.length < length) {
+    token += '0';
+  }
+  return token.slice(0, length);
+}
+
+/** Strip a caller-supplied prefix to safe `[A-Za-z0-9]` characters. */
+function sanitisePrefix(prefix: string | undefined): string {
+  if (!prefix) return '';
+  return prefix.replace(/[^A-Za-z0-9]/g, '');
+}


### PR DESCRIPTION

## Description
This PR introduces foundational infrastructure for deduplicated, cached API setup across concurrent Playwright E2E tests. Two concurrent tests requesting the same loan-product template now share one in-flight HTTP call via a module-level Map cache. Alongside it, portable test-data type definitions and a shard-aware unique-name generator unblock factory functions in the next PR.

Why these changes:

In-flight deduplication (WA-2.7) - eliminates duplicate API calls when parallel tests request identical templates; rejected promises are evicted so transient CI failures don't poison the suite.
E2E naming convention (WA-2.8) - every test-created entity (client, loan, user) carries a unique, shard-tagged name (E2E_S{shard}_{ts}_{rand}) for cleanup traceability and self-diagnosing stuck records in CI.
Portable type surface - TestClient, TestGroup, TestUser, TestLoan interfaces carry zero imports so the React port can adopt them verbatim.
Key design decisions:

Generic dedupe<T>(key, fn, opts?) primitive ships in this PR; domain-specific wrappers (getLoanTemplate, etc.) land in PR-3 alongside the factory functions that consume them.
Module-level cache outlives per-test FineractApiClient fixture so concurrent tests within the same process share cached values.
Sorted URLSearchParams.toString() keying convention recommended to prevent cache misses on parameter-order changes.
All dynamic inputs (now, random, shard) injectable for deterministic unit testing.

Validation
 43 unit tests pass (auto-discovered by existing unit project in playwright.config.ts)
 ESLint exit 0 on all 5 new files
 Prettier formatted to match multilineArraysWrapThreshold: 1
 MPL-2.0 headers with Copyright since 2026 Mifos Initiative
 No production files modified — scope-leak correction applied (see Related Issues)
 Portability — naming.ts + test-data types have zero Playwright imports; React port can adopt verbatim

## Related issues and discussion

 https://mifosforge.jira.com/browse/WEB-1013

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic, shard-aware naming for end-to-end test data, helping generate unique, readable names more reliably.
  * Added shared setup caching so repeated API setup work can be reused during test runs, improving consistency and efficiency.

* **Bug Fixes**
  * Improved handling of edge cases in name generation, including invalid characters, timestamps, and random token lengths.
  * Added stronger cache behavior for failed setup calls so retries and recovery work predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->