### PR TITLE
fix(WEB-1030): improve custom datatable labels and responsiveness

### DIFF
--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-view/fixed-deposit-account-view.component.html
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-view/fixed-deposit-account-view.component.html
@@ -175,7 +175,7 @@
           #datatable="routerLinkActive"
           [active]="datatable.isActive"
         >
-          {{ savingsDatatable.registeredTableName }}
+          {{ savingsDatatable.registeredTableName | datatableDisplayLabel }}
         </a>
       }
     </nav>

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-view/recurring-deposits-account-view.component.html
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-view/recurring-deposits-account-view.component.html
@@ -181,7 +181,7 @@
           #datatable="routerLinkActive"
           [active]="datatable.isActive"
         >
-          {{ savingsDatatable.registeredTableName }}
+          {{ savingsDatatable.registeredTableName | datatableDisplayLabel }}
         </a>
       }
     </nav>

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -645,7 +645,7 @@
               #datatable="routerLinkActive"
               [active]="datatable.isActive"
             >
-              {{ loanDatatable.registeredTableName }}
+              {{ loanDatatable.registeredTableName | datatableDisplayLabel }}
             </a>
           }
         }

--- a/src/app/pipes/datatable-display-label.pipe.spec.ts
+++ b/src/app/pipes/datatable-display-label.pipe.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { DatatableDisplayLabelPipe, formatDatatableDisplayLabel } from './datatable-display-label.pipe';
+
+describe('DatatableDisplayLabelPipe', () => {
+  const pipe = new DatatableDisplayLabelPipe();
+
+  it.each([
+    [
+      'PAYMENT_DETAILS',
+      'Payment details'
+    ],
+    [
+      'PAYMENT_REFERENCE',
+      'Payment reference'
+    ],
+    [
+      'CUSTOMER_ACCOUNT_NUMBER',
+      'Customer account number'
+    ],
+    [
+      'm_savings_account_transaction_1',
+      'M savings account transaction 1'
+    ],
+    [
+      'VALIDA_DEBITO',
+      'Valida debito'
+    ],
+    [
+      'REMITTANCE_INFORMATION',
+      'Remittance information'
+    ],
+    [
+      'CODIGO_MONEDA',
+      'Codigo moneda'
+    ]
+  ])('formats %s as %s', (rawLabel: string, displayLabel: string) => {
+    expect(formatDatatableDisplayLabel(rawLabel)).toBe(displayLabel);
+    expect(pipe.transform(rawLabel)).toBe(displayLabel);
+  });
+
+  it('returns an empty string for nullish labels', () => {
+    expect(formatDatatableDisplayLabel(null)).toBe('');
+    expect(formatDatatableDisplayLabel(undefined)).toBe('');
+    expect(pipe.transform(null)).toBe('');
+    expect(pipe.transform(undefined)).toBe('');
+  });
+});

--- a/src/app/pipes/datatable-display-label.pipe.ts
+++ b/src/app/pipes/datatable-display-label.pipe.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+export function formatDatatableDisplayLabel(label: unknown): string {
+  if (label === null || typeof label === 'undefined') {
+    return '';
+  }
+
+  const formattedLabel = String(label).replace(/_/g, ' ').toLowerCase();
+  return formattedLabel.charAt(0).toUpperCase() + formattedLabel.slice(1);
+}
+
+@Pipe({ name: 'datatableDisplayLabel' })
+export class DatatableDisplayLabelPipe implements PipeTransform {
+  transform(value: unknown): string {
+    return formatDatatableDisplayLabel(value);
+  }
+}

--- a/src/app/pipes/pipes.module.ts
+++ b/src/app/pipes/pipes.module.ts
@@ -12,6 +12,7 @@ import { AccountsFilterPipe } from './accounts-filter.pipe';
 import { ChargesFilterPipe } from './charges-filter.pipe';
 import { ChargesPenaltyFilterPipe } from './charges-penalty-filter.pipe';
 import { DateFormatPipe } from './date-format.pipe';
+import { DatatableDisplayLabelPipe } from './datatable-display-label.pipe';
 import { DatetimeFormatPipe } from './datetime-format.pipe';
 import { ExternalIdentifierPipe } from './external-identifier.pipe';
 import { FindPipe } from './find.pipe';
@@ -33,6 +34,7 @@ import { YesnoPipe } from './yesno.pipe';
     FindPipe,
     UrlToStringPipe,
     DateFormatPipe,
+    DatatableDisplayLabelPipe,
     DatetimeFormatPipe,
     ExternalIdentifierPipe,
     FormatNumberPipe,
@@ -49,6 +51,7 @@ import { YesnoPipe } from './yesno.pipe';
     FindPipe,
     UrlToStringPipe,
     DateFormatPipe,
+    DatatableDisplayLabelPipe,
     DatetimeFormatPipe,
     ExternalIdentifierPipe,
     FormatNumberPipe,
@@ -66,6 +69,7 @@ import { YesnoPipe } from './yesno.pipe';
     FindPipe,
     UrlToStringPipe,
     DateFormatPipe,
+    DatatableDisplayLabelPipe,
     DatetimeFormatPipe,
     ExternalIdentifierPipe,
     FormatNumberPipe,

--- a/src/app/savings/savings-account-view/savings-account-view.component.html
+++ b/src/app/savings/savings-account-view/savings-account-view.component.html
@@ -213,7 +213,7 @@
             #datatable="routerLinkActive"
             [active]="datatable.isActive"
           >
-            {{ savingsDatatable.registeredTableName }}
+            {{ savingsDatatable.registeredTableName | datatableDisplayLabel }}
           </a>
         }
       </nav>

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.html
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.html
@@ -26,7 +26,7 @@
         [active]="datatable.isActive"
         *mifosxHasPermission="'READ_' + entityDatatable.registeredTableName"
       >
-        {{ entityDatatable.registeredTableName }}
+        {{ entityDatatable.registeredTableName | datatableDisplayLabel }}
       </a>
     }
   </nav>

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.html
@@ -9,7 +9,7 @@
 <div class="tab-container mat-typography">
   <div class="layout-row align-start">
     <div class="m-b-10">
-      <h3>{{ datatableName }}</h3>
+      <h3>{{ formatTabLabel(datatableName) }}</h3>
     </div>
     <div class="action-button m-b-7 gap-10px">
       <span *mifosxHasPermission="'CREATE_' + datatableName">

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
@@ -26,15 +26,18 @@
 
       .table-scroll-wrapper {
         overflow-x: auto;
+        max-width: 100%;
         width: 100%;
       }
     }
   }
 
   table {
-    width: 100%;
+    min-width: 100%;
+    width: max-content;
     border-radius: 4px;
     overflow: hidden;
+    table-layout: auto;
 
     th {
       background-color: rgb(0 0 0 / 4%);
@@ -43,13 +46,20 @@
       border-bottom: 2px solid rgb(0 0 0 / 12%);
       font-size: 0.875rem;
       letter-spacing: 0.5px;
-      text-transform: uppercase;
+      min-width: 12rem;
+      max-width: 24rem;
+      white-space: normal;
+      overflow-wrap: anywhere;
     }
 
     td {
       padding: 16px 24px;
       border-bottom: 1px solid rgb(0 0 0 / 6%);
       font-size: 0.9375rem;
+      min-width: 12rem;
+      max-width: 24rem;
+      white-space: normal;
+      overflow-wrap: anywhere;
     }
 
     .data-row {
@@ -62,11 +72,15 @@
     }
 
     .checkbox-column {
+      width: 60px;
+      min-width: 60px;
       max-width: 60px;
       text-align: center;
     }
 
     .mat-column-select {
+      width: 60px;
+      min-width: 60px;
       max-width: 60px;
     }
   }

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
@@ -10,6 +10,7 @@ import { SelectionModel } from '@angular/cdk/collections';
 import { DecimalPipe, NgClass } from '@angular/common';
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   Input,
   OnChanges,
@@ -21,7 +22,7 @@ import {
 } from '@angular/core';
 import { MatCheckboxChange as MatCheckboxChange, MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
-import { formatTabLabel } from 'app/shared/utils/format-tab-label.util';
+import { formatDatatableDisplayLabel } from '@pipes/datatable-display-label.pipe';
 import {
   MatTable,
   MatColumnDef,
@@ -75,13 +76,14 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges {
   formatTabLabel(label: string): string {
-    return formatTabLabel(label);
+    return formatDatatableDisplayLabel(label);
   }
   private route = inject(ActivatedRoute);
   private dateUtils = inject(Dates);
   private systemService = inject(SystemService);
   private settingsService = inject(SettingsService);
   private dialog = inject(MatDialog);
+  private changeDetectorRef = inject(ChangeDetectorRef);
   private datatables = inject(Datatables);
   private dateFormat = inject(DateFormatPipe);
   private dateTimeFormat = inject(DatetimeFormatPipe);
@@ -118,6 +120,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
     this.selection = new SelectionModel(true, []);
     this.route.params.subscribe((routeParams: any) => {
       this.datatableName = routeParams.datatableName;
+      this.changeDetectorRef.markForCheck();
     });
     this.setData();
     this.isSelected = false;
@@ -128,10 +131,18 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    this.setData();
+    if (changes.dataObject && this.dataObject) {
+      this.selection = new SelectionModel(true, []);
+      this.isSelected = false;
+      this.setData();
+      this.changeDetectorRef.markForCheck();
+    }
   }
 
   setData() {
+    if (!this.dataObject) {
+      return;
+    }
     this.datatableColumns = [this.SELECT_NAME_FIELD];
     this.dataObject.columnHeaders.filter((columnHeader: any) => {
       if (!this.datatables.isEntityId(columnHeader.columnName)) {
@@ -162,6 +173,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
       }
       this.isSelected = false;
       this.isLoading = false;
+      this.changeDetectorRef.markForCheck();
     });
   }
 
@@ -178,7 +190,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
       dataTableEntryObject
     );
     const data = {
-      title: 'Add ' + formatTabLabel(this.datatableName) + ' for ' + this.entityType,
+      title: 'Add ' + formatDatatableDisplayLabel(this.datatableName) + ' for ' + this.entityType,
       formfields: formfields
     };
     const addDialogRef = this.dialog.open(FormDialogComponent, { data, width: '50rem' });
@@ -205,7 +217,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
    */
   delete() {
     const deleteDataTableDialogRef = this.dialog.open(DeleteDialogComponent, {
-      data: { deleteContext: `the contents of ${formatTabLabel(this.datatableName)}` }
+      data: { deleteContext: `the contents of ${formatDatatableDisplayLabel(this.datatableName)}` }
     });
     deleteDataTableDialogRef.afterClosed().subscribe((response: any) => {
       if (response.delete) {
@@ -222,7 +234,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
   deleteSelected() {
     const deleteDataTableDialogRef = this.dialog.open(DeleteDialogComponent, {
       data: {
-        deleteContext: `the ${this.selection.selected.length} items selected of ${formatTabLabel(this.datatableName)}`
+        deleteContext: `the ${this.selection.selected.length} items selected of ${formatDatatableDisplayLabel(this.datatableName)}`
       }
     });
     deleteDataTableDialogRef.afterClosed().subscribe((response: any) => {
@@ -320,6 +332,6 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
   }
 
   getInputName(attr: string): string {
-    return this.datatables.getName(attr);
+    return formatDatatableDisplayLabel(this.datatables.getName(attr));
   }
 }

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
@@ -36,7 +36,7 @@
             @for (columnHeader of dataObject.columnHeaders; track columnHeader; let i = $index) {
               <div class="data-item" [ngClass]="setAttributeClass(columnHeader.columnName)">
                 <div class="data-label mat-body-strong">
-                  {{ datatables.toDisplayLabel(columnHeader.columnName) }}
+                  {{ formatDisplayLabel(columnHeader.columnName) }}
                 </div>
                 <div class="data-value">
                   @switch (getColumnType(columnHeader.columnDisplayType, columnHeader.columnType)) {

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
@@ -6,7 +6,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, Input, OnInit, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnChanges,
+  OnInit,
+  SimpleChanges,
+  inject
+} from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { Datatables } from 'app/core/utils/datatables';
@@ -28,7 +37,7 @@ import { DatetimeFormatPipe } from '../../../../pipes/datetime-format.pipe';
 import { FormatNumberPipe } from '../../../../pipes/format-number.pipe';
 import { PrettyPrintPipe } from '../../../../pipes/pretty-print.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
-import { formatTabLabel } from 'app/shared/utils/format-tab-label.util';
+import { formatDatatableDisplayLabel } from '@pipes/datatable-display-label.pipe';
 
 @Component({
   selector: 'mifosx-datatable-single-row',
@@ -51,8 +60,9 @@ import { formatTabLabel } from 'app/shared/utils/format-tab-label.util';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DatatableSingleRowComponent implements OnInit {
+export class DatatableSingleRowComponent implements OnInit, OnChanges {
   private route = inject(ActivatedRoute);
+  private changeDetectorRef = inject(ChangeDetectorRef);
   private dateUtils = inject(Dates);
   private dialog = inject(MatDialog);
   private settingsService = inject(SettingsService);
@@ -65,13 +75,24 @@ export class DatatableSingleRowComponent implements OnInit {
   datatableName: string;
 
   formatTabLabel(label: string): string {
-    return formatTabLabel(label);
+    return formatDatatableDisplayLabel(label);
+  }
+
+  formatDisplayLabel(label: string): string {
+    return formatDatatableDisplayLabel(label);
   }
 
   ngOnInit() {
     this.route.params.subscribe((routeParams: any) => {
       this.datatableName = routeParams.datatableName;
+      this.changeDetectorRef.markForCheck();
     });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.dataObject) {
+      this.changeDetectorRef.markForCheck();
+    }
   }
 
   add() {
@@ -86,7 +107,7 @@ export class DatatableSingleRowComponent implements OnInit {
       dataTableEntryObject
     );
     const data = {
-      title: 'Add ' + formatTabLabel(this.datatableName) + ' for ' + this.entityType,
+      title: 'Add ' + formatDatatableDisplayLabel(this.datatableName) + ' for ' + this.entityType,
       formfields: formfields
     };
     const addDialogRef = this.dialog.open(FormDialogComponent, { data, width: '50rem' });
@@ -104,6 +125,7 @@ export class DatatableSingleRowComponent implements OnInit {
           .subscribe(() => {
             this.systemService.getEntityDatatable(this.entityId, this.datatableName).subscribe((dataObject: any) => {
               this.dataObject = dataObject;
+              this.changeDetectorRef.markForCheck();
             });
           });
       }
@@ -138,7 +160,7 @@ export class DatatableSingleRowComponent implements OnInit {
       return formfield;
     });
     const data = {
-      title: 'Edit ' + formatTabLabel(this.datatableName) + ' for ' + this.entityType,
+      title: 'Edit ' + formatDatatableDisplayLabel(this.datatableName) + ' for ' + this.entityType,
       formfields: formfields,
       layout: { addButtonText: 'Submit' },
       pristine: false
@@ -158,6 +180,7 @@ export class DatatableSingleRowComponent implements OnInit {
           .subscribe(() => {
             this.systemService.getEntityDatatable(this.entityId, this.datatableName).subscribe((dataObject: any) => {
               this.dataObject = dataObject;
+              this.changeDetectorRef.markForCheck();
             });
           });
       }
@@ -166,13 +189,14 @@ export class DatatableSingleRowComponent implements OnInit {
 
   delete() {
     const deleteDataTableDialogRef = this.dialog.open(DeleteDialogComponent, {
-      data: { deleteContext: ` the contents of ${formatTabLabel(this.datatableName)}` }
+      data: { deleteContext: ` the contents of ${formatDatatableDisplayLabel(this.datatableName)}` }
     });
     deleteDataTableDialogRef.afterClosed().subscribe((response: any) => {
       if (response?.delete) {
         this.systemService.deleteDatatableContent(this.entityId, this.datatableName).subscribe(() => {
           this.systemService.getEntityDatatable(this.entityId, this.datatableName).subscribe((dataObject: any) => {
             this.dataObject = dataObject;
+            this.changeDetectorRef.markForCheck();
           });
         });
       }

--- a/src/app/standalone-shared.module.ts
+++ b/src/app/standalone-shared.module.ts
@@ -22,6 +22,7 @@ import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular
 import { MatButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { DateFormatPipe } from '@pipes/date-format.pipe';
+import { DatatableDisplayLabelPipe } from '@pipes/datatable-display-label.pipe';
 import { DocumentationLinkPipe } from '@pipes/documentation-link.pipe';
 import { TranslatePipe as NgxTranslatePipe } from '@ngx-translate/core';
 import { TranslatePipe } from '@pipes/translate.pipe';
@@ -52,6 +53,7 @@ export const STANDALONE_SHARED_IMPORTS = [
   MatButton,
   MatCheckbox,
   DateFormatPipe,
+  DatatableDisplayLabelPipe,
   DocumentationLinkPipe,
   HasPermissionDirective,
 


### PR DESCRIPTION

- Format custom datatable labels into sentence case for improved readability.
- Improve multi-row datatable responsiveness to ensure wide tables remain fully accessible.

## Related issues

Fixes WEB-1030

## Before / After

 **Before** 
<img width="1426" height="749" alt="Screenshot 2026-07-11 at 3 49 47 PM" src="https://github.com/user-attachments/assets/87a439e0-cc48-4fe6-b077-ee3af2bd6e52" />

**After** 

https://github.com/user-attachments/assets/bd7974cd-e5e1-4679-9335-efd216deb54a




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardized datatable and tab labels across savings, deposits, loans, and transaction views for clearer, human-readable text.
  - Improved table sizing, column widths, text wrapping, and checkbox alignment on multi-row datatables.
  - Enhanced refresh behavior so datatable content updates more reliably after changes and data loading.

- **Tests**
  - Added coverage for label formatting, including empty and undefined values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->