### PR TITLE
fix(WEB-1038): include template id on update

### DIFF
--- a/src/app/templates/create-edit-template/create-edit-template.component.spec.ts
+++ b/src/app/templates/create-edit-template/create-edit-template.component.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ThemingService } from 'app/shared/theme-toggle/theming.service';
+import { TemplatesService } from '../templates.service';
+import { CreateEditComponent } from './create-edit-template.component';
+
+describe('CreateEditComponent', () => {
+  const templateData = {
+    entities: [
+      { id: 0, name: 'client' },
+      { id: 1, name: 'loan' }
+    ],
+    types: [
+      { id: 0, name: 'Document' },
+      { id: 2, name: 'SMS' }
+    ],
+    template: {
+      id: 76,
+      entity: 'client',
+      type: 'SMS',
+      name: 'SELF_SERVICE_LOGIN_SUCCESS_EMAIL_SUBJECT',
+      text: '<p>Original</p>',
+      mappers: [] as any[]
+    }
+  };
+
+  let router: { navigate: jest.Mock };
+  let templatesService: { createTemplate: jest.Mock; updateTemplate: jest.Mock };
+
+  function createComponent(mode: 'create' | 'edit', data = templateData): CreateEditComponent {
+    TestBed.resetTestingModule();
+    router = { navigate: jest.fn() };
+    templatesService = {
+      createTemplate: jest.fn().mockReturnValue(of({ resourceId: 77 })),
+      updateTemplate: jest.fn().mockReturnValue(of({ resourceId: data.template?.id }))
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        FormBuilder,
+        { provide: ActivatedRoute, useValue: { data: of({ templateData: data, mode }) } },
+        { provide: Router, useValue: router },
+        { provide: TemplatesService, useValue: templatesService },
+        { provide: ThemingService, useValue: { theme: of('light-theme') } }
+      ]
+    });
+
+    let component: CreateEditComponent;
+    TestBed.runInInjectionContext(() => {
+      component = new CreateEditComponent();
+    });
+    component.ngOnInit();
+    return component;
+  }
+
+  it('includes the template id in the update payload on edit submit', () => {
+    const component = createComponent('edit');
+    jest.spyOn(component, 'getEditorContent').mockReturnValue('<p>Updated</p>');
+
+    component.submit();
+
+    expect(templatesService.updateTemplate).toHaveBeenCalledWith(
+      {
+        id: templateData.template.id,
+        entity: 0,
+        type: 2,
+        name: 'SELF_SERVICE_LOGIN_SUCCESS_EMAIL_SUBJECT',
+        text: '<p>Updated</p>',
+        mappers: []
+      },
+      templateData.template.id
+    );
+    expect(templatesService.createTemplate).not.toHaveBeenCalled();
+  });
+
+  it('does not add an id to the create payload', () => {
+    const component = createComponent('create');
+    component.templateForm.patchValue({
+      entity: 1,
+      type: 2,
+      name: 'New Template',
+      text: '<p>Draft</p>'
+    });
+    jest.spyOn(component, 'getEditorContent').mockReturnValue('<p>Created</p>');
+
+    component.submit();
+
+    const [payload] = templatesService.createTemplate.mock.calls[0];
+    expect(payload).not.toHaveProperty('id');
+    expect(payload).toMatchObject({
+      entity: 1,
+      type: 2,
+      name: 'New Template',
+      text: '<p>Created</p>'
+    });
+    expect(templatesService.updateTemplate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/templates/create-edit-template/create-edit-template.component.ts
+++ b/src/app/templates/create-edit-template/create-edit-template.component.ts
@@ -286,6 +286,7 @@ export class CreateEditComponent implements OnInit {
         );
       });
     } else {
+      template.id = this.templateData.template.id;
       this.templateService.updateTemplate(template, this.templateData.template.id).subscribe(() => {
         this.router.navigate(['../'], { relativeTo: this.route });
       });


### PR DESCRIPTION
## Summary 

Includes the existing template ID in the update request payload when editing a template.

The current template update API requires the template ID in both the request path and request body. The Web App previously supplied it only in the path, causing template updates to fail with an `id.not-null` validation error.

The template creation flow remains unchanged.

## Related issues and discussion

#WEB-1038



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template editing so the existing template ID is preserved when saving changes.

* **Tests**
  * Added unit test coverage for the template create/edit flows, verifying the correct save action is called and that submitted data matches expectations for both modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->