### PR TITLE
WEB-1017: Add Copilot core services and confirmation dialog

### DIFF
--- a/src/app/copilot/components/confirmation-card/confirmation-card.component.html
+++ b/src/app/copilot/components/confirmation-card/confirmation-card.component.html
@@ -5,5 +5,34 @@
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
-<!-- TODO: warning stripe + summary rows + [Cancel] [Confirm] buttons. -->
-<p>confirmation-card works</p>
+<div class="card card--confirm">
+  <div class="card__head">
+    <div class="card__icon-wrap card__icon-wrap--confirmation">
+      <svg class="card__type-icon" viewBox="0 0 24 24">
+        <path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+      </svg>
+    </div>
+    <div class="card__head-text">
+      <span class="card__badge card__badge--confirmation">{{ 'copilot.cardType.confirmation' | translate }}</span>
+      <span class="card__title">{{ card.title }}</span>
+    </div>
+  </div>
+  <div class="card__rows">
+    <div *ngFor="let entry of objectEntries(card.data)" class="card__row">
+      <span class="card__label">{{ entry[0] }}</span>
+      <span class="card__value">{{ entry[1] }}</span>
+    </div>
+  </div>
+  <div class="card__warn-stripe">
+    <svg viewBox="0 0 24 24"><path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" /></svg>
+    <span>{{ 'copilot.confirmWarning' | translate }}</span>
+  </div>
+  <div class="card__actions">
+    <button type="button" class="card__btn card__btn--accent" (click)="cancelled.emit()">
+      {{ 'labels.buttons.Cancel' | translate }}
+    </button>
+    <button type="button" class="card__btn card__btn--warn" (click)="confirmed.emit()">
+      {{ 'labels.buttons.Confirm' | translate }}
+    </button>
+  </div>
+</div>

--- a/src/app/copilot/components/confirmation-card/confirmation-card.component.ts
+++ b/src/app/copilot/components/confirmation-card/confirmation-card.component.ts
@@ -8,12 +8,16 @@
 
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
 import { ActionCard } from '../../core/models/action-card.model';
 
 /** Mandatory confirmation shown before any write action ("involves real money"). */
 @Component({
   selector: 'mifosx-confirmation-card',
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    TranslateModule
+  ],
   templateUrl: './confirmation-card.component.html',
   styleUrls: ['./confirmation-card.component.scss']
 })
@@ -21,4 +25,12 @@ export class ConfirmationCardComponent {
   @Input() card!: ActionCard;
   @Output() confirmed = new EventEmitter<void>();
   @Output() cancelled = new EventEmitter<void>();
+
+  /** Ordered label/value pairs for the confirmation summary. */
+  objectEntries(data: Record<string, string>): [
+    string,
+    string
+  ][] {
+    return Object.entries(data ?? {});
+  }
 }

--- a/src/app/copilot/core/idempotency.spec.ts
+++ b/src/app/copilot/core/idempotency.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { IdempotencyKeyFactory } from './idempotency';
+
+describe('IdempotencyKeyFactory', () => {
+  let factory: IdempotencyKeyFactory;
+
+  beforeEach(() => {
+    factory = new IdempotencyKeyFactory();
+  });
+
+  it('builds the documented key shape', () => {
+    expect(factory.generate(42, 'approve_and_disburse_loan', 107, 1719360000000)).toBe(
+      'usr-42-approve_and_disburse_loan-107-1719360000000'
+    );
+  });
+
+  it('is deterministic for identical inputs (so retries dedupe)', () => {
+    const a = factory.generate(7, 'record_repayment', 3892, 1719360000000);
+    const b = factory.generate(7, 'record_repayment', 3892, 1719360000000);
+    expect(a).toBe(b);
+  });
+
+  it('differs when any input differs', () => {
+    const base = factory.generate(7, 'record_repayment', 3892, 1000);
+    expect(base).not.toBe(factory.generate(8, 'record_repayment', 3892, 1000));
+    expect(base).not.toBe(factory.generate(7, 'create_loan', 3892, 1000));
+    expect(base).not.toBe(factory.generate(7, 'record_repayment', 9999, 1000));
+    expect(base).not.toBe(factory.generate(7, 'record_repayment', 3892, 2000));
+  });
+
+  it('slugs tool names with spaces or punctuation', () => {
+    expect(factory.generate(1, 'Approve & Disburse Loan', 5, 10)).toBe('usr-1-approve_disburse_loan-5-10');
+  });
+});

--- a/src/app/copilot/core/idempotency.ts
+++ b/src/app/copilot/core/idempotency.ts
@@ -14,11 +14,22 @@
  */
 export class IdempotencyKeyFactory {
   /**
-   * Build a key, e.g. `usr-42-approve_and_disburse_loan-107-<ts>`.
-   * @param timestamp injected (Date.now() is not called inside core logic to keep it testable).
+   * Build a key, e.g. `usr-42-approve_and_disburse_loan-107-1719360000000`.
+   * Deterministic: identical inputs always yield the same key, so a retry or
+   * double-click reuses it and Fineract deduplicates. Timestamp is injected
+   * (Date.now() is not called here) to keep the function pure and testable.
    */
-  generate(_userId: number, _toolName: string, _entityId: number, _timestamp: number): string {
-    // TODO: assemble deterministic key.
-    throw new Error('Not implemented');
+  generate(userId: number, toolName: string, entityId: number, timestamp: number): string {
+    const safeTool = this.slug(toolName);
+    return `usr-${userId}-${safeTool}-${entityId}-${timestamp}`;
+  }
+
+  /** Lowercase, keep word chars, collapse the rest to underscores. */
+  private slug(value: string): string {
+    return (value ?? '')
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '');
   }
 }

--- a/src/app/copilot/core/permission-checker.spec.ts
+++ b/src/app/copilot/core/permission-checker.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { PermissionChecker } from './permission-checker';
+
+describe('PermissionChecker', () => {
+  let checker: PermissionChecker;
+
+  beforeEach(() => {
+    checker = new PermissionChecker();
+  });
+
+  describe('isWriteTool', () => {
+    it('flags explicit high-impact write tools', () => {
+      expect(checker.isWriteTool('approve_and_disburse_loan')).toBe(true);
+      expect(checker.isWriteTool('record_repayment')).toBe(true);
+    });
+
+    it('flags any tool with a mutating verb prefix (covers all MCP tools)', () => {
+      for (const tool of [
+        'create_savings_account',
+        'update_client',
+        'delete_charge',
+        'disburse_loan',
+        'reject_loan',
+        'transfer_funds',
+        'waive_charge',
+        'reschedule_loan'
+      ]) {
+        expect(checker.isWriteTool(tool)).toBe(true);
+      }
+    });
+
+    it('treats read/query tools as non-write', () => {
+      for (const tool of [
+        'search_clients',
+        'get_loan',
+        'list_savings',
+        'view_client',
+        'fetch_repayment_schedule'
+      ]) {
+        expect(checker.isWriteTool(tool)).toBe(false);
+      }
+      expect(checker.isWriteTool('')).toBe(false);
+    });
+  });
+
+  describe('canUseTool', () => {
+    it('allows read tools for every role, including unknown', () => {
+      expect(checker.canUseTool('field_agent', 'search_clients')).toBe(true);
+      expect(checker.canUseTool('auditor', 'get_loan')).toBe(true);
+      expect(checker.canUseTool('whoever', 'list_savings')).toBe(true);
+    });
+
+    it('blocks a field_agent and auditor from any write', () => {
+      expect(checker.canUseTool('field_agent', 'approve_and_disburse_loan')).toBe(false);
+      expect(checker.canUseTool('auditor', 'create_client')).toBe(false);
+    });
+
+    it('lets branch_manager and loan_officer perform writes (incl. approving loans)', () => {
+      expect(checker.canUseTool('branch_manager', 'approve_and_disburse_loan')).toBe(true);
+      expect(checker.canUseTool('loan_officer', 'approve_and_disburse_loan')).toBe(true);
+      expect(checker.canUseTool('loan_officer', 'disburse_loan')).toBe(true);
+    });
+
+    it('normalizes display role names', () => {
+      expect(checker.canUseTool('Branch Manager', 'create_loan')).toBe(true);
+      expect(checker.canUseTool('Field Agent', 'record_repayment')).toBe(false);
+    });
+
+    it('denies writes for an unknown or empty role (safe default)', () => {
+      expect(checker.canUseTool('', 'record_repayment')).toBe(false);
+      expect(checker.canUseTool('ghost', 'create_loan')).toBe(false);
+    });
+  });
+
+  describe('allowedTools', () => {
+    it('filters a tool list to those the role may invoke', () => {
+      const tools = [
+        'search_clients',
+        'approve_and_disburse_loan',
+        'get_loan',
+        'create_client'
+      ];
+      expect(checker.allowedTools('field_agent', tools)).toEqual([
+        'search_clients',
+        'get_loan'
+      ]);
+      expect(checker.allowedTools('loan_officer', tools)).toEqual(tools);
+    });
+  });
+});

--- a/src/app/copilot/core/permission-checker.ts
+++ b/src/app/copilot/core/permission-checker.ts
@@ -6,33 +6,89 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-/** MCP tools that perform write operations and require confirmation. */
+/**
+ * High-impact write tools that always require a confirmation dialog. This is an
+ * explicit allow-list of the most sensitive operations; broader detection is
+ * handled by WRITE_VERB so the gate covers all ~100 MCP tools, not just these.
+ */
 export const WRITE_TOOLS = [
   'approve_and_disburse_loan',
-  'create_client',
+  'disburse_loan',
   'create_loan',
-  'record_repayment'
+  'create_client',
+  'record_repayment',
+  'reject_loan',
+  'withdraw_loan',
+  'close_loan',
+  'transfer_funds'
 ];
 
 /**
- * Maps a user role to the set of MCP tools it may invoke.
- * Pure logic, see permission-checker.spec.ts.
+ * Verb prefixes that mark a tool as mutating. The Mifos MCP server exposes ~100
+ * tools; rather than enumerate them all, any tool whose name starts with one of
+ * these verbs is treated as a write (defense in depth alongside WRITE_TOOLS).
+ */
+const WRITE_VERB =
+  /^(create|update|delete|remove|add|edit|modify|approve|reject|withdraw|disburse|undo|activate|deactivate|close|reopen|assign|unassign|transfer|record|make|pay|post|submit|reschedule|writeoff|write_off|waive|charge|apply|cancel|block|unblock|freeze)[_-]/i;
+
+/** Roles allowed to perform write operations. Everyone may read. */
+const WRITE_ROLES = new Set([
+  'super_user',
+  'admin',
+  'administrator',
+  'branch_manager',
+  'loan_officer'
+]);
+
+/** Roles explicitly restricted to read-only, even if otherwise matched. */
+const READ_ONLY_ROLES = new Set([
+  'field_agent',
+  'auditor',
+  'read_only',
+  'viewer',
+  'self_service_user'
+]);
+
+/**
+ * Client-side permission gate for MCP tool calls. Read tools are allowed for any
+ * authenticated user; write tools are restricted by role. This is a first-line
+ * guard only: Fineract still enforces its own RBAC server-side on every call.
+ * Pure logic, no Angular dependency; see permission-checker.spec.ts.
  */
 export class PermissionChecker {
-  /** Returns the tool names allowed for the given role. */
-  allowedTools(_role: string): string[] {
-    // TODO: define role -> tool mapping.
-    throw new Error('Not implemented');
-  }
-
-  /** True if the role may invoke the named tool. */
-  canUseTool(_role: string, _toolName: string): boolean {
-    // TODO: check membership against allowedTools.
-    throw new Error('Not implemented');
-  }
-
   /** True if the tool mutates data and therefore needs a confirmation dialog. */
   isWriteTool(toolName: string): boolean {
-    return WRITE_TOOLS.includes(toolName);
+    const name = (toolName ?? '').trim();
+    if (!name) {
+      return false;
+    }
+    return WRITE_TOOLS.includes(name) || WRITE_VERB.test(name);
+  }
+
+  /** True if the role may perform write operations at all. */
+  canWrite(role: string): boolean {
+    const key = this.normalize(role);
+    if (READ_ONLY_ROLES.has(key)) {
+      return false;
+    }
+    return WRITE_ROLES.has(key);
+  }
+
+  /** True if the role may invoke the named tool (reads: always; writes: role-gated). */
+  canUseTool(role: string, toolName: string): boolean {
+    if (!this.isWriteTool(toolName)) {
+      return true;
+    }
+    return this.canWrite(role);
+  }
+
+  /** Filters a list of tool names to those the role may invoke. */
+  allowedTools(role: string, toolNames: string[]): string[] {
+    return (toolNames ?? []).filter((tool) => this.canUseTool(role, tool));
+  }
+
+  /** Normalize a display role ("Loan Officer") to a key ("loan_officer"). */
+  private normalize(role: string): string {
+    return (role ?? '').trim().toLowerCase().replace(/\s+/g, '_');
   }
 }

--- a/src/app/copilot/core/response-parser.spec.ts
+++ b/src/app/copilot/core/response-parser.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { ResponseParser } from './response-parser';
+
+describe('ResponseParser', () => {
+  let parser: ResponseParser;
+
+  beforeEach(() => {
+    parser = new ResponseParser();
+  });
+
+  it('parses a valid action card', () => {
+    const raw =
+      'Here are the details.\n```action_card\n{"type":"loan","title":"Loan #107","data":{"Status":"Active","Balance":"5000"}}\n```';
+    const cards = parser.parseCards(raw);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].type).toBe('loan');
+    expect(cards[0].title).toBe('Loan #107');
+    expect(cards[0].data['Balance']).toBe('5000');
+  });
+
+  it('parses multiple cards in one response', () => {
+    const raw =
+      '```action_card\n{"type":"client","title":"Rajesh","data":{}}\n```\n```action_card\n{"type":"savings","title":"Acct","data":{"Bal":"10"}}\n```';
+    expect(parser.parseCards(raw)).toHaveLength(2);
+  });
+
+  it('skips malformed JSON without throwing', () => {
+    const raw = '```action_card\n{not valid json}\n```';
+    expect(parser.parseCards(raw)).toEqual([]);
+  });
+
+  it('skips cards with an invalid type', () => {
+    const raw = '```action_card\n{"type":"wizardry","title":"X","data":{}}\n```';
+    expect(parser.parseCards(raw)).toEqual([]);
+  });
+
+  it('skips cards missing a title or data', () => {
+    expect(parser.parseCards('```action_card\n{"type":"loan","data":{}}\n```')).toEqual([]);
+    expect(parser.parseCards('```action_card\n{"type":"loan","title":"X"}\n```')).toEqual([]);
+  });
+
+  it('coerces non-string data values to strings', () => {
+    const raw = '```action_card\n{"type":"loan","title":"L","data":{"n":5,"ok":true,"x":null}}\n```';
+    const [card] = parser.parseCards(raw);
+    expect(card.data).toEqual({ n: '5', ok: 'true', x: '' });
+  });
+
+  it('parses suggestion blocks, stripping list markers', () => {
+    const raw = '```suggest\n- Show client portfolio\n2. View overdue loans\n```';
+    expect(parser.parseSuggestions(raw)).toEqual([
+      'Show client portfolio',
+      'View overdue loans'
+    ]);
+  });
+
+  it('keeps leading numbers that are part of the suggestion text', () => {
+    const raw = '```suggest\n2026 portfolio summary\n10% arrears report\n```';
+    expect(parser.parseSuggestions(raw)).toEqual([
+      '2026 portfolio summary',
+      '10% arrears report'
+    ]);
+  });
+
+  it('assembles text with fences stripped and blank lines collapsed', () => {
+    const raw =
+      'Summary line.\n\n```action_card\n{"type":"loan","title":"L","data":{}}\n```\n\n```suggest\nMore info\n```';
+    const result = parser.parse(raw);
+    expect(result.text).toBe('Summary line.');
+    expect(result.actionCards).toHaveLength(1);
+    expect(result.suggestedPrompts).toEqual(['More info']);
+  });
+
+  it('returns safe empties for empty, null, and plain-text input', () => {
+    expect(parser.parse('')).toEqual({ text: '', actionCards: [], suggestedPrompts: [] });
+    expect(parser.parse(null as unknown as string).actionCards).toEqual([]);
+    const plain = parser.parse('Just a plain answer with no blocks.');
+    expect(plain.text).toBe('Just a plain answer with no blocks.');
+    expect(plain.actionCards).toEqual([]);
+    expect(plain.suggestedPrompts).toEqual([]);
+  });
+
+  it('keeps action button definitions when present', () => {
+    const raw =
+      '```action_card\n{"type":"confirmation","title":"Confirm","data":{},"actions":[{"label":"Confirm","style":"warn","action":"approve"}]}\n```';
+    const [card] = parser.parseCards(raw);
+    expect(card.actions).toHaveLength(1);
+    expect(card.actions?.[0].label).toBe('Confirm');
+  });
+
+  it('drops malformed action buttons (bad style, missing label)', () => {
+    const raw =
+      '```action_card\n{"type":"loan","title":"L","data":{},"actions":[{"label":"Ok","style":"warn"},{"label":"Bad","style":"explode"},{"style":"primary"}]}\n```';
+    const [card] = parser.parseCards(raw);
+    expect(card.actions).toHaveLength(1);
+    expect(card.actions?.[0].label).toBe('Ok');
+  });
+});

--- a/src/app/copilot/core/response-parser.ts
+++ b/src/app/copilot/core/response-parser.ts
@@ -7,29 +7,152 @@
  */
 
 import { McpResponse } from './models/mcp-response.model';
-import { ActionCard } from './models/action-card.model';
+import { ActionCard, ActionButtonStyle, ActionCardButton, ActionCardType } from './models/action-card.model';
+
+const CARD_BLOCK = /```action_card\s*([\s\S]*?)```/gi;
+const SUGGEST_BLOCK = /```suggest\s*([\s\S]*?)```/gi;
+const VALID_TYPES: ReadonlyArray<ActionCardType> = [
+  'client',
+  'loan',
+  'savings',
+  'insight',
+  'confirmation'
+];
+const VALID_STYLES: ReadonlyArray<ActionButtonStyle> = [
+  'primary',
+  'warn',
+  'accent'
+];
 
 /**
- * Parses raw MCP/LLM output into structured action cards and follow-ups.
- * Must degrade gracefully on malformed or partial responses - never throw
- * to the UI. Pure logic, see response-parser.spec.ts.
+ * Parses assistant output into structured action cards and follow-up prompts.
+ * The assistant is instructed (via the system prompt) to emit ```action_card```
+ * and ```suggest``` fenced blocks. Parsing always degrades gracefully and never
+ * throws to the UI: malformed blocks are skipped and bad input yields safe empties.
  */
 export class ResponseParser {
-  /** Extract action-card tokens from a completed response body. */
-  parseCards(_raw: string): ActionCard[] {
-    // TODO: implement ACTION_CARD token parsing.
-    throw new Error('Not implemented');
+  /** Extract valid action cards from fenced ```action_card``` JSON blocks. */
+  parseCards(raw: string): ActionCard[] {
+    const cards: ActionCard[] = [];
+    for (const match of (raw ?? '').matchAll(CARD_BLOCK)) {
+      const card = this.toCard(match[1]);
+      if (card) {
+        cards.push(card);
+      }
+    }
+    return cards;
   }
 
-  /** Extract suggested follow-up prompts. */
-  parseSuggestions(_raw: string): string[] {
-    // TODO: implement follow-up extraction.
-    throw new Error('Not implemented');
+  /** Extract follow-up prompts from fenced ```suggest``` blocks (one per line). */
+  parseSuggestions(raw: string): string[] {
+    const suggestions: string[] = [];
+    for (const match of (raw ?? '').matchAll(SUGGEST_BLOCK)) {
+      for (const line of match[1].split('\n')) {
+        const trimmed = line.replace(/^\s*(?:[-*•]|\d+[.)])\s+/, '').trim();
+        if (trimmed) {
+          suggestions.push(trimmed);
+        }
+      }
+    }
+    return suggestions;
   }
 
-  /** Assemble a full response object from accumulated stream text. */
-  parse(_raw: string): McpResponse {
-    // TODO: combine text + cards + suggestions.
-    throw new Error('Not implemented');
+  /** Assemble the full response: prose (fences stripped) plus cards and suggestions. */
+  parse(raw: string): McpResponse {
+    const text = (raw ?? '')
+      .replace(CARD_BLOCK, '')
+      .replace(SUGGEST_BLOCK, '')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
+    return {
+      text,
+      actionCards: this.parseCards(raw),
+      suggestedPrompts: this.parseSuggestions(raw)
+    };
+  }
+
+  /** Parse and validate a single card block; returns null when malformed. */
+  private toCard(jsonBlock: string): ActionCard | null {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonBlock.trim());
+    } catch {
+      return null;
+    }
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    const candidate = parsed as Record<string, unknown>;
+    const type = candidate['type'];
+    const title = candidate['title'];
+    const data = candidate['data'];
+    if (typeof type !== 'string' || !VALID_TYPES.includes(type as ActionCardType)) {
+      return null;
+    }
+    if (typeof title !== 'string' || !title.trim()) {
+      return null;
+    }
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      return null;
+    }
+    const card: ActionCard = {
+      type: type as ActionCardType,
+      title,
+      data: this.toStringRecord(data as Record<string, unknown>)
+    };
+    const actions = this.toActions(candidate['actions']);
+    if (actions.length) {
+      card.actions = actions;
+    }
+    return card;
+  }
+
+  /** Validate the actions array, keeping only well-formed buttons. */
+  private toActions(raw: unknown): ActionCardButton[] {
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+    const buttons: ActionCardButton[] = [];
+    for (const item of raw) {
+      if (!item || typeof item !== 'object') {
+        continue;
+      }
+      const entry = item as Record<string, unknown>;
+      const label = entry['label'];
+      const style = entry['style'];
+      if (typeof label !== 'string' || !label.trim()) {
+        continue;
+      }
+      if (typeof style !== 'string' || !VALID_STYLES.includes(style as ActionButtonStyle)) {
+        continue;
+      }
+      const button: ActionCardButton = { label, style: style as ActionButtonStyle };
+      if (typeof entry['action'] === 'string') {
+        button.action = entry['action'];
+      }
+      if (typeof entry['route'] === 'string') {
+        button.route = entry['route'];
+      }
+      buttons.push(button);
+    }
+    return buttons;
+  }
+
+  /** Coerce a data object's values to display strings (objects are JSON-encoded). */
+  private toStringRecord(input: Record<string, unknown>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [
+      key,
+      value
+    ] of Object.entries(input)) {
+      if (value == null) {
+        out[key] = '';
+      } else if (typeof value === 'object') {
+        out[key] = JSON.stringify(value);
+      } else {
+        out[key] = String(value);
+      }
+    }
+    return out;
   }
 }


### PR DESCRIPTION
## Related issue
[WEB-1017](https://mifosforge.jira.com/browse/WEB-1017)

## Overview
Adds the pure-logic core that backs the Mifos Copilot read/write flows, plus the write-action confirmation UI. No MCP/LLM wiring yet; that follows once the server (Java MCP plugin) contract is finalized. These are foundational, fully unit-tested building blocks.

## What changed
- **ResponseParser** (`core/response-parser.ts`) — parses structured `action_card` and `suggest` blocks into typed `ActionCard[]` and follow-up prompts; validates card type, title, data, and each action button; degrades gracefully and never throws.
- **PermissionChecker** (`core/permission-checker.ts`) — first-line client gate: pattern-based write detection covering all MCP tools (not a hardcoded subset), role tiers with safe default-deny (read-only roles blocked from writes; loan officer / branch manager allowed). Fineract still enforces RBAC server-side.
- **IdempotencyKeyFactory** (`core/idempotency.ts`) — deterministic correlation/idempotency keys so retries and double-clicks dedupe in Fineract.
- **Confirmation card** (`confirmation-card`) — warning, action summary, Cancel/Confirm for write actions, reusing existing translated button labels.

## Verification
- Unit tests for response parser, permission checker, and idempotency (43 Copilot tests pass).
- ESLint (TS + templates) clean, prettier clean, `ng build` green.

## Notes
- MCP client, chat orchestration, and panel wiring come in a follow-up once the endpoint contract (Java plugin, SSE, Fineract auth/RBAC) is confirmed.

## Checklist
- [x] Single commit (squashed).
- [x] Read and understood `web-app/.github/CONTRIBUTING.md`.

[WEB-1017]: https://mifosforge.jira.com/browse/WEB-1017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fully interactive confirmation card with translated labels, item details, and confirm/cancel actions.
  * Improved handling of assistant responses so action cards and suggested prompts can be displayed more reliably.
* **Bug Fixes**
  * Fixed tool access checks to better distinguish read-only and write actions.
  * Made generated request keys consistent and safer for retry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->