### PR TITLE
Tag Docker image with git tag on main releases

### DIFF
--- a/.github/workflows/create-docker-hub-image.yml
+++ b/.github/workflows/create-docker-hub-image.yml
@@ -3,6 +3,8 @@ name: Publish Image in Docker Hub
 on:
   push:
     branches: [main, dev]
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -12,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -41,12 +45,23 @@ jobs:
 
       - name: Build and Push Multi-Arch Docker Image
         run: |
-          TAGS="--tag $DOCKER_ORGANIZATION/web-app:${{ steps.extract_branch.outputs.branch }}"
-
-          if [ "${{ steps.extract_branch.outputs.branch }}" == "main" ]; then
-            TAGS="$TAGS --tag $DOCKER_ORGANIZATION/web-app:${{ steps.git_hashes.outputs.short_hash }} --tag $DOCKER_ORGANIZATION/web-app:${{ steps.git_hashes.outputs.long_hash }}"
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+              echo "Tag is not on main, skipping."
+              exit 0
+            fi
+            TAGS="--tag $DOCKER_ORGANIZATION/web-app:${GITHUB_REF#refs/tags/}"
           else
-            TAGS="$TAGS --tag $DOCKER_ORGANIZATION/web-app:${{ steps.extract_branch.outputs.branch }}-${{ steps.git_hashes.outputs.short_hash }}"
+            TAGS="--tag $DOCKER_ORGANIZATION/web-app:${{ steps.extract_branch.outputs.branch }}"
+
+            if [ "${{ steps.extract_branch.outputs.branch }}" == "main" ]; then
+              TAGS="$TAGS --tag $DOCKER_ORGANIZATION/web-app:${{ steps.git_hashes.outputs.short_hash }} --tag $DOCKER_ORGANIZATION/web-app:${{ steps.git_hashes.outputs.long_hash }}"
+              for tag in $(git tag --points-at HEAD); do
+                TAGS="$TAGS --tag $DOCKER_ORGANIZATION/web-app:$tag"
+              done
+            else
+              TAGS="$TAGS --tag $DOCKER_ORGANIZATION/web-app:${{ steps.extract_branch.outputs.branch }}-${{ steps.git_hashes.outputs.short_hash }}"
+            fi
           fi
 
           docker build --push --build-arg="PUPPETEER_SKIP_DOWNLOAD_ARG=true" --platform linux/amd64,linux/arm64 $TAGS .


### PR DESCRIPTION
## Description

Adds tagging of docker images with the same git tags present on that commit.

I've been trying to run the mifos web app, but it was not easy to pull the latest release from docker hub. Having a docker image tagged with `v1.0.0-fineract1.14` would have been super useful. This PR adds that.

## Related issues and discussion

I read `web-app/.github/CONTRIBUTING.md`. It instructs new contributors to ask if they should implement a new feature on slack first. I am having trouble joining the slack, it seems like I need an email under a set of subdomains:

<img width="408" height="285" alt="image" src="https://github.com/user-attachments/assets/ebfa5a6e-a251-488c-8c4d-fee3cf885964" />

which I don't have.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] If you have multiple commits please combine them into one commit by squashing them.

- [X] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.
