### PR TITLE
WEB-657: Working Capital loan creation with Originators

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.html
@@ -26,8 +26,8 @@
         </mat-select-trigger>
         <mat-option>
           <ngx-mat-select-search
-            placeholderLabel="{{ placeHolderLabel }}"
-            noEntriesFoundLabel="{{ noEntriesFoundLabel }}"
+            placeholderLabel="{{ 'labels.text.Search' | translate }}"
+            noEntriesFoundLabel="{{ 'labels.text.No data found' | translate }}"
             [formControl]="filterFormCtrl"
           ></ngx-mat-select-search>
         </mat-option>
@@ -51,6 +51,46 @@
 
   @if (loanProductSelected) {
     <div class="layout-row-wrap layout-lt-md-column gap-2percent">
+      <mat-form-field class="flex-48" (click)="submitPicker.open()">
+        <mat-label>{{ 'labels.inputs.Submitted on' | translate }}</mat-label>
+        <input
+          matInput
+          [min]="minDate"
+          [max]="maxDate"
+          [matDatepicker]="submitPicker"
+          matTooltip="{{ 'tooltips.Date the loan account application' | translate }}"
+          required
+          formControlName="submittedOnDate"
+        />
+        <mat-datepicker-toggle matSuffix [for]="submitPicker"></mat-datepicker-toggle>
+        <mat-datepicker #submitPicker></mat-datepicker>
+        @if (loansAccountDetailsForm.controls.submittedOnDate?.hasError('required')) {
+          <mat-error>
+            {{ 'labels.inputs.Submitted on' | translate }} {{ 'labels.commons.is' | translate }}
+            <strong>{{ 'labels.commons.required' | translate }}</strong>
+          </mat-error>
+        }
+      </mat-form-field>
+      <mat-form-field class="flex-48" (click)="disbursementPicker.open()">
+        <mat-label>{{ 'labels.inputs.Disbursement on' | translate }}</mat-label>
+        <input
+          matInput
+          [min]="loansAccountDetailsForm.value.submittedOnDate"
+          [max]="maxDate"
+          [matDatepicker]="disbursementPicker"
+          matTooltip="{{ 'tooltips.Date that the loan account disbursed' | translate }}"
+          required
+          formControlName="expectedDisbursementDate"
+        />
+        <mat-datepicker-toggle matSuffix [for]="disbursementPicker"></mat-datepicker-toggle>
+        <mat-datepicker #disbursementPicker></mat-datepicker>
+        @if (loansAccountDetailsForm.controls.expectedDisbursementDate?.hasError('required')) {
+          <mat-error>
+            {{ 'labels.inputs.Disbursement on' | translate }} {{ 'labels.commons.is' | translate }}
+            <strong>{{ 'labels.commons.required' | translate }}</strong>
+          </mat-error>
+        }
+      </mat-form-field>
       <mat-form-field class="flex-48">
         <mat-label>{{ 'labels.inputs.External id' | translate }}</mat-label>
         <input
@@ -58,6 +98,48 @@
           formControlName="externalId"
           matTooltip="{{ 'tooltips.Provides an external id' | translate }}"
         />
+      </mat-form-field>
+      <mat-form-field class="flex-48">
+        <mat-label>{{ 'labels.inputs.Loan Originator' | translate }}</mat-label>
+        <mat-select
+          formControlName="originatorExternalId"
+          panelClass="originator-select-panel"
+          matTooltip="{{ 'tooltips.Provides an external id' | translate }}"
+          (selectionChange)="onOriginatorSelectionChange($event)"
+          multiple
+        >
+          <mat-select-trigger>
+            {{ selectedOriginatorLabel }}
+          </mat-select-trigger>
+          <mat-option>
+            <ngx-mat-select-search
+              placeholderLabel="{{ 'labels.text.Search' | translate }}"
+              noEntriesFoundLabel="{{ 'labels.text.No data found' | translate }}"
+              [formControl]="originatorFilterCtrl"
+            ></ngx-mat-select-search>
+          </mat-option>
+          @for (originator of filteredOriginatorOptions | async; track originator.externalId) {
+            <mat-option [value]="originator.externalId">
+              {{ originatorLabel(originator) }}
+            </mat-option>
+          }
+          @if (canAddOriginator) {
+            <mat-option [value]="originatorSearchTerm">
+              {{ 'labels.buttons.Add' | translate }} "{{ originatorSearchTerm }}"
+            </mat-option>
+          }
+        </mat-select>
+        @if (loansAccountDetailsForm.get('originatorExternalId')?.value?.length) {
+          <button
+            type="button"
+            matSuffix
+            mat-icon-button
+            [attr.aria-label]="'labels.buttons.Clear' | translate"
+            (click)="clearOriginator($event)"
+          >
+            <fa-icon icon="close" size="md"></fa-icon>
+          </button>
+        }
       </mat-form-field>
       @if (loanProductService.isLoanProduct) {
         <mat-form-field class="flex-48">
@@ -94,46 +176,7 @@
           }
         </mat-select>
       </mat-form-field>
-      <mat-form-field class="flex-48" (click)="submitPicker.open()">
-        <mat-label>{{ 'labels.inputs.Submitted on' | translate }}</mat-label>
-        <input
-          matInput
-          [min]="minDate"
-          [max]="maxDate"
-          [matDatepicker]="submitPicker"
-          matTooltip="{{ 'tooltips.Date the loan account application' | translate }}"
-          required
-          formControlName="submittedOnDate"
-        />
-        <mat-datepicker-toggle matSuffix [for]="submitPicker"></mat-datepicker-toggle>
-        <mat-datepicker #submitPicker></mat-datepicker>
-        @if (loansAccountDetailsForm.controls.submittedOnDate?.hasError('required')) {
-          <mat-error>
-            {{ 'labels.inputs.Submitted on' | translate }} {{ 'labels.commons.is' | translate }}
-            <strong>{{ 'labels.commons.required' | translate }}</strong>
-          </mat-error>
-        }
-      </mat-form-field>
-      <mat-form-field class="flex-48" (click)="disbursementPicker.open()">
-        <mat-label>{{ 'labels.inputs.Disbursement on' | translate }}</mat-label>
-        <input
-          matInput
-          [min]="loansAccountDetailsForm.value.submittedOnDate"
-          [max]="maxDate"
-          [matDatepicker]="disbursementPicker"
-          matTooltip="{{ 'tooltips.Date that the loan account disbursed' | translate }}"
-          required
-          formControlName="expectedDisbursementDate"
-        />
-        <mat-datepicker-toggle matSuffix [for]="disbursementPicker"></mat-datepicker-toggle>
-        <mat-datepicker #disbursementPicker></mat-datepicker>
-        @if (loansAccountDetailsForm.controls.submittedOnDate?.hasError('required')) {
-          <mat-error>
-            {{ 'labels.inputs.Disbursement on' | translate }} {{ 'labels.commons.is' | translate }}
-            <strong>{{ 'labels.commons.required' | translate }}</strong>
-          </mat-error>
-        }
-      </mat-form-field>
+
       @if (loanProductService.isLoanProduct) {
         <mat-divider class="flex-98"></mat-divider>
         <h3 class="mat-h3 flex-fill">{{ 'labels.heading.Savings Linkage' | translate }}</h3>

--- a/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.ts
@@ -34,12 +34,16 @@ import { AsyncPipe } from '@angular/common';
 import { MatDivider } from '@angular/material/divider';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
+import { MatIconButton } from '@angular/material/button';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { LoanProductBasicDetails } from 'app/loans/models/loan-product.model';
 import { LoanProductService } from 'app/products/loan-products/services/loan-product.service';
 import { MatSelectChange, MatSelectTrigger } from '@angular/material/select';
 import { LoanProductBaseComponent } from 'app/products/loan-products/common/loan-product-base.component';
+import { LoanOriginator } from 'app/loans/models/loan-account.model';
+import { SystemService } from 'app/system/system.service';
+import { GlobalConfiguration } from 'app/system/configurations/global-configurations-tab/configuration.model';
 
 /**
  * Loans Account Details Step
@@ -58,6 +62,7 @@ import { LoanProductBaseComponent } from 'app/products/loan-products/common/loan
     FaIconComponent,
     MatStepperNext,
     MatSelectTrigger,
+    MatIconButton,
     AsyncPipe
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -71,6 +76,12 @@ export class LoansAccountDetailsStepComponent extends LoanProductBaseComponent i
   private settingsService = inject(SettingsService);
   private commons = inject(Commons);
   private cdr = inject(ChangeDetectorRef);
+  private systemService = inject(SystemService);
+
+  /** Global configuration name that toggles creating a new originator during loan application. */
+  private static readonly ORIGINATOR_CREATION_CONFIG = 'enable-originator-creation-during-loan-application';
+  /** Whether the user is allowed to add a new originator externalId (driven by the global config). */
+  originatorCreationEnabled = false;
 
   //** Defining PlaceHolders for the search bar */
   placeHolderLabel = '';
@@ -95,6 +106,12 @@ export class LoansAccountDetailsStepComponent extends LoanProductBaseComponent i
   fundOptions: any;
   /** Account Linking Options */
   accountLinkingOptions: any;
+  /** Loan Originators catalog (resolved from the route; may be empty) */
+  originatorOptions: LoanOriginator[] = [];
+  /** Filtered originators for the select-search dropdown */
+  protected filteredOriginatorOptions: ReplaySubject<LoanOriginator[]> = new ReplaySubject<LoanOriginator[]>(1);
+  /** Control for the originator filter search box */
+  protected originatorFilterCtrl: UntypedFormControl = new UntypedFormControl('');
   /** For edit loan accounts form */
   isFieldOfficerPatched = false;
   /** Loans Account Details Form */
@@ -129,6 +146,20 @@ export class LoansAccountDetailsStepComponent extends LoanProductBaseComponent i
     this.placeHolderLabel = this.translateService.instant('labels.text.Search');
     this.noEntriesFoundLabel = this.translateService.instant('labels.text.No data found');
     this.maxDate = this.settingsService.maxFutureDate;
+    this.originatorOptions = (this.route.snapshot.data['loanOriginatorsData'] ?? []).filter(
+      (originator: LoanOriginator) => originator.status === 'ACTIVE'
+    );
+    this.filteredOriginatorOptions.next(this.originatorOptions.slice());
+    this.originatorFilterCtrl.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.filterOriginators());
+    this.systemService
+      .getConfigurationByName(LoansAccountDetailsStepComponent.ORIGINATOR_CREATION_CONFIG)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((config: GlobalConfiguration) => {
+        this.originatorCreationEnabled = config?.enabled ?? false;
+        this.cdr.markForCheck();
+      });
     this.productList = this.loanProductsBasicDetails
       ? this.loanProductsBasicDetails.sort(this.commons.dynamicSort('name'))
       : [];
@@ -149,7 +180,10 @@ export class LoansAccountDetailsStepComponent extends LoanProductBaseComponent i
         loanProductId = this.loansAccountTemplate.loanProductId;
         this.loansAccountDetailsForm.patchValue({
           loanOfficerId: this.loansAccountTemplate.loanOfficerId,
-          loanPurposeId: this.loansAccountTemplate.loanPurposeId
+          loanPurposeId: this.loansAccountTemplate.loanPurposeId,
+          originatorExternalId: (this.loansAccountTemplate.originators ?? []).map(
+            (originator: LoanOriginator) => originator.externalId
+          )
         });
       } else if (this.loanProductService.isWorkingCapital && this.loansAccountTemplate.product) {
         loanProductId = this.loansAccountTemplate.product.id;
@@ -206,7 +240,8 @@ export class LoansAccountDetailsStepComponent extends LoanProductBaseComponent i
         '',
         Validators.required
       ],
-      externalId: ['']
+      externalId: [''],
+      originatorExternalId: [[]]
     });
   }
 
@@ -215,13 +250,100 @@ export class LoansAccountDetailsStepComponent extends LoanProductBaseComponent i
    */
   get loansAccountDetails() {
     if (this.productSelected) {
-      const loanAccountDetails = {
-        ...this.loansAccountDetailsForm.getRawValue(),
+      const { originatorExternalId, ...rest } = this.loansAccountDetailsForm.getRawValue();
+      const loanAccountDetails: any = {
+        ...rest,
         productId: this.productSelected.id
       };
+      // The backend expects the originator(s) as an array of objects with the externalId.
+      if (originatorExternalId?.length) {
+        loanAccountDetails.originators = originatorExternalId.map((externalId: string) => ({ externalId }));
+      }
       return loanAccountDetails;
     }
     return null;
+  }
+
+  /**
+   * Filters the loan originators catalog by name/externalId and pushes the
+   * result to the select-search list.
+   */
+  private filterOriginators(): void {
+    const search = (this.originatorFilterCtrl.value || '').toLowerCase();
+    if (!search) {
+      this.filteredOriginatorOptions.next(this.originatorOptions.slice());
+      return;
+    }
+    this.filteredOriginatorOptions.next(
+      this.originatorOptions.filter(
+        (originator) =>
+          (originator.externalId || '').toLowerCase().includes(search) ||
+          (originator.name || '').toLowerCase().includes(search)
+      )
+    );
+  }
+
+  /** Current trimmed search term typed in the originator select-search. */
+  get originatorSearchTerm(): string {
+    return (this.originatorFilterCtrl.value || '').trim();
+  }
+
+  /**
+   * Whether the typed term can be added as a new externalId. Requires the global
+   * config to be enabled and no exact match in the catalog.
+   */
+  get canAddOriginator(): boolean {
+    const term = this.originatorSearchTerm;
+    return (
+      this.originatorCreationEnabled &&
+      !!term &&
+      !this.originatorOptions.some((originator) => originator.externalId.toLowerCase() === term.toLowerCase())
+    );
+  }
+
+  /** Builds the display label "name : externalId" (or just externalId when name is empty). */
+  originatorLabel(originator: LoanOriginator): string {
+    return originator.name ? `${originator.name} : ${originator.externalId}` : originator.externalId;
+  }
+
+  /** Label rendered in the select trigger for the currently selected/added value(s). */
+  get selectedOriginatorLabel(): string {
+    const values: string[] = this.loansAccountDetailsForm?.get('originatorExternalId')?.value ?? [];
+    if (!values.length) {
+      return '';
+    }
+    return values
+      .map((value) => {
+        const match = this.originatorOptions.find((originator) => originator.externalId === value);
+        return match ? this.originatorLabel(match) : value;
+      })
+      .join(', ');
+  }
+
+  /**
+   * Handles a selection in the originator dropdown. When a chosen value is a
+   * newly typed externalId (not in the catalog), it is added as a persistent
+   * option so the selection survives once the search filter is cleared.
+   */
+  onOriginatorSelectionChange(event: MatSelectChange): void {
+    const selectedIds: string[] = event.value ?? [];
+    const newOriginators = selectedIds
+      .filter((externalId) => !this.originatorOptions.some((originator) => originator.externalId === externalId))
+      .map((externalId) => ({ id: 0, externalId, name: '', status: 'ACTIVE' }) as LoanOriginator);
+    if (newOriginators.length) {
+      this.originatorOptions = [
+        ...this.originatorOptions,
+        ...newOriginators
+      ];
+    }
+    this.originatorFilterCtrl.setValue('');
+  }
+
+  /** Clears all the selected loan originator values. */
+  clearOriginator($event: Event): void {
+    this.loansAccountDetailsForm.get('originatorExternalId')?.setValue([]);
+    this.loansAccountDetailsForm.markAsDirty();
+    $event.stopPropagation();
   }
 
   getLoanProductType(productType: string) {

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
@@ -74,6 +74,15 @@
     </div>
   }
 
+  @if (loansAccount.originators?.length) {
+    <div class="flex-fill">
+      <span class="flex-30">{{ 'labels.inputs.Loan Originator' | translate }}:</span>
+      <span class="flex-70">
+        {{ originatorsLabel(loansAccount.originators) }}
+      </span>
+    </div>
+  }
+
   @if (loanProductService.isWorkingCapital) {
     <h3 class="mat-h3 margin-t flex-fill">{{ 'labels.heading.Terms' | translate }}</h3>
 

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.ts
@@ -177,6 +177,10 @@ export class LoansAccountPreviewStepComponent extends LoanProductBaseComponent i
     return match ? { id: match.id, code: match.code, value: match.value } : null;
   }
 
+  originatorsLabel(originators: { externalId: string }[]): string {
+    return (originators ?? []).map((originator) => originator.externalId).join(', ');
+  }
+
   loanProductName(id: number): string {
     const productType: string = this.loanProductService.productType.value;
     const product = this.loanProductsBasicDetails.find((p) => p.productType === productType && p.id === id);

--- a/src/app/loans/loans-routing.module.ts
+++ b/src/app/loans/loans-routing.module.ts
@@ -77,6 +77,7 @@ import { LoanDeferredIncomeDataResolver } from './common-resolvers/loan-deferred
 import { LoanBuyDownFeesDataResolver } from './common-resolvers/loan-buy-down-fees-data.resolver';
 import { LoanOriginatorsTabComponent } from './loans-view/loan-originators-tab/loan-originators-tab.component';
 import { LoanOriginatorsResolver } from './common-resolvers/loan-originators.resolver';
+import { LoanOriginatorsResolver as LoanOriginatorsCatalogResolver } from 'app/organization/loan-originators/loan-originators.resolver';
 import { LoanProductsResolver } from './common-resolvers/loan-products.resolver';
 import { LoanDelinquencyRangeScheduleResolver } from './common-resolvers/working-capital/loan-delinquency-actions.resolver';
 import { LoanBreachActionsResolver } from './common-resolvers/working-capital/loan-breach-actions.resolver';
@@ -104,7 +105,8 @@ const routes: Routes = [
         component: CreateLoansAccountComponent,
         resolve: {
           loansAccountTemplate: LoansAccountTemplateResolver,
-          loanProductsBasicDetails: LoanProductsResolver
+          loanProductsBasicDetails: LoanProductsResolver,
+          loanOriginatorsData: LoanOriginatorsCatalogResolver
         }
       },
       {
@@ -400,7 +402,8 @@ const routes: Routes = [
         component: EditLoansAccountComponent,
         resolve: {
           loanProductsBasicDetails: LoanProductsResolver,
-          loansAccountAndTemplate: LoansAccountAndTemplateResolver
+          loansAccountAndTemplate: LoansAccountAndTemplateResolver,
+          loanOriginatorsData: LoanOriginatorsCatalogResolver
         }
       },
       {

--- a/src/app/loans/loans-view/loan-account-actions/attach-originator/attach-originator.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/attach-originator/attach-originator.component.ts
@@ -66,8 +66,10 @@ export class AttachOriginatorComponent extends LoanAccountActionsBaseComponent i
    */
   submit() {
     const approveLoanFormData = this.attachLoanOriginatorForm.value;
-    this.loanService.attachLoanOriginator(this.loanId, approveLoanFormData.originatorId).subscribe((response: any) => {
-      this.gotoLoanDefaultView();
-    });
+    this.loanService
+      .attachLoanOriginator(this.loanProductService.loanAccountPath, this.loanId, approveLoanFormData.originatorId)
+      .subscribe((response: any) => {
+        this.gotoLoanView('originators');
+      });
   }
 }

--- a/src/app/loans/loans-view/loan-originators-tab/loan-originators-tab.component.html
+++ b/src/app/loans/loans-view/loan-originators-tab/loan-originators-tab.component.html
@@ -37,13 +37,17 @@
     <ng-container matColumnDef="originatorType">
       <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Originator Type' | translate }}</th>
       <td mat-cell *matCellDef="let item">
-        {{ item.originatorType.name }}
+        @if (item.originatorType) {
+          {{ item.originatorType.name }}
+        }
       </td>
     </ng-container>
     <ng-container matColumnDef="channelType">
       <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Channel Type' | translate }}</th>
       <td mat-cell *matCellDef="let item">
-        {{ item.channelType.name }}
+        @if (item.channelType) {
+          {{ item.channelType.name }}
+        }
       </td>
     </ng-container>
     <ng-container matColumnDef="actions">

--- a/src/app/loans/loans-view/loan-originators-tab/loan-originators-tab.component.ts
+++ b/src/app/loans/loans-view/loan-originators-tab/loan-originators-tab.component.ts
@@ -79,14 +79,22 @@ export class LoanOriginatorsTabComponent extends LoanAccountTabBaseComponent {
     super();
     this.clientId = this.route.parent.parent.snapshot.paramMap.get('clientId');
     this.loanId = this.route.parent?.parent?.snapshot.paramMap.get('loanId');
+    this.loanOriginatorsData = [];
     this.route.parent.parent.data
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((data: { loanDetailsData: any }) => {
         this.loanStatus = data.loanDetailsData.status;
+        if ('originators' in data.loanDetailsData) {
+          this.loanOriginatorsData = data.loanDetailsData.originators;
+        }
       });
-    this.route.parent.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanOriginatorsData: any }) => {
-      this.loanOriginatorsData = data.loanOriginatorsData.originators;
-    });
+    if (this.loanProductService.isLoanProduct) {
+      this.route.parent.data
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((data: { loanOriginatorsData: any }) => {
+          this.loanOriginatorsData = data.loanOriginatorsData.originators ?? [];
+        });
+    }
   }
 
   detachLoanOriginator(loanOriginator: LoanOriginator): void {
@@ -107,9 +115,11 @@ export class LoanOriginatorsTabComponent extends LoanAccountTabBaseComponent {
     });
     detachCodeDialogRef.afterClosed().subscribe((response?: { confirm?: boolean }) => {
       if (response?.confirm && this.loanId) {
-        this.loansService.detachLoanOriginator(this.loanId, String(loanOriginator.id)).subscribe((response) => {
-          this.reload();
-        });
+        this.loansService
+          .detachLoanOriginator(this.loanProductService.loanAccountPath, this.loanId, String(loanOriginator.id))
+          .subscribe((response) => {
+            this.reload();
+          });
       }
     });
   }

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -757,14 +757,22 @@ export class LoansService {
     return this.http.post('/loans?command=calculateLoanSchedule', payload);
   }
 
-  attachLoanOriginator(loanId: string, originatorId: string): Observable<any> {
+  attachLoanOriginator(
+    productType: 'loans' | 'working-capital-loans',
+    loanId: string,
+    originatorId: string
+  ): Observable<any> {
     const emptyBody = {};
-    return this.http.post(`/loans/${loanId}/originators/${originatorId}`, emptyBody);
+    return this.http.post(`/${productType}/${loanId}/originators/${originatorId}`, emptyBody);
   }
 
-  detachLoanOriginator(loanId: string, originatorId: string): Observable<any> {
+  detachLoanOriginator(
+    productType: 'loans' | 'working-capital-loans',
+    loanId: string,
+    originatorId: string
+  ): Observable<any> {
     const emptyBody = {};
-    return this.http.delete(`/loans/${loanId}/originators/${originatorId}`, emptyBody);
+    return this.http.delete(`/${productType}/${loanId}/originators/${originatorId}`, emptyBody);
   }
 
   /**

--- a/src/app/loans/models/loan-account.model.ts
+++ b/src/app/loans/models/loan-account.model.ts
@@ -179,8 +179,8 @@ export interface LoanOriginator {
   externalId: string;
   name: string;
   status: string;
-  originatorType: CodeValue;
-  channelType: CodeValue;
+  originatorType?: CodeValue;
+  channelType?: CodeValue;
 }
 
 export interface DelinquencyRangeSchedule {

--- a/src/app/organization/loan-originators/loan-originators.resolver.ts
+++ b/src/app/organization/loan-originators/loan-originators.resolver.ts
@@ -19,7 +19,9 @@ import { ActivatedRouteSnapshot } from '@angular/router';
 /**
  * Loan Originators data resolver.
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class LoanOriginatorsResolver {
   private organizationService = inject(OrganizationService);
 


### PR DESCRIPTION
## Description

Loan Origination functionality is currently build and available for term loans and working capital loans, so It is possible to create a loan account with Originator data

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots

https://github.com/user-attachments/assets/475207cf-a3d4-4a1c-8b97-62d42d5638c8

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a searchable **Loan Originator** selector during loan account setup, with optional “add new” capability when enabled.
  * Loan account preview now displays the selected originator when present.
* **Improvements**
  * Repositioned key date fields earlier in the form with improved date-picker behavior, validation, and constraints.
  * Originator details and originators tab rendering are more resilient to missing type/channel information.
  * Originator attach/detach actions now work for both loans and working-capital-loans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->