### PR TITLE
WEB-1025: sanitize CSV/XLSX exports to prevent formula injection

### DIFF
--- a/src/app/core/utils/csv.utils.spec.ts
+++ b/src/app/core/utils/csv.utils.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { sanitizeCsvValue } from './csv.utils';
+
+describe('sanitizeCsvValue', () => {
+  describe('null/undefined handling', () => {
+    it('should return an empty string for null', () => {
+      expect(sanitizeCsvValue(null)).toBe('');
+    });
+
+    it('should return an empty string for undefined', () => {
+      expect(sanitizeCsvValue(undefined)).toBe('');
+    });
+  });
+
+  describe('formula-injection trigger characters', () => {
+    const triggers = [
+      { name: 'equals', value: '=1+1', expected: "'=1+1" },
+      { name: 'plus', value: '+1', expected: "'+1" },
+      { name: 'minus', value: '-1', expected: "'-1" },
+      { name: 'at', value: '@SUM(A1)', expected: "'@SUM(A1)" },
+      { name: 'pipe', value: '|cmd', expected: "'|cmd" },
+      { name: 'percent', value: '%value', expected: "'%value" },
+      { name: 'tab', value: '\tvalue', expected: "'\tvalue" },
+      { name: 'carriage return', value: '\rvalue', expected: "'\rvalue" }
+    ];
+
+    triggers.forEach((t) => {
+      it(`should prefix a value starting with a leading ${t.name} character with a single quote`, () => {
+        expect(sanitizeCsvValue(t.value)).toBe(t.expected);
+      });
+    });
+
+    it('should prefix a classic DDE payload', () => {
+      expect(sanitizeCsvValue('=cmd|"/C calc"!A0')).toBe('\'=cmd|"/C calc"!A0');
+    });
+
+    it('should only trigger on the leading character, not interior occurrences', () => {
+      expect(sanitizeCsvValue('a=1')).toBe('a=1');
+      expect(sanitizeCsvValue('value@domain')).toBe('value@domain');
+    });
+  });
+
+  describe('safe values', () => {
+    it('should leave a plain string untouched', () => {
+      expect(sanitizeCsvValue('John Doe')).toBe('John Doe');
+    });
+
+    it('should leave an empty string untouched', () => {
+      expect(sanitizeCsvValue('')).toBe('');
+    });
+
+    it('should leave a numeric string untouched', () => {
+      expect(sanitizeCsvValue('12345')).toBe('12345');
+    });
+  });
+
+  describe('value coercion', () => {
+    it('should stringify a number', () => {
+      expect(sanitizeCsvValue(42)).toBe('42');
+    });
+
+    it('should stringify zero', () => {
+      expect(sanitizeCsvValue(0)).toBe('0');
+    });
+
+    it('should stringify a negative number by prefixing the leading minus', () => {
+      expect(sanitizeCsvValue(-5)).toBe("'-5");
+    });
+
+    it('should stringify a boolean', () => {
+      expect(sanitizeCsvValue(true)).toBe('true');
+      expect(sanitizeCsvValue(false)).toBe('false');
+    });
+
+    it('should stringify an object', () => {
+      expect(sanitizeCsvValue({ a: 1 })).toBe('[object Object]');
+    });
+
+    it('should stringify an object whose toString begins with a trigger character', () => {
+      const value = { toString: () => '=danger' };
+      expect(sanitizeCsvValue(value)).toBe("'=danger");
+    });
+  });
+});

--- a/src/app/core/utils/csv.utils.ts
+++ b/src/app/core/utils/csv.utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Sanitizes a value for safe inclusion in a CSV file to prevent CSV injection (formula injection) attacks.
+ *
+ * Spreadsheet applications (Excel, LibreOffice, etc.) may execute cell values that begin
+ * with formula trigger characters (=, +, -, @, |, %) as formulas, enabling data exfiltration
+ * or arbitrary command execution on the client machine.
+ *
+ * This function prefixes such values with a single quote (') to force plain-text treatment
+ * in all major spreadsheet applications, per OWASP CSV Injection prevention guidance.
+ *
+ * @param {any} value The raw cell value to sanitize.
+ * @returns {string} The sanitized string value safe for CSV output.
+ */
+export function sanitizeCsvValue(value: any): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const str = String(value);
+  // Prefix formula-injection trigger characters with a single quote so spreadsheets
+  // treat the value as plain text rather than a formula.
+  if (/^[=+\-@|%\t\r]/.test(str)) {
+    return `'${str}`;
+  }
+  return str;
+}

--- a/src/app/reports/run-report/run-report.component.ts
+++ b/src/app/reports/run-report/run-report.component.ts
@@ -21,6 +21,7 @@ import { ReportParameter } from '../common-models/report-parameter.model';
 import { SelectOption } from '../common-models/select-option.model';
 import { Dates } from 'app/core/utils/dates';
 import { GlobalConfiguration } from 'app/system/configurations/global-configurations-tab/configuration.model';
+import { sanitizeCsvValue } from 'app/core/utils/csv.utils';
 
 import * as ExcelJS from 'exceljs';
 import { AlertService } from 'app/core/alert/alert.service';
@@ -535,11 +536,11 @@ export class RunReportComponent implements OnInit {
   async exportToXLS(reportName: string, csvData: any, displayedColumns: string[]): Promise<void> {
     const fileName = `${reportName}.xlsx`;
 
-    // Format data for ExcelJS
+    // Format data for ExcelJS - sanitize all values to prevent formula injection
     const data = csvData.map((object: any) => {
       const row: Record<string, any> = {};
       for (let i = 0; i < displayedColumns.length; i++) {
-        row[displayedColumns[i]] = object.row[i];
+        row[displayedColumns[i]] = sanitizeCsvValue(object.row[i]);
       }
       return row;
     });
@@ -549,7 +550,7 @@ export class RunReportComponent implements OnInit {
     const worksheet = workbook.addWorksheet('report');
 
     // Add header
-    worksheet.addRow(displayedColumns);
+    worksheet.addRow(displayedColumns.map(sanitizeCsvValue));
 
     // Add data rows
     data.forEach((rowObj: any) => {

--- a/src/app/reports/run-report/table-and-sms/table-and-sms.component.ts
+++ b/src/app/reports/run-report/table-and-sms/table-and-sms.component.ts
@@ -34,6 +34,7 @@ import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
 import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
 import { environment } from '../../../../environments/environment';
 import { ProgressBarService } from 'app/core/progress-bar/progress-bar.service';
+import { sanitizeCsvValue } from 'app/core/utils/csv.utils';
 
 import * as ExcelJS from 'exceljs';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -191,10 +192,11 @@ export class TableAndSmsComponent implements OnChanges {
 
   exportToXLS(): void {
     const fileName = `${this.dataObject.report.name}.xlsx`;
+    // Sanitize all values to prevent formula injection in spreadsheet applications
     const data = this.csvData.map((object: any) => {
       const row: { [key: string]: any } = {};
       for (let i = 0; i < this.displayedColumns.length; i++) {
-        row[this.displayedColumns[i]] = object.row[i];
+        row[this.displayedColumns[i]] = sanitizeCsvValue(object.row[i]);
       }
       return row;
     });
@@ -203,7 +205,7 @@ export class TableAndSmsComponent implements OnChanges {
     const worksheet = workbook.addWorksheet('Report');
 
     // Add header row
-    worksheet.addRow(this.displayedColumns);
+    worksheet.addRow(this.displayedColumns.map(sanitizeCsvValue));
 
     // Add data rows
     data.forEach((rowObj: any) => {
@@ -226,8 +228,8 @@ export class TableAndSmsComponent implements OnChanges {
    */
   downloadCSV(fileName: string, delimiter: string) {
     const headers = this.displayedColumns;
-    let csv = this.csvData.map((object: any) => object.row.join(delimiter));
-    csv.unshift(`data:text/csv;charset=utf-8,${headers.join(delimiter)}`);
+    let csv = this.csvData.map((object: any) => object.row.map((cell: any) => sanitizeCsvValue(cell)).join(delimiter));
+    csv.unshift(`data:text/csv;charset=utf-8,${headers.map(sanitizeCsvValue).join(delimiter)}`);
     csv = csv.join('\r\n');
     const link = document.createElement('a');
     link.setAttribute('href', encodeURI(csv));

--- a/src/app/system/audit-trails/audit-trails.component.ts
+++ b/src/app/system/audit-trails/audit-trails.component.ts
@@ -16,6 +16,9 @@ import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
 /** Custom Data Source */
 import { AuditTrailsDataSource } from './audit-trail.datasource';
 
+/** Custom Utils */
+import { sanitizeCsvValue } from 'app/core/utils/csv.utils';
+
 /** Custom Services */
 import { SystemService } from '../system.service';
 import { SettingsService } from 'app/settings/settings.service';
@@ -530,7 +533,6 @@ export class AuditTrailsComponent implements OnInit, AfterViewInit {
    */
   downloadCSV() {
     const dateFormat = this.settingsService.dateFormat;
-    const replacer = (key: any, value: any) => (value === undefined ? '' : value);
     const header = [
       'ID',
       'Resource ID',
@@ -562,13 +564,23 @@ export class AuditTrailsComponent implements OnInit, AfterViewInit {
       .subscribe((response: any) => {
         if (response !== undefined) {
           let csv = response.pageItems.map((row: any) =>
-            headerCode.map((fieldName) =>
-              (fieldName === 'madeOnDate' || fieldName === 'checkedOnDate') &&
-              row[fieldName] != null &&
-              row[fieldName] !== ''
-                ? JSON.stringify(this.dateUtils.formatDate(row[fieldName], 'yyyy-MM-ddTHH:mm:ssZ'))
-                : JSON.stringify(row[fieldName], replacer)
-            )
+            headerCode.map((fieldName) => {
+              // Resolve the raw string value first, THEN sanitize before JSON.stringify wraps
+              // it in double-quotes for CSV quoting. Sanitizing the JSON.stringify output would
+              // be ineffective because the leading " masks formula-trigger characters from the
+              // sanitizer, and Excel strips those outer quotes when parsing the CSV cell.
+              let rawValue: string;
+              if (
+                (fieldName === 'madeOnDate' || fieldName === 'checkedOnDate') &&
+                row[fieldName] != null &&
+                row[fieldName] !== ''
+              ) {
+                rawValue = this.dateUtils.formatDate(row[fieldName], 'yyyy-MM-ddTHH:mm:ssZ');
+              } else {
+                rawValue = row[fieldName] == null ? '' : String(row[fieldName]);
+              }
+              return JSON.stringify(sanitizeCsvValue(rawValue));
+            })
           );
           csv.unshift(`data:text/csv;charset=utf-8,${header.join()}`);
           csv = csv.join('\r\n');


### PR DESCRIPTION
## Description

Exported CSV and XLSX files were built by writing field values directly into CSV rows and spreadsheet cells. Any value beginning with a formula-trigger character (`= + - @ | %`) is interpreted as a formula by Excel/LibreOffice, which exposes the app to CSV / Formula Injection (CWE-1236) — potentially client-side command execution, data exfiltration via spreadsheet functions, and tampering with exported report/audit content.

This change makes exports safe by neutralizing such values so spreadsheets
treat them as plain text:

- Adds a centralized `sanitizeCsvValue()` utility (`src/app/core/utils/csv.utils.ts`) that prefixes values starting with a formula-trigger character with a single quote, per OWASP CSV Injection guidance.
- Applies it at every client-side CSV/XLSX serialization point:
  - `reports/run-report/table-and-sms/table-and-sms.component.ts` — `exportToXLS()` and `downloadCSV()`
  - `reports/run-report/run-report.component.ts` — `exportToXLS()`
  - `system/audit-trails/audit-trails.component.ts` — `downloadCSV()` (raw value is sanitized before `JSON.stringify` quoting, otherwise the leading `"` would hide the trigger character)

Server-generated downloads (BIRT/Pentaho outputs, receipts, bulk-import files) are out of scope, as their content is produced by the backend and cannot be sanitized on the front end.

No new dependencies are required; normal values export unchanged (no regression).

## Related issues and discussion

[WEB-1025](https://mifosforge.jira.com/browse/WEB-1025)

## Screenshots, if any

N/A — no UI changes (export logic only).

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

[WEB-1025]: https://mifosforge.jira.com/browse/WEB-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV and XLSX exports now sanitize both cell values and headers to reduce spreadsheet formula injection risk.
  * Report, table, and audit trail downloads now consistently handle `null`/`undefined` as empty values before generating files.
* **Tests**
  * Added Jest coverage for CSV sanitization to ensure safe strings remain unchanged and risky leading characters are escaped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->