### PR TITLE
fix(WEB-1033): refresh Transfer Funds client autocomplete

### DIFF
--- a/src/app/account-transfers/make-account-transfers/make-account-transfers.component.ts
+++ b/src/app/account-transfers/make-account-transfers/make-account-transfers.component.ts
@@ -9,6 +9,7 @@
 /** Angular Imports */
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   OnInit,
   AfterViewInit,
@@ -81,6 +82,7 @@ export class MakeAccountTransfersComponent implements OnInit, AfterViewInit {
   private clientsService = inject(ClientsService);
   private translateService = inject(TranslateService);
   private destroyRef = inject(DestroyRef);
+  private cdr = inject(ChangeDetectorRef);
 
   /** Stepper reference */
   @ViewChild('transferStepper') transferStepper: MatStepper;
@@ -315,8 +317,13 @@ export class MakeAccountTransfersComponent implements OnInit, AfterViewInit {
         .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe((value: any) => {
           if (typeof value === 'string' && value.length >= 2) {
+            const searchedValue = value;
             this.clientsService.getFilteredClients('displayName', 'ASC', true, value).subscribe((data: any) => {
+              if (this.beneficiaryForm.controls.toClientId.value !== searchedValue) {
+                return;
+              }
               this.clientsData = data.pageItems;
+              this.cdr.markForCheck();
             });
           } else if (typeof value === 'number') {
             this.changeEvent();


### PR DESCRIPTION
### Summary

Fix the Transfer Funds client autocomplete so that matching clients are displayed immediately after the search response is received.

### Changes
Refresh the autocomplete after updating the client list in the async callback.
Preserve existing transfer flow and API behavior. 

<img width="1117" height="714" alt="Screenshot 2026-07-14 at 3 20 25 PM" src="https://github.com/user-attachments/assets/05ae23aa-f2a8-4317-9b98-1811ba5d2899" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client search suggestions so updated results appear reliably while typing.
  * Enhanced the responsiveness of account transfer client selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->