### PR TITLE
Update loans-account-terms-step.component.ts

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -204,12 +204,13 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
    * Executes on change of input values
    */
   ngOnChanges(changes: SimpleChanges) {
-    if (this.loanProductService.isLoanProduct) {
-      if (this.loansAccountProductTemplate) {
-        this.loansAccountTermsData = this.loansAccountProductTemplate;
-        if (this.loanId != null && this.loansAccountTemplate?.accountNo) {
-          this.loansAccountTermsData = this.loansAccountTemplate;
-        }
+    if (this.loansAccountProductTemplate) {
+          const templateChange = changes['loansAccountProductTemplate'];
+          const isInitialLoad = !templateChange || templateChange.isFirstChange();
+          this.loansAccountTermsData = this.loansAccountProductTemplate;
+          if (isInitialLoad && this.loanId != null && this.loansAccountTemplate?.accountNo) {
+            this.loansAccountTermsData = this.loansAccountTemplate;
+          }
         // Resolve the currency from the finalized terms data (the account template in edit mode),
         // matching ngOnInit and the non-loan-product branch, so the amount field reflects the
         // account currency instead of the product template currency.


### PR DESCRIPTION
## Problem

When editing an existing loan account and changing the selected **Loan Product**
in the Details step, the **Terms** step does not update to reflect the newly
selected product — it keeps showing the original loan's data.

So the bug is not a missing/broken API call — it's in how the response is
(mis)handled afterward.

## Root cause

`LoansAccountTermsStepComponent.ngOnChanges` couldn't distinguish between two
cases that both fire the same lifecycle hook:

1. The initial page load in edit mode (where showing the loan's own existing
   data is correct), and
2. A subsequent product change while already editing (where the freshly
   fetched product template should be used instead).

```ts
// before
if (this.loansAccountProductTemplate) {
  this.loansAccountTermsData = this.loansAccountProductTemplate;
  if (this.loanId != null && this.loansAccountTemplate?.accountNo) {
    this.loansAccountTermsData = this.loansAccountTemplate;
  }
  ...
```

`this.loanId != null && this.loansAccountTemplate?.accountNo` is true for the
entire lifetime of the edit page, regardless of which product is currently
selected. So every time a new product template arrived, this branch
immediately discarded it and fell back to the loan's original (stale) data —
the Terms form just kept re-patching the same old values.

This has been present since #WEB-711 (Working Capital product configuration,
2026-02-15). Notably, the sibling Working Capital branch a few lines below
already guards against this exact scenario via `SimpleChanges.isFirstChange()`
/ previous-vs-current product id comparison — the plain-loan branch above it
never received the equivalent fix.

## Fix

Use `SimpleChanges` to detect whether this is the *first* time
`loansAccountProductTemplate` changed (initial load) versus a later change
(user picked a different product), and only fall back to the stale loan data
on the initial load:

```ts
if (this.loansAccountProductTemplate) {
  const templateChange = changes['loansAccountProductTemplate'];
  const isInitialLoad = !templateChange || templateChange.isFirstChange();
  this.loansAccountTermsData = this.loansAccountProductTemplate;
  if (isInitialLoad && this.loanId != null && this.loansAccountTemplate?.accountNo) {
    this.loansAccountTermsData = this.loansAccountTemplate;
  }
  ...
```

No other logic in the method changed — all downstream consumers of
`loansAccountTermsData` (currency resolution, form patching, attribute-override
disabling, etc.) now simply operate on the correct source depending on which
case applies.

## Testing

- Opened an existing loan for editing — Terms step still correctly shows the
  loan's own current data on load (unchanged behavior).
- Changed the selected product in the Details step — Terms step now updates
  to reflect the newly selected product's template (previously stayed on the
  old product's terms).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loan account terms handling during updates.
  * Preserved the product-specific terms when loan details change, while continuing to load the appropriate template terms initially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->