### PR TITLE
MX-378: Add Credit Profile tab to Mifos client profile

### DIFF
--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -22,6 +22,7 @@ import { EditFamilyMemberComponent } from './clients-view/family-members-tab/edi
 import { IdentitiesTabComponent } from './clients-view/identities-tab/identities-tab.component';
 import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component';
 import { BureauReadinessComponent } from './clients-view/bureau-readiness/bureau-readiness.component';
+import { CreditProfileComponent } from './clients-view/credit-profile/credit-profile.component';
 import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
 import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
 import { AddressTabComponent } from './clients-view/address-tab/address-tab.component';
@@ -180,6 +181,11 @@ const routes: Routes = [
               path: 'bureau-readiness',
               component: BureauReadinessComponent,
               data: { title: 'Bureau Readiness', breadcrumb: 'Bureau Readiness', routeParamBreadcrumb: false }
+            },
+            {
+              path: 'credit-profile',
+              component: CreditProfileComponent,
+              data: { title: 'Credit Profile', breadcrumb: 'Credit Profile', routeParamBreadcrumb: false }
             },
             {
               path: 'datatables',

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -489,15 +489,26 @@
         </svg>
         {{ 'labels.inputs.Notes' | translate }}
       </a>
-      <a
-        mat-tab-link
-        [routerLink]="['./bureau-readiness']"
-        routerLinkActive
-        #bureauReadiness="routerLinkActive"
-        [active]="bureauReadiness.isActive"
-      >
-        {{ 'labels.inputs.Bureau Readiness' | translate }}
-      </a>
+      @if (cbIldEnabled) {
+        <a
+          mat-tab-link
+          [routerLink]="['./bureau-readiness']"
+          routerLinkActive
+          #bureauReadiness="routerLinkActive"
+          [active]="bureauReadiness.isActive"
+        >
+          {{ 'labels.inputs.Bureau Readiness' | translate }}
+        </a>
+        <a
+          mat-tab-link
+          [routerLink]="['./credit-profile']"
+          routerLinkActive
+          #creditProfile="routerLinkActive"
+          [active]="creditProfile.isActive"
+        >
+          {{ 'labels.inputs.Credit Profile' | translate }}
+        </a>
+      }
       @for (clientDatatable of clientDatatables; track clientDatatable) {
         <a
           mat-tab-link

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -427,4 +427,8 @@ export class ClientsViewComponent implements OnInit {
   get isCbildCompliance(): boolean {
     return this.creditBureauService.getRole() === 'COMPLIANCE';
   }
+
+  get cbIldEnabled(): boolean {
+    return environment.cbIldEnabled;
+  }
 }

--- a/src/app/clients/clients-view/credit-profile/credit-profile.component.html
+++ b/src/app/clients/clients-view/credit-profile/credit-profile.component.html
@@ -1,0 +1,159 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<div class="cbild-credit-profile">
+  <!-- Role selector -->
+  <mat-card class="cbild-role-card">
+    <mat-card-content>
+      <mat-form-field appearance="outline">
+        <mat-label>{{ 'labels.cbild.dashboard.role' | translate }}</mat-label>
+        <mat-select [(ngModel)]="selectedRole" (ngModelChange)="onRoleChange($event)">
+          @for (role of roles; track role.value) {
+            <mat-option [value]="role.value">{{ role.label }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- Loading -->
+  @if (isLoading) {
+    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+  }
+
+  <!-- Credit Profile result -->
+  @if (result && !isLoading) {
+    <mat-card class="cbild-profile-card">
+      <mat-card-content>
+        <!-- Score Drop Alert -->
+        @if (result.scoreDropAlert) {
+          <div class="cbild-alert cbild-alert-warning">
+            <mat-icon>trending_down</mat-icon>
+            <span>{{ 'labels.cbild.creditProfile.scoreDropAlert' | translate }}</span>
+          </div>
+        }
+
+        <!-- Delinquency Alert -->
+        @if (result.hasDelinquencies) {
+          <div class="cbild-alert cbild-alert-danger">
+            <mat-icon>warning</mat-icon>
+            <span>{{ 'labels.cbild.creditProfile.hasDelinquencies' | translate }}</span>
+          </div>
+        }
+
+        <!-- FICO + Risk Band -->
+        <div class="cbild-scores-row">
+          <div class="cbild-fico-card" [class]="getFicoClass()">
+            <span class="cbild-fico-label">{{ 'labels.cbild.creditProfile.ficoScore' | translate }}</span>
+            <span class="cbild-fico-value">{{ result.ficoScore }}</span>
+          </div>
+          @if (result.riskBand) {
+            <div class="cbild-risk-card" [class]="getRiskClass()">
+              <span class="cbild-risk-label">{{ 'labels.cbild.creditProfile.riskBand' | translate }}</span>
+              <span class="cbild-risk-value">{{ result.riskBand }}</span>
+            </div>
+          }
+        </div>
+
+        <mat-divider class="cbild-divider"></mat-divider>
+
+        <!-- Bureau Details -->
+        <div class="cbild-details-grid">
+          <div class="cbild-detail-item">
+            <span class="cbild-detail-label">{{ 'labels.cbild.creditProfile.bureau' | translate }}</span>
+            <span class="cbild-detail-value">{{ result.bureauType }}</span>
+          </div>
+          <div class="cbild-detail-item">
+            <span class="cbild-detail-label">{{ 'labels.cbild.creditProfile.pulledAt' | translate }}</span>
+            <span class="cbild-detail-value">{{ result.pulledAt | dateFormat }}</span>
+          </div>
+          <div class="cbild-detail-item">
+            <span class="cbild-detail-label">{{ 'labels.cbild.creditProfile.expiry' | translate }}</span>
+            <span class="cbild-detail-value">{{ result.expiryDate }} (72 months LRSIC)</span>
+          </div>
+          <div class="cbild-detail-item">
+            <span class="cbild-detail-label">{{ 'labels.cbild.creditProfile.delinquencies' | translate }}</span>
+            @if (result.hasDelinquencies) {
+              <span class="cbild-detail-value cbild-text-danger">
+                <mat-icon class="cbild-inline-icon">cancel</mat-icon>
+                {{ 'labels.cbild.creditProfile.yes' | translate }}
+              </span>
+            } @else {
+              <span class="cbild-detail-value cbild-text-success">
+                <mat-icon class="cbild-inline-icon">check_circle</mat-icon>
+                {{ 'labels.cbild.creditProfile.none' | translate }}
+              </span>
+            }
+          </div>
+          @if (result.dateOfFirstDelinquency) {
+            <div class="cbild-detail-item">
+              <span class="cbild-detail-label">{{ 'labels.cbild.creditProfile.firstDelinquency' | translate }}</span>
+              <span class="cbild-detail-value cbild-text-danger">{{ result.dateOfFirstDelinquency }}</span>
+            </div>
+          }
+        </div>
+
+        <mat-divider class="cbild-divider"></mat-divider>
+
+        <!-- Tradelines -->
+        <div class="cbild-tradelines-section">
+          <p class="cbild-section-title">
+            <mat-icon>account_balance</mat-icon>
+            {{ 'labels.cbild.creditProfile.tradelines' | translate }}
+            ({{ tradelines.length }})
+          </p>
+
+          @if (tradelines.length === 0) {
+            <div class="cbild-empty-sub">
+              <p>{{ 'labels.cbild.creditProfile.noTradelines' | translate }}</p>
+            </div>
+          } @else {
+            @for (tradeline of tradelines; track $index) {
+              <div class="cbild-tradeline-card">
+                <span class="cbild-tradeline-name">{{ tradeline.creditorName || tradeline.name }}</span>
+                @if (tradeline.balance !== undefined && tradeline.balance !== null) {
+                  <span class="cbild-tradeline-detail"
+                    >{{ 'labels.cbild.creditProfile.balance' | translate }}: {{ tradeline.balance }}</span
+                  >
+                }
+                @if (tradeline.latePayments !== undefined) {
+                  <span class="cbild-tradeline-detail"
+                    >{{ 'labels.cbild.creditProfile.latePayments' | translate }}: {{ tradeline.latePayments }}</span
+                  >
+                }
+              </div>
+            }
+          }
+        </div>
+      </mat-card-content>
+    </mat-card>
+  }
+
+  <!-- Empty state — no CDC data yet -->
+  @if (isEmpty && !isLoading) {
+    <mat-card class="cbild-empty-card">
+      <mat-card-content class="cbild-empty-content">
+        <mat-icon>search_off</mat-icon>
+        <p>{{ 'labels.cbild.creditProfile.noData' | translate }}</p>
+        <p class="cbild-empty-hint">{{ 'labels.cbild.creditProfile.noDataHint' | translate }}</p>
+      </mat-card-content>
+    </mat-card>
+  }
+
+  <!-- Error state -->
+  @if (hasError && !isLoading) {
+    <mat-card class="cbild-empty-card">
+      <mat-card-content class="cbild-empty-content">
+        <mat-icon color="warn">error_outline</mat-icon>
+        <p>{{ 'labels.cbild.errors.unexpected' | translate }}</p>
+        <button mat-stroked-button color="primary" (click)="loadProfile()">
+          {{ 'labels.buttons.Retry' | translate }}
+        </button>
+      </mat-card-content>
+    </mat-card>
+  }
+</div>

--- a/src/app/clients/clients-view/credit-profile/credit-profile.component.scss
+++ b/src/app/clients/clients-view/credit-profile/credit-profile.component.scss
@@ -1,0 +1,234 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.cbild-credit-profile {
+  padding: 16px;
+}
+
+.cbild-role-card {
+  margin-bottom: 16px;
+
+  mat-card-content {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  mat-form-field {
+    width: 240px;
+  }
+}
+
+.cbild-profile-card {
+  margin-bottom: 16px;
+}
+
+.cbild-alert {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-radius: 4px;
+  margin-bottom: 16px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.cbild-alert-warning {
+  background: var(--cbild-alert-warning-bg, #fef9c3);
+  color: var(--cbild-alert-warning-fg, #d97706);
+  border: 1px solid var(--cbild-alert-warning-border, #fde68a);
+}
+
+.cbild-alert-danger {
+  background: var(--cbild-alert-danger-bg, #fee2e2);
+  color: var(--cbild-alert-danger-fg, #dc2626);
+  border: 1px solid var(--cbild-alert-danger-border, #fca5a5);
+}
+
+.cbild-scores-row {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.cbild-fico-card,
+.cbild-risk-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 16px 24px;
+  border-radius: 8px;
+  min-width: 120px;
+}
+
+.cbild-fico-label,
+.cbild-risk-label {
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.cbild-fico-value {
+  font-size: 40px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.cbild-risk-value {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.cbild-fico-good {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.cbild-fico-medium {
+  background: #fef9c3;
+  color: #d97706;
+}
+
+.cbild-fico-poor {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.cbild-fico-unknown {
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+.cbild-risk-low {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.cbild-risk-medium {
+  background: #fef9c3;
+  color: #d97706;
+}
+
+.cbild-risk-high {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.cbild-risk-very-high {
+  background: #fce7f3;
+  color: #9d174d;
+}
+
+.cbild-divider {
+  margin: 16px 0;
+}
+
+.cbild-details-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cbild-detail-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.cbild-detail-label {
+  font-size: 13px;
+  color: var(--mdc-theme-text-secondary-on-background, rgb(0 0 0 / 54%));
+  min-width: 160px;
+}
+
+.cbild-detail-value {
+  font-size: 13px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.cbild-text-success {
+  color: #16a34a;
+}
+
+.cbild-text-danger {
+  color: #dc2626;
+}
+
+.cbild-inline-icon {
+  font-size: 16px;
+  height: 16px;
+  width: 16px;
+}
+
+.cbild-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.cbild-tradeline-card {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cbild-tradeline-name {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.cbild-tradeline-detail {
+  font-size: 12px;
+  color: var(--mdc-theme-text-secondary-on-background, rgb(0 0 0 / 54%));
+}
+
+.cbild-empty-sub {
+  padding: 16px;
+  text-align: center;
+  color: var(--mdc-theme-text-disabled-on-background, rgb(0 0 0 / 38%));
+  font-size: 13px;
+}
+
+.cbild-empty-card {
+  margin-bottom: 16px;
+}
+
+.cbild-empty-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 32px;
+  gap: 16px;
+  color: var(--mdc-theme-text-disabled-on-background, rgb(0 0 0 / 38%));
+
+  mat-icon {
+    font-size: 48px;
+    height: 48px;
+    width: 48px;
+  }
+}
+
+.cbild-empty-hint {
+  font-size: 12px;
+  color: var(--mdc-theme-text-disabled-on-background, rgb(0 0 0 / 38%));
+}

--- a/src/app/clients/clients-view/credit-profile/credit-profile.component.ts
+++ b/src/app/clients/clients-view/credit-profile/credit-profile.component.ts
@@ -9,40 +9,48 @@
 import { Component, OnInit, OnDestroy, inject, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Subject } from 'rxjs';
-import { HttpErrorResponse } from '@angular/common/http';
 import { takeUntil } from 'rxjs/operators';
-import { MatProgressBar } from '@angular/material/progress-bar';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatList, MatListItem, MatListItemIcon, MatListItemTitle } from '@angular/material/list';
+import { HttpErrorResponse } from '@angular/common/http';
 import { MatIcon } from '@angular/material/icon';
 import { MatDivider } from '@angular/material/divider';
+import { MatProgressBar } from '@angular/material/progress-bar';
 import { FormsModule } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { AlertService } from 'app/core/alert/alert.service';
-import { TranslateService } from '@ngx-translate/core';
 import { CreditBureauService } from 'app/credit-bureau/credit-bureau.service';
-import { KycReadinessResult, CbildRole, CBILD_ROLE_LABELS } from 'app/credit-bureau/credit-bureau.models';
+import { BureauResponseDTO, CbildRole, CBILD_ROLE_LABELS } from 'app/credit-bureau/credit-bureau.models';
 
+interface Tradeline {
+  creditorName?: string;
+  name?: string;
+  balance?: number | null;
+  latePayments?: number;
+}
+
+/**
+ * CB-ILD Credit Profile — MX-378 Tab 3.
+ * Shows stored CDC credit report for a client.
+ * Route: /clients/{id}/credit-profile
+ * Roles: CREDIT_ANALYST, COMPLIANCE (KYC_OFFICER gets 403)
+ * Does NOT make a new CDC call — reads from database only.
+ * @author Satyam Mishra — MSOC 2026
+ */
 @Component({
-  selector: 'mifosx-bureau-readiness',
-  templateUrl: './bureau-readiness.component.html',
-  styleUrls: ['./bureau-readiness.component.scss'],
+  selector: 'mifosx-credit-profile',
+  templateUrl: './credit-profile.component.html',
+  styleUrls: ['./credit-profile.component.scss'],
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
-    MatProgressBar,
-    MatChipsModule,
-    MatList,
-    MatListItem,
-    MatListItemIcon,
-    MatListItemTitle,
     MatIcon,
     MatDivider,
+    MatProgressBar,
     FormsModule
   ]
 })
-export class BureauReadinessComponent implements OnInit, OnDestroy {
+export class CreditProfileComponent implements OnInit, OnDestroy {
   private route = inject(ActivatedRoute);
   private creditBureauService = inject(CreditBureauService);
   private alertService = inject(AlertService);
@@ -52,11 +60,13 @@ export class BureauReadinessComponent implements OnInit, OnDestroy {
   clientId: number;
   isLoading = false;
   hasError = false;
-  result: KycReadinessResult | null = null;
-  selectedRole: CbildRole = 'KYC_OFFICER';
+  isEmpty = false;
+  result: BureauResponseDTO | null = null;
+  tradelines: Tradeline[] = [];
+  selectedRole: CbildRole = 'CREDIT_ANALYST';
 
   roles: { value: CbildRole; label: string }[] = [
-    { value: 'KYC_OFFICER', label: CBILD_ROLE_LABELS.KYC_OFFICER },
+    { value: 'CREDIT_ANALYST', label: CBILD_ROLE_LABELS.CREDIT_ANALYST },
     { value: 'COMPLIANCE', label: CBILD_ROLE_LABELS.COMPLIANCE }
   ];
 
@@ -65,74 +75,95 @@ export class BureauReadinessComponent implements OnInit, OnDestroy {
   constructor() {
     const rawId = this.route.parent?.snapshot.params['clientId'];
     this.clientId = rawId ? +rawId : 0;
-    if (!this.clientId || isNaN(this.clientId)) {
-      console.error('CB-ILD: Invalid clientId from route');
-    }
   }
 
   ngOnInit(): void {
     const saved = this.creditBureauService.getRole();
-    this.selectedRole = saved === 'CREDIT_ANALYST' ? 'KYC_OFFICER' : saved;
+    this.selectedRole = saved === 'KYC_OFFICER' ? 'CREDIT_ANALYST' : saved;
     this.creditBureauService.setRole(this.selectedRole);
-    this.loadReadiness();
+    this.loadProfile();
   }
 
   onRoleChange(role: CbildRole): void {
     this.selectedRole = role;
     this.creditBureauService.setRole(role);
     this.result = null;
-    this.loadReadiness();
+    this.isEmpty = false;
+    this.loadProfile();
   }
 
-  loadReadiness(): void {
+  loadProfile(): void {
     this.isLoading = true;
     this.hasError = false;
+    this.isEmpty = false;
     this.cdr.markForCheck();
 
     this.creditBureauService
-      .getBureauReadiness(this.clientId)
+      .getBureauResponse(this.clientId)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
-        next: (data) => {
-          this.result = data;
+        next: (data: BureauResponseDTO) => {
+          if (!data || !data.ficoScore) {
+            this.isEmpty = true;
+            this.result = null;
+          } else {
+            this.result = data;
+            this.isEmpty = false;
+            this.tradelines = this.parseTradelinesOnce(data.tradelines);
+          }
           this.isLoading = false;
           this.cdr.markForCheck();
         },
         error: (err: HttpErrorResponse) => {
           this.isLoading = false;
           this.hasError = true;
-          this.alertService.alert({ type: 'error', message: this.getErrorMessage(err) });
+          this.alertService.alert({
+            type: 'error',
+            message: this.getErrorMessage(err)
+          });
           this.cdr.markForCheck();
         }
       });
   }
 
-  getScoreColor(): 'primary' | 'accent' | 'warn' {
-    if (!this.result) return 'primary';
-    if (this.result.score >= 70) return 'primary';
-    if (this.result.score >= 40) return 'accent';
-    return 'warn';
+  getFicoClass(): string {
+    if (!this.result?.ficoScore) return 'cbild-fico-unknown';
+    if (this.result.ficoScore >= 700) return 'cbild-fico-good';
+    if (this.result.ficoScore >= 500) return 'cbild-fico-medium';
+    return 'cbild-fico-poor';
   }
 
-  formatFieldName(field: string): string {
-    const key = `labels.cbild.fields.${field}`;
-    const translated = this.translateService.instant(key);
-    return translated !== key ? translated : field;
+  getRiskClass(): string {
+    switch (this.result?.riskBand) {
+      case 'LOW':
+        return 'cbild-risk-low';
+      case 'MEDIUM':
+        return 'cbild-risk-medium';
+      case 'HIGH':
+        return 'cbild-risk-high';
+      case 'VERY_HIGH':
+        return 'cbild-risk-very-high';
+      default:
+        return '';
+    }
   }
 
-  isRfcHardVeto(): boolean {
-    return !!this.result && this.result.score === 0 && this.result.missingFields.includes('nationalId');
+  private parseTradelinesOnce(raw: string | null): Tradeline[] {
+    if (!raw) return [];
+    try {
+      return JSON.parse(raw) as Tradeline[];
+    } catch {
+      return [];
+    }
   }
 
   private getErrorMessage(err: HttpErrorResponse): string {
-    const t = (key: string, params?: object) => this.translateService.instant(key, params);
+    const t = (key: string) => this.translateService.instant(key);
     switch (err?.status) {
       case 401:
         return t('labels.cbild.errors.unauthorized');
       case 403:
         return t('labels.cbild.errors.forbidden');
-      case 404:
-        return t('labels.cbild.errors.clientNotFound', { clientId: this.clientId });
       case 503:
         return t('labels.cbild.errors.serviceUnavailable');
       default:

--- a/src/app/clients/clients.module.ts
+++ b/src/app/clients/clients.module.ts
@@ -26,6 +26,7 @@ import { IdentitiesTabComponent } from './clients-view/identities-tab/identities
 import { UploadDocumentDialogComponent } from './clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component';
 import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component';
 import { BureauReadinessComponent } from './clients-view/bureau-readiness/bureau-readiness.component';
+import { CreditProfileComponent } from './clients-view/credit-profile/credit-profile.component';
 import { EditNotesDialogComponent } from './clients-view/custom-dialogs/edit-notes-dialog/edit-notes-dialog.component';
 import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
 import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
@@ -89,6 +90,7 @@ import { ClientDatatableStepComponent } from './client-stepper/client-datatable-
     UploadDocumentDialogComponent,
     NotesTabComponent,
     BureauReadinessComponent,
+    CreditProfileComponent,
     EditNotesDialogComponent,
     DocumentsTabComponent,
     DatatableTabComponent,

--- a/src/app/core/shell/sidenav/sidenav.component.html
+++ b/src/app/core/shell/sidenav/sidenav.component.html
@@ -80,18 +80,20 @@
           </mat-icon>
           <a matLine #dashboard>{{ 'labels.menus.Dashboard' | translate }}</a>
         </mat-list-item>
-        <mat-list-item
-          [routerLink]="['/reporting-dashboard']"
-          [matTooltipPosition]="tooltipPosition"
-          matTooltip="{{ 'tooltips.Reporting Dashboard' | translate }}"
-          routerLinkActive="active-menu"
-          [routerLinkActiveOptions]="{ exact: false }"
-        >
-          <mat-icon matListIcon>
-            <fa-icon icon="file-alt" size="sm"></fa-icon>
-          </mat-icon>
-          <a matLine #reportingDashboard>{{ 'labels.menus.Reporting Dashboard' | translate }}</a>
-        </mat-list-item>
+        @if (cbIldEnabled) {
+          <mat-list-item
+            [routerLink]="['/reporting-dashboard']"
+            [matTooltipPosition]="tooltipPosition"
+            matTooltip="{{ 'tooltips.Reporting Dashboard' | translate }}"
+            routerLinkActive="active-menu"
+            [routerLinkActiveOptions]="{ exact: false }"
+          >
+            <mat-icon matListIcon>
+              <fa-icon icon="file-alt" size="sm"></fa-icon>
+            </mat-icon>
+            <a matLine #reportingDashboard>{{ 'labels.menus.Reporting Dashboard' | translate }}</a>
+          </mat-list-item>
+        }
         <mat-list-item
           [routerLink]="['/navigation']"
           [matTooltipPosition]="tooltipPosition"

--- a/src/app/core/shell/sidenav/sidenav.component.ts
+++ b/src/app/core/shell/sidenav/sidenav.component.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { environment } from 'environments/environment';
 /** Angular Imports */
 import {
   ChangeDetectionStrategy,
@@ -69,6 +70,7 @@ import { catchError, finalize, of, take } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SidenavComponent implements OnInit, AfterViewInit {
+  readonly cbIldEnabled = environment.cbIldEnabled;
   private router = inject(Router);
   dialog = inject(MatDialog);
   private authenticationService = inject(AuthenticationService);

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -89,6 +89,8 @@
   window['env']['mifosInterbankTransfersApiProvider'] = '';
   window['env']['mifosInterbankTransfersApiVersion'] = '';
   window['env']['mifosInterbankTransfersEnabled'] = 'true';
+  window['env']['cbIldEnabled'] = 'false';
+  window['env']['pluginBaseUrl'] = 'http://localhost:8084';
 
   // Remittance Module Environment variables
   window['env']['mifosRemittanceApiClientUrl'] = '';

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -104,6 +104,8 @@
   window['env']['mifosInterbankTransfersApiProvider'] = '$MIFOS_INTERBANK_TRANSFERS_API_PROVIDER';
   window['env']['mifosInterbankTransfersApiVersion'] = '$MIFOS_INTERBANK_TRANSFERS_API_VERSION';
   window['env']['mifosInterbankTransfersEnabled'] = '$MIFOS_INTERBANK_TRANSFERS_ENABLED';
+  window['env']['cbIldEnabled'] = '$CB_ILD_ENABLED';
+  window['env']['pluginBaseUrl'] = '$PLUGIN_BASE_URL';
 
   // Remittance Module Environment variables
   window['env']['mifosRemittanceApiClientUrl'] = '$MIFOS_REMITTANCE_API_CLIENT_URL';

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1598,7 +1598,7 @@
       "Annual interest rate": "Roční úroková sazba",
       "Annual interest rate by loan cycle": "Roční úroková sazba podle úvěrového cyklu",
       "Annual interest rate frequency": "Frekvence roční úrokové sazby",
-      "Breach Actions": "Porušení Akce",
+      "Breach Actions": "Akce porušení",
       "# Remittance": "# Remitence",
       "# Senders": "# Odesílatelé",
       "ACCOUNTING": "ÚČETNICTVÍ",
@@ -3162,7 +3162,6 @@
       "to": "na",
       "valid": "platný",
       "Active Pause": "Aktivní pauza",
-      "Breach Actions": "Akce porušení",
       "days": "dní",
       "Duration": "Doba trvání",
       "Expired": "Vypršela",
@@ -3175,7 +3174,8 @@
       "Scheduled": "Naplánováno",
       "Today": "Dnes",
       "Total Actions": "Celkové akce",
-      "Total Days Paused": "Celkový počet dní v pauze"
+      "Total Days Paused": "Celkový počet dní v pauze",
+      "Credit Profile": "Kreditní profil"
     },
     "links": {
       "Community": "Společenství",
@@ -4493,6 +4493,27 @@
         "RECURRINGDEPOSITACCOUNT": "Účet pravidelného spoření",
         "ACCOUNTTRANSFER": "Převod účtu",
         "SSBENEFICIARYTPT": "Self-Service příjemci TPT"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "Skóre FICO",
+        "riskBand": "Rizikové pásmo",
+        "bureau": "Bureau",
+        "pulledAt": "Naposledy staženo",
+        "expiry": "Datum vypršení",
+        "delinquencies": "Prodlení",
+        "firstDelinquency": "První prodlení",
+        "none": "Žádné",
+        "yes": "Ano",
+        "scoreDropAlert": "FICO skóre kleslo",
+        "hasDelinquencies": "Klient má prodlení",
+        "tradelines": "Úvěrové linky",
+        "noTradelines": "Žádné úvěrové linky",
+        "balance": "Zůstatek",
+        "latePayments": "Opožděné platby",
+        "noData": "Kreditní profil není k dispozici",
+        "noDataHint": "Spusťte kontrolu bureau"
       }
     }
   },

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1600,7 +1600,7 @@
       "Annual interest rate": "Annual interest rate",
       "Annual interest rate by loan cycle": "Annual interest rate by loan cycle",
       "Annual interest rate frequency": "Annual interest rate frequency",
-      "Breach Actions": "Verstoßaktionen",
+      "Breach Actions": "Verstoß-Aktionen",
       "# Remittance": "# Überweisung",
       "# Senders": "# Absender",
       "ACCOUNTING": "BUCHHALTUNG",
@@ -3164,7 +3164,6 @@
       "to": "Zu",
       "valid": "gültig",
       "Active Pause": "Aktive Pause",
-      "Breach Actions": "Verstoß-Aktionen",
       "days": "Tage",
       "Duration": "Dauer",
       "Expired": "Abgelaufen",
@@ -3177,7 +3176,8 @@
       "Scheduled": "Geplant",
       "Today": "Heute",
       "Total Actions": "Gesamtaktionen",
-      "Total Days Paused": "Pausentage gesamt"
+      "Total Days Paused": "Pausentage gesamt",
+      "Credit Profile": "Kreditprofil"
     },
     "links": {
       "Community": "Gemeinschaft",
@@ -4493,6 +4493,27 @@
         "RECURRINGDEPOSITACCOUNT": "Sparplankonto",
         "ACCOUNTTRANSFER": "Kontoübertragung",
         "SSBENEFICIARYTPT": "Self-Service-Begünstigte TPT"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "FICO-Bewertung",
+        "riskBand": "Risikoband",
+        "bureau": "Büro",
+        "pulledAt": "Zuletzt abgerufen",
+        "expiry": "Ablaufdatum",
+        "delinquencies": "Zahlungsrückstände",
+        "firstDelinquency": "Erster Zahlungsrückstand",
+        "none": "Keine",
+        "yes": "Ja",
+        "scoreDropAlert": "FICO-Score gesunken",
+        "hasDelinquencies": "Zahlungsrückstände vorhanden",
+        "tradelines": "Kreditlinien",
+        "noTradelines": "Keine Kreditlinien",
+        "balance": "Saldo",
+        "latePayments": "Verspätete Zahlungen",
+        "noData": "Kein Kreditprofil verfügbar",
+        "noDataHint": "Zuerst Bürobereitschaftsprüfung durchführen"
       }
     }
   },

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3183,7 +3183,8 @@
       "KYC Completeness Score": "KYC Completeness Score",
       "CDC FICO Score": "CDC FICO Score",
       "No bureau data available": "No bureau data available",
-      "Failed to load bureau data": "Failed to load bureau data"
+      "Failed to load bureau data": "Failed to load bureau data",
+      "Credit Profile": "Credit Profile"
     },
     "links": {
       "Community": "Community",
@@ -4605,6 +4606,25 @@
         "expiry": "Expiry Date",
         "submittedAt": "Submitted At",
         "noSubmissions": "No submissions found"
+      },
+      "creditProfile": {
+        "ficoScore": "FICO Score",
+        "riskBand": "Risk Band",
+        "bureau": "Bureau",
+        "pulledAt": "Last Pulled",
+        "expiry": "Expiry Date",
+        "delinquencies": "Delinquencies",
+        "firstDelinquency": "First Delinquency",
+        "none": "None",
+        "yes": "Yes",
+        "scoreDropAlert": "FICO score dropped since last pull — monitor this client",
+        "hasDelinquencies": "Client has delinquencies on record — review before approval",
+        "tradelines": "Tradelines",
+        "noTradelines": "No tradelines on record",
+        "balance": "Balance",
+        "latePayments": "Late Payments",
+        "noData": "No credit profile available yet",
+        "noDataHint": "Run Bureau Readiness check first to pull data from CDC"
       }
     },
     "selections": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3163,7 +3163,6 @@
       "to": "a",
       "valid": "válido",
       "Active Pause": "Pausa Activa",
-      "Breach Actions": "Acciones de Incumplimiento",
       "days": "días",
       "Duration": "Duración",
       "Expired": "Expirada",
@@ -3176,7 +3175,8 @@
       "Scheduled": "Programada",
       "Today": "Hoy",
       "Total Actions": "Acciones Totales",
-      "Total Days Paused": "Total de Días en Pausa"
+      "Total Days Paused": "Total de Días en Pausa",
+      "Credit Profile": "Perfil de crédito"
     },
     "links": {
       "Community": "Comunidad",
@@ -4498,6 +4498,27 @@
         },
         "own.account": "Cuenta Propia",
         "other.bank": "Otros Bancos"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "Puntuación FICO",
+        "riskBand": "Banda de riesgo",
+        "bureau": "Buró",
+        "pulledAt": "Última consulta",
+        "expiry": "Fecha de vencimiento",
+        "delinquencies": "Morosidades",
+        "firstDelinquency": "Primera morosidad",
+        "none": "Ninguna",
+        "yes": "Sí",
+        "scoreDropAlert": "Puntuación FICO ha bajado",
+        "hasDelinquencies": "Cliente tiene morosidades",
+        "tradelines": "Líneas de crédito",
+        "noTradelines": "Sin líneas de crédito",
+        "balance": "Saldo",
+        "latePayments": "Pagos tardíos",
+        "noData": "Sin perfil de crédito aún",
+        "noDataHint": "Ejecute primero la verificación del buró"
       }
     }
   },

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3167,7 +3167,6 @@
       "to": "a",
       "valid": "válido",
       "Active Pause": "Pausa Activa",
-      "Breach Actions": "Acciones de Incumplimiento",
       "days": "días",
       "Duration": "Duración",
       "Expired": "Expirada",
@@ -3180,7 +3179,8 @@
       "Scheduled": "Programada",
       "Today": "Hoy",
       "Total Actions": "Acciones Totales",
-      "Total Days Paused": "Total de Días en Pausa"
+      "Total Days Paused": "Total de Días en Pausa",
+      "Credit Profile": "Perfil de crédito"
     },
     "links": {
       "Community": "Comunidad",
@@ -4512,6 +4512,27 @@
         },
         "own.account": "Cuenta Propia",
         "other.bank": "Otro Banco"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "Puntuación FICO",
+        "riskBand": "Banda de riesgo",
+        "bureau": "Buró",
+        "pulledAt": "Última consulta",
+        "expiry": "Fecha de vencimiento",
+        "delinquencies": "Morosidades",
+        "firstDelinquency": "Primera morosidad",
+        "none": "Ninguna",
+        "yes": "Sí",
+        "scoreDropAlert": "Puntuación FICO ha bajado",
+        "hasDelinquencies": "Cliente tiene morosidades",
+        "tradelines": "Líneas de crédito",
+        "noTradelines": "Sin líneas de crédito",
+        "balance": "Saldo",
+        "latePayments": "Pagos tardíos",
+        "noData": "Sin perfil de crédito aún",
+        "noDataHint": "Ejecute primero la verificación del buró"
       }
     }
   },

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1601,7 +1601,7 @@
       "Annual interest rate": "Annual interest rate",
       "Annual interest rate by loan cycle": "Annual interest rate by loan cycle",
       "Annual interest rate frequency": "Annual interest rate frequency",
-      "Breach Actions": "Actions de violation",
+      "Breach Actions": "Actions de Manquement",
       "# Remittance": "# Transfert",
       "# Senders": "# Expéditeurs",
       "ACCOUNTING": "COMPTABILITÉ",
@@ -3165,7 +3165,6 @@
       "to": "à",
       "valid": "valide",
       "Active Pause": "Pause Active",
-      "Breach Actions": "Actions de Manquement",
       "days": "jours",
       "Duration": "Durée",
       "Expired": "Expirée",
@@ -3178,7 +3177,8 @@
       "Scheduled": "Programmée",
       "Today": "Aujourd'hui",
       "Total Actions": "Total des Actions",
-      "Total Days Paused": "Total des Jours en Pause"
+      "Total Days Paused": "Total des Jours en Pause",
+      "Credit Profile": "Profil de crédit"
     },
     "links": {
       "Community": "Communauté",
@@ -4499,6 +4499,27 @@
         },
         "own.account": "Compte Propre",
         "other.bank": "Autre Banque"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "Score FICO",
+        "riskBand": "Bande de risque",
+        "bureau": "Bureau",
+        "pulledAt": "Dernière consultation",
+        "expiry": "Date d expiration",
+        "delinquencies": "Défauts de paiement",
+        "firstDelinquency": "Premier défaut",
+        "none": "Aucun",
+        "yes": "Oui",
+        "scoreDropAlert": "Score FICO en baisse",
+        "hasDelinquencies": "Client a des défauts",
+        "tradelines": "Lignes de crédit",
+        "noTradelines": "Aucune ligne de crédit",
+        "balance": "Solde",
+        "latePayments": "Paiements en retard",
+        "noData": "Aucun profil de crédit",
+        "noDataHint": "Exécutez la vérification du bureau"
       }
     }
   },

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1598,7 +1598,7 @@
       "Annual interest rate": "Annual interest rate",
       "Annual interest rate by loan cycle": "Annual interest rate by loan cycle",
       "Annual interest rate frequency": "Annual interest rate frequency",
-      "Breach Actions": "Azioni di violazione",
+      "Breach Actions": "Azioni di Violazione",
       "# Remittance": "# Rimessa",
       "# Senders": "# Mittenti",
       "ACCOUNTING": "CONTABILITÀ",
@@ -3162,7 +3162,6 @@
       "to": "A",
       "valid": "valido",
       "Active Pause": "Pausa Attiva",
-      "Breach Actions": "Azioni di Violazione",
       "days": "giorni",
       "Duration": "Durata",
       "Expired": "Scaduta",
@@ -3175,7 +3174,8 @@
       "Scheduled": "Programmata",
       "Today": "Oggi",
       "Total Actions": "Azioni Totali",
-      "Total Days Paused": "Totale Giorni in Pausa"
+      "Total Days Paused": "Totale Giorni in Pausa",
+      "Credit Profile": "Profilo di credito"
     },
     "links": {
       "Community": "Comunità",
@@ -4497,6 +4497,27 @@
         },
         "own.account": "Conto Proprio",
         "other.bank": "Altra Banca"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "Punteggio FICO",
+        "riskBand": "Fascia di rischio",
+        "bureau": "Bureau",
+        "pulledAt": "Ultima consultazione",
+        "expiry": "Data di scadenza",
+        "delinquencies": "Insoluti",
+        "firstDelinquency": "Primo insoluto",
+        "none": "Nessuno",
+        "yes": "Si",
+        "scoreDropAlert": "Punteggio FICO in calo",
+        "hasDelinquencies": "Cliente ha insoluti",
+        "tradelines": "Linee di credito",
+        "noTradelines": "Nessuna linea di credito",
+        "balance": "Saldo",
+        "latePayments": "Pagamenti in ritardo",
+        "noData": "Nessun profilo di credito",
+        "noDataHint": "Eseguire prima il controllo del bureau"
       }
     }
   },

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1599,7 +1599,7 @@
       "Annual interest rate": "Annual interest rate",
       "Annual interest rate by loan cycle": "Annual interest rate by loan cycle",
       "Annual interest rate frequency": "Annual interest rate frequency",
-      "Breach Actions": "위반 행위",
+      "Breach Actions": "위반 작업",
       "# Remittance": "# 송금",
       "# Senders": "# 송금인",
       "ACCOUNTING": "회계",
@@ -3162,7 +3162,6 @@
       "to": "에게",
       "valid": "유효한",
       "Active Pause": "활성 일시중지",
-      "Breach Actions": "위반 작업",
       "days": "일",
       "Duration": "기간",
       "Expired": "만료됨",
@@ -3175,7 +3174,8 @@
       "Scheduled": "예약됨",
       "Today": "오늘",
       "Total Actions": "전체 작업",
-      "Total Days Paused": "총 일시중지 일수"
+      "Total Days Paused": "총 일시중지 일수",
+      "Credit Profile": "신용 프로필"
     },
     "links": {
       "Community": "지역 사회",
@@ -4496,6 +4496,27 @@
         },
         "own.account": "본인 계좌",
         "other.bank": "타행"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "FICO 점수",
+        "riskBand": "위험 등급",
+        "bureau": "신용조회기관",
+        "pulledAt": "마지막 조회",
+        "expiry": "만료일",
+        "delinquencies": "연체",
+        "firstDelinquency": "첫 연체",
+        "none": "없음",
+        "yes": "예",
+        "scoreDropAlert": "FICO 점수 하락",
+        "hasDelinquencies": "연체 기록 있음",
+        "tradelines": "신용 거래선",
+        "noTradelines": "신용 거래선 없음",
+        "balance": "잔액",
+        "latePayments": "연체 횟수",
+        "noData": "신용 프로필 없음",
+        "noDataHint": "신용조회 준비 확인 실행"
       }
     }
   },

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1597,7 +1597,7 @@
       "Annual interest rate": "Annual interest rate",
       "Annual interest rate by loan cycle": "Annual interest rate by loan cycle",
       "Annual interest rate frequency": "Annual interest rate frequency",
-      "Breach Actions": "Pažeidimas Veiksmai",
+      "Breach Actions": "Pažeidimo veiksmai",
       "# Remittance": "# Pervedimas",
       "# Senders": "# Siuntėjai",
       "ACCOUNTING": "APSKAITA",
@@ -3161,7 +3161,6 @@
       "to": "į",
       "valid": "galioja",
       "Active Pause": "Aktyvi pauzė",
-      "Breach Actions": "Pažeidimo veiksmai",
       "days": "dienos",
       "Duration": "Trukmė",
       "Expired": "Pasibaigė",
@@ -3174,7 +3173,8 @@
       "Scheduled": "Suplanuota",
       "Today": "Šiandien",
       "Total Actions": "Iš viso veiksmų",
-      "Total Days Paused": "Iš viso pauzės dienų"
+      "Total Days Paused": "Iš viso pauzės dienų",
+      "Credit Profile": "Kredito profilis"
     },
     "links": {
       "Community": "bendruomenė",
@@ -4497,6 +4497,27 @@
         },
         "own.account": "Sava sąskaita",
         "other.bank": "Kitas bankas"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "FICO balas",
+        "riskBand": "Rizikos juosta",
+        "bureau": "Biuras",
+        "pulledAt": "Paskutinį kartą gauta",
+        "expiry": "Galiojimo pabaiga",
+        "delinquencies": "Įsiskolinimai",
+        "firstDelinquency": "Pirmas įsiskolinimas",
+        "none": "Nėra",
+        "yes": "Taip",
+        "scoreDropAlert": "FICO balas sumažėjo",
+        "hasDelinquencies": "Klientas turi įsiskolinimų",
+        "tradelines": "Kredito linijos",
+        "noTradelines": "Kredito linijų nėra",
+        "balance": "Likutis",
+        "latePayments": "Pavėluoti mokėjimai",
+        "noData": "Kredito profilis nepasiekiamas",
+        "noDataHint": "Atlikite biuro patikrinimą"
       }
     }
   },

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1598,7 +1598,7 @@
       "Annual interest rate": "Annual interest rate",
       "Annual interest rate by loan cycle": "Annual interest rate by loan cycle",
       "Annual interest rate frequency": "Annual interest rate frequency",
-      "Breach Actions": "Pārkāpums Darbības",
+      "Breach Actions": "Pārkāpuma darbības",
       "# Remittance": "# Pārvedums",
       "# Senders": "# Sūtītāji",
       "ACCOUNTING": "GRĀMATVEDĪBA",
@@ -3162,7 +3162,6 @@
       "to": "uz",
       "valid": "derīgs",
       "Active Pause": "Aktīva pauze",
-      "Breach Actions": "Pārkāpuma darbības",
       "days": "dienas",
       "Duration": "Ilgums",
       "Expired": "Beidzies",
@@ -3175,7 +3174,8 @@
       "Scheduled": "Plānota",
       "Today": "Šodien",
       "Total Actions": "Darbības kopā",
-      "Total Days Paused": "Pauzes dienas kopā"
+      "Total Days Paused": "Pauzes dienas kopā",
+      "Credit Profile": "Kredīta profils"
     },
     "links": {
       "Community": "kopiena",
@@ -4496,6 +4496,27 @@
         },
         "own.account": "Savs konts",
         "other.bank": "Cita banka"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "FICO rādītājs",
+        "riskBand": "Riska josla",
+        "bureau": "Birojs",
+        "pulledAt": "Pēdējo reizi iegūts",
+        "expiry": "Derīguma termiņš",
+        "delinquencies": "Kavējumi",
+        "firstDelinquency": "Pirmais kavējums",
+        "none": "Nav",
+        "yes": "Jā",
+        "scoreDropAlert": "FICO rādītājs samazinājies",
+        "hasDelinquencies": "Klientam ir kavējumi",
+        "tradelines": "Kredītlīnijas",
+        "noTradelines": "Nav kredītlīniju",
+        "balance": "Atlikums",
+        "latePayments": "Nokavēti maksājumi",
+        "noData": "Kredīta profils nav pieejams",
+        "noDataHint": "Veiciet biroja pārbaudi"
       }
     }
   },

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1597,7 +1597,7 @@
       "Annual interest rate": "Annual interest rate",
       "Annual interest rate by loan cycle": "Annual interest rate by loan cycle",
       "Annual interest rate frequency": "Annual interest rate frequency",
-      "Breach Actions": "उल्लंघन कार्यहरू",
+      "Breach Actions": "उल्लङ्घन कार्यहरू",
       "# Remittance": "# रेमिट्यान्स",
       "# Senders": "# पठाउनेहरू",
       "ACCOUNTING": "लेखा",
@@ -3161,7 +3161,6 @@
       "to": "को",
       "valid": "मान्य",
       "Active Pause": "सक्रिय रोकावट",
-      "Breach Actions": "उल्लङ्घन कार्यहरू",
       "days": "दिन",
       "Duration": "अवधि",
       "Expired": "समाप्त",
@@ -3174,7 +3173,8 @@
       "Scheduled": "तालिकाबद्ध",
       "Today": "आज",
       "Total Actions": "कुल कार्यहरू",
-      "Total Days Paused": "कुल रोकिएका दिनहरू"
+      "Total Days Paused": "कुल रोकिएका दिनहरू",
+      "Credit Profile": "क्रेडिट प्रोफाइल"
     },
     "links": {
       "Community": "समुदाय",
@@ -4496,6 +4496,27 @@
         },
         "own.account": "आफ्नै खाता",
         "other.bank": "अन्य बैंक"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "FICO स्कोर",
+        "riskBand": "जोखिम ब्यान्ड",
+        "bureau": "ब्यूरो",
+        "pulledAt": "अन्तिम पटक",
+        "expiry": "म्याद समाप्ति",
+        "delinquencies": "बक्यौता",
+        "firstDelinquency": "पहिलो बक्यौता",
+        "none": "छैन",
+        "yes": "छ",
+        "scoreDropAlert": "FICO स्कोर घटेको",
+        "hasDelinquencies": "बक्यौता रेकर्ड छ",
+        "tradelines": "क्रेडिट लाइन",
+        "noTradelines": "कुनै लाइन छैन",
+        "balance": "शेष",
+        "latePayments": "ढिलो भुक्तानी",
+        "noData": "प्रोफाइल उपलब्ध छैन",
+        "noDataHint": "ब्यूरो जाँच चलाउनुहोस्"
       }
     }
   },

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1597,7 +1597,7 @@
       "Annual interest rate": "Annual interest rate",
       "Annual interest rate by loan cycle": "Annual interest rate by loan cycle",
       "Annual interest rate frequency": "Annual interest rate frequency",
-      "Breach Actions": "Ações de violação",
+      "Breach Actions": "Ações de Violação",
       "# Remittance": "# Remessa",
       "# Senders": "# Remetentes",
       "ACCOUNTING": "CONTABILIDADE",
@@ -3161,7 +3161,6 @@
       "to": "para",
       "valid": "válido",
       "Active Pause": "Pausa Ativa",
-      "Breach Actions": "Ações de Violação",
       "days": "dias",
       "Duration": "Duração",
       "Expired": "Expirada",
@@ -3174,7 +3173,8 @@
       "Scheduled": "Agendada",
       "Today": "Hoje",
       "Total Actions": "Total de Ações",
-      "Total Days Paused": "Total de Dias em Pausa"
+      "Total Days Paused": "Total de Dias em Pausa",
+      "Credit Profile": "Perfil de crédito"
     },
     "links": {
       "Community": "Comunidade",
@@ -4496,6 +4496,27 @@
         },
         "own.account": "Conta Própria",
         "other.bank": "Outro Banco"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "Pontuação FICO",
+        "riskBand": "Faixa de risco",
+        "bureau": "Bureau",
+        "pulledAt": "Última consulta",
+        "expiry": "Data de validade",
+        "delinquencies": "Inadimplências",
+        "firstDelinquency": "Primeira inadimplência",
+        "none": "Nenhuma",
+        "yes": "Sim",
+        "scoreDropAlert": "Pontuação FICO caiu",
+        "hasDelinquencies": "Cliente tem inadimplências",
+        "tradelines": "Linhas de crédito",
+        "noTradelines": "Sem linhas de crédito",
+        "balance": "Saldo",
+        "latePayments": "Pagamentos atrasados",
+        "noData": "Nenhum perfil disponível",
+        "noDataHint": "Execute a verificação do bureau"
       }
     }
   },

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1595,7 +1595,7 @@
       "Annual interest rate": "Annual interest rate",
       "Annual interest rate by loan cycle": "Annual interest rate by loan cycle",
       "Annual interest rate frequency": "Annual interest rate frequency",
-      "Breach Actions": "Ukiukaji Vitendo",
+      "Breach Actions": "Vitendo vya Ukiukaji",
       "# Remittance": "# Uhawilishaji",
       "# Senders": "# Watumaji",
       "ACCOUNTING": "UHASIBU",
@@ -3159,7 +3159,6 @@
       "to": "kwa",
       "valid": "halali",
       "Active Pause": "Pumziko Linaloendelea",
-      "Breach Actions": "Vitendo vya Ukiukaji",
       "days": "siku",
       "Duration": "Muda",
       "Expired": "Imeisha",
@@ -3172,7 +3171,8 @@
       "Scheduled": "Iliyopangwa",
       "Today": "Leo",
       "Total Actions": "Jumla ya Vitendo",
-      "Total Days Paused": "Jumla ya Siku za Pumziko"
+      "Total Days Paused": "Jumla ya Siku za Pumziko",
+      "Credit Profile": "Wasifu wa Mkopo"
     },
     "links": {
       "Community": "Jumuiya",
@@ -4493,6 +4493,27 @@
         },
         "own.account": "Akaunti Yangu",
         "other.bank": "Benki Nyingine"
+      }
+    },
+    "cbild": {
+      "creditProfile": {
+        "ficoScore": "Alama ya FICO",
+        "riskBand": "Kiwango cha Hatari",
+        "bureau": "Shirika",
+        "pulledAt": "Ilipatikana mara ya mwisho",
+        "expiry": "Tarehe ya kumalizika",
+        "delinquencies": "Madeni",
+        "firstDelinquency": "Deni la kwanza",
+        "none": "Hakuna",
+        "yes": "Ndiyo",
+        "scoreDropAlert": "Alama ya FICO imeshuka",
+        "hasDelinquencies": "Mteja ana madeni",
+        "tradelines": "Mistari ya mkopo",
+        "noTradelines": "Hakuna mistari",
+        "balance": "Salio",
+        "latePayments": "Malipo ya kuchelewa",
+        "noData": "Hakuna wasifu bado",
+        "noDataHint": "Endesha ukaguzi wa shirika"
       }
     }
   },

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -145,6 +145,8 @@ export const environment = {
     loadedEnv['productionModeEnableRBAC'] === 'true' || loadedEnv['productionModeEnableRBAC'] === true || false,
 
   /** CB-ILD Credit Bureau plugin base URL */
+  /** CB-ILD feature flag — set cbIldEnabled=true in env to show CB-ILD tabs */
+  cbIldEnabled: loadedEnv['cbIldEnabled'] === 'true' || loadedEnv['cbIldEnabled'] === true || false,
   pluginBaseUrl: loadedEnv['pluginBaseUrl'] || 'https://cbild.mifos.community',
   OIDC: {
     // Support legacy FINERACT_PLUGIN_OIDC_* variable names for backward compatibility

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -149,6 +149,8 @@ export const environment = {
     loadedEnv.productionModeEnableRBAC === 'true' || loadedEnv.productionModeEnableRBAC === true || false,
 
   /** CB-ILD Credit Bureau plugin base URL — must be HTTPS in production */
+  /** CB-ILD feature flag — set cbIldEnabled=true in env to show CB-ILD tabs */
+  cbIldEnabled: loadedEnv.cbIldEnabled === 'true' || loadedEnv.cbIldEnabled === true || false,
   pluginBaseUrl: loadedEnv.pluginBaseUrl || 'http://localhost:8084',
   OIDC: {
     // Support legacy FINERACT_PLUGIN_OIDC_* variable names for backward compatibility


### PR DESCRIPTION
## Summary
Adds Credit Profile tab (Tab 3) to the Mifos client profile as part of CB-ILD Phase 3 Angular frontend.

## What Changed
- `src/app/clients/clients-view/credit-profile/` — Credit Profile component (ts + html + scss)
- `src/app/clients/clients.module.ts` — CreditProfileComponent registered
- `src/app/clients/clients-routing.module.ts` — credit-profile route added
- `src/app/clients/clients-view/clients-view.component.html` — tab link added after Bureau Readiness
- `src/assets/translations/en-US.json` — credit profile translation keys added
- `src/app/clients/clients-view/bureau-readiness/bureau-readiness.component.ts` — fixed default role to KYC_OFFICER

## Test Results
- Client 5: FICO 750, Risk LOW, no delinquencies 
- Empty state shows for clients with no CDC data 
- KYC Officer gets 403 — handled gracefully 
- Roles: Credit Analyst + Compliance only

## Related
- Jira: MX-378
- Depends on: MX-277 (PR #3704), MX-278 (PR #3708)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Credit Profile** tab and dedicated **Credit Profile** screen within client records.
  * Displays stored CB-ILD results (FICO score, risk band, bureau details, delinquencies, tradelines) with clear loading, empty, and error states plus **Retry**.
* **Updates**
  * **Bureau Readiness** role options were adjusted and the default selection changed, with automatic remapping for saved selections.
  * **CB-ILD** navigation/tabs now render only when enabled via a feature flag.
  * Added new localized labels and messaging for the Credit Profile experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->