### PR TITLE
WEB-657: implement wc loan pause resume action and logic

### DIFF
--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.html
@@ -34,7 +34,7 @@
       </span>
     </div>
     <div class="kpi-status">
-      @if (hasActivePause()) {
+      @if (hasPauseActiveToday()) {
         <span class="status-chip">
           <span class="dot"></span>
           {{ 'labels.inputs.Pause Active' | translate }}
@@ -133,6 +133,17 @@
         }
       </div>
       <div class="toolbar-right">
+        @if (hasActivePause()) {
+          <button
+            type="button"
+            class="btn btn-warn"
+            (click)="resumeBreachAction()"
+            *mifosxHasPermission="'CREATE_WC_BREACH_ACTION'"
+          >
+            <fa-icon icon="play"></fa-icon>
+            {{ 'labels.buttons.Resume Breach' | translate }}
+          </button>
+        }
         <button
           type="button"
           class="btn btn-primary"
@@ -166,7 +177,9 @@
                 </td>
                 <td>
                   <span class="action-badge">
-                    <fa-icon icon="pause"></fa-icon>
+                    <fa-icon
+                      [icon]="row.action === 'RESUME' ? 'play' : row.action === 'RESCHEDULE' ? 'calendar' : 'pause'"
+                    ></fa-icon>
                     {{ row.action | titlecase }}
                   </span>
                 </td>
@@ -180,23 +193,31 @@
                   <span class="date-cell">{{ row.startDateObj | dateFormat }}</span>
                 </td>
                 <td>
-                  @if (row.endDateObj) {
-                    <span class="date-cell">{{ row.endDateObj | dateFormat }}</span>
+                  @if (row.action !== 'RESUME') {
+                    @if (row.endDateObj) {
+                      <span class="date-cell">{{ row.endDateObj | dateFormat }}</span>
+                    } @else {
+                      <span class="date-cell muted">{{ 'labels.inputs.Ongoing' | translate }}</span>
+                    }
                   } @else {
-                    <span class="date-cell muted">{{ 'labels.inputs.Ongoing' | translate }}</span>
+                    <span class="date-cell muted">—</span>
                   }
                 </td>
                 <td>
-                  <span class="duration">
-                    <span class="days">{{ row.durationDays }}{{ row.isOngoing ? '+' : '' }}</span>
-                    <span class="duration-unit">{{ 'labels.inputs.days' | translate }}</span>
-                    <span class="duration-bar">
-                      <span
-                        [attr.class]="'duration-bar-fill duration-bar-fill--' + row.status"
-                        [style.width.%]="durationBarWidth(row)"
-                      ></span>
+                  @if (row.action !== 'RESUME') {
+                    <span class="duration">
+                      <span class="days">{{ row.durationDays }}{{ row.isOngoing ? '+' : '' }}</span>
+                      <span class="duration-unit">{{ 'labels.inputs.days' | translate }}</span>
+                      <span class="duration-bar">
+                        <span
+                          [attr.class]="'duration-bar-fill duration-bar-fill--' + row.status"
+                          [style.width.%]="durationBarWidth(row)"
+                        ></span>
+                      </span>
                     </span>
-                  </span>
+                  } @else {
+                    <span class="date-cell muted">—</span>
+                  }
                 </td>
               </tr>
             }

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.ts
@@ -23,6 +23,7 @@ import {
   MatRow
 } from '@angular/material/table';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { TranslateService } from '@ngx-translate/core';
 import { Dates } from 'app/core/utils/dates';
 import { LoanDelinquencyActionDialogComponent } from 'app/loans/custom-dialog/loan-delinquency-action-dialog/loan-delinquency-action-dialog.component';
 import { LoansService } from 'app/loans/loans.service';
@@ -36,6 +37,7 @@ import {
   WorkingCapitalBreachAction,
   WorkingCapitalNearBreachActions
 } from 'app/loans/models/working-capital/working-capital-loan-account.model';
+import { ConfirmationDialogComponent } from 'app/shared/confirmation-dialog/confirmation-dialog.component';
 
 type BreachActionStatus = 'active' | 'scheduled' | 'expired';
 type BreachActionFilter = 'all' | BreachActionStatus;
@@ -50,6 +52,7 @@ interface BreachActionRow {
   status: BreachActionStatus;
   statusLabelKey: string;
   isOngoing: boolean;
+  isResumedPause: boolean;
   durationDays: number;
   label: string;
 }
@@ -95,6 +98,7 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
   private loansService = inject(LoansService);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
+  private translateService = inject(TranslateService);
   dialog = inject(MatDialog);
 
   // Pause dashboard state
@@ -128,13 +132,17 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
   rows = computed<BreachActionRow[]>(() => {
     const businessDate = this.settingsService.businessDate;
     return this.breachActions().map((item, index) => {
+      const isResumeAction = item.action === 'RESUME';
+      const isResumedPause = item.action === 'PAUSE' && !!item.effectiveEndDate;
       const start = this.dateUtils.parseDate(item.startDate);
-      const end = this.dateUtils.parseDate(item.endDate);
+      const end = isResumeAction ? null : this.dateUtils.parseDate(item.effectiveEndDate ?? item.endDate);
       const reference = end ?? businessDate;
       const durationDays = Math.max(1, Math.round((reference.getTime() - start.getTime()) / MS_PER_DAY));
 
       let status: BreachActionStatus;
-      if (start.getTime() < businessDate.getTime() && end.getTime() < businessDate.getTime()) {
+      if (isResumeAction) {
+        status = 'active';
+      } else if (start.getTime() < businessDate.getTime() && end.getTime() < businessDate.getTime()) {
         status = 'expired';
       } else if (start.getTime() > businessDate.getTime() && end.getTime() > businessDate.getTime()) {
         status = 'scheduled';
@@ -154,6 +162,7 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
         status,
         statusLabelKey: this.statusKey(status),
         isOngoing: !end && status === 'active',
+        isResumedPause: isResumedPause,
         durationDays,
         label: `P${index + 1}`
       };
@@ -176,8 +185,9 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
 
   kpis = computed(() => {
     const rows = this.rows();
-    const activeCount = rows.filter((row) => row.status === 'active').length;
-    const totalDays = rows.reduce((sum, row) => sum + row.durationDays, 0);
+    const pauseRows = rows.filter((row) => row.action === 'PAUSE');
+    const activeCount = pauseRows.filter((row) => row.status === 'active').length;
+    const totalDays = pauseRows.reduce((sum, row) => sum + row.durationDays, 0);
     const lastAction = rows.length
       ? rows.reduce((latest, row) => (row.startDateObj.getTime() > latest.startDateObj.getTime() ? row : latest))
       : null;
@@ -189,7 +199,11 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
     };
   });
 
-  hasActivePause = computed<boolean>(() => this.kpis().activeCount > 0);
+  hasActivePause = computed<boolean>(() =>
+    this.rows().some((r) => r.action === 'PAUSE' && r.status === 'active' && !r.isResumedPause)
+  );
+
+  hasPauseActiveToday = computed<boolean>(() => this.rows().some((r) => r.action === 'PAUSE' && r.status === 'active'));
 
   timelineYear = computed<number>(() => {
     const rows = this.rows();
@@ -203,23 +217,26 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
     const today = this.startOfToday();
     const daysInYear = this.isLeapYear(year) ? 366 : 365;
     const pxPerDay = TIMELINE_INNER_WIDTH / daysInYear;
+    const ongoingLabel = this.translateService.instant('labels.inputs.Ongoing');
 
-    return this.rows().map((row) => {
-      const endRef = row.endDateObj ?? today;
-      const startDay = this.clamp(Math.floor((row.startDateObj.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
-      const endDay = this.clamp(Math.floor((endRef.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
-      const x = TIMELINE_PADDING_LEFT + startDay * pxPerDay;
-      const width = Math.max(8, (endDay - startDay) * pxPerDay);
-      const tooltip = `${row.label} · ${this.shortDate(row.startDateObj)} → ${row.endDateObj ? this.shortDate(row.endDateObj) : 'Ongoing'} (${row.durationDays}d)`;
-      return {
-        label: row.label,
-        status: row.status,
-        x,
-        width,
-        midX: x + width / 2,
-        tooltip
-      };
-    });
+    return this.rows()
+      .filter((row) => row.action === 'PAUSE')
+      .map((row) => {
+        const endRef = row.endDateObj ?? today;
+        const startDay = this.clamp(Math.floor((row.startDateObj.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
+        const endDay = this.clamp(Math.floor((endRef.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
+        const x = TIMELINE_PADDING_LEFT + startDay * pxPerDay;
+        const width = Math.max(8, (endDay - startDay) * pxPerDay);
+        const tooltip = `${row.label} · ${this.shortDate(row.startDateObj)} → ${row.endDateObj ? this.shortDate(row.endDateObj) : ongoingLabel} (${row.durationDays}d)`;
+        return {
+          label: row.label,
+          status: row.status,
+          x,
+          width,
+          midX: x + width / 2,
+          tooltip
+        };
+      });
   });
 
   todayMarker = computed<number | null>(() => {
@@ -266,7 +283,7 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
         }) => {
           this.breachActionsList = data.loanBreachActions || [];
           this.nearBreachActions = data.loanNearBreachActions || [];
-          this.setBreachActions((data.loanBreachActions as unknown as LoanDelinquencyAction[]) || []);
+          this.setBreachActions((data.loanBreachActions as LoanDelinquencyAction[]) || []);
         }
       );
   }
@@ -314,6 +331,39 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
       const startDate: Date = response.data.value.startDate;
       const endDate: Date = response.data.value.endDate;
       this.sendBreachAction(action, startDate, endDate);
+    });
+  }
+
+  resumeBreachAction(): void {
+    const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+      data: {
+        heading: this.translateService.instant('labels.buttons.Resume Breach'),
+        dialogContext: this.translateService.instant(
+          'labels.dialogContext.Are you sure you want to resume the breach pause'
+        )
+      }
+    });
+    dialogRef.afterClosed().subscribe((response: { data: any }) => {
+      if (!response) {
+        return;
+      }
+      const businessDate = this.settingsService.businessDate;
+      this.sendResumeBreachAction(businessDate);
+    });
+  }
+
+  sendResumeBreachAction(startDate: Date): void {
+    const payload = {
+      action: 'resume',
+      locale: this.locale,
+      dateFormat: this.dateFormat,
+      startDate: this.dateUtils.formatDate(startDate, this.dateFormat)
+    };
+
+    this.loansService.createBreachAction(this.loanId, payload).subscribe(() => {
+      this.loansService.getBreachActions(this.loanId).subscribe((breachActions: LoanDelinquencyAction[]) => {
+        this.setBreachActions(breachActions);
+      });
     });
   }
 

--- a/src/app/loans/models/loan-account.model.ts
+++ b/src/app/loans/models/loan-account.model.ts
@@ -48,6 +48,7 @@ export interface LoanDelinquencyAction {
   action: string;
   startDate: number[];
   endDate: number[];
+  effectiveEndDate?: number[];
   createdById: number;
   createdOn: Date;
   updatedById: number;

--- a/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
+++ b/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
@@ -63,7 +63,9 @@ export interface WorkingCapitalBreachActionRequest {
 export interface WorkingCapitalBreachAction {
   id: number;
   action: string;
-  startDate: Date;
+  startDate: number[];
+  endDate?: number[];
+  effectiveEndDate?: number[];
   minimumPayment?: number;
   minimumPaymentType?: string;
   frequency?: number;

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -772,7 +772,8 @@
       "Yes": "Ano",
       "undo_account_transfer": "Vrátit převod účtu",
       "All": "Vše",
-      "Pause Breach": "Pozastavit porušení"
+      "Pause Breach": "Pozastavit porušení",
+      "Resume Breach": "Obnovení porušení"
     },
     "catalogs": {
       "% Amount": "% Amount",
@@ -3339,6 +3340,7 @@
       "Withdrawn": "Stažený"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "Opravdu chcete obnovit porušení?",
       "Are you sure you want Unassign Staff": "Opravdu chcete odebrat přiřazení zaměstnance?",
       "Are you sure you want to calculate interest ?": "Jste si jisti, že chcete spočítat zájem?",
       "Are you sure you want to post interest ?": "Jste si jisti, že chcete zveřejnit zájem?",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -773,7 +773,8 @@
       "Yes": "Ja",
       "undo_account_transfer": "Kontotransfer rückgängig machen",
       "All": "Alle",
-      "Pause Breach": "Verstoß pausieren"
+      "Pause Breach": "Verstoß pausieren",
+      "Resume Breach": "Verstoß fortsetzen"
     },
     "catalogs": {
       "% Amount": "Menge",
@@ -3341,6 +3342,7 @@
       "Withdrawn": "Zurückgezogen"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "Sind Sie sicher, dass Sie den Verstoß wirklich fortsetzen",
       "Are you sure you want Unassign Staff": "Sind Sie sicher, dass Sie das Personal freistellen möchten",
       "Are you sure you want to calculate interest ?": "Sind Sie sicher, dass Sie Zinsen berechnen möchten ?",
       "Are you sure you want to post interest ?": "Sind Sie sicher, dass Sie Zinsen buchen möchten ?",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -774,7 +774,8 @@
       "Yes": "Yes",
       "undo_account_transfer": "Undo Account Transfer",
       "All": "All",
-      "Pause Breach": "Pause Breach"
+      "Pause Breach": "Pause Breach",
+      "Resume Breach": "Resume Breach"
     },
     "catalogs": {
       "% Amount": "% Amount",
@@ -3342,6 +3343,7 @@
       "Withdrawn": "Withdrawn"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "Are you sure you want to resume the breach pause",
       "Are you sure you want Unassign Staff": "Are you sure you want Unassign Staff",
       "Are you sure you want to calculate interest ?": "Are you sure you want to calculate interest ?",
       "Are you sure you want to post interest ?": "Are you sure you want to post interest ?",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -771,7 +771,8 @@
       "Yes": "Sí",
       "undo_account_transfer": "Revertir transferencia de cuenta",
       "All": "Todos",
-      "Pause Breach": "Pausar Incumplimiento"
+      "Pause Breach": "Pausar Incumplimiento",
+      "Resume Breach": "Reanudar Incumplimiento"
     },
     "catalogs": {
       "% Amount": "% Monto",
@@ -3340,6 +3341,7 @@
       "Withdrawn": "Retirado"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "¿Estás seguro de que quieres reanudar la pausa del incumplimiento?",
       "Are you sure you want Unassign Staff": "¿Estás seguro de que deseas desasignar al asesor?",
       "Are you sure you want to calculate interest ?": "¿Estás seguro de que deseas calcular los intereses?",
       "Are you sure you want to post interest ?": "¿Estás seguro de que deseas contabilizar los intereses?",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -772,7 +772,8 @@
       "Yes": "Sí",
       "undo_account_transfer": "Revertir transferencia de cuenta",
       "All": "Todos",
-      "Pause Breach": "Pausar Incumplimiento"
+      "Pause Breach": "Pausar Incumplimiento",
+      "Resume Breach": "Reanudar Incumplimiento"
     },
     "catalogs": {
       "% Amount": "% Monto",
@@ -3343,6 +3344,7 @@
       "Withdrawn": "Retirado"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "¿Estás seguro de que quieres reanudar la pausa del incumplimiento?",
       "Are you sure you want Unassign Staff": "¿Estás seguro de que deseas desasignar al asesor?",
       "Are you sure you want to calculate interest ?": "¿Estás seguro de que deseas calcular los intereses?",
       "Are you sure you want to post interest ?": "¿Estás seguro de que deseas contabilizar los intereses?",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -771,7 +771,8 @@
       "Yes": "Oui",
       "undo_account_transfer": "Annuler le transfert de compte",
       "All": "Tous",
-      "Pause Breach": "Suspendre le Manquement"
+      "Pause Breach": "Suspendre le Manquement",
+      "Resume Breach": "Reprendre le Manquement"
     },
     "catalogs": {
       "% Amount": "Montant",
@@ -3342,6 +3343,7 @@
       "Withdrawn": "Retiré"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "Êtes-vous sûr de vouloir reprendre le manquement après sa mise en pause ?",
       "Are you sure you want Unassign Staff": "Êtes-vous sûr de vouloir désassigner le personnel",
       "Are you sure you want to calculate interest ?": "Êtes-vous sûr de vouloir calculer les intérêts ?",
       "Are you sure you want to post interest ?": "Êtes-vous sûr de vouloir enregistrer les intérêts ?",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -771,7 +771,8 @@
       "Yes": "SÌ",
       "undo_account_transfer": "Annulla trasferimento conto",
       "All": "Tutti",
-      "Pause Breach": "Sospendi Violazione"
+      "Pause Breach": "Sospendi Violazione",
+      "Resume Breach": "Riprendi Violazione"
     },
     "catalogs": {
       "% Amount": "Quantità",
@@ -3338,6 +3339,7 @@
       "Withdrawn": "Ritirato"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "Sei sicuro di voler riprendere la violazione dopo la pausa ?",
       "Are you sure you want Unassign Staff": "Sei sicuro di voler deassegnare il personale",
       "Are you sure you want to calculate interest ?": "Sei sicuro di voler calcolare gli interessi ?",
       "Are you sure you want to post interest ?": "Sei sicuro di voler registrare gli interessi ?",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -771,7 +771,8 @@
       "Yes": "예",
       "undo_account_transfer": "계좌 이체 취소",
       "All": "전체",
-      "Pause Breach": "위반 일시중지"
+      "Pause Breach": "위반 일시중지",
+      "Resume Breach": "중단된 작업 재개"
     },
     "catalogs": {
       "% Amount": "양",
@@ -3338,6 +3339,7 @@
       "Withdrawn": "빼는"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "중단된 작업을 재개하시겠습니까?",
       "Are you sure you want Unassign Staff": "직원 해제를 하시겠습니까?",
       "Are you sure you want to calculate interest ?": "이자를 계산하시겠습니까?",
       "Are you sure you want to post interest ?": "이자를 등록하시겠습니까?",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -771,7 +771,8 @@
       "Yes": "Taip",
       "undo_account_transfer": "Atšaukti sąskaitos pervedimą",
       "All": "Visi",
-      "Pause Breach": "Pristabdyti pažeidimą"
+      "Pause Breach": "Pristabdyti pažeidimą",
+      "Resume Breach": "Atnaujinti pažeidimą"
     },
     "catalogs": {
       "% Amount": "Suma",
@@ -3338,6 +3339,7 @@
       "Withdrawn": "Pasitraukė"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "Ar tikrai norite atnaujinti pažeidimo sustabdymą?",
       "Are you sure you want Unassign Staff": "Ar tikrai norite atšaukti darbuotojo priskyrimą?",
       "Are you sure you want to calculate interest ?": "Ar tikrai norite skaičiuoti palūkanas?",
       "Are you sure you want to post interest ?": "Ar tikrai norite paskelbti palūkanas?",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -771,7 +771,8 @@
       "Yes": "Jā",
       "undo_account_transfer": "Atcelt konta pārskaitījumu",
       "All": "Visi",
-      "Pause Breach": "Apturēt pārkāpumu"
+      "Pause Breach": "Apturēt pārkāpumu",
+      "Resume Breach": "Pārtraukuma atsākšana"
     },
     "catalogs": {
       "% Amount": "Summa",
@@ -3338,6 +3339,7 @@
       "Withdrawn": "Atsaukts"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "Vai esat pārliecināts, ka vēlaties atsākt pārtraukumu?",
       "Are you sure you want Unassign Staff": "Vai tiešām vēlaties atcelt darbinieka piešķiršanu?",
       "Are you sure you want to calculate interest ?": "Vai tiešām vēlaties aprēķināt procentus?",
       "Are you sure you want to post interest ?": "Vai tiešām vēlaties reģistrēt procentus?",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -771,7 +771,8 @@
       "Yes": "हो",
       "undo_account_transfer": "खाता स्थानान्तरण रद्द गर्नुहोस्",
       "All": "सबै",
-      "Pause Breach": "उल्लङ्घन रोक्नुहोस्"
+      "Pause Breach": "उल्लङ्घन रोक्नुहोस्",
+      "Resume Breach": "उल्लंघन पुनः सुरु गर्नुहोस्"
     },
     "catalogs": {
       "% Amount": "रकम",
@@ -3338,6 +3339,7 @@
       "Withdrawn": "फिर्ता लिन"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "के तपाईं उल्लंघन रोकी राखिएको अवस्था पुनः सुरु गर्न चाहनुहुन्छ?",
       "Are you sure you want Unassign Staff": "के तपाईं निश्चित हुनुहुन्छ कि तपाईंले कर्मचारीलाई अनपाइन्ट गर्न चाहनुहुन्छ?",
       "Are you sure you want to calculate interest ?": "के तपाईं निश्चित हुनुहुन्छ कि तपाईं ब्याजहरू गणना गर्न चाहनुहुन्छ?",
       "Are you sure you want to post interest ?": "के तपाईं निश्चित हुनुहुन्छ कि तपाईं ब्याज पोस्ट गर्न चाहनुहुन्छ?",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -771,7 +771,8 @@
       "Yes": "Sim",
       "undo_account_transfer": "Reverter transferência de conta",
       "All": "Todos",
-      "Pause Breach": "Pausar Violação"
+      "Pause Breach": "Pausar Violação",
+      "Resume Breach": "Retomar Violação"
     },
     "catalogs": {
       "% Amount": "Quantia",
@@ -3338,6 +3339,7 @@
       "Withdrawn": "Retirado"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "Tem a certeza de que quer retomar a violação?",
       "Are you sure you want Unassign Staff": "Tem a certeza que deseja desassociar o funcionário?",
       "Are you sure you want to calculate interest ?": "Tem a certeza que deseja calcular juros?",
       "Are you sure you want to post interest ?": "Tem a certeza que deseja registar juros?",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -771,7 +771,8 @@
       "Yes": "Ndiyo",
       "undo_account_transfer": "Futa uhamisho wa akaunti",
       "All": "Vyote",
-      "Pause Breach": "Sitisha Ukiukaji"
+      "Pause Breach": "Sitisha Ukiukaji",
+      "Resume Breach": "Endelea Ukiukaji"
     },
     "catalogs": {
       "% Amount": "Kiasi",
@@ -3335,6 +3336,7 @@
       "Withdrawn": "Kutolewa"
     },
     "dialogContext": {
+      "Are you sure you want to resume the breach pause": "Je, una hakika unataka kuendelea na kusitishwa kwa ukiukaji?",
       "Are you sure you want Unassign Staff": "Je, una uhakika unataka kuondoa wafanyakazi?",
       "Are you sure you want to calculate interest ?": "Je, una uhakika unataka kuhesabu riba?",
       "Are you sure you want to post interest ?": "Je, una uhakika unataka kuchapisha riba?",


### PR DESCRIPTION
## Description

Implemented the resume breach pause action for the UI. When a breach pause is resumed the pause is considered to have ended on the resume date.

## Related issues and discussion

#{WEB-657}

## Screenshots, if any

<img width="2516" height="1112" alt="image" src="https://github.com/user-attachments/assets/a51fa1e8-beff-4b67-8e42-562164b9ed90" />

When a loan has an active breach pause, a resume button is visible.

<img width="2516" height="1112" alt="image" src="https://github.com/user-attachments/assets/d3b6c5d0-535b-43e0-9206-80255300647c" />

Clicking the button opens a confirmation window.

<img width="2516" height="1112" alt="image" src="https://github.com/user-attachments/assets/2a2841bf-ac91-4511-89c2-84707802c11a" />

Once the breach pause has been resumed, the total days paused is recalculated, the pause breach action is now shown with it's effective end date. Because the backend recalculates the periods with the end date inclusive. The current date is considered by the UI to be the last day of the breach pause, so it shows the pause as active.

<img width="2516" height="1112" alt="image" src="https://github.com/user-attachments/assets/b3197457-b480-4a5c-a0e4-b99362657704" />

By the next day the pause is shown as expired.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Resume Breach** action with a localized confirmation prompt.
  * Updated the breach actions tab UI to support resume vs pause items, including action badges and toolbar actions.
  * Enhanced the actions table display for resume items (muted end-date/duration) and improved ongoing/pause labeling.
  * Added/updated translations for the new button and confirmation text across multiple languages.
* **Bug Fixes**
  * Improved active pause indicators, KPIs, and timeline rendering to better reflect current pause/resume states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->