### PR TITLE
WEB-657: Loan product advanced accounting no data issue

### DIFF
--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary-adv-accounting/loan-product-summary-adv-accounting.component.html
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary-adv-accounting/loan-product-summary-adv-accounting.component.html
@@ -49,6 +49,7 @@
           <td mat-cell *matCellDef="let feesIncome">
             @if (feesIncome.incomeAccount) {
               <span>
+                ({{ feesIncome.incomeAccount?.glCode }})
                 {{ feesIncome.incomeAccount.name }}
               </span>
             }
@@ -74,6 +75,7 @@
         <ng-container matColumnDef="incomeAccountId">
           <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Income Account' | translate }}</th>
           <td mat-cell *matCellDef="let penaltyIncome">
+            ({{ penaltyIncome.incomeAccount?.glCode }})
             {{ penaltyIncome.incomeAccount?.name }}
           </td>
         </ng-container>
@@ -89,7 +91,7 @@
       </h4>
       <table class="mat-elevation-z1 flex-100" mat-table [dataSource]="chargeOffReasonToExpenseAccountMappings">
         <ng-container matColumnDef="chargeOffReasonCodeValueId">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Charge-off Reason' | translate }}</th>
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Charge-off reason' | translate }}</th>
           <td mat-cell *matCellDef="let chargeOffReasonToExpenseAccountMapping">
             {{ chargeOffReasonToExpenseAccountMapping.reasonCodeValue?.name }}
           </td>

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary-adv-accounting/loan-product-summary-adv-accounting.component.scss
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary-adv-accounting/loan-product-summary-adv-accounting.component.scss
@@ -11,6 +11,12 @@
 
 table {
   width: 100%;
+  table-layout: fixed;
+}
+
+th:first-child,
+td:first-child {
+  width: 50%;
 }
 
 h2,

--- a/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
+++ b/src/app/products/loan-products/common/loan-product-summary/loan-product-summary.component.ts
@@ -260,7 +260,7 @@ export class LoanProductSummaryComponent extends LoanProductBaseComponent implem
           const incomeAccountId = m.incomeAccountId ?? m.glAccount?.id;
           const chargeId = m.chargeId ?? m.value?.id;
           this.feeToIncomeAccountMappings.push({
-            incomeAccount: this.glAccountLookUp(incomeAccountId, incomeAccountData),
+            incomeAccount: this.glAccountLookUp(incomeAccountId, incomeAccountData.concat(liabilityAccountData)),
             charge: this.chargeLookUp(chargeId, this.loanProductsTemplate.chargeOptions)
           });
         });

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component.scss
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component.scss
@@ -8,6 +8,17 @@
 
 table {
   width: 100%;
+  table-layout: fixed;
+}
+
+th:first-child,
+td:first-child {
+  width: 35%;
+}
+
+th:last-child,
+td:last-child {
+  width: 20%;
 }
 
 .mat-elevation-z1 {

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/advanced-accounting-mapping-rule/advanced-accounting-mapping-rule.component.ts
@@ -135,7 +135,10 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
         } else if (this.formType === 'FeesIncome') {
           const addData: AccountingMappingDTO = {
             value: this.getValueData(response.data.value.chargeId),
-            glAccount: this.getGlAccountData(response.data.value.incomeAccountId)
+            glAccount: this.getGlAccountDataFromList(
+              response.data.value.incomeAccountId,
+              this.incomeAndLiabilityAccountData
+            )
           };
           this.addTableData(addData);
         } else if (this.formType === 'PenaltyIncome') {
@@ -216,12 +219,15 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
         } else if (this.formType === 'FeesIncome') {
           updateData = {
             value: this.getValueData(response.data.value.chargeId),
-            glAccount: this.getGlAccountData(response.data.value.incomeAccountId)
+            glAccount: this.getGlAccountDataFromList(
+              response.data.value.incomeAccountId,
+              this.incomeAndLiabilityAccountData
+            )
           };
         } else if (this.formType === 'PenaltyIncome') {
           updateData = {
             value: this.getValueData(response.data.value.chargeId),
-            glAccount: this.getGlAccountData(response.data.value.incomeAccountId)
+            glAccount: this.getGlAccountDataFromList(response.data.value.incomeAccountId, this.incomeAccountData)
           };
         }
         if (updateData) {
@@ -308,7 +314,7 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
       new SelectBase({
         controlName: 'chargeId',
         label: 'Fees',
-        value: values ? values.chargeId : this.chargeData[0].id,
+        value: values ? values.value.id : this.chargeData[0].id,
         options: { label: 'name', value: 'id', data: this.chargeData },
         required: true,
         order: 1
@@ -316,7 +322,7 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
       new SelectBase({
         controlName: 'incomeAccountId',
         label: 'Income Account',
-        value: values ? values.incomeAccountId : this.incomeAndLiabilityAccountData[0].id,
+        value: values ? values.glAccount.id : this.incomeAndLiabilityAccountData[0].id,
         options: { label: 'name', value: 'id', data: this.incomeAndLiabilityAccountData },
         required: true,
         order: 2
@@ -330,7 +336,7 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
       new SelectBase({
         controlName: 'chargeId',
         label: 'Penalty',
-        value: values ? values.chargeId : this.penaltyData[0].id,
+        value: values ? values.value.id : this.penaltyData[0].id,
         options: { label: 'name', value: 'id', data: this.penaltyData },
         required: true,
         order: 1
@@ -338,7 +344,7 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
       new SelectBase({
         controlName: 'incomeAccountId',
         label: 'Income Account',
-        value: values ? values.incomeAccountId : this.incomeAccountData[0].id,
+        value: values ? values.glAccount.id : this.incomeAccountData[0].id,
         options: { label: 'name', value: 'id', data: this.incomeAccountData },
         required: true,
         order: 2
@@ -355,7 +361,7 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
     const formfields: FormfieldBase[] = [
       new SelectBase({
         controlName: 'reasonCodeValueId',
-        label: this.formType === 'ChargeOffReasonExpense' ? 'Charge-off Reason' : 'Write-off reason',
+        label: this.formType === 'ChargeOffReasonExpense' ? 'Charge-off reason' : 'Write-off reason',
         value: values ? values.value.id : reasonOptions[0].id,
         options: { label: 'name', value: 'id', data: reasonOptions },
         required: true,
@@ -418,6 +424,14 @@ export class AdvancedAccountingMappingRuleComponent implements OnInit {
           return glAccount;
         }
       }
+    }
+    return null;
+  }
+
+  getGlAccountDataFromList(valueId: number, glAccountData: any[]): GLAccount | null {
+    const glAccount = glAccountData.find((i: GLAccount) => i.id === valueId);
+    if (glAccount) {
+      return glAccount;
     }
     return null;
   }

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.html
@@ -300,7 +300,7 @@
             ></mifosx-advanced-accounting-mapping-rule>
             <mifosx-advanced-accounting-mapping-rule
               class="flex-100 m-t-10"
-              [textField]="'Charge-off Reason'"
+              [textField]="'Charge-off reason'"
               [formType]="'ChargeOffReasonExpense'"
               [formArray]="chargeOffReasonToExpenseAccountMappings"
               [textHeading]="'Map Charge-off reasons to Expense accounts'"
@@ -522,7 +522,7 @@
             ></mifosx-advanced-accounting-mapping-rule>
             <mifosx-advanced-accounting-mapping-rule
               class="flex-100 m-t-10"
-              [textField]="'Charge-off Reason'"
+              [textField]="'Charge-off reason'"
               [formType]="'ChargeOffReasonExpense'"
               [formArray]="chargeOffReasonToExpenseAccountMappings"
               [textHeading]="'Map Charge-off reasons to Expense accounts'"

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component.ts
@@ -863,7 +863,7 @@ export class LoanProductAccountingStepComponent extends LoanProductBaseComponent
     const formfields: FormfieldBase[] = [
       new SelectBase({
         controlName: 'chargeOffReasonCodeValueId',
-        label: 'Charge-off Reason',
+        label: 'Charge-off reason',
         value: values ? values.chargeOffReasonCodeValueId : reasonOptions[0].id,
         options: { label: 'name', value: 'id', data: reasonOptions },
         required: true,

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component.ts
@@ -68,7 +68,7 @@ export class LoanProductCurrencyStepComponent implements OnInit {
           this.loanProductsTemplate.installmentAmountInMultiplesOf === 0 ||
           this.loanProductsTemplate.installmentAmountInMultiplesOf === undefined ||
           this.loanProductsTemplate.installmentAmountInMultiplesOf === null
-            ? 0
+            ? 1
             : this.loanProductsTemplate.installmentAmountInMultiplesOf
       });
     }


### PR DESCRIPTION
## Description

Loan product advanced accounting no data issue, the data not was added, then it was not saved

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots

https://github.com/user-attachments/assets/6a1f88af-86bb-4903-a66f-5f0ad568d219


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated advanced loan product accounting tables to display the selected account’s GL code in parentheses.
  * Standardized “Charge-off reason” capitalization across advanced accounting headers and dropdowns.
  * Fixed advanced accounting mapping rule form initialization so Fees/Penalties income and charge-off reason fields use the correct selected values.
  * Set installment amount multiple default to **1** when unset.
* **Improvements**
  * Improved accounting table layout consistency with fixed table sizing and more stable column widths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->