### PR TITLE
MX-278: Add Reporting Dashboard

### DIFF
--- a/src/app/core/shell/sidenav/sidenav.component.html
+++ b/src/app/core/shell/sidenav/sidenav.component.html
@@ -81,6 +81,18 @@
           <a matLine #dashboard>{{ 'labels.menus.Dashboard' | translate }}</a>
         </mat-list-item>
         <mat-list-item
+          [routerLink]="['/reporting-dashboard']"
+          [matTooltipPosition]="tooltipPosition"
+          matTooltip="{{ 'tooltips.Reporting Dashboard' | translate }}"
+          routerLinkActive="active-menu"
+          [routerLinkActiveOptions]="{ exact: false }"
+        >
+          <mat-icon matListIcon>
+            <fa-icon icon="file-alt" size="sm"></fa-icon>
+          </mat-icon>
+          <a matLine #reportingDashboard>{{ 'labels.menus.Reporting Dashboard' | translate }}</a>
+        </mat-list-item>
+        <mat-list-item
           [routerLink]="['/navigation']"
           [matTooltipPosition]="tooltipPosition"
           matTooltip="{{ 'tooltips.Navigation' | translate }}"

--- a/src/app/credit-bureau/credit-bureau.service.ts
+++ b/src/app/credit-bureau/credit-bureau.service.ts
@@ -88,21 +88,21 @@ export class CreditBureauService {
     });
   }
 
-  getSubmissionHistory(clientId: number, page = 0, size = 20): Observable<PagedResult<SubmissionRecord>> {
-    const params = new HttpParams()
-      .set('clientId', clientId.toString())
-      .set('page', page.toString())
-      .set('size', size.toString());
+  getSubmissionHistory(page = 0, size = 20, clientId?: number): Observable<PagedResult<SubmissionRecord>> {
+    let params = new HttpParams().set('page', page.toString()).set('size', size.toString());
+    if (clientId !== undefined && clientId !== null) {
+      params = params.set('clientId', clientId.toString());
+    }
     return this.externalHttp.get<PagedResult<SubmissionRecord>>(`${this.baseUrl}/api/submissions/history`, {
       headers: this.getHeaders(),
       params
     });
   }
 
-  runSubmissions(clientIds: number[]): Observable<SubmissionRunResponse> {
+  runSubmissions(clientIds?: number[]): Observable<SubmissionRunResponse> {
     return this.externalHttp.post<SubmissionRunResponse>(
       `${this.baseUrl}/api/submissions/run`,
-      { clientIds },
+      clientIds && clientIds.length > 0 ? { clientIds } : null,
       { headers: this.getHeaders() }
     );
   }

--- a/src/app/home/home-routing.module.ts
+++ b/src/app/home/home-routing.module.ts
@@ -16,6 +16,7 @@ import { Route } from '../core/route/route.service';
 /** Custom Components */
 import { HomeComponent } from './home.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { ReportingDashboardComponent } from './reporting-dashboard/reporting-dashboard.component';
 
 /** Custom Resolvers */
 import { OfficesResolver } from '../accounting/common-resolvers/offices.resolver';
@@ -40,6 +41,11 @@ const routes: Routes = [
       resolve: {
         offices: OfficesResolver
       }
+    },
+    {
+      path: 'reporting-dashboard',
+      component: ReportingDashboardComponent,
+      data: { title: 'Reporting Dashboard', breadcrumb: 'Reporting Dashboard' }
     }
   ])
 ];

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -20,6 +20,7 @@ import { HomeComponent } from './home.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { WarningDialogComponent } from './warning-dialog/warning-dialog.component';
+import { ReportingDashboardComponent } from './reporting-dashboard/reporting-dashboard.component';
 import { SessionTimeoutDialogComponent } from './timeout-dialog/session-timeout-dialog.component';
 
 /**
@@ -37,7 +38,8 @@ import { SessionTimeoutDialogComponent } from './timeout-dialog/session-timeout-
     HomeComponent,
     DashboardComponent,
     WarningDialogComponent,
-    SessionTimeoutDialogComponent
+    SessionTimeoutDialogComponent,
+    ReportingDashboardComponent
   ],
   providers: []
 })

--- a/src/app/home/reporting-dashboard/reporting-dashboard.component.html
+++ b/src/app/home/reporting-dashboard/reporting-dashboard.component.html
@@ -1,0 +1,150 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<div class="cbild-reporting-dashboard">
+  <!-- Role selector -->
+  <mat-card class="cbild-role-card">
+    <mat-card-content>
+      <mat-form-field appearance="outline">
+        <mat-label>{{ 'labels.cbild.dashboard.role' | translate }}</mat-label>
+        <mat-select [(ngModel)]="selectedRole" (ngModelChange)="onRoleChange($event)">
+          @for (role of roles; track role.value) {
+            <mat-option [value]="role.value">{{ role.label }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+      <button
+        mat-raised-button
+        color="primary"
+        class="cbild-batch-btn"
+        [disabled]="isBatchRunning || isLoading"
+        (click)="runBatch()"
+      >
+        @if (isBatchRunning) {
+          <mat-icon>hourglass_empty</mat-icon>
+        } @else {
+          <mat-icon>play_arrow</mat-icon>
+        }
+        {{ 'labels.cbild.dashboard.runBatch' | translate }}
+      </button>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- Loading bar -->
+  @if (isLoading) {
+    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+  }
+
+  <!-- Stat cards -->
+  @if (!isLoading && !hasError) {
+    <div class="cbild-stats-row">
+      <mat-card class="cbild-stat-card">
+        <mat-card-content>
+          <p class="cbild-stat-label">{{ 'labels.cbild.dashboard.total' | translate }}</p>
+          <p class="cbild-stat-value cbild-stat-total">{{ totalElements }}</p>
+        </mat-card-content>
+      </mat-card>
+      <mat-card class="cbild-stat-card">
+        <mat-card-content>
+          <p class="cbild-stat-label">{{ 'labels.cbild.dashboard.accepted' | translate }}</p>
+          <p class="cbild-stat-value cbild-stat-accepted">{{ acceptedCount }}</p>
+        </mat-card-content>
+      </mat-card>
+      <mat-card class="cbild-stat-card">
+        <mat-card-content>
+          <p class="cbild-stat-label">{{ 'labels.cbild.dashboard.pendingRetry' | translate }}</p>
+          <p class="cbild-stat-value cbild-stat-pending">{{ pendingRetryCount }}</p>
+        </mat-card-content>
+      </mat-card>
+      <mat-card class="cbild-stat-card">
+        <mat-card-content>
+          <p class="cbild-stat-label">{{ 'labels.cbild.dashboard.permanentlyFailed' | translate }}</p>
+          <p class="cbild-stat-value cbild-stat-failed">{{ permanentlyFailedCount }}</p>
+        </mat-card-content>
+      </mat-card>
+    </div>
+  }
+
+  <!-- Submission history table -->
+  @if (!isLoading && !hasError && dataSource.data.length > 0) {
+    <mat-card class="cbild-table-card">
+      <mat-card-content>
+        <div class="mat-elevation-z2">
+          <table mat-table [dataSource]="dataSource">
+            <ng-container matColumnDef="clientId">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.cbild.dashboard.clientId' | translate }}</th>
+              <td mat-cell *matCellDef="let row">{{ row.clientId }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="triggerType">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.cbild.dashboard.triggerType' | translate }}</th>
+              <td mat-cell *matCellDef="let row">{{ row.triggerType }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="status">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.cbild.dashboard.status' | translate }}</th>
+              <td mat-cell *matCellDef="let row">
+                <span [class]="'cbild-status-badge ' + getStatusClass(row.status)">
+                  {{ row.status }}
+                </span>
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="cdcReferenceId">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.cbild.dashboard.cdcRef' | translate }}</th>
+              <td mat-cell *matCellDef="let row">{{ row.cdcReferenceId || '—' }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="expiryDate">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.cbild.dashboard.expiry' | translate }}</th>
+              <td mat-cell *matCellDef="let row">{{ row.expiryDate || '—' }}</td>
+            </ng-container>
+
+            <ng-container matColumnDef="submittedAt">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.cbild.dashboard.submittedAt' | translate }}</th>
+              <td mat-cell *matCellDef="let row">{{ row.submittedAt | dateFormat }}</td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+          </table>
+          <mat-paginator
+            [length]="totalElements"
+            [pageSize]="pageSize"
+            [pageSizeOptions]="[10, 20, 50]"
+            showFirstLastButtons
+            (page)="onPageChange($event.pageIndex, $event.pageSize)"
+          >
+          </mat-paginator>
+        </div>
+      </mat-card-content>
+    </mat-card>
+  }
+
+  <!-- Empty state -->
+  @if (!isLoading && !hasError && dataSource.data.length === 0) {
+    <mat-card class="cbild-empty-card">
+      <mat-card-content class="cbild-empty-content">
+        <mat-icon>inbox</mat-icon>
+        <p>{{ 'labels.cbild.dashboard.noSubmissions' | translate }}</p>
+      </mat-card-content>
+    </mat-card>
+  }
+
+  <!-- Error state -->
+  @if (hasError && !isLoading) {
+    <mat-card class="cbild-empty-card">
+      <mat-card-content class="cbild-empty-content">
+        <mat-icon color="warn">error_outline</mat-icon>
+        <p>{{ 'labels.cbild.errors.unexpected' | translate }}</p>
+        <button mat-stroked-button color="primary" (click)="loadHistory()">
+          {{ 'labels.buttons.Retry' | translate }}
+        </button>
+      </mat-card-content>
+    </mat-card>
+  }
+</div>

--- a/src/app/home/reporting-dashboard/reporting-dashboard.component.scss
+++ b/src/app/home/reporting-dashboard/reporting-dashboard.component.scss
@@ -1,0 +1,133 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.cbild-reporting-dashboard {
+  padding: 16px;
+}
+
+.cbild-role-card {
+  margin-bottom: 16px;
+
+  mat-card-content {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+
+  mat-form-field {
+    width: 240px;
+  }
+}
+
+.cbild-batch-btn {
+  height: 40px;
+
+  mat-icon {
+    margin-right: 8px;
+  }
+}
+
+.cbild-stats-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+
+  .cbild-stat-card {
+    flex: 1 1 calc(25% - 16px);
+    min-width: 160px;
+  }
+}
+
+.cbild-stat-card {
+  text-align: center;
+}
+
+.cbild-stat-label {
+  font-size: 12px;
+  color: var(--mdc-theme-text-secondary-on-background, rgb(0 0 0 / 54%));
+  margin-bottom: 8px;
+}
+
+.cbild-stat-value {
+  font-size: 32px;
+  font-weight: 500;
+  margin: 0;
+}
+
+.cbild-stat-total {
+  color: var(--mdc-theme-primary, #009fdf);
+}
+
+.cbild-stat-accepted {
+  color: var(--mdc-theme-success, #16a34a);
+}
+
+.cbild-stat-pending {
+  color: var(--mdc-theme-warning, #d97706);
+}
+
+.cbild-stat-failed {
+  color: var(--mdc-theme-error, #dc2626);
+}
+
+.cbild-table-card {
+  margin-bottom: 16px;
+}
+
+table {
+  width: 100%;
+}
+
+.cbild-status-badge {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.cbild-status-accepted {
+  background: var(--cbild-status-accepted-bg, #dcfce7);
+  color: var(--cbild-status-accepted-fg, #16a34a);
+}
+
+.cbild-status-rejected {
+  background: var(--cbild-status-rejected-bg, #fee2e2);
+  color: var(--cbild-status-rejected-fg, #dc2626);
+}
+
+.cbild-status-pending {
+  background: var(--cbild-status-pending-bg, #fef9c3);
+  color: var(--cbild-status-pending-fg, #d97706);
+}
+
+.cbild-status-failed {
+  background: var(--cbild-status-failed-bg, #fee2e2);
+  color: var(--cbild-status-failed-fg, #991b1b);
+}
+
+.cbild-empty-card {
+  margin-bottom: 16px;
+}
+
+.cbild-empty-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 32px;
+  gap: 16px;
+  color: var(--mdc-theme-text-disabled-on-background, rgb(0 0 0 / 38%));
+
+  mat-icon {
+    font-size: 48px;
+    height: 48px;
+    width: 48px;
+  }
+}

--- a/src/app/home/reporting-dashboard/reporting-dashboard.component.ts
+++ b/src/app/home/reporting-dashboard/reporting-dashboard.component.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  inject,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  ViewChild
+} from '@angular/core';
+import { Subject, timer } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { HttpErrorResponse } from '@angular/common/http';
+import { MatTableModule, MatTableDataSource } from '@angular/material/table';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { MatIcon } from '@angular/material/icon';
+import { MatDivider } from '@angular/material/divider';
+import { FormsModule } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { AlertService } from 'app/core/alert/alert.service';
+import { CreditBureauService } from 'app/credit-bureau/credit-bureau.service';
+import { SubmissionRecord, PagedResult, CbildRole, CBILD_ROLE_LABELS } from 'app/credit-bureau/credit-bureau.models';
+
+@Component({
+  selector: 'mifosx-reporting-dashboard',
+  templateUrl: './reporting-dashboard.component.html',
+  styleUrls: ['./reporting-dashboard.component.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    MatTableModule,
+    MatPaginatorModule,
+    MatProgressBar,
+    MatIcon,
+    MatDivider,
+    FormsModule
+  ]
+})
+export class ReportingDashboardComponent implements OnInit, OnDestroy {
+  private creditBureauService = inject(CreditBureauService);
+  private alertService = inject(AlertService);
+  private cdr = inject(ChangeDetectorRef);
+  private translateService = inject(TranslateService);
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  isLoading = false;
+  hasError = false;
+  isBatchRunning = false;
+  dataSource = new MatTableDataSource<SubmissionRecord>([]);
+  totalElements = 0;
+  pageSize = 20;
+  pageIndex = 0;
+  selectedRole: CbildRole = 'CREDIT_ANALYST';
+
+  roles: { value: CbildRole; label: string }[] = [
+    { value: 'CREDIT_ANALYST', label: CBILD_ROLE_LABELS.CREDIT_ANALYST },
+    { value: 'COMPLIANCE', label: CBILD_ROLE_LABELS.COMPLIANCE }
+  ];
+
+  displayedColumns = [
+    'clientId',
+    'triggerType',
+    'status',
+    'cdcReferenceId',
+    'expiryDate',
+    'submittedAt'
+  ];
+
+  get acceptedCount(): number {
+    return this.dataSource.data.filter((s) => s.status === 'ACCEPTED').length;
+  }
+
+  get pendingRetryCount(): number {
+    return this.dataSource.data.filter((s) => s.status === 'PENDING_RETRY').length;
+  }
+
+  get permanentlyFailedCount(): number {
+    return this.dataSource.data.filter((s) => s.status === 'PERMANENTLY_FAILED').length;
+  }
+
+  private destroy$ = new Subject<void>();
+
+  ngOnInit(): void {
+    const savedRole = this.creditBureauService.getRole();
+    this.selectedRole = savedRole === 'KYC_OFFICER' ? 'CREDIT_ANALYST' : savedRole;
+    this.creditBureauService.setRole(this.selectedRole);
+    this.loadHistory();
+  }
+
+  onRoleChange(role: CbildRole): void {
+    this.selectedRole = role;
+    this.creditBureauService.setRole(role);
+    this.pageIndex = 0;
+    this.loadHistory();
+  }
+
+  loadHistory(): void {
+    this.isLoading = true;
+    this.hasError = false;
+    this.cdr.markForCheck();
+
+    this.creditBureauService
+      .getSubmissionHistory(this.pageIndex, this.pageSize)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (data: PagedResult<SubmissionRecord>) => {
+          const key = Object.keys(data._embedded || {})[0];
+          this.dataSource.data = key ? (data._embedded[key] as SubmissionRecord[]) : [];
+          this.totalElements = data.page?.totalElements || 0;
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isLoading = false;
+          this.hasError = true;
+          this.alertService.alert({
+            type: 'error',
+            message: this.getErrorMessage(err)
+          });
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  onPageChange(pageIndex: number, pageSize: number): void {
+    this.pageIndex = pageIndex;
+    this.pageSize = pageSize;
+    this.loadHistory();
+  }
+
+  runBatch(): void {
+    this.isBatchRunning = true;
+    this.cdr.markForCheck();
+
+    this.creditBureauService
+      .runSubmissions()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.isBatchRunning = false;
+          this.alertService.alert({
+            type: 'success',
+            message: this.translateService.instant('labels.cbild.dashboard.batchStarted')
+          });
+          timer(3000)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(() => this.loadHistory());
+          this.cdr.markForCheck();
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isBatchRunning = false;
+          this.alertService.alert({
+            type: 'error',
+            message: this.getErrorMessage(err)
+          });
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  getStatusClass(status: string): string {
+    switch (status) {
+      case 'ACCEPTED':
+        return 'cbild-status-accepted';
+      case 'REJECTED':
+        return 'cbild-status-rejected';
+      case 'PENDING_RETRY':
+        return 'cbild-status-pending';
+      case 'PERMANENTLY_FAILED':
+        return 'cbild-status-failed';
+      default:
+        return '';
+    }
+  }
+
+  private getErrorMessage(err: HttpErrorResponse): string {
+    const t = (key: string) => this.translateService.instant(key);
+    switch (err?.status) {
+      case 401:
+        return t('labels.cbild.errors.unauthorized');
+      case 403:
+        return t('labels.cbild.errors.forbidden');
+      case 503:
+        return t('labels.cbild.errors.serviceUnavailable');
+      default:
+        return err?.error?.message || t('labels.cbild.errors.unexpected');
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3309,7 +3309,8 @@
       "Apply Additional Shares": "Apply Additional Shares",
       "Redeem Shares": "Redeem Shares",
       "Approve Additional Shares": "Approve Additional Shares",
-      "Reject Additional Shares": "Reject Additional Shares"
+      "Reject Additional Shares": "Reject Additional Shares",
+      "Reporting Dashboard": "Reporting Dashboard"
     },
     "placeholders": {
       "# Remittance": "# Remittance",
@@ -4544,8 +4545,7 @@
       "No Upcoming Charges Found": "No Upcoming Charges Found",
       "unableToUpdateDiscount": "Unable to update discount.",
       "validationSaved": "Validation data saved successfully.",
-      "workingCapitalDiscountUpdated": "Working capital discount was updated successfully.",
-      "unableToUpdateDiscount": "Unable to update discount."
+      "workingCapitalDiscountUpdated": "Working capital discount was updated successfully."
     },
     "cbild": {
       "fields": {
@@ -4562,6 +4562,22 @@
         "clientNotFound": "Client {{ clientId }} not found in Fineract.",
         "serviceUnavailable": "CDC or Fineract is unreachable. Please try again later.",
         "unexpected": "An unexpected error occurred. Please try again."
+      },
+      "dashboard": {
+        "role": "Your CB-ILD Role",
+        "runBatch": "Run Batch",
+        "batchStarted": "Batch submission started for all active clients",
+        "total": "Total Submissions",
+        "accepted": "Accepted",
+        "pendingRetry": "Pending Retry",
+        "permanentlyFailed": "Permanently Failed",
+        "clientId": "Client ID",
+        "triggerType": "Trigger Type",
+        "status": "Status",
+        "cdcRef": "CDC Reference ID",
+        "expiry": "Expiry Date",
+        "submittedAt": "Submitted At",
+        "noSubmissions": "No submissions found"
       }
     }
   },
@@ -4783,7 +4799,8 @@
     "Withdraw": "Withdraw",
     "Yes": "Yes",
     "loan product will be active and available to clients": "The date that the loan product will be active and available to clients. If blank, the loan product will be active as soon as it is created.",
-    "loan product will become inactive and unavailable to clients": "The date that the loan product will become inactive and unavailable to clients. If blank, the load product will never become inactive."
+    "loan product will become inactive and unavailable to clients": "The date that the loan product will become inactive and unavailable to clients. If blank, the load product will never become inactive.",
+    "Reporting Dashboard": "CB-ILD Reporting Dashboard"
   },
   "countries": {
     "AF": "Afghanistan",


### PR DESCRIPTION
## Summary
Adds CB-ILD Reporting Dashboard — a standalone page in the Mifos sidenav showing all CDC submission history across clients.

## What Changed
- `src/app/home/reporting-dashboard/` — ReportingDashboard component (ts + html + scss)
- `src/app/home/home.module.ts` — ReportingDashboardComponent registered
- `src/app/home/home-routing.module.ts` — /reporting-dashboard route added
- `src/app/core/shell/sidenav/sidenav.component.html` — nav link added after Dashboard
- `src/assets/translations/en-US.json` — CB-ILD dashboard translation keys added
- `src/app/credit-bureau/credit-bureau.service.ts` — getSubmissionHistory clientId now optional
- CB-ILD backend: SubmissionController.java — clientId optional for all-clients view
- CB-ILD backend: SubmissionRecordRepository.java — findAllByOrderBySubmittedAtDesc added

## Test Results
- 60 submissions visible across all clients 
- Pagination working (10/20/50 per page) 
- Run Batch returns 202 — starts in background 
- Retry queue = 0 — system healthy 
- Roles: Credit Analyst + Compliance only (KYC Officer gets 403) 

## Related
- Jira: MX-278
- Depends on: MX-277 (merged PR #3704)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Reporting Dashboard” item to the main navigation and created a dedicated reporting page.
  * Implemented role-based reporting with “run batch”, progress feedback, summary stat cards, submission history table with pagination, plus empty and error states.
  * Added English dashboard labels, statuses, and tooltip/help text for the new experience.
* **Bug Fixes**
  * Improved credit-bureau reporting requests to better support optional client filtering and pagination in submission history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->