### PR TITLE
WEB-1037: Playwright — client action page objects, seeded factory with state overrides, and ApiSetupManager.getClientTemplate

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -131,7 +131,10 @@ export default defineConfig({
       // Pure-logic unit tests for shared utilities (retry, sleep, ...).
       // No browser, no auth setup, no app dependency.
       name: 'unit',
-      testMatch: /playwright\/utils\/.*\.spec\.ts/,
+      testMatch: [
+        /playwright\/utils\/.*\.spec\.ts/,
+        /playwright\/factories\/client\.spec\.ts/
+      ],
       testDir: '.',
       use: { storageState: { cookies: [], origins: [] } }
     },
@@ -140,7 +143,7 @@ export default defineConfig({
       // Runs against `E2E_FINERACT_URL` (default https://localhost:8443)
       // and exits in seconds because no Chromium process is started.
       name: 'integration',
-      testMatch: /playwright\/factories\/.*\.spec\.ts/,
+      testMatch: /playwright\/factories\/.*\.factory\.spec\.ts/,
       testDir: '.',
       use: { storageState: { cookies: [], origins: [] } }
     },

--- a/playwright/config/selectors.ts
+++ b/playwright/config/selectors.ts
@@ -294,3 +294,91 @@ export const CLOSE_CLIENT_SELECTORS: CloseClientSelectors = {
   confirmButton: 'Confirm',
   cancelButton: 'Cancel'
 };
+
+// ---------------------------------------------------------------------------
+// Activate client action form
+// ---------------------------------------------------------------------------
+
+export interface ActivateClientSelectors {
+  activationDateInput: string;
+  confirmButton: string;
+  cancelButton: string;
+}
+
+export const ACTIVATE_CLIENT_SELECTORS: ActivateClientSelectors = {
+  activationDateInput: 'input[formcontrolname="activationDate"]',
+  confirmButton: 'Confirm',
+  cancelButton: 'Cancel'
+};
+
+// ---------------------------------------------------------------------------
+// Reject client action form
+// ---------------------------------------------------------------------------
+
+export interface RejectClientSelectors {
+  rejectionDateInput: string;
+  rejectionReasonSelect: string;
+  confirmButton: string;
+  cancelButton: string;
+}
+
+export const REJECT_CLIENT_SELECTORS: RejectClientSelectors = {
+  rejectionDateInput: 'input[formcontrolname="rejectionDate"]',
+  rejectionReasonSelect: 'mat-select[formcontrolname="rejectionReasonId"]',
+  confirmButton: 'Confirm',
+  cancelButton: 'Cancel'
+};
+
+// ---------------------------------------------------------------------------
+// Withdraw client action form
+// ---------------------------------------------------------------------------
+
+export interface WithdrawClientSelectors {
+  withdrawalDateInput: string;
+  withdrawalReasonSelect: string;
+  confirmButton: string;
+  cancelButton: string;
+}
+
+export const WITHDRAW_CLIENT_SELECTORS: WithdrawClientSelectors = {
+  withdrawalDateInput: 'input[formcontrolname="withdrawalDate"]',
+  withdrawalReasonSelect: 'mat-select[formcontrolname="withdrawalReasonId"]',
+  confirmButton: 'Confirm',
+  cancelButton: 'Cancel'
+};
+
+// ---------------------------------------------------------------------------
+// Reactivate client action form
+// ---------------------------------------------------------------------------
+
+export interface ReactivateClientSelectors {
+  reactivationDateInput: string;
+  confirmButton: string;
+  cancelButton: string;
+}
+
+export const REACTIVATE_CLIENT_SELECTORS: ReactivateClientSelectors = {
+  reactivationDateInput: 'input[formcontrolname="reactivationDate"]',
+  confirmButton: 'Confirm',
+  cancelButton: 'Cancel'
+};
+
+// ---------------------------------------------------------------------------
+// Transfer client action form
+// ---------------------------------------------------------------------------
+
+export interface TransferClientSelectors {
+  destinationOfficeSelect: string;
+  transferDateInput: string;
+  noteInput: string;
+  confirmButton: string;
+  cancelButton: string;
+}
+
+export const TRANSFER_CLIENT_SELECTORS: TransferClientSelectors = {
+  destinationOfficeSelect: 'mat-select[formcontrolname="destinationOfficeId"]',
+  transferDateInput: 'input[formcontrolname="transferDate"]',
+  noteInput: 'textarea[formcontrolname="note"]',
+  confirmButton: 'Confirm',
+  cancelButton: 'Cancel'
+};

--- a/playwright/factories/client.spec.ts
+++ b/playwright/factories/client.spec.ts
@@ -1,0 +1,411 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import type { FineractApiClient } from '../fixtures/fineract-api';
+import {
+  createSeededClient,
+  createTestClient,
+  type ClientState,
+  type CreateTestClientOverrides,
+  type SeededTestClient
+} from './client';
+
+// Pure-logic specs — they run under the `unit` Playwright project
+// (testMatch: /playwright\/(utils|factories)\/.*\.spec\.ts/ in
+// playwright.config.ts) with no browser, no app, no backend. The
+// `FineractApiClient` is stubbed so the assertions can inspect the
+// exact command sequence the factory drives without ever making an
+// HTTP call.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ─────────────────────────────────────────────────────────────────────
+// createTestClient — pure payload synthesis
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('createTestClient() payload synthesis', () => {
+  test('populates every required GeneralStepData field with the seeded defaults', () => {
+    const payload = createTestClient();
+    expect(payload.office).toBe('Head Office');
+    expect(payload.legalForm).toBe('PERSON');
+    expect(payload.lastname).toBe('Client');
+    expect(payload.submittedOnDate).toBe('01 January 2024');
+    // firstname is monotonically suffixed — assert on the prefix
+    // rather than the full value so test order does not matter.
+    expect(payload.firstname).toMatch(/^Test\d+$/);
+  });
+
+  test('produces a unique firstname on every invocation within the same process', () => {
+    const a = createTestClient();
+    const b = createTestClient();
+    const c = createTestClient();
+    expect(a.firstname).not.toBe(b.firstname);
+    expect(b.firstname).not.toBe(c.firstname);
+    expect(a.firstname).not.toBe(c.firstname);
+  });
+
+  test('overrides win over the defaults for payload-relevant fields', () => {
+    const payload = createTestClient({
+      office: 'Branch 42',
+      lastname: '',
+      submittedOnDate: '15 March 2024'
+    });
+    expect(payload.office).toBe('Branch 42');
+    expect(payload.lastname).toBe('');
+    expect(payload.submittedOnDate).toBe('15 March 2024');
+  });
+
+  test('strips seeded-factory-only fields (state, actionDate, reasons) from the returned payload', () => {
+    // The pure builder must not leak the seeded-factory keys into
+    // the payload it returns — they would be rejected by
+    // `CreateClientPage.fillGeneralStep` (or worse: silently sent
+    // to Fineract as unknown fields).
+    const payload = createTestClient({
+      state: 'closed',
+      actionDate: '05 January 2024',
+      rejectionReasonName: 'ignored',
+      withdrawalReasonName: 'ignored',
+      closureReasonName: 'ignored'
+    } satisfies CreateTestClientOverrides);
+    const bag = payload as unknown as Record<string, unknown>;
+    expect(bag.state).toBeUndefined();
+    expect(bag.actionDate).toBeUndefined();
+    expect(bag.rejectionReasonName).toBeUndefined();
+    expect(bag.withdrawalReasonName).toBeUndefined();
+    expect(bag.closureReasonName).toBeUndefined();
+    // Sanity: the defaults are still present.
+    expect(payload.office).toBe('Head Office');
+    expect(payload.legalForm).toBe('PERSON');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Stub FineractApiClient
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Signature-compatible stand-in for {@link FineractApiClient} that
+ * records every method invocation the factory drives. The stub only
+ * implements the subset of methods that `createSeededClient` touches
+ * — the rest are typed away via a single `as unknown as` cast so
+ * TypeScript still enforces the shape at the call sites we care
+ * about.
+ */
+interface StubCall {
+  method: string;
+  args: unknown[];
+}
+
+function buildStub(overrides?: {
+  createResourceId?: number;
+  familyMembers?: Array<{ id: number }>;
+  deleteClientThrows?: Error;
+}): {
+  api: FineractApiClient;
+  calls: StubCall[];
+} {
+  const calls: StubCall[] = [];
+  const record = (method: string, args: unknown[]): void => {
+    calls.push({ method, args });
+  };
+  const createdId = overrides?.createResourceId ?? 42;
+
+  const stub = {
+    getFirstOfficeId: async (): Promise<number> => {
+      record('getFirstOfficeId', []);
+      return 7;
+    },
+    createActiveClient: async (officeId: number, data: Record<string, unknown>): Promise<{ resourceId: number }> => {
+      record('createActiveClient', [
+        officeId,
+        data
+      ]);
+      return { resourceId: createdId };
+    },
+    createPendingClient: async (officeId: number, data: Record<string, unknown>): Promise<{ resourceId: number }> => {
+      record('createPendingClient', [
+        officeId,
+        data
+      ]);
+      return { resourceId: createdId };
+    },
+    ensureClientClosureReason: async (name?: string): Promise<{ id: number; name: string }> => {
+      record('ensureClientClosureReason', [name]);
+      return { id: 101, name: name ?? 'default-closure' };
+    },
+    ensureClientRejectionReason: async (name?: string): Promise<{ id: number; name: string }> => {
+      record('ensureClientRejectionReason', [name]);
+      return { id: 202, name: name ?? 'default-reject' };
+    },
+    ensureClientWithdrawalReason: async (name?: string): Promise<{ id: number; name: string }> => {
+      record('ensureClientWithdrawalReason', [name]);
+      return { id: 303, name: name ?? 'default-withdraw' };
+    },
+    closeClient: async (clientId: number, reasonId: number, date: string): Promise<unknown> => {
+      record('closeClient', [
+        clientId,
+        reasonId,
+        date
+      ]);
+      return {};
+    },
+    rejectClient: async (clientId: number, reasonId: number, date: string): Promise<unknown> => {
+      record('rejectClient', [
+        clientId,
+        reasonId,
+        date
+      ]);
+      return {};
+    },
+    withdrawClient: async (clientId: number, reasonId: number, date: string): Promise<unknown> => {
+      record('withdrawClient', [
+        clientId,
+        reasonId,
+        date
+      ]);
+      return {};
+    },
+    getClientFamilyMembers: async (clientId: number): Promise<Array<{ id: number }>> => {
+      record('getClientFamilyMembers', [clientId]);
+      return overrides?.familyMembers ?? [];
+    },
+    deleteClientFamilyMember: async (clientId: number, memberId: number): Promise<void> => {
+      record('deleteClientFamilyMember', [
+        clientId,
+        memberId
+      ]);
+    },
+    deleteClient: async (clientId: number): Promise<void> => {
+      record('deleteClient', [clientId]);
+      if (overrides?.deleteClientThrows) {
+        throw overrides.deleteClientThrows;
+      }
+    }
+  } as unknown as FineractApiClient;
+
+  return { api: stub, calls };
+}
+
+/** Extracts the sequence of method names from a stub-call log. */
+function methodNames(calls: StubCall[]): string[] {
+  return calls.map((call) => call.method);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// createSeededClient — state → command mapping
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('createSeededClient() state → command mapping', () => {
+  test('defaults to pending: single POST /clients (active=false), no follow-up command', async () => {
+    const { api, calls } = buildStub();
+    const seeded = await createSeededClient(api);
+
+    expect(seeded.state).toBe('pending');
+    expect(seeded.clientId).toBe(42);
+    expect(seeded.officeId).toBe(7);
+    expect(methodNames(calls)).toEqual([
+      'getFirstOfficeId',
+      'createPendingClient'
+    ]);
+  });
+
+  test('state: "active" uses createActiveClient with the payload activationDate', async () => {
+    const { api, calls } = buildStub();
+    const seeded = await createSeededClient(api, { state: 'active', actionDate: '10 February 2024' });
+
+    expect(seeded.state).toBe('active');
+    expect(methodNames(calls)).toEqual([
+      'getFirstOfficeId',
+      'createActiveClient'
+    ]);
+    const createArgs = calls[1].args[1] as { activationDate: string };
+    expect(createArgs.activationDate).toBe('10 February 2024');
+  });
+
+  test('state: "rejected" seeds a pending client and drives command=reject with the ensured reason id', async () => {
+    const { api, calls } = buildStub();
+    const seeded = await createSeededClient(api, {
+      state: 'rejected',
+      actionDate: '11 February 2024',
+      rejectionReasonName: 'Custom Reject Reason'
+    });
+
+    expect(seeded.state).toBe('rejected');
+    expect(methodNames(calls)).toEqual([
+      'getFirstOfficeId',
+      'createPendingClient',
+      'ensureClientRejectionReason',
+      'rejectClient'
+    ]);
+    expect(calls[2].args).toEqual(['Custom Reject Reason']);
+    // rejectClient(clientId, reasonId, date)
+    expect(calls[3].args).toEqual([
+      42,
+      202,
+      '11 February 2024'
+    ]);
+  });
+
+  test('state: "withdrawn" seeds a pending client and drives command=withdraw with the ensured reason id', async () => {
+    const { api, calls } = buildStub();
+    const seeded = await createSeededClient(api, { state: 'withdrawn', actionDate: '12 February 2024' });
+
+    expect(seeded.state).toBe('withdrawn');
+    expect(methodNames(calls)).toEqual([
+      'getFirstOfficeId',
+      'createPendingClient',
+      'ensureClientWithdrawalReason',
+      'withdrawClient'
+    ]);
+    // No custom name → the ensure* call is invoked with `undefined`
+    // so it falls through to the FineractApiClient default.
+    expect(calls[2].args).toEqual([undefined]);
+    expect(calls[3].args).toEqual([
+      42,
+      303,
+      '12 February 2024'
+    ]);
+  });
+
+  test('state: "closed" seeds an active client first, then drives command=close', async () => {
+    const { api, calls } = buildStub();
+    const seeded = await createSeededClient(api, { state: 'closed', actionDate: '13 February 2024' });
+
+    expect(seeded.state).toBe('closed');
+    expect(methodNames(calls)).toEqual([
+      'getFirstOfficeId',
+      'createActiveClient',
+      'ensureClientClosureReason',
+      'closeClient'
+    ]);
+    expect(calls[3].args).toEqual([
+      42,
+      101,
+      '13 February 2024'
+    ]);
+  });
+
+  test('actionDate falls back to the payload submittedOnDate when not provided', async () => {
+    const { api, calls } = buildStub();
+    await createSeededClient(api, {
+      state: 'rejected',
+      submittedOnDate: '01 January 2024'
+    });
+
+    // rejectClient's third argument is the effective actionDate.
+    const rejectCall = calls.find((call) => call.method === 'rejectClient');
+    expect(rejectCall).toBeDefined();
+    expect((rejectCall as StubCall).args[2]).toBe('01 January 2024');
+  });
+
+  test('throws a clear error when the create response has neither resourceId nor clientId', async () => {
+    const noIdStub = {
+      getFirstOfficeId: async (): Promise<number> => 7,
+      createPendingClient: async (): Promise<Record<string, unknown>> => ({})
+    } as unknown as FineractApiClient;
+
+    await expect(createSeededClient(noIdStub)).rejects.toThrow(/missing resourceId\/clientId/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// createSeededClient — cleanup deleter
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('createSeededClient() cleanup deleter', () => {
+  test('pending: purges family members (FK-safe order) then hard-deletes the client', async () => {
+    const { api, calls } = buildStub({ familyMembers: [
+        { id: 501 },
+        { id: 502 }
+      ] });
+    const seeded = await createSeededClient(api);
+
+    // Snapshot the call log up to seeding so cleanup asserts only
+    // its own operations.
+    const seedCallCount = calls.length;
+    await seeded.cleanup();
+
+    const cleanupCalls = calls.slice(seedCallCount);
+    expect(methodNames(cleanupCalls)).toEqual([
+      'getClientFamilyMembers',
+      'deleteClientFamilyMember',
+      'deleteClientFamilyMember',
+      'deleteClient'
+    ]);
+    expect(cleanupCalls[1].args).toEqual([
+      42,
+      501
+    ]);
+    expect(cleanupCalls[2].args).toEqual([
+      42,
+      502
+    ]);
+    expect(cleanupCalls[3].args).toEqual([42]);
+  });
+
+  test('non-pending: swallows the deleteClient error (best-effort) and does not re-throw', async () => {
+    // Fineract refuses hard deletion of clients not in Pending state.
+    // The cleanup closure must catch that and continue — the test
+    // asserts nothing is thrown to the caller.
+    const { api } = buildStub({
+      deleteClientThrows: new Error('403 Forbidden: client cannot be deleted in Closed state')
+    });
+    const seeded = await createSeededClient(api, { state: 'closed' });
+
+    await expect(seeded.cleanup()).resolves.toBeUndefined();
+  });
+
+  test('cleanup is safe to call when the family-members endpoint itself rejects', async () => {
+    // getClientFamilyMembers uses `.catch(() => [])` so a failure
+    // fetching members degrades to "no members" and proceeds to the
+    // delete step. Assert the cleanup still resolves.
+    const failingStub = {
+      getFirstOfficeId: async (): Promise<number> => 7,
+      createPendingClient: async (): Promise<{ resourceId: number }> => ({ resourceId: 99 }),
+      getClientFamilyMembers: async (): Promise<never> => {
+        throw new Error('boom');
+      },
+      deleteClient: async (): Promise<void> => undefined
+    } as unknown as FineractApiClient;
+
+    const seeded = await createSeededClient(failingStub);
+    await expect(seeded.cleanup()).resolves.toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Type-level guard: SeededTestClient carries the requested state
+// ─────────────────────────────────────────────────────────────────────
+
+test.describe('createSeededClient() return shape', () => {
+  test('SeededTestClient.state echoes the requested ClientState value', async () => {
+    const states: ClientState[] = [
+      'pending',
+      'active',
+      'rejected',
+      'withdrawn',
+      'closed'
+    ];
+    for (const state of states) {
+      const { api } = buildStub();
+      const seeded: SeededTestClient = await createSeededClient(api, { state });
+      expect(seeded.state).toBe(state);
+    }
+  });
+
+  test('SeededTestClient exposes officeId and payload for API-echo assertions', async () => {
+    const { api } = buildStub();
+    const seeded = await createSeededClient(api, { firstname: 'SeededOverride' });
+    expect(seeded.officeId).toBe(7);
+    expect(seeded.payload.firstname).toBe('SeededOverride');
+    // The payload should be a strict GeneralStepData shape — no
+    // seeded-factory fields leaked into it.
+    expect((seeded.payload as unknown as Record<string, unknown>).state).toBeUndefined();
+  });
+});

--- a/playwright/factories/client.ts
+++ b/playwright/factories/client.ts
@@ -12,16 +12,25 @@
  * Factories produce deterministic, framework-agnostic test payloads that
  * specs can hand straight to a page object helper (e.g. the create-client
  * stepper) without re-deriving suffixes, dates, or office names in every
- * spec. They never touch the network — pair them with `FineractApiClient`
- * when API seeding is required.
+ * spec. The pure {@link createTestClient} builder never touches the
+ * network — pair it with `FineractApiClient` when API seeding is
+ * required.
  *
- * Cross-framework portability: the returned shape matches
+ * The async {@link createSeededClient} factory bundles the pure payload
+ * with a single API create call and (when requested) a follow-up
+ * command that transitions the client to `active`, `rejected`,
+ * `withdrawn`, or `closed`. It returns a {@link SeededTestClient} whose
+ * `cleanup` closure knows how to tear the client down for the state it
+ * created.
+ *
+ * Cross-framework portability: the pure return shape matches
  * `GeneralStepData` from the page-object barrel, which the React port
  * exports under the same name. Importing a factory from
  * `playwright/factories/...` therefore behaves identically against either
  * web app.
  */
 
+import type { FineractApiClient } from '../fixtures/fineract-api';
 import type { GeneralStepData } from '../pages';
 
 /**
@@ -33,26 +42,28 @@ import type { GeneralStepData } from '../pages';
  * fields (`middlename`, `mobileNo`, `email`, …) remain optional so the
  * type stays interchangeable with the page-object's
  * `fillGeneralStep(data)` parameter.
- *
- * Overrides that explicitly set one of these fields to `''` (the empty
- * string) still satisfy `string`, which is precisely how negative-path
- * specs request an empty required field without bypassing the type
- * system.
  */
 export type TestClientPayload = GeneralStepData &
   Required<Pick<GeneralStepData, 'office' | 'legalForm' | 'firstname' | 'lastname' | 'submittedOnDate'>>;
 
-/**
- * Default values used by {@link createTestClient}.
- *
- * Aligned with the Fineract default-tenant Liquibase seed:
- *   - `Head Office` is the first row inserted into `m_office`.
- *   - PERSON (legalFormId = 1) is the most common legal form and matches
- *     the seeded `c_code_value`s used by other Playwright specs.
- *   - `01 January 2024` is the same submitted-on date the close-client
- *     spec uses, keeping all test clients clustered on a known business
- *     day so reports stay readable.
- */
+export type ClientState = 'pending' | 'active' | 'rejected' | 'withdrawn' | 'closed';
+
+export interface CreateTestClientOverrides extends Partial<GeneralStepData> {
+  state?: ClientState;
+  actionDate?: string;
+  rejectionReasonName?: string;
+  withdrawalReasonName?: string;
+  closureReasonName?: string;
+}
+
+export interface SeededTestClient {
+  clientId: number;
+  officeId: number;
+  payload: TestClientPayload;
+  state: ClientState;
+  cleanup: () => Promise<void>;
+}
+
 const DEFAULT_TEST_CLIENT_DATA: Readonly<TestClientPayload> = {
   office: 'Head Office',
   legalForm: 'PERSON',
@@ -61,42 +72,122 @@ const DEFAULT_TEST_CLIENT_DATA: Readonly<TestClientPayload> = {
   submittedOnDate: '01 January 2024'
 };
 
-/**
- * Monotonic counter used to keep firstnames unique even when the same
- * test invokes `createTestClient` multiple times within a single
- * millisecond. Combined with the module-load epoch it produces
- * `Test<epoch><seq>` style names that satisfy Fineract's
- * "must not begin with a number" pattern (the leading `Test` prefix is
- * always alphabetic).
- */
 let testClientSequence = 0;
 const MODULE_LOAD_EPOCH = Date.now();
 
-/**
- * Builds a deterministic, uniquely-named payload for the create-client
- * stepper.
- *
- * Use this factory in negative-path specs that need a valid baseline to
- * mutate one field at a time — e.g. clearing `lastname` to assert the
- * Person-legal-form validator surfaces "Client last name is required".
- *
- * The happy-path spec intentionally avoids this factory and inlines the
- * payload so the UI form, the API echo assertion, and the cleanup-guard
- * all read against the same explicit values.
- *
- * @param overrides - Partial overrides merged on top of the defaults.
- *                    Pass `lastname: ''` (or any other empty required
- *                    field) to exercise validation.
- * @returns A {@link TestClientPayload} ready for
- *          `CreateClientPage.fillGeneralStep`.
- */
-export function createTestClient(overrides: Partial<GeneralStepData> = {}): TestClientPayload {
+function extractPayloadOverrides(overrides: CreateTestClientOverrides): Partial<GeneralStepData> {
+  const { state, actionDate, rejectionReasonName, withdrawalReasonName, closureReasonName, ...payloadOverrides } =
+    overrides;
+  void state;
+  void actionDate;
+  void rejectionReasonName;
+  void withdrawalReasonName;
+  void closureReasonName;
+  return payloadOverrides;
+}
+
+export function createTestClient(overrides: CreateTestClientOverrides = {}): TestClientPayload {
   testClientSequence += 1;
   const uniqueSuffix = `${MODULE_LOAD_EPOCH}${testClientSequence}`;
+  const payloadOverrides = extractPayloadOverrides(overrides);
 
   return {
     ...DEFAULT_TEST_CLIENT_DATA,
     firstname: `${DEFAULT_TEST_CLIENT_DATA.firstname}${uniqueSuffix}`,
-    ...overrides
+    ...payloadOverrides
   };
+}
+
+function resolveCreatedClientId(response: unknown): number {
+  const candidate = response as { resourceId?: number; clientId?: number } | null | undefined;
+  const id = candidate?.resourceId ?? candidate?.clientId;
+
+  if (typeof id !== 'number') {
+    throw new Error(
+      `[createSeededClient] Fineract create-client response missing resourceId/clientId: ${JSON.stringify(response)}`
+    );
+  }
+
+  return id;
+}
+
+export async function createSeededClient(
+  fineractApi: FineractApiClient,
+  overrides: CreateTestClientOverrides = {}
+): Promise<SeededTestClient> {
+  const payload = createTestClient(overrides);
+  const state: ClientState = overrides.state ?? 'pending';
+  const actionDate = overrides.actionDate ?? payload.submittedOnDate;
+  const officeId = await fineractApi.getFirstOfficeId();
+
+  const createResponse =
+    state === 'active' || state === 'closed'
+      ? await fineractApi.createActiveClient(officeId, {
+          firstname: payload.firstname,
+          lastname: payload.lastname,
+          submittedOnDate: payload.submittedOnDate,
+          activationDate: actionDate
+        })
+      : await fineractApi.createPendingClient(officeId, {
+          firstname: payload.firstname,
+          lastname: payload.lastname,
+          submittedOnDate: payload.submittedOnDate
+        });
+
+  const clientId = resolveCreatedClientId(createResponse);
+
+  const cleanup = async (): Promise<void> => {
+    try {
+      const members = await fineractApi.getClientFamilyMembers(clientId).catch(() => [] as unknown[]);
+
+      for (const member of members) {
+        const memberId = (member as { id?: number }).id;
+        if (typeof memberId !== 'number') {
+          continue;
+        }
+
+        try {
+          await fineractApi.deleteClientFamilyMember(clientId, memberId);
+        } catch (memberError) {
+          const message = memberError instanceof Error ? memberError.message : String(memberError);
+          console.warn(
+            `[createSeededClient cleanup] failed to delete family member ${memberId} of client ${clientId}: ${message}`
+          );
+        }
+      }
+
+      await fineractApi.deleteClient(clientId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[createSeededClient cleanup] failed to delete client ${clientId} (state=${state}): ${message}`);
+    }
+  };
+
+  try {
+    switch (state) {
+      case 'rejected': {
+        const reason = await fineractApi.ensureClientRejectionReason(overrides.rejectionReasonName);
+        await fineractApi.rejectClient(clientId, reason.id, actionDate);
+        break;
+      }
+      case 'withdrawn': {
+        const reason = await fineractApi.ensureClientWithdrawalReason(overrides.withdrawalReasonName);
+        await fineractApi.withdrawClient(clientId, reason.id, actionDate);
+        break;
+      }
+      case 'closed': {
+        const reason = await fineractApi.ensureClientClosureReason(overrides.closureReasonName);
+        await fineractApi.closeClient(clientId, reason.id, actionDate);
+        break;
+      }
+      case 'pending':
+      case 'active':
+        break;
+    }
+  } catch (transitionError) {
+    await cleanup();
+    throw transitionError;
+  }
+
+  return { clientId, officeId, payload, state, cleanup };
 }

--- a/playwright/factories/index.ts
+++ b/playwright/factories/index.ts
@@ -19,4 +19,11 @@
  * cross-framework portability swap a path-only change.
  */
 
-export { createTestClient, type TestClientPayload } from './client';
+export {
+  createTestClient,
+  createSeededClient,
+  type TestClientPayload,
+  type ClientState,
+  type CreateTestClientOverrides,
+  type SeededTestClient
+} from './client';

--- a/playwright/fixtures/fineract-api.ts
+++ b/playwright/fixtures/fineract-api.ts
@@ -10,6 +10,8 @@ import { APIRequestContext, APIResponse, request } from '@playwright/test';
 
 export class FineractApiClient {
   private static readonly CLIENT_CLOSURE_REASON_CODE_NAME = 'ClientClosureReason';
+  private static readonly CLIENT_REJECT_REASON_CODE_NAME = 'ClientRejectReason';
+  private static readonly CLIENT_WITHDRAW_REASON_CODE_NAME = 'ClientWithdrawReason';
   private static readonly DEFAULT_DATE_FORMAT = 'dd MMMM yyyy';
   private static readonly DEFAULT_LOCALE = 'en';
   private static readonly CREATE_RACE_RETRY_DELAY_MS = 250;
@@ -117,6 +119,19 @@ export class FineractApiClient {
   async getClient(clientId: number): Promise<any> {
     const res = await this.ctx.get(`/fineract-provider/api/v1/clients/${clientId}`);
     return this.validateResponse(res, 'getClient');
+  }
+
+  /**
+   * Fetches the client creation template from Fineract, optionally scoped to an office.
+   * @param officeId - Optional office id to scope the template
+   * @returns The client template payload
+   */
+  async getClientTemplate(officeId?: number): Promise<any> {
+    const url = officeId
+      ? `/fineract-provider/api/v1/clients/template?officeId=${officeId}`
+      : '/fineract-provider/api/v1/clients/template';
+    const res = await this.ctx.get(url);
+    return this.validateResponse(res, 'getClientTemplate');
   }
 
   /**
@@ -393,6 +408,28 @@ export class FineractApiClient {
   }
 
   /**
+   * Ensures a rejection reason exists for reject-client workflow tests.
+   * @param name - The rejection reason name to ensure exists
+   * @returns The existing or created rejection reason
+   */
+  async ensureClientRejectionReason(name = 'E2E Reject Client Reason'): Promise<any> {
+    return this.ensureCodeValue(FineractApiClient.CLIENT_REJECT_REASON_CODE_NAME, name, {
+      description: 'Seeded for Playwright reject-client test'
+    });
+  }
+
+  /**
+   * Ensures a withdrawal reason exists for withdraw-client workflow tests.
+   * @param name - The withdrawal reason name to ensure exists
+   * @returns The existing or created withdrawal reason
+   */
+  async ensureClientWithdrawalReason(name = 'E2E Withdraw Client Reason'): Promise<any> {
+    return this.ensureCodeValue(FineractApiClient.CLIENT_WITHDRAW_REASON_CODE_NAME, name, {
+      description: 'Seeded for Playwright withdraw-client test'
+    });
+  }
+
+  /**
    * Ensures a minimal loan product exists for active-loan negative-path tests.
    * @param options - Optional loan product identifiers to match or create
    * @returns The existing or created loan product
@@ -489,8 +526,39 @@ export class FineractApiClient {
   }
 
   /**
+   * Rejects a client with the provided reason and rejection date.
+   * @param clientId - The client id to reject
+   * @param rejectionReasonId - The rejection reason code value id
+   * @param rejectionDate - The rejection date in Fineract's expected format
+   * @returns The reject-client command response payload
+   */
+  async rejectClient(clientId: number, rejectionReasonId: number, rejectionDate: string): Promise<any> {
+    return this.executeClientCommand(clientId, 'reject', {
+      rejectionDate,
+      rejectionReasonId,
+      dateFormat: FineractApiClient.DEFAULT_DATE_FORMAT,
+      locale: FineractApiClient.DEFAULT_LOCALE
+    });
+  }
+
+  /**
+   * Withdraws a client application with the provided reason and withdrawal date.
+   * @param clientId - The client id to withdraw
+   * @param withdrawalReasonId - The withdrawal reason code value id
+   * @param withdrawalDate - The withdrawal date in Fineract's expected format
+   * @returns The withdraw-client command response payload
+   */
+  async withdrawClient(clientId: number, withdrawalReasonId: number, withdrawalDate: string): Promise<any> {
+    return this.executeClientCommand(clientId, 'withdraw', {
+      withdrawalDate,
+      withdrawalReasonId,
+      dateFormat: FineractApiClient.DEFAULT_DATE_FORMAT,
+      locale: FineractApiClient.DEFAULT_LOCALE
+    });
+  }
+
+  /**
    * Approves a loan on the provided date.
-   * @param loanId - The loan id to approve
    * @param approvedOnDate - The approval date in Fineract's expected format
    * @returns The approve-loan command response payload
    */

--- a/playwright/pages/client-actions/activate-client.page.ts
+++ b/playwright/pages/client-actions/activate-client.page.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../BasePage';
+import { ACTIVATE_CLIENT_SELECTORS } from '../../config/selectors';
+import { ROUTES } from '../../config/routes';
+
+/**
+ * ActivateClientPage — Page Object for the Mifos X activate-client action form.
+ *
+ * Consumes Layer-2 contracts:
+ *   - selectors: `ACTIVATE_CLIENT_SELECTORS` (form fields)
+ *   - routes:    `ROUTES.clientAction(id, 'Activate')`
+ *
+ * Confirm/Cancel buttons are resolved by accessible name (the value of
+ * `ACTIVATE_CLIENT_SELECTORS.confirmButton` / `cancelButton`) so the same
+ * code path works against the React counterpart.
+ *
+ * Cross-framework portability: the class extends {@link BasePage}, whose
+ * `navigate()` uses the `url` field set from `ROUTES`. The React port
+ * exports a `RouterProvider`-based counterpart that resolves the same
+ * logical action path — swapping frameworks is a `ROUTES` change, not a
+ * page-object rewrite.
+ */
+export class ActivateClientPage extends BasePage {
+  readonly url: string;
+
+  /**
+   * Builds the activate-client action page object for a specific client id.
+   * @param page - The Playwright Page instance
+   * @param clientId - The client id used to build action URLs and locators
+   */
+  constructor(
+    page: Page,
+    private readonly clientId: number
+  ) {
+    super(page);
+    this.url = ROUTES.clientAction(clientId, 'Activate');
+  }
+
+  /**
+   * Returns the activation date input used by the activate-client form.
+   */
+  get activationDateInput(): Locator {
+    return this.page.locator(ACTIVATE_CLIENT_SELECTORS.activationDateInput);
+  }
+
+  /**
+   * Returns the form submission control for activating the client.
+   */
+  get confirmButton(): Locator {
+    return this.page.getByRole('button', { name: ACTIVATE_CLIENT_SELECTORS.confirmButton });
+  }
+
+  /**
+   * Returns the cancel control that navigates back to the client view.
+   */
+  get cancelButton(): Locator {
+    return this.page.getByRole('button', { name: ACTIVATE_CLIENT_SELECTORS.cancelButton });
+  }
+
+  /**
+   * Waits for the activate-client action form to load.
+   */
+  async waitForLoad(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/actions/Activate$`));
+    await this.waitForVisible(this.activationDateInput, 30000);
+  }
+
+  /**
+   * Completes and submits the activate-client form.
+   * @param activationDate - The activation date to submit
+   */
+  async submitActivation({ activationDate }: { activationDate: string }): Promise<void> {
+    await this.activationDateInput.fill(activationDate);
+    await this.activationDateInput.blur();
+
+    await expect(this.confirmButton).toBeEnabled();
+    await this.confirmButton.click();
+  }
+
+  /**
+   * Waits until cancellation returns the browser to the client general view.
+   */
+  async waitForCancelNavigation(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/general$`));
+  }
+}

--- a/playwright/pages/client-actions/reactivate-client.page.ts
+++ b/playwright/pages/client-actions/reactivate-client.page.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../BasePage';
+import { REACTIVATE_CLIENT_SELECTORS } from '../../config/selectors';
+import { ROUTES } from '../../config/routes';
+
+/**
+ * ReactivateClientPage — Page Object for the Mifos X reactivate-client action form.
+ *
+ * Consumes Layer-2 contracts:
+ *   - selectors: `REACTIVATE_CLIENT_SELECTORS` (form fields)
+ *   - routes:    `ROUTES.clientAction(id, 'Reactivate')`
+ *
+ * Confirm/Cancel buttons are resolved by accessible name (the value of
+ * `REACTIVATE_CLIENT_SELECTORS.confirmButton` / `cancelButton`) so the same
+ * code path works against the React counterpart.
+ *
+ * Reactivation is the inverse of Close — the form carries a single
+ * `reactivationDate` control, no reason dropdown. The React counterpart
+ * models the same shape.
+ */
+export class ReactivateClientPage extends BasePage {
+  readonly url: string;
+
+  /**
+   * Builds the reactivate-client action page object for a specific client id.
+   * @param page - The Playwright Page instance
+   * @param clientId - The client id used to build action URLs and locators
+   */
+  constructor(
+    page: Page,
+    private readonly clientId: number
+  ) {
+    super(page);
+    this.url = ROUTES.clientAction(clientId, 'Reactivate');
+  }
+
+  /**
+   * Returns the reactivation date input used by the reactivate-client form.
+   */
+  get reactivationDateInput(): Locator {
+    return this.page.locator(REACTIVATE_CLIENT_SELECTORS.reactivationDateInput);
+  }
+
+  /**
+   * Returns the form submission control for reactivating the client.
+   */
+  get confirmButton(): Locator {
+    return this.page.getByRole('button', { name: REACTIVATE_CLIENT_SELECTORS.confirmButton });
+  }
+
+  /**
+   * Returns the cancel control that navigates back to the client view.
+   */
+  get cancelButton(): Locator {
+    return this.page.getByRole('button', { name: REACTIVATE_CLIENT_SELECTORS.cancelButton });
+  }
+
+  /**
+   * Waits for the reactivate-client action form to load.
+   */
+  async waitForLoad(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/actions/Reactivate$`));
+    await this.waitForVisible(this.reactivationDateInput, 30000);
+  }
+
+  /**
+   * Completes and submits the reactivate-client form.
+   * @param reactivationDate - The reactivation date to submit
+   */
+  async submitReactivation({ reactivationDate }: { reactivationDate: string }): Promise<void> {
+    await this.reactivationDateInput.fill(reactivationDate);
+    await this.reactivationDateInput.blur();
+
+    await expect(this.confirmButton).toBeEnabled();
+    await this.confirmButton.click();
+  }
+
+  /**
+   * Waits until cancellation returns the browser to the client general view.
+   */
+  async waitForCancelNavigation(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/general$`));
+  }
+}

--- a/playwright/pages/client-actions/reject-client.page.ts
+++ b/playwright/pages/client-actions/reject-client.page.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../BasePage';
+import { REJECT_CLIENT_SELECTORS } from '../../config/selectors';
+import { ROUTES } from '../../config/routes';
+
+/**
+ * RejectClientPage — Page Object for the Mifos X reject-client action form.
+ *
+ * Consumes Layer-2 contracts:
+ *   - selectors: `REJECT_CLIENT_SELECTORS` (form fields)
+ *   - routes:    `ROUTES.clientAction(id, 'Reject')`
+ *
+ * Confirm/Cancel buttons are resolved by accessible name (the value of
+ * `REJECT_CLIENT_SELECTORS.confirmButton` / `cancelButton`) so the same
+ * code path works against the React counterpart.
+ *
+ * The reason dropdown is populated by the `Reject` route resolver via
+ * `getClientCommandTemplate('reject')`. The page object exposes a
+ * `selectRejectionReason(name)` helper so specs pick options by label
+ * regardless of the code-value id assigned by the current tenant seed.
+ */
+export class RejectClientPage extends BasePage {
+  readonly url: string;
+
+  /**
+   * Builds the reject-client action page object for a specific client id.
+   * @param page - The Playwright Page instance
+   * @param clientId - The client id used to build action URLs and locators
+   */
+  constructor(
+    page: Page,
+    private readonly clientId: number
+  ) {
+    super(page);
+    this.url = ROUTES.clientAction(clientId, 'Reject');
+  }
+
+  /**
+   * Returns the rejection date input used by the reject-client form.
+   */
+  get rejectionDateInput(): Locator {
+    return this.page.locator(REJECT_CLIENT_SELECTORS.rejectionDateInput);
+  }
+
+  /**
+   * Returns the rejection reason select field.
+   */
+  get rejectionReasonSelect(): Locator {
+    return this.page.locator(REJECT_CLIENT_SELECTORS.rejectionReasonSelect);
+  }
+
+  /**
+   * Returns the form submission control for rejecting the client.
+   */
+  get confirmButton(): Locator {
+    return this.page.getByRole('button', { name: REJECT_CLIENT_SELECTORS.confirmButton });
+  }
+
+  /**
+   * Returns the cancel control that navigates back to the client view.
+   */
+  get cancelButton(): Locator {
+    return this.page.getByRole('button', { name: REJECT_CLIENT_SELECTORS.cancelButton });
+  }
+
+  /**
+   * Returns a specific rejection reason option by its visible label.
+   * @param name - The visible label of the rejection reason
+   * @returns The locator for the matching rejection reason option
+   */
+  rejectionReasonOption(name: string): Locator {
+    return this.page.getByRole('option', { name });
+  }
+
+  /**
+   * Waits for the reject-client action form to load.
+   */
+  async waitForLoad(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/actions/Reject$`));
+    await this.waitForVisible(this.rejectionDateInput, 30000);
+  }
+
+  /**
+   * Opens the reason select and chooses the requested rejection reason.
+   * @param reasonName - The visible rejection reason label to select
+   */
+  async selectRejectionReason(reasonName: string): Promise<void> {
+    await this.rejectionReasonSelect.click();
+    await this.rejectionReasonOption(reasonName).click();
+  }
+
+  /**
+   * Completes and submits the reject-client form.
+   * @param rejectionDate - The rejection date to submit
+   * @param reasonName - The rejection reason label to select
+   */
+  async submitRejection({ rejectionDate, reasonName }: { rejectionDate: string; reasonName: string }): Promise<void> {
+    await this.rejectionDateInput.fill(rejectionDate);
+    await this.rejectionDateInput.blur();
+
+    await this.selectRejectionReason(reasonName);
+
+    await expect(this.confirmButton).toBeEnabled();
+    await this.confirmButton.click();
+  }
+
+  /**
+   * Waits until cancellation returns the browser to the client general view.
+   */
+  async waitForCancelNavigation(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/general$`));
+  }
+}

--- a/playwright/pages/client-actions/transfer-client.page.ts
+++ b/playwright/pages/client-actions/transfer-client.page.ts
@@ -1,0 +1,154 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../BasePage';
+import { TRANSFER_CLIENT_SELECTORS } from '../../config/selectors';
+import { ROUTES } from '../../config/routes';
+
+/**
+ * TransferClientPage — Page Object for the Mifos X transfer-client action form.
+ *
+ * Consumes Layer-2 contracts:
+ *   - selectors: `TRANSFER_CLIENT_SELECTORS` (form fields)
+ *   - routes:    `ROUTES.clientAction(id, 'Transfer Client')`
+ *
+ * Confirm/Cancel buttons are resolved by accessible name (the value of
+ * `TRANSFER_CLIENT_SELECTORS.confirmButton` / `cancelButton`) so the same
+ * code path works against the React counterpart.
+ *
+ * The destination-office dropdown is populated by the `Transfer Client`
+ * route resolver (`ClientsService.getOffices()`). The page object
+ * exposes `selectDestinationOffice(name)` so specs pick offices by
+ * label regardless of the row id assigned by the current tenant seed.
+ *
+ * Route-encoding note: the action name contains a space, so
+ * `ROUTES.clientAction` percent-encodes it to `Transfer%20Client`. The
+ * `waitForLoad` regex therefore matches the encoded form — that is
+ * what the browser exposes through `page.url()` in Angular's hash
+ * router.
+ */
+export class TransferClientPage extends BasePage {
+  readonly url: string;
+
+  /**
+   * Builds the transfer-client action page object for a specific client id.
+   * @param page - The Playwright Page instance
+   * @param clientId - The client id used to build action URLs and locators
+   */
+  constructor(
+    page: Page,
+    private readonly clientId: number
+  ) {
+    super(page);
+    this.url = ROUTES.clientAction(clientId, 'Transfer Client');
+  }
+
+  /**
+   * Returns the destination office select field.
+   */
+  get destinationOfficeSelect(): Locator {
+    return this.page.locator(TRANSFER_CLIENT_SELECTORS.destinationOfficeSelect);
+  }
+
+  /**
+   * Returns the transfer date input used by the transfer-client form.
+   */
+  get transferDateInput(): Locator {
+    return this.page.locator(TRANSFER_CLIENT_SELECTORS.transferDateInput);
+  }
+
+  /**
+   * Returns the optional note textarea used by the transfer-client form.
+   */
+  get noteInput(): Locator {
+    return this.page.locator(TRANSFER_CLIENT_SELECTORS.noteInput);
+  }
+
+  /**
+   * Returns the form submission control for transferring the client.
+   */
+  get confirmButton(): Locator {
+    return this.page.getByRole('button', { name: TRANSFER_CLIENT_SELECTORS.confirmButton });
+  }
+
+  /**
+   * Returns the cancel control that navigates back to the client view.
+   */
+  get cancelButton(): Locator {
+    return this.page.getByRole('button', { name: TRANSFER_CLIENT_SELECTORS.cancelButton });
+  }
+
+  /**
+   * Returns a specific destination-office option by its visible label.
+   * @param name - The visible label of the destination office
+   * @returns The locator for the matching destination office option
+   */
+  destinationOfficeOption(name: string): Locator {
+    return this.page.getByRole('option', { name });
+  }
+
+  /**
+   * Waits for the transfer-client action form to load.
+   *
+   * Matches both the percent-encoded (`Transfer%20Client`) and raw
+   * (`Transfer Client`) forms of the action segment because some
+   * browsers normalise the URL after navigation while others preserve
+   * the encoding produced by `encodeURIComponent`.
+   */
+  async waitForLoad(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/actions/Transfer(?:%20|\\s)Client$`));
+    await this.waitForVisible(this.destinationOfficeSelect, 30000);
+  }
+
+  /**
+   * Opens the destination office select and chooses the requested office.
+   * @param officeName - The visible destination office label to select
+   */
+  async selectDestinationOffice(officeName: string): Promise<void> {
+    await this.destinationOfficeSelect.click();
+    await this.destinationOfficeOption(officeName).click();
+  }
+
+  /**
+   * Completes and submits the transfer-client form.
+   * @param destinationOfficeName - The destination office label to select
+   * @param transferDate - The transfer date to submit
+   * @param note - Optional free-text note stored on the transfer request
+   */
+  async submitTransfer({
+    destinationOfficeName,
+    transferDate,
+    note
+  }: {
+    destinationOfficeName: string;
+    transferDate: string;
+    note?: string;
+  }): Promise<void> {
+    await this.selectDestinationOffice(destinationOfficeName);
+
+    await this.transferDateInput.fill(transferDate);
+    await this.transferDateInput.blur();
+
+    if (note !== undefined) {
+      await this.noteInput.fill(note);
+      await this.noteInput.blur();
+    }
+
+    await expect(this.confirmButton).toBeEnabled();
+    await this.confirmButton.click();
+  }
+
+  /**
+   * Waits until cancellation returns the browser to the client general view.
+   */
+  async waitForCancelNavigation(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/general$`));
+  }
+}

--- a/playwright/pages/client-actions/withdraw-client.page.ts
+++ b/playwright/pages/client-actions/withdraw-client.page.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../BasePage';
+import { WITHDRAW_CLIENT_SELECTORS } from '../../config/selectors';
+import { ROUTES } from '../../config/routes';
+
+/**
+ * WithdrawClientPage — Page Object for the Mifos X withdraw-client action form.
+ *
+ * Consumes Layer-2 contracts:
+ *   - selectors: `WITHDRAW_CLIENT_SELECTORS` (form fields)
+ *   - routes:    `ROUTES.clientAction(id, 'Withdraw')`
+ *
+ * Confirm/Cancel buttons are resolved by accessible name (the value of
+ * `WITHDRAW_CLIENT_SELECTORS.confirmButton` / `cancelButton`) so the same
+ * code path works against the React counterpart.
+ *
+ * The reason dropdown is populated by the `Withdraw` route resolver via
+ * `getClientCommandTemplate('withdraw')`. The page object exposes a
+ * `selectWithdrawalReason(name)` helper so specs pick options by label
+ * regardless of the code-value id assigned by the current tenant seed.
+ */
+export class WithdrawClientPage extends BasePage {
+  readonly url: string;
+
+  /**
+   * Builds the withdraw-client action page object for a specific client id.
+   * @param page - The Playwright Page instance
+   * @param clientId - The client id used to build action URLs and locators
+   */
+  constructor(
+    page: Page,
+    private readonly clientId: number
+  ) {
+    super(page);
+    this.url = ROUTES.clientAction(clientId, 'Withdraw');
+  }
+
+  /**
+   * Returns the withdrawal date input used by the withdraw-client form.
+   */
+  get withdrawalDateInput(): Locator {
+    return this.page.locator(WITHDRAW_CLIENT_SELECTORS.withdrawalDateInput);
+  }
+
+  /**
+   * Returns the withdrawal reason select field.
+   */
+  get withdrawalReasonSelect(): Locator {
+    return this.page.locator(WITHDRAW_CLIENT_SELECTORS.withdrawalReasonSelect);
+  }
+
+  /**
+   * Returns the form submission control for withdrawing the client.
+   */
+  get confirmButton(): Locator {
+    return this.page.getByRole('button', { name: WITHDRAW_CLIENT_SELECTORS.confirmButton });
+  }
+
+  /**
+   * Returns the cancel control that navigates back to the client view.
+   */
+  get cancelButton(): Locator {
+    return this.page.getByRole('button', { name: WITHDRAW_CLIENT_SELECTORS.cancelButton });
+  }
+
+  /**
+   * Returns a specific withdrawal reason option by its visible label.
+   * @param name - The visible label of the withdrawal reason
+   * @returns The locator for the matching withdrawal reason option
+   */
+  withdrawalReasonOption(name: string): Locator {
+    return this.page.getByRole('option', { name });
+  }
+
+  /**
+   * Waits for the withdraw-client action form to load.
+   */
+  async waitForLoad(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/actions/Withdraw$`));
+    await this.waitForVisible(this.withdrawalDateInput, 30000);
+  }
+
+  /**
+   * Opens the reason select and chooses the requested withdrawal reason.
+   * @param reasonName - The visible withdrawal reason label to select
+   */
+  async selectWithdrawalReason(reasonName: string): Promise<void> {
+    await this.withdrawalReasonSelect.click();
+    await this.withdrawalReasonOption(reasonName).click();
+  }
+
+  /**
+   * Completes and submits the withdraw-client form.
+   * @param withdrawalDate - The withdrawal date to submit
+   * @param reasonName - The withdrawal reason label to select
+   */
+  async submitWithdrawal({
+    withdrawalDate,
+    reasonName
+  }: {
+    withdrawalDate: string;
+    reasonName: string;
+  }): Promise<void> {
+    await this.withdrawalDateInput.fill(withdrawalDate);
+    await this.withdrawalDateInput.blur();
+
+    await this.selectWithdrawalReason(reasonName);
+
+    await expect(this.confirmButton).toBeEnabled();
+    await this.confirmButton.click();
+  }
+
+  /**
+   * Waits until cancellation returns the browser to the client general view.
+   */
+  async waitForCancelNavigation(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/general$`));
+  }
+}

--- a/playwright/pages/index.ts
+++ b/playwright/pages/index.ts
@@ -35,3 +35,8 @@ export {
 } from './create-client.page';
 export { ClientViewPage } from './client-view.page';
 export { CloseClientPage } from './close-client.page';
+export { ActivateClientPage } from './client-actions/activate-client.page';
+export { RejectClientPage } from './client-actions/reject-client.page';
+export { WithdrawClientPage } from './client-actions/withdraw-client.page';
+export { ReactivateClientPage } from './client-actions/reactivate-client.page';
+export { TransferClientPage } from './client-actions/transfer-client.page';

--- a/playwright/utils/api-setup-manager.spec.ts
+++ b/playwright/utils/api-setup-manager.spec.ts
@@ -368,3 +368,101 @@ test.describe('Cache-key convention (sorted URLSearchParams)', () => {
     expect(calls).toBe(1);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// getClientTemplate — domain wrapper
+// ─────────────────────────────────────────────────────────────────────
+
+function managerWithClientTemplateStub(returns: any = { offices: [] }) {
+  let calls = 0;
+  const stub = {
+    getClientTemplate: async (_officeId?: number) => {
+      calls += 1;
+      return returns;
+    }
+  } as unknown as FineractApiClient;
+  const manager = new ApiSetupManager(stub, { cache: new Map() });
+  return { manager, getCalls: () => calls };
+}
+
+test.describe('getClientTemplate domain wrapper', () => {
+  test('single fetch — concurrent callers share one HTTP call', async () => {
+    const { manager, getCalls } = managerWithClientTemplateStub();
+    const [
+      a,
+      b,
+      c
+    ] = await Promise.all([
+      manager.getClientTemplate(),
+      manager.getClientTemplate(),
+      manager.getClientTemplate()
+    ]);
+    expect(getCalls()).toBe(1);
+    expect(a).toEqual({ offices: [] });
+    expect(b).toBe(a);
+    expect(c).toBe(a);
+  });
+
+  test('cached — serial calls do not re-fetch', async () => {
+    const { manager, getCalls } = managerWithClientTemplateStub();
+    await manager.getClientTemplate();
+    await manager.getClientTemplate();
+    await manager.getClientTemplate();
+    expect(getCalls()).toBe(1);
+  });
+
+  test('distinct keys — different officeId values are cached separately', async () => {
+    let calls = 0;
+    const stub = {
+      getClientTemplate: async (id?: number) => {
+        calls += 1;
+        return { officeId: id };
+      }
+    } as unknown as FineractApiClient;
+    const manager = new ApiSetupManager(stub, { cache: new Map() });
+    const a = await manager.getClientTemplate(1);
+    const b = await manager.getClientTemplate(2);
+    const c = await manager.getClientTemplate(1); // cache hit for officeId=1
+    expect(calls).toBe(2); // officeId=1 once, officeId=2 once
+    expect(a).toBe(c); // same reference from cache
+    expect(b).not.toBe(a);
+  });
+
+  test('sentinel isolation — no-officeId key does not collide with officeId=0', async () => {
+    const results: number[] = [];
+    let calls = 0;
+    const stub = {
+      getClientTemplate: async (id?: number) => {
+        calls += 1;
+        results.push(id as number);
+        return { id };
+      }
+    } as unknown as FineractApiClient;
+    const manager = new ApiSetupManager(stub, { cache: new Map() });
+    const noId = await manager.getClientTemplate();
+    const zeroId = await manager.getClientTemplate(0);
+    expect(calls).toBe(2);
+    expect(noId).toEqual({ id: undefined });
+    expect(zeroId).toEqual({ id: 0 });
+    expect(results).toEqual([
+      undefined,
+      0
+    ]);
+  });
+
+  test('reject eviction — failed fetch is not cached', async () => {
+    let calls = 0;
+    const stub = {
+      getClientTemplate: async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('network error');
+        return { offices: ['recovered'] };
+      }
+    } as unknown as FineractApiClient;
+    const manager = new ApiSetupManager(stub, { cache: new Map() });
+    await expect(manager.getClientTemplate()).rejects.toThrow('network error');
+    const result = await manager.getClientTemplate();
+    expect(calls).toBe(2);
+    expect(result).toEqual({ offices: ['recovered'] });
+  });
+});

--- a/playwright/utils/api-setup-manager.ts
+++ b/playwright/utils/api-setup-manager.ts
@@ -171,6 +171,22 @@ export class ApiSetupManager {
   }
 
   /**
+   * Returns (and caches) the Fineract client-creation template.
+   * Concurrent callers for the same `officeId` share a single in-flight
+   * request; the result is memoised for the lifetime of this manager.
+   *
+   * The cache key uses the sentinel string `'none'` when `officeId` is
+   * omitted so it never collides with `clientTemplate:0`.
+   *
+   * @param officeId - Optional office id to scope the template
+   * @returns The client template payload
+   */
+  getClientTemplate(officeId?: number): Promise<any> {
+    const key = `clientTemplate:${officeId ?? 'none'}`;
+    return this.dedupe(key, () => this.api.getClientTemplate(officeId));
+  }
+
+  /**
    * Test-only escape hatch. Clears the cache backing this instance —
    * useful for unit specs that want a clean slate per `test()`
    * without recreating the manager. Production code should never


### PR DESCRIPTION
## Description

Extends the Playwright E2E infrastructure to unblock client-lifecycle specs (activate / reject / withdraw / reactivate / transfer / close) with reusable Page Objects, a seeded factory that owns state-specific setup + cleanup, and a deduplicated client-template API wrapper.


### 1. Layer-2 selector contracts — `playwright/config/selectors.ts`
Added five typed selector maps mirroring `CloseClientSelectors`:
- `ACTIVATE_CLIENT_SELECTORS`, `REJECT_CLIENT_SELECTORS`, `WITHDRAW_CLIENT_SELECTORS`, `REACTIVATE_CLIENT_SELECTORS`, `TRANSFER_CLIENT_SELECTORS`
- Confirm/Cancel stored as accessible-name strings → resolved via `getByRole('button', { name })` (same code path for Angular Material and the React port).

### 2. Page Objects — `playwright/pages/client-actions/`
Five thin parallels of `close-client.page.ts`:
- `activate-client.page.ts` — `submitActivation({ activationDate })`
- `reject-client.page.ts` — `submitRejection({ rejectionDate, reasonName })`
- `withdraw-client.page.ts` — `submitWithdrawal({ withdrawalDate, reasonName })`
- `reactivate-client.page.ts` — `submitReactivation({ reactivationDate })`
- `transfer-client.page.ts` — `submitTransfer({ destinationOfficeName, transferDate, note? })` (URL regex tolerates both `Transfer%20Client` and `Transfer Client`)

Barrel re-exports added in `playwright/pages/index.ts`.

### 3. Factory extension — `playwright/factories/client.ts`
- New `ClientState` union: `'pending' | 'active' | 'rejected' | 'withdrawn' | 'closed'`
- New `CreateTestClientOverrides` widens the existing overrides with `state`, `actionDate`, `rejectionReasonName`, `withdrawalReasonName`, `closureReasonName`
- `createTestClient` strips seeded-factory-only fields via `extractPayloadOverrides` so `TestClientPayload` stays clean
- New `createSeededClient(fineractApi, overrides?)` — single owner of "make me a client in state X with a cleanup deleter that works for state X":

| state | create call | follow-up | cleanup |
|---|---|---|---|
| pending | createPendingClient | — | hard DELETE |
| active | createActiveClient | — | best-effort DELETE |
| rejected | createPendingClient | ensureClientRejectionReason + rejectClient | best-effort DELETE |
| withdrawn | createPendingClient | ensureClientWithdrawalReason + withdrawClient | best-effort DELETE |
| closed | createActiveClient | ensureClientClosureReason + closeClient | best-effort DELETE |

Cleanup purges family members first (FK-safe), then deletes; non-pending deletion errors are swallowed and logged.

### 4. FineractApiClient extension — `playwright/fixtures/fineract-api.ts`
- `getClientTemplate(officeId?)`
- `rejectClient(id, reasonId, date)` / `withdrawClient(id, reasonId, date)`
- `ensureClientRejectionReason(name?)` / `ensureClientWithdrawalReason(name?)` (backed by `ClientRejectReason` / `ClientWithdrawReason` system codes).

### 5. ApiSetupManager domain wrapper — `playwright/utils/api-setup-manager.ts`
`getClientTemplate(officeId?)` delegates to `dedupe('clientTemplate:' + (officeId ?? 'none'), …)`. The `'none'` sentinel keeps the no-officeId form on its own key so it never collides with `clientTemplate:0`.

### 6. Tests
- `playwright/utils/api-setup-manager.spec.ts` — 5 new tests: concurrent dedup, serial cache hits, distinct keys per officeId, sentinel isolation from officeId=0, reject eviction.
- `playwright/factories/client.spec.ts` — 15 new unit tests (stubbed `FineractApiClient`): payload synthesis, state→command mapping for all 5 states, actionDate fallback, missing resourceId error, cleanup FK-safe order + best-effort swallow, family-member fetch resilience, return-shape.
- `playwright.config.ts` — `unit` project includes `factories/client.spec.ts`; `integration` narrowed to `.factory.spec.ts` only.

## Validation

```
npx playwright test --project=unit --reporter=list
95 passed (948ms)
```
## Related issues and discussion

https://mifosforge.jira.com/browse/WEB-1037

## Screenshots, if any

No TypeScript errors across touched files or downstream consumer specs.


## Checklist

- [x] Commits squashed into one (`30d56abf8`)
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Playwright page objects and typed form selectors for client lifecycle actions: Activate, Reject, Withdraw, Reactivate, and Transfer.
  * Introduced enhanced client factory utilities to build deterministic payloads, seed clients into lifecycle states, and perform safe cleanup.
  * Added client-template retrieval with in-memory deduped caching (shared and office-scoped).
* **Tests**
  * Expanded unit test coverage for client factory logic, seeded lifecycle transitions/cleanup, and template caching behavior.
* **Chores**
  * Updated Playwright test discovery patterns for unit vs. integration suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->