### PR TITLE
WEB-657: Working Capital loan delinquency pause resume

### DIFF
--- a/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.html
+++ b/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.html
@@ -74,8 +74,76 @@
     }
   }
 
+  @if (timelineBars().length > 0) {
+    <div class="timeline-section">
+      <div class="section-header">
+        <span class="section-title"> {{ 'labels.heading.Pause Timeline' | translate }} · {{ timelineYear() }} </span>
+        <div class="legend">
+          <span class="legend-item">
+            <span class="legend-swatch legend-active"></span>{{ 'labels.inputs.Active' | translate }}
+          </span>
+          <span class="legend-item">
+            <span class="legend-swatch legend-scheduled"></span>{{ 'labels.inputs.Scheduled' | translate }}
+          </span>
+          <span class="legend-item">
+            <span class="legend-swatch legend-expired"></span>{{ 'labels.inputs.Expired' | translate }}
+          </span>
+        </div>
+      </div>
+
+      <svg class="timeline" viewBox="0 0 1200 180" preserveAspectRatio="none">
+        <text class="lane-label" x="6" y="92">{{ 'labels.inputs.Pauses' | translate }}</text>
+
+        <g class="grid-group">
+          @for (line of monthGridLines; track $index) {
+            <line class="month-grid" [attr.x1]="line" y1="28" [attr.x2]="line" y2="130" />
+          }
+        </g>
+
+        <line class="baseline" x1="60" y1="130" x2="1200" y2="130" />
+
+        <g>
+          @for (label of monthLabels; track label.name) {
+            <text class="month-label" [attr.x]="label.x" y="152" text-anchor="middle">{{ label.name }}</text>
+          }
+        </g>
+
+        <g>
+          @for (bar of timelineBars(); track bar.label) {
+            <rect
+              [attr.class]="'pause-bar-edge pause-bar-edge--' + bar.status"
+              [attr.x]="bar.x"
+              y="64"
+              [attr.width]="bar.width"
+              height="48"
+              rx="4"
+            />
+            <rect
+              [attr.class]="'pause-bar pause-bar--' + bar.status"
+              [attr.x]="bar.x"
+              y="68"
+              [attr.width]="bar.width"
+              height="40"
+              rx="4"
+            >
+              <title>{{ bar.tooltip }}</title>
+            </rect>
+            <text class="bar-tag" [attr.x]="bar.midX" y="92" text-anchor="middle">{{ bar.label }}</text>
+          }
+        </g>
+
+        @if (todayMarker() !== null) {
+          <line class="today-line" [attr.x1]="todayMarker()" y1="28" [attr.x2]="todayMarker()" y2="140" />
+          <text class="today-label" [attr.x]="todayMarker()" y="22" text-anchor="middle">
+            {{ 'labels.inputs.Today' | translate }}
+          </text>
+        }
+      </svg>
+    </div>
+  }
+
   <div class="layout-row m-t-20 m-b-10 align-end align-items-center gap-5px">
-    @if (allowPause) {
+    @if (allowPause()) {
       <button
         mat-raised-button
         color="primary"
@@ -98,10 +166,10 @@
     }
   </div>
 
-  @if (loanDelinquencyActions.length > 0) {
+  @if (loanDelinquencyActions().length > 0) {
     <div class="m-t-10">
       <h3>{{ 'labels.heading.Loan Delinquency Actions' | translate }}</h3>
-      <table mat-table [dataSource]="loanDelinquencyActions">
+      <table mat-table [dataSource]="loanDelinquencyActions()">
         <ng-container matColumnDef="identifier">
           <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Id' | translate }}</th>
           <td mat-cell *matCellDef="let item">{{ item.id }}</td>
@@ -117,51 +185,62 @@
         <ng-container matColumnDef="endDate">
           <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.End Date' | translate }}</th>
           <td mat-cell *matCellDef="let item">
-            @if (item.endDate) {
-              {{ item.endDate | dateFormat }}
+            @if (item.effectiveEndDate ?? item.endDate; as endDate) {
+              {{ endDate | dateFormat }}
             }
           </td>
         </ng-container>
-        @if (loanProductService.isLoanProduct) {
-          <ng-container matColumnDef="createdOn">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Created On' | translate }}</th>
-            <td mat-cell *matCellDef="let item">{{ item.createdOn | datetimeFormat }}</td>
-          </ng-container>
-        }
-        @if (loanProductService.isWorkingCapital) {
-          <ng-container matColumnDef="minimumPayment">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Minimum Payment' | translate }}</th>
-            <td mat-cell *matCellDef="let item">
-              @if (item.action === 'RESCHEDULE') {
-                {{ item.minimumPayment | formatNumber: '' : 0 }}
-                {{ item.minimumPaymentType | translateKey: 'catalogs' }}
-              }
-            </td>
-          </ng-container>
-          <ng-container matColumnDef="frequency">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Frequency' | translate }}</th>
-            <td mat-cell *matCellDef="let item">
-              @if (item.action === 'RESCHEDULE') {
-                {{ item.frequency | formatNumber: '' : 0 }} {{ item.frequencyType | translateKey: 'catalogs' }}
-              }
-            </td>
-          </ng-container>
-        }
+        <ng-container matColumnDef="createdOn">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Created On' | translate }}</th>
+          <td mat-cell *matCellDef="let item">{{ item.createdOn | datetimeFormat }}</td>
+        </ng-container>
+        <ng-container matColumnDef="minimumPayment">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Minimum Payment' | translate }}</th>
+          <td mat-cell *matCellDef="let item">
+            @if (item.action === 'RESCHEDULE') {
+              {{ item.minimumPayment | formatNumber: '' : 0 }}
+              {{ item.minimumPaymentType | translateKey: 'catalogs' }}
+            }
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="frequency">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Frequency' | translate }}</th>
+          <td mat-cell *matCellDef="let item">
+            @if (item.action === 'RESCHEDULE') {
+              {{ item.frequency | formatNumber: '' : 0 }} {{ item.frequencyType | translateKey: 'catalogs' }}
+            }
+          </td>
+        </ng-container>
         <ng-container matColumnDef="actions">
           <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
           <td mat-cell *matCellDef="let item">
-            @if (loanProductService.isLoanProduct && isCurrentAndPauseAction(item)) {
-              <span>
-                <button
-                  mat-button
-                  color="primary"
-                  (click)="resumeDelinquencyClassification(item)"
-                  *mifosxHasPermission="'CREATE_DELINQUENCY_ACTION'"
-                  matTooltip="{{ 'tooltips.Resume Delinquency Classification' | translate }}"
-                >
-                  <fa-icon icon="play" class="m-r-10"></fa-icon>
-                </button>
-              </span>
+            @if (isCurrentAndPauseAction(item)) {
+              @if (loanProductService.isLoanProduct) {
+                <span>
+                  <button
+                    mat-button
+                    color="primary"
+                    (click)="resumeDelinquencyClassification(item)"
+                    *mifosxHasPermission="'CREATE_DELINQUENCY_ACTION'"
+                    matTooltip="{{ 'tooltips.Resume Delinquency Classification' | translate }}"
+                  >
+                    <fa-icon icon="play" class="m-r-10"></fa-icon>
+                  </button>
+                </span>
+              }
+              @if (loanProductService.isWorkingCapital) {
+                <span>
+                  <button
+                    mat-button
+                    color="primary"
+                    (click)="resumeDelinquencyClassification(item)"
+                    *mifosxHasPermission="'CREATE_WC_DELINQUENCY_ACTION'"
+                    matTooltip="{{ 'tooltips.Resume Delinquency Classification' | translate }}"
+                  >
+                    <fa-icon icon="play" class="m-r-10"></fa-icon>
+                  </button>
+                </span>
+              }
             }
           </td>
         </ng-container>

--- a/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.scss
+++ b/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.scss
@@ -6,6 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+@use 'assets/styles/pause-timeline';
+
 table {
   width: 100%;
 }

--- a/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.ts
+++ b/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.ts
@@ -6,7 +6,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  inject,
+  signal
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
@@ -48,6 +57,21 @@ import { LoanDelinquencyActionRescheduleDialogComponent } from 'app/loans/custom
 import { StringEnumOptionData } from 'app/shared/models/option-data.model';
 import { ProductsService } from 'app/products/products.service';
 
+type DelinquencyActionStatus = 'active' | 'scheduled' | 'expired';
+
+interface DelinquencyTimelineBar {
+  label: string;
+  status: DelinquencyActionStatus;
+  x: number;
+  width: number;
+  midX: number;
+  tooltip: string;
+}
+
+const TIMELINE_PADDING_LEFT = 60;
+const TIMELINE_INNER_WIDTH = 1140;
+const MS_PER_DAY = 86_400_000;
+
 @Component({
   selector: 'mifosx-loan-delinquency-tags-tab',
   templateUrl: './loan-delinquency-tags-tab.component.html',
@@ -82,12 +106,12 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
+  private cdr = inject(ChangeDetectorRef);
   dialog = inject(MatDialog);
 
   loanDelinquencyTags: LoanDelinquencyTags[] = [];
-  loanDelinquencyActions: LoanDelinquencyAction[] = [];
+  loanDelinquencyActions = signal<LoanDelinquencyAction[]>([]);
   wcLoanDelinquencyRangeSchedule: DelinquencyRangeSchedule[] = [];
-  currentLoanDelinquencyAction: LoanDelinquencyAction | null;
   currency: Currency;
   installmentLevelDelinquency: InstallmentLevelDelinquency[] = [];
   loanDelinquencyTagsColumns: string[] = [
@@ -113,22 +137,110 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
     'minPaymentCriteriaMet'
   ];
 
-  allowPause = true;
   loanId: any;
   loanProductId: any;
 
   locale: string;
   dateFormat: string;
 
-  businessDate: Date | null = null;
-
   frequencyTypeOptions: StringEnumOptionData[] = [];
   minimumPaymentTypeOptions: StringEnumOptionData[] = [];
+
+  businessDate = computed<Date | null>(() => this.settingsService.businessDate);
+
+  currentLoanDelinquencyAction = computed<LoanDelinquencyAction | null>(() => {
+    const actions = this.loanDelinquencyActions();
+    return actions.length > 0 ? actions[actions.length - 1] : null;
+  });
+
+  allowPause = computed<boolean>(() => {
+    const current = this.currentLoanDelinquencyAction();
+    if (current == null || this.loanProductService.isWorkingCapital) {
+      return true;
+    }
+    return !this.isCurrentAndPauseAction(current);
+  });
+
+  timelineYear = computed<number>(() => {
+    const actions = this.loanDelinquencyActions();
+    if (actions.length === 0) {
+      return (this.businessDate() ?? new Date()).getFullYear();
+    }
+    return this.dateUtils.parseDate(actions[0].startDate).getFullYear();
+  });
+
+  timelineBars = computed<DelinquencyTimelineBar[]>(() => {
+    const year = this.timelineYear();
+    const yearStart = new Date(year, 0, 1).getTime();
+    const daysInYear = this.isLeapYear(year) ? 366 : 365;
+    const pxPerDay = TIMELINE_INNER_WIDTH / daysInYear;
+    const ongoingLabel = this.translateService.instant('labels.inputs.Ongoing');
+
+    return this.loanDelinquencyActions()
+      .filter((item) => item.action === 'PAUSE')
+      .map((item, index) => {
+        const start = this.dateUtils.parseDate(item.startDate);
+        const endDate = item.effectiveEndDate ?? item.endDate;
+        const end = endDate ? this.dateUtils.parseDate(endDate) : null;
+        const endRef = end ?? this.businessDate() ?? start;
+        const durationDays = Math.max(1, Math.round((endRef.getTime() - start.getTime()) / MS_PER_DAY));
+        const startDay = this.clamp(Math.floor((start.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
+        const endDay = this.clamp(Math.floor((endRef.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
+        const x = TIMELINE_PADDING_LEFT + startDay * pxPerDay;
+        const width = Math.max(8, (endDay - startDay) * pxPerDay);
+        const label = `P${index + 1}`;
+        const tooltip = `${label} · ${this.shortDate(start)} → ${end ? this.shortDate(end) : ongoingLabel} (${durationDays}d)`;
+        return {
+          label,
+          status: this.actionStatus(start, end),
+          x,
+          width,
+          midX: x + width / 2,
+          tooltip
+        };
+      });
+  });
+
+  todayMarker = computed<number | null>(() => {
+    const businessDate = this.businessDate();
+    const year = this.timelineYear();
+    if (!businessDate || businessDate.getFullYear() !== year) {
+      return null;
+    }
+    const yearStart = new Date(year, 0, 1).getTime();
+    const daysInYear = this.isLeapYear(year) ? 366 : 365;
+    const day = Math.floor((businessDate.getTime() - yearStart) / MS_PER_DAY);
+    return TIMELINE_PADDING_LEFT + day * (TIMELINE_INNER_WIDTH / daysInYear);
+  });
+
+  monthGridLines = Array.from({ length: 13 }, (_, i) => {
+    return TIMELINE_PADDING_LEFT + (i * TIMELINE_INNER_WIDTH) / 12;
+  });
+
+  monthLabels = this.dateUtils.monthLabels.map((name, i) => ({
+    name,
+    x: TIMELINE_PADDING_LEFT + (i * TIMELINE_INNER_WIDTH) / 12 + TIMELINE_INNER_WIDTH / 24
+  }));
 
   constructor() {
     super();
     this.loanId = this.route.parent.parent.snapshot.params['loanId'];
-    this.businessDate = this.settingsService.businessDate;
+    this.loanDelinquencyActionsColumns = this.loanProductService.isWorkingCapital ? [
+          'identifier',
+          'action',
+          'startDate',
+          'endDate',
+          'minimumPayment',
+          'frequency',
+          'actions'
+        ] : [
+          'identifier',
+          'action',
+          'startDate',
+          'endDate',
+          'createdOn',
+          'actions'
+        ];
 
     this.route.parent.data
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -152,6 +264,7 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
             this.loanProductId = loanDelinquencyDataResponse.product.id;
           }
           this.wcLoanDelinquencyRangeSchedule = data.wcLoanDelinquencyRangeSchedule;
+          this.cdr.markForCheck();
         }
       );
   }
@@ -159,7 +272,6 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
   ngOnInit(): void {
     this.locale = this.settingsService.language.code;
     this.dateFormat = this.settingsService.dateFormat;
-    this.currentLoanDelinquencyAction = null;
     if (this.loanProductService.isWorkingCapital) {
       this.productsServices
         .getLoanProductsTemplate(this.loanProductService.loanProductPath)
@@ -167,38 +279,6 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
           this.frequencyTypeOptions = response.periodFrequencyTypeOptions;
           this.minimumPaymentTypeOptions = response.delinquencyMinimumPaymentTypeOptions;
         });
-    }
-
-    if (this.loanProductService.isLoanProduct) {
-      this.loanDelinquencyActionsColumns = [
-        'identifier',
-        'action',
-        'startDate',
-        'endDate',
-        'createdOn',
-        'actions'
-      ];
-    } else if (this.loanProductService.isWorkingCapital) {
-      this.loanDelinquencyActionsColumns = [
-        'identifier',
-        'action',
-        'startDate',
-        'endDate',
-        'minimumPayment',
-        'frequency',
-        'actions'
-      ];
-    }
-  }
-
-  validateDelinquencyActions(): void {
-    if (this.loanDelinquencyActions.length > 0) {
-      this.currentLoanDelinquencyAction = this.loanDelinquencyActions[this.loanDelinquencyActions.length - 1];
-      if (this.loanProductService.isLoanProduct) {
-        this.allowPause = this.currentLoanDelinquencyAction.action === 'RESUME';
-      } else if (this.loanProductService.isWorkingCapital) {
-        this.allowPause = true;
-      }
     }
   }
 
@@ -249,7 +329,19 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
     });
     removePauseDialogRef.afterClosed().subscribe((response: any) => {
       if (response.confirm) {
-        this.sendDelinquencyAction('resume', null, null, null, null, null, null);
+        if (this.loanProductService.isLoanProduct) {
+          this.sendDelinquencyAction('resume', null, null, null, null, null, null);
+        } else {
+          this.sendDelinquencyAction(
+            'resume',
+            this.dateUtils.parseDate(this.businessDate()),
+            null,
+            null,
+            null,
+            null,
+            null
+          );
+        }
       }
     });
   }
@@ -300,36 +392,20 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
   }
 
   setLoanDelinquencyAction(loanDelinquencyActions: LoanDelinquencyAction[]): void {
-    this.loanDelinquencyActions = loanDelinquencyActions || [];
-    this.loanDelinquencyActions = this.loanDelinquencyActions.sort(
+    const sorted = [...(loanDelinquencyActions || [])].sort(
       (objA: LoanDelinquencyAction, objB: LoanDelinquencyAction) =>
         this.dateUtils.parseDate(objA.startDate).getTime() - this.dateUtils.parseDate(objB.startDate).getTime()
     );
-    this.validateDelinquencyActions();
+    this.loanDelinquencyActions.set(sorted);
   }
 
   isCurrentAndPauseAction(item: LoanDelinquencyAction): boolean {
-    if (this.currentLoanDelinquencyAction != null) {
-      if (this.currentLoanDelinquencyAction.id === item.id) {
-        if (item.action === 'PAUSE') {
-          const businessDate: Date = this.settingsService.businessDate;
-          const startDate: Date = this.dateUtils.parseDate(item.startDate);
-          if (businessDate < startDate) {
-            this.allowPause = true;
-            return false;
-          }
-          if (item.endDate) {
-            const endDate: Date = this.dateUtils.parseDate(item.endDate);
-            if (businessDate > endDate) {
-              this.allowPause = true;
-              return false;
-            }
-          }
-          return true;
-        }
-      }
-    }
-    return false;
+    return (
+      this.currentLoanDelinquencyAction()?.id === item.id &&
+      item.action === 'PAUSE' &&
+      !this.dateUtils.isBefore(this.businessDate(), this.dateUtils.parseDate(item.startDate)) &&
+      !this.dateUtils.isAfter(this.businessDate(), this.dateUtils.parseDate(item.effectiveEndDate ?? item.endDate))
+    );
   }
 
   actionClass(action: string): string {
@@ -337,5 +413,31 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
       return 'status-pending';
     }
     return 'status-active';
+  }
+
+  private actionStatus(start: Date, end: Date | null): DelinquencyActionStatus {
+    const businessDate = this.businessDate();
+    if (!businessDate) {
+      return 'active';
+    }
+    if (this.dateUtils.isBefore(businessDate, start)) {
+      return 'scheduled';
+    }
+    if (end && this.dateUtils.isAfter(businessDate, end)) {
+      return 'expired';
+    }
+    return 'active';
+  }
+
+  private isLeapYear(year: number): boolean {
+    return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  }
+
+  private clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  private shortDate(date: Date): string {
+    return date.toLocaleDateString('en-US', { month: 'short', day: '2-digit' });
   }
 }

--- a/src/app/settings/settings.service.ts
+++ b/src/app/settings/settings.service.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
 import { AlertService } from 'app/core/alert/alert.service';
 import { Dates } from 'app/core/utils/dates';
 
@@ -30,6 +30,9 @@ export class SettingsService {
   public static cobDateType = 'COB_DATE';
   minAllowedDate = new Date(1950, 0, 1);
   maxAllowedDate = new Date(2100, 0, 1);
+
+  /** Reactive backing for the business date so signal consumers recompute when it changes. */
+  private readonly businessDateValue = signal<string | null>(localStorage.getItem('mifosXServerDate'));
 
   /**
    * Sets date format setting throughout the app.
@@ -105,6 +108,7 @@ export class SettingsService {
    */
   setBusinessDate(date: string) {
     localStorage.setItem('mifosXServerDate', date);
+    this.businessDateValue.set(date);
   }
 
   /**
@@ -226,7 +230,10 @@ export class SettingsService {
    * Returns current Business date server
    */
   get businessDate(): Date {
-    return this.dateUtils.convertToDate(localStorage.getItem('mifosXServerDate'), SettingsService.businessDateFormat);
+    return this.dateUtils.convertToDate(
+      this.businessDateValue() ?? localStorage.getItem('mifosXServerDate'),
+      SettingsService.businessDateFormat
+    );
   }
 
   /**

--- a/src/app/shared/footer/footer.component.html
+++ b/src/app/shared/footer/footer.component.html
@@ -5,6 +5,17 @@
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
+<!-- Business date: independent of variant -->
+@if (displayBackEndInfo && isBusinessDateDefined) {
+  <div class="business-date-field">
+    <span class="business-date-label">{{ 'labels.text.Current Business Date' | translate }}</span>
+    <span class="business-date-chip">
+      <span class="business-date-dot" aria-hidden="true"></span>
+      {{ businessDate | date: 'EEEE, MMMM dd, y' }}
+    </span>
+  </div>
+}
+
 @if (variant === 'compact') {
   <!-- Compact mode for Login -->
   <div class="footer-compact">
@@ -69,14 +80,6 @@
               {{ renderTime | date: 'dd MMMM yyyy HH:mm:ss' }}
             </td>
           </tr>
-          @if (isBusinessDateDefined) {
-            <tr>
-              <td class="footer-content">{{ 'labels.text.Current Business Date' | translate }}:</td>
-              <td class="right footer-content business-date">
-                <b>{{ businessDate | date: 'EEEE, MMMM dd, y' }}</b>
-              </td>
-            </tr>
-          }
         </table>
       </div>
     </div>

--- a/src/app/shared/footer/footer.component.scss
+++ b/src/app/shared/footer/footer.component.scss
@@ -9,6 +9,64 @@
 @use 'assets/styles/helper';
 @use 'assets/styles/colours' as *;
 
+// ===== Business Date (independent of variant) =====
+.business-date-field {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin: 6px 0;
+}
+
+.business-date-label {
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ds-text-3);
+}
+
+.business-date-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border: 1px solid color-mix(in srgb, var(--ds-paid) 35%, transparent);
+  border-radius: 20px;
+  background: var(--ds-paid-bg);
+  color: var(--ds-paid);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.business-date-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ds-paid);
+  animation: business-date-pulse 2.5s ease-in-out infinite;
+}
+
+@keyframes business-date-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .business-date-dot {
+    animation: none;
+  }
+}
+
 // ===== Compact Mode (Login) =====
 .footer-compact {
   display: flex;
@@ -84,10 +142,6 @@
   .divider {
     margin: 2.5rem 1rem 0.5rem;
     width: 4rem;
-  }
-
-  .business-date {
-    color: $status-approved;
   }
 
   table {

--- a/src/app/shared/footer/footer.component.ts
+++ b/src/app/shared/footer/footer.component.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnDestroy, OnInit, inject } from '@angular/core';
 import { Alert } from 'app/core/alert/alert.model';
 import { AlertService } from 'app/core/alert/alert.service';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
@@ -45,6 +45,7 @@ export class FooterComponent implements OnInit, OnDestroy {
   private dateUtils = inject(Dates);
   private versionService = inject(VersionService);
   private translateService = inject(TranslateService);
+  private cdr = inject(ChangeDetectorRef);
 
   username: string = '';
   name: string = '';
@@ -175,6 +176,7 @@ export class FooterComponent implements OnInit, OnDestroy {
         this.dateUtils.formatDate(this.businessDate, SettingsService.businessDateFormat)
       );
       this.isBusinessDateDefined = true;
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/assets/styles/_pause-timeline.scss
+++ b/src/assets/styles/_pause-timeline.scss
@@ -1,0 +1,169 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// Shared pause-timeline styles (SVG year timeline with pause bars).
+// Consumed by loan tabs that chart PAUSE actions over time
+// (e.g. breach actions, delinquency tags). Uses the shared --ds-* tokens.
+
+.timeline-section {
+  padding: 22px 24px 18px;
+  background: var(--ds-surface);
+}
+
+.section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 14px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.section-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ds-text-2);
+}
+
+.legend {
+  display: flex;
+  gap: 16px;
+  font-size: 11.5px;
+  color: var(--ds-text-2);
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+
+  &.legend-active {
+    background: var(--ds-paid);
+  }
+
+  &.legend-scheduled {
+    background: var(--ds-blue-700);
+  }
+
+  &.legend-expired {
+    background: var(--ds-zero);
+  }
+}
+
+.timeline {
+  width: 100%;
+  height: 180px;
+  overflow: visible;
+}
+
+.month-grid {
+  stroke: var(--ds-border);
+  stroke-width: 1;
+  stroke-dasharray: 2 3;
+}
+
+.month-label,
+.lane-label {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 10.5px;
+  font-weight: 600;
+  fill: var(--ds-text-3);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.lane-label {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.baseline {
+  stroke: var(--ds-border);
+  stroke-width: 1.5;
+}
+
+.pause-bar {
+  cursor: pointer;
+  transition:
+    transform 0.14s ease,
+    filter 0.14s ease;
+  transform-origin: center center;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+
+  &--active {
+    fill: var(--ds-paid);
+  }
+
+  &--scheduled {
+    fill: var(--ds-blue-700);
+  }
+
+  &--expired {
+    fill: var(--ds-zero);
+  }
+}
+
+.pause-bar-edge {
+  &--active {
+    fill: var(--ds-paid);
+    opacity: 0.18;
+  }
+
+  &--scheduled {
+    fill: var(--ds-blue-700);
+    opacity: 0.2;
+  }
+
+  &--expired {
+    fill: var(--ds-zero);
+    opacity: 0.18;
+  }
+}
+
+.bar-tag {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  fill: #fff;
+}
+
+:host-context(.dark-theme) .bar-tag {
+  fill: #0d1b2a;
+}
+
+.today-line {
+  stroke: var(--ds-alert);
+  stroke-width: 1.5;
+  stroke-dasharray: 4 3;
+}
+
+.today-label {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 10px;
+  font-weight: 700;
+  fill: var(--ds-alert);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+@media (width <= 599px) {
+  .timeline {
+    height: 220px;
+  }
+}


### PR DESCRIPTION
## Description

User should be able to resume the active paused Delinquency from the UI

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots

https://github.com/user-attachments/assets/a4d3b66f-a716-4fa7-8d6e-51470689b151


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Current Business Date** section in the footer, displayed independently of the versions layout.

* **UI Enhancements**
  * Updated the **Loan Delinquency** pause timeline to render only when pause data exists, with improved “today” alignment and bar/status behavior.
  * Refreshed shared **Pause Timeline** visuals, including interactive bar styling, legend, and responsive sizing.

* **Bug Fixes**
  * Corrected **Loan Delinquency Actions** table behavior: improved visibility, resume (“play”) permissions by loan type, and end-date display logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ