### PR TITLE
WEB-657: rename wc loan accounting rule CASH_BASED to ACC_DEF_REV_AM

### DIFF
--- a/src/app/core/utils/accounting.ts
+++ b/src/app/core/utils/accounting.ts
@@ -40,7 +40,7 @@ export class Accounting {
     } else {
       return [
         'NONE',
-        'CASH_BASED'
+        'ACC_DEF_REV_AM'
       ];
     }
   }
@@ -58,6 +58,8 @@ export class Accounting {
       return 'Accrual (upfront)';
     } else if (value.startsWith('CASH')) {
       return 'Cash';
+    } else if (value === 'ACC_DEF_REV_AM') {
+      return 'ACC_DEF_REV_AM';
     } else if (value === 'NONE') {
       return 'NONE';
     }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -298,7 +298,7 @@ export class LoanProductAccountingStepComponent extends LoanProductBaseComponent
       }
     } else if (this.loanProductService.isWorkingCapital) {
       switch (accountingRuleId) {
-        case 'CASH_BASED':
+        case 'ACC_DEF_REV_AM':
           this.loanProductAccountingForm.patchValue({
             fundSourceAccountId: accountingMappings.fundSourceAccount.id,
             loanPortfolioAccountId: accountingMappings.loanPortfolioAccount.id,
@@ -606,7 +606,7 @@ export class LoanProductAccountingStepComponent extends LoanProductBaseComponent
           this.loanProductAccountingForm.removeControl('receivablePenaltyAccountId');
 
           this.loanProductAccountingForm.removeControl('advancedAccountingRules');
-        } else if (accountingRule === 'CASH_BASED') {
+        } else if (accountingRule === 'ACC_DEF_REV_AM') {
           this.loanProductAccountingForm.addControl(
             'fundSourceAccountId',
             new UntypedFormControl('', Validators.required)

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -476,6 +476,7 @@
     "accounting": {
       "Accrual (periodic)": "Akruální (periodické)",
       "Accrual (upfront)": "Akruální (předem)",
+      "ACC_DEF_REV_AM": "Časové rozlišení s odpisem odložených výnosů",
       "CASH_BASED": "Hotovost",
       "Cash": "Hotovost",
       "NONE": "Žádný",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -477,6 +477,7 @@
     "accounting": {
       "Accrual (periodic)": "Abgrenzung (periodisch)",
       "Accrual (upfront)": "Rückstellung (im Voraus)",
+      "ACC_DEF_REV_AM": "Abgrenzung mit Abschreibung auf abgegrenzte Umsatzerlöse",
       "CASH_BASED": "Kasse",
       "Cash": "Kasse",
       "NONE": "Keiner",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -478,6 +478,7 @@
     "accounting": {
       "Accrual (periodic)": "Accrual (periodic)",
       "Accrual (upfront)": "Accrual (upfront)",
+      "ACC_DEF_REV_AM": "Accrual with deferred revenue amortization",
       "CASH_BASED": "Cash",
       "Cash": "Cash",
       "NONE": "None",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -475,6 +475,7 @@
     "accounting": {
       "Accrual (periodic)": "Devengo (periódico)",
       "Accrual (upfront)": "Devengo (adelantado)",
+      "ACC_DEF_REV_AM": "Provisión con amortización de ingresos diferidos",
       "CASH_BASED": "Efectivo",
       "Cash": "Efectivo",
       "NONE": "Ninguno",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -475,6 +475,7 @@
     "accounting": {
       "Accrual (periodic)": "Devengo (periódico)",
       "Accrual (upfront)": "Devengo (adelantado)",
+      "ACC_DEF_REV_AM": "Acumulación con amortización de ingresos diferidos",
       "CASH_BASED": "Efectivo",
       "Cash": "Efectivo",
       "NONE": "Ninguno",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -475,6 +475,7 @@
     "accounting": {
       "Accrual (periodic)": "Accumulation (périodique)",
       "Accrual (upfront)": "Accumulation (d'avance)",
+      "ACC_DEF_REV_AM": "Comptabilisation avec amortissement des produits différés",
       "CASH_BASED": "Espèces",
       "Cash": "Espèces",
       "NONE": "Aucun",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -475,6 +475,7 @@
     "accounting": {
       "Accrual (periodic)": "Accantonamento (periodico)",
       "Accrual (upfront)": "Accantonamento (in anticipo)",
+      "ACC_DEF_REV_AM": "Accantonamento con ammortamento dei ricavi differiti",
       "CASH_BASED": "Contanti",
       "Cash": "Contanti",
       "NONE": "Nessuno",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -475,6 +475,7 @@
     "accounting": {
       "Accrual (periodic)": "발생(정기적)",
       "Accrual (upfront)": "발생(선불)",
+      "ACC_DEF_REV_AM": "이연매출 상각액을 반영한 발생주의 회계",
       "CASH_BASED": "현금",
       "Cash": "현금",
       "NONE": "없음",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -475,6 +475,7 @@
     "accounting": {
       "Accrual (periodic)": "Kaupiamasis (periodinis)",
       "Accrual (upfront)": "Sukaupimas (išankstinis)",
+      "ACC_DEF_REV_AM": "Atsidėjimai su atidėtų pajamų amortizacija",
       "CASH_BASED": "Grynieji pinigai",
       "Cash": "Grynieji pinigai",
       "NONE": "Nė vienas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -475,6 +475,7 @@
     "accounting": {
       "Accrual (periodic)": "Uzkrāšana (periodiski)",
       "Accrual (upfront)": "Uzkrāšana (iepriekšēja)",
+      "ACC_DEF_REV_AM": "Uzkrājums ar atlikto ieņēmumu amortizāciju",
       "CASH_BASED": "Skaidra nauda",
       "Cash": "Skaidra nauda",
       "NONE": "Nav",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -475,6 +475,7 @@
     "accounting": {
       "Accrual (periodic)": "उपार्जन (आवधिक)",
       "Accrual (upfront)": "उपार्जन (अगाडि)",
+      "ACC_DEF_REV_AM": "स्थगित राजस्व परिशोधन सहितको उपार्जन",
       "CASH_BASED": "नगद",
       "Cash": "नगद",
       "NONE": "कुनै पनि छैन",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -475,6 +475,7 @@
     "accounting": {
       "Accrual (periodic)": "Acumulação (periódica)",
       "Accrual (upfront)": "Acumulação (antecipada)",
+      "ACC_DEF_REV_AM": "Acumulação com amortização de receitas diferidas",
       "CASH_BASED": "Dinheiro",
       "Cash": "Dinheiro",
       "NONE": "Nenhum",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -475,6 +475,7 @@
     "accounting": {
       "Accrual (periodic)": "Accrual (mara kwa mara)",
       "Accrual (upfront)": "Accrual (mbele)",
+      "ACC_DEF_REV_AM": "Ukusanyaji pamoja na upunguzaji wa mapato yaliyocheleweshwa",
       "CASH_BASED": "Fedha taslimu",
       "Cash": "Fedha taslimu",
       "NONE": "Hakuna",


### PR DESCRIPTION
## Description

Originally WC loans were created with a cash based accounting scheme in mind. But that does not accurately reflect the current model. Which is closer to an accrual based accounting. So the new name of this accounting will be "Accrual with deferred revenue amortization".

## Related issues and discussion

#{WEB-657}

<img width="1760" height="302" alt="image" src="https://github.com/user-attachments/assets/20cc772f-6d3a-4a58-8a71-ce2a6c1faa84" />

<img width="1168" height="600" alt="image" src="https://github.com/user-attachments/assets/88f9d169-f60a-4329-a757-22b599a2e430" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new accounting rule option for loan products, including updated form behavior and account label naming.
  * Expanded language support by adding the new accounting label translation across multiple locales.

* **Bug Fixes**
  * Updated rule mapping so the new accounting option is recognized and named consistently across loan accounting logic and the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->