### PR TITLE
WEB-1028: Refresh datatable tab data on route updates

### DIFF
--- a/src/app/clients/clients-view/datatable-tab/datatable-tab.component.ts
+++ b/src/app/clients/clients-view/datatable-tab/datatable-tab.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
@@ -24,6 +24,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class DatatableTabComponent {
   private route = inject(ActivatedRoute);
+  private changeDetectorRef = inject(ChangeDetectorRef);
   private destroyRef = inject(DestroyRef);
 
   entityId: string;
@@ -36,6 +37,7 @@ export class DatatableTabComponent {
     this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientDatatable: any }) => {
       this.entityDatatable = data.clientDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
+      this.changeDetectorRef.markForCheck();
     });
   }
 }

--- a/src/app/loans/loans-view/datatable-tab/datatable-tab.component.ts
+++ b/src/app/loans/loans-view/datatable-tab/datatable-tab.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { EntityDatatableTabComponent } from '../../../shared/tabs/entity-datatable-tab/entity-datatable-tab.component';
@@ -25,6 +25,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 export class DatatableTabComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
+  private changeDetectorRef = inject(ChangeDetectorRef);
 
   entityId: string;
   /** Loan Datatable */
@@ -42,12 +43,14 @@ export class DatatableTabComponent implements OnInit {
     this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanDatatable: any }) => {
       this.entityDatatable = data.loanDatatable;
       this.multiRowDatatableFlag = this.entityDatatable.columnHeaders[0].columnName === 'id' ? true : false;
+      this.changeDetectorRef.markForCheck();
     });
   }
 
   ngOnInit() {
     this.route.parent.parent.params.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((params) => {
       this.entityId = params['loanId'];
+      this.changeDetectorRef.markForCheck();
     });
   }
 }

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
@@ -10,6 +10,7 @@ import { SelectionModel } from '@angular/cdk/collections';
 import { DecimalPipe, NgClass } from '@angular/common';
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   Input,
   OnChanges,
@@ -82,6 +83,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
   private systemService = inject(SystemService);
   private settingsService = inject(SettingsService);
   private dialog = inject(MatDialog);
+  private changeDetectorRef = inject(ChangeDetectorRef);
   private datatables = inject(Datatables);
   private dateFormat = inject(DateFormatPipe);
   private dateTimeFormat = inject(DatetimeFormatPipe);
@@ -118,6 +120,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
     this.selection = new SelectionModel(true, []);
     this.route.params.subscribe((routeParams: any) => {
       this.datatableName = routeParams.datatableName;
+      this.changeDetectorRef.markForCheck();
     });
     this.setData();
     this.isSelected = false;
@@ -128,10 +131,18 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    this.setData();
+    if (changes.dataObject && this.dataObject) {
+      this.selection = new SelectionModel(true, []);
+      this.isSelected = false;
+      this.setData();
+      this.changeDetectorRef.markForCheck();
+    }
   }
 
   setData() {
+    if (!this.dataObject) {
+      return;
+    }
     this.datatableColumns = [this.SELECT_NAME_FIELD];
     this.dataObject.columnHeaders.filter((columnHeader: any) => {
       if (!this.datatables.isEntityId(columnHeader.columnName)) {
@@ -162,6 +173,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
       }
       this.isSelected = false;
       this.isLoading = false;
+      this.changeDetectorRef.markForCheck();
     });
   }
 

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
@@ -6,7 +6,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  inject
+} from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { Datatables } from 'app/core/utils/datatables';
@@ -51,8 +60,9 @@ import { formatTabLabel } from 'app/shared/utils/format-tab-label.util';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DatatableSingleRowComponent implements OnInit {
+export class DatatableSingleRowComponent implements OnInit, OnChanges {
   private route = inject(ActivatedRoute);
+  private changeDetectorRef = inject(ChangeDetectorRef);
   private dateUtils = inject(Dates);
   private dialog = inject(MatDialog);
   private settingsService = inject(SettingsService);
@@ -71,7 +81,14 @@ export class DatatableSingleRowComponent implements OnInit {
   ngOnInit() {
     this.route.params.subscribe((routeParams: any) => {
       this.datatableName = routeParams.datatableName;
+      this.changeDetectorRef.markForCheck();
     });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.dataObject) {
+      this.changeDetectorRef.markForCheck();
+    }
   }
 
   add() {
@@ -104,6 +121,7 @@ export class DatatableSingleRowComponent implements OnInit {
           .subscribe(() => {
             this.systemService.getEntityDatatable(this.entityId, this.datatableName).subscribe((dataObject: any) => {
               this.dataObject = dataObject;
+              this.changeDetectorRef.markForCheck();
             });
           });
       }
@@ -158,6 +176,7 @@ export class DatatableSingleRowComponent implements OnInit {
           .subscribe(() => {
             this.systemService.getEntityDatatable(this.entityId, this.datatableName).subscribe((dataObject: any) => {
               this.dataObject = dataObject;
+              this.changeDetectorRef.markForCheck();
             });
           });
       }
@@ -173,6 +192,7 @@ export class DatatableSingleRowComponent implements OnInit {
         this.systemService.deleteDatatableContent(this.entityId, this.datatableName).subscribe(() => {
           this.systemService.getEntityDatatable(this.entityId, this.datatableName).subscribe((dataObject: any) => {
             this.dataObject = dataObject;
+            this.changeDetectorRef.markForCheck();
           });
         });
       }


### PR DESCRIPTION
Fixes WEB-1028.

When switching between datatable tabs, the selected tab changed but the displayed datatable content could remain stale until the page was refreshed.

This change ensures datatable views refresh correctly when switching between datatable tabs so the newly selected datatable is displayed immediately without requiring a browser refresh.

Jira Ticket-
https://mifosforge.jira.com/browse/WEB-1028 

Checks:
- Targeted ESLint passed
- Targeted Prettier passed
- TypeScript no-emit passed



https://github.com/user-attachments/assets/1999a4cc-2940-4173-82ac-a77f64965b30



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh behavior so datatable tabs update correctly after loading client and loan data.
  * Fixed stale displays in single-row and multi-row datatable views by ensuring UI updates reliably when inputs and route-driven data change.
  * Updated add, edit, and delete flows so the currently visible table state is refreshed immediately after successful operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->