### PR TITLE
WEB-657: Loan Charge adjustment even if the charge has being paid

### DIFF
--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.html
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.html
@@ -269,49 +269,47 @@
           {{ 'labels.inputs.Actions' | translate }}
         </th>
         <td mat-cell *matCellDef="let charge" class="col-c" (click)="$event.stopPropagation()">
-          @if (!isPaid(charge) && !isWaived(charge)) {
-            <div class="act-group">
-              <button
-                mat-icon-button
-                type="button"
-                [matMenuTriggerFor]="chargeMenu"
-                [attr.aria-label]="'labels.inputs.Actions' | translate"
-              >
-                <mat-icon>more_vert</mat-icon>
-              </button>
+          <div class="act-group">
+            <button
+              mat-icon-button
+              type="button"
+              [matMenuTriggerFor]="chargeMenu"
+              [attr.aria-label]="'labels.inputs.Actions' | translate"
+            >
+              <mat-icon>more_vert</mat-icon>
+            </button>
 
-              <mat-menu #chargeMenu="matMenu" class="charge-actions-menu">
-                @if (status === 'Active' && !charge.paid) {
-                  <button mat-menu-item (click)="adjustCharge(charge.id)">
-                    <mat-icon matMenuItemIcon>tune</mat-icon>
-                    {{ 'tooltips.Adjust Charge' | translate }}
-                  </button>
-                }
-                @if (status === 'Submitted and pending approval') {
-                  <button mat-menu-item (click)="editCharge(charge)">
-                    <mat-icon matMenuItemIcon>edit</mat-icon>
-                    {{ 'tooltips.Edit Charge' | translate }}
-                  </button>
-                  <button mat-menu-item class="menu-item-danger" (click)="deleteCharge(charge.id)">
-                    <mat-icon matMenuItemIcon>delete</mat-icon>
-                    {{ 'labels.buttons.Delete' | translate }}
-                  </button>
-                }
-                @if (charge.chargePayable && !charge.paid && status === 'Active') {
-                  <button mat-menu-item (click)="payCharge(charge.id)">
-                    <mat-icon matMenuItemIcon>payments</mat-icon>
-                    {{ 'labels.buttons.Pay Charge' | translate }}
-                  </button>
-                }
-                @if (!charge.actionFlag) {
-                  <button mat-menu-item (click)="waiveCharge(charge.id)">
-                    <mat-icon matMenuItemIcon>check_circle</mat-icon>
-                    {{ 'labels.buttons.Waive Charge' | translate }}
-                  </button>
-                }
-              </mat-menu>
-            </div>
-          }
+            <mat-menu #chargeMenu="matMenu" class="charge-actions-menu">
+              @if (status === 'Active') {
+                <button mat-menu-item (click)="adjustCharge(charge.id)">
+                  <mat-icon matMenuItemIcon>tune</mat-icon>
+                  {{ 'tooltips.Adjust Charge' | translate }}
+                </button>
+              }
+              @if (status === 'Submitted and pending approval') {
+                <button mat-menu-item (click)="editCharge(charge)">
+                  <mat-icon matMenuItemIcon>edit</mat-icon>
+                  {{ 'tooltips.Edit Charge' | translate }}
+                </button>
+                <button mat-menu-item class="menu-item-danger" (click)="deleteCharge(charge.id)">
+                  <mat-icon matMenuItemIcon>delete</mat-icon>
+                  {{ 'labels.buttons.Delete' | translate }}
+                </button>
+              }
+              @if (charge.chargePayable && !charge.paid && status === 'Active') {
+                <button mat-menu-item (click)="payCharge(charge.id)">
+                  <mat-icon matMenuItemIcon>payments</mat-icon>
+                  {{ 'labels.buttons.Pay Charge' | translate }}
+                </button>
+              }
+              @if (!charge.actionFlag) {
+                <button mat-menu-item (click)="waiveCharge(charge.id)">
+                  <mat-icon matMenuItemIcon>check_circle</mat-icon>
+                  {{ 'labels.buttons.Waive Charge' | translate }}
+                </button>
+              }
+            </mat-menu>
+          </div>
         </td>
       </ng-container>
 


### PR DESCRIPTION
## Description

User should be able to add “charge-adjustment” transaction for charges that are marked paid as well

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Charges table so the actions dropdown is consistently shown for each row.
  * Refined which actions appear based on charge state, ensuring accurate visibility for Active, paid/waived, and “Submitted and pending approval” charges.
  * Made “Adjust Charge” available for Active charges without being blocked by paid status, and updated “Pay,” “Edit,” “Delete,” and “Waive” conditions accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->