### PR TITLE
WEB-976: Fix generated report downloads

### DIFF
--- a/src/app/core/utils/file-download.utils.spec.ts
+++ b/src/app/core/utils/file-download.utils.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { downloadBlob } from './file-download.utils';
+
+describe('downloadBlob', () => {
+  const objectUrl = 'blob:report-download';
+  let createObjectURLSpy: jest.SpyInstance;
+  let revokeObjectURLSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn()
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn()
+    });
+    createObjectURLSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValue(objectUrl);
+    revokeObjectURLSpy = jest.spyOn(URL, 'revokeObjectURL').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    createObjectURLSpy.mockRestore();
+    revokeObjectURLSpy.mockRestore();
+  });
+
+  it('creates and clicks a temporary download link', () => {
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
+    const blob = new Blob(['report'], { type: 'text/plain' });
+
+    downloadBlob(blob, 'client-report.xlsx');
+
+    const link = document.body.querySelector('a[download="client-report.xlsx"]') as HTMLAnchorElement;
+    expect(createObjectURLSpy).toHaveBeenCalledWith(blob);
+    expect(link).toBeTruthy();
+    expect(link.href).toBe(objectUrl);
+    expect(link.style.display).toBe('none');
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    clickSpy.mockRestore();
+  });
+
+  it('removes the temporary link and revokes the object URL', () => {
+    const clickSpy = jest.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation();
+
+    downloadBlob(new Blob(['report']), 'client-report.xlsx');
+
+    expect(document.body.querySelector('a[download="client-report.xlsx"]')).toBeTruthy();
+
+    jest.runOnlyPendingTimers();
+
+    expect(document.body.querySelector('a[download="client-report.xlsx"]')).toBeNull();
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith(objectUrl);
+
+    clickSpy.mockRestore();
+  });
+});

--- a/src/app/core/utils/file-download.utils.ts
+++ b/src/app/core/utils/file-download.utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Triggers a browser download for generated file content.
+ *
+ * @param {Blob} blob File content to download.
+ * @param {string} fileName Name to use for the downloaded file.
+ */
+export function downloadBlob(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.style.display = 'none';
+
+  document.body.appendChild(link);
+  link.click();
+
+  setTimeout(() => {
+    if (link.parentNode) {
+      link.parentNode.removeChild(link);
+    }
+    URL.revokeObjectURL(url);
+  }, 0);
+}

--- a/src/app/reports/run-report/run-report.component.ts
+++ b/src/app/reports/run-report/run-report.component.ts
@@ -22,6 +22,7 @@ import { SelectOption } from '../common-models/select-option.model';
 import { Dates } from 'app/core/utils/dates';
 import { GlobalConfiguration } from 'app/system/configurations/global-configurations-tab/configuration.model';
 import { sanitizeCsvValue } from 'app/core/utils/csv.utils';
+import { downloadBlob } from 'app/core/utils/file-download.utils';
 
 import * as ExcelJS from 'exceljs';
 import { AlertService } from 'app/core/alert/alert.service';
@@ -563,16 +564,6 @@ export class RunReportComponent implements OnInit {
       type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
     });
 
-    // Native download logic (no FileSaver)
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = fileName;
-    document.body.appendChild(a);
-    a.click();
-    setTimeout(() => {
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    }, 0);
+    downloadBlob(blob, fileName);
   }
 }

--- a/src/app/reports/run-report/table-and-sms/table-and-sms.component.ts
+++ b/src/app/reports/run-report/table-and-sms/table-and-sms.component.ts
@@ -35,6 +35,7 @@ import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.componen
 import { environment } from '../../../../environments/environment';
 import { ProgressBarService } from 'app/core/progress-bar/progress-bar.service';
 import { sanitizeCsvValue } from 'app/core/utils/csv.utils';
+import { downloadBlob } from 'app/core/utils/file-download.utils';
 
 import * as ExcelJS from 'exceljs';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -184,13 +185,13 @@ export class TableAndSmsComponent implements OnChanges {
     };
     const exportDialogRef = this.dialog.open(FormDialogComponent, { data });
     exportDialogRef.afterClosed().subscribe((response: { data: any }) => {
-      if (response.data) {
+      if (response?.data) {
         this.downloadCSV(response.data.value.fileName, response.data.value.delimiter);
       }
     });
   }
 
-  exportToXLS(): void {
+  async exportToXLS(): Promise<void> {
     const fileName = `${this.dataObject.report.name}.xlsx`;
     // Sanitize all values to prevent formula injection in spreadsheet applications
     const data = this.csvData.map((object: any) => {
@@ -212,15 +213,9 @@ export class TableAndSmsComponent implements OnChanges {
       worksheet.addRow(this.displayedColumns.map((col) => rowObj[col]));
     });
 
-    workbook.xlsx.writeBuffer().then((buffer: any) => {
-      const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'filename.xlsx';
-      a.click();
-      URL.revokeObjectURL(url);
-    });
+    const buffer = await workbook.xlsx.writeBuffer();
+    const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    downloadBlob(blob, fileName);
   }
 
   /**


### PR DESCRIPTION
## Description

- fix generated XLS report downloads to use the real report filename instead of `filename.xlsx`
- trigger downloads through a temporary document-attached anchor for consistent browser behavior
- reuse the same download helper from both report export paths
- keep existing spreadsheet formula-injection sanitization intact
- add unit coverage for generated browser downloads and object URL cleanup

## Related issues and discussion

- Jira: https://mifosforge.jira.com/browse/WEB-976

## Screenshots, if any

No layout changes.

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

## Testing

- `./node_modules/.bin/jest --config jest.config.ts src/app/core/utils/file-download.utils.spec.ts --runInBand --coverage=false`
- `./node_modules/.bin/eslint . && ./node_modules/.bin/stylelint "src/**/*.scss" && ./node_modules/.bin/prettier . --check && ./node_modules/.bin/htmlhint "src" --config .htmlhintrc`
- `node --max-old-space-size=16384 ./node_modules/@angular/cli/bin/ng build --configuration production --output-hashing=none --output-path /tmp/mifos-web-app-build-check-*`
- `semgrep scan --config p/default --error --quiet src/app/core/utils/file-download.utils.ts src/app/core/utils/file-download.utils.spec.ts src/app/reports/run-report/table-and-sms/table-and-sms.component.ts src/app/reports/run-report/run-report.component.ts`
- `gitleaks git --log-opts origin/dev..HEAD --no-banner --redact`
- `git diff --check origin/dev...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Report results can now be exported to XLSX with smooth, automatic browser downloads.
  - Standardized download handling across report export screens.

- **Bug Fixes**
  - Improved cleanup after downloads by reliably removing temporary elements and revoking temporary URLs.
  - More resilient export flow when expected export data is missing.

- **Tests**
  - Added automated coverage to verify download initiation, correct link setup, and post-download cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->