### PR TITLE
WEB-657: Working Capital Loan charge adjustment

### DIFF
--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.html
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.html
@@ -269,47 +269,49 @@
           {{ 'labels.inputs.Actions' | translate }}
         </th>
         <td mat-cell *matCellDef="let charge" class="col-c" (click)="$event.stopPropagation()">
-          <div class="act-group">
-            <button
-              mat-icon-button
-              type="button"
-              [matMenuTriggerFor]="chargeMenu"
-              [attr.aria-label]="'labels.inputs.Actions' | translate"
-            >
-              <mat-icon>more_vert</mat-icon>
-            </button>
+          @if (status === 'Active' || status === 'Submitted and pending approval') {
+            <div class="act-group">
+              <button
+                mat-icon-button
+                type="button"
+                [matMenuTriggerFor]="chargeMenu"
+                [attr.aria-label]="'labels.inputs.Actions' | translate"
+              >
+                <mat-icon>more_vert</mat-icon>
+              </button>
 
-            <mat-menu #chargeMenu="matMenu" class="charge-actions-menu">
-              @if (status === 'Active') {
-                <button mat-menu-item (click)="adjustCharge(charge.id)">
-                  <mat-icon matMenuItemIcon>tune</mat-icon>
-                  {{ 'tooltips.Adjust Charge' | translate }}
-                </button>
-              }
-              @if (status === 'Submitted and pending approval') {
-                <button mat-menu-item (click)="editCharge(charge)">
-                  <mat-icon matMenuItemIcon>edit</mat-icon>
-                  {{ 'tooltips.Edit Charge' | translate }}
-                </button>
-                <button mat-menu-item class="menu-item-danger" (click)="deleteCharge(charge.id)">
-                  <mat-icon matMenuItemIcon>delete</mat-icon>
-                  {{ 'labels.buttons.Delete' | translate }}
-                </button>
-              }
-              @if (charge.chargePayable && !charge.paid && status === 'Active') {
-                <button mat-menu-item (click)="payCharge(charge.id)">
-                  <mat-icon matMenuItemIcon>payments</mat-icon>
-                  {{ 'labels.buttons.Pay Charge' | translate }}
-                </button>
-              }
-              @if (!charge.actionFlag) {
-                <button mat-menu-item (click)="waiveCharge(charge.id)">
-                  <mat-icon matMenuItemIcon>check_circle</mat-icon>
-                  {{ 'labels.buttons.Waive Charge' | translate }}
-                </button>
-              }
-            </mat-menu>
-          </div>
+              <mat-menu #chargeMenu="matMenu" class="charge-actions-menu">
+                @if (status === 'Active') {
+                  <button mat-menu-item (click)="adjustCharge(charge.id)">
+                    <mat-icon matMenuItemIcon>tune</mat-icon>
+                    {{ 'tooltips.Adjust Charge' | translate }}
+                  </button>
+                }
+                @if (status === 'Submitted and pending approval') {
+                  <button mat-menu-item (click)="editCharge(charge)">
+                    <mat-icon matMenuItemIcon>edit</mat-icon>
+                    {{ 'tooltips.Edit Charge' | translate }}
+                  </button>
+                  <button mat-menu-item class="menu-item-danger" (click)="deleteCharge(charge.id)">
+                    <mat-icon matMenuItemIcon>delete</mat-icon>
+                    {{ 'labels.buttons.Delete' | translate }}
+                  </button>
+                }
+                @if (charge.chargePayable && !charge.paid && status === 'Active') {
+                  <button mat-menu-item (click)="payCharge(charge.id)">
+                    <mat-icon matMenuItemIcon>payments</mat-icon>
+                    {{ 'labels.buttons.Pay Charge' | translate }}
+                  </button>
+                }
+                @if (!charge.actionFlag) {
+                  <button mat-menu-item (click)="waiveCharge(charge.id)">
+                    <mat-icon matMenuItemIcon>check_circle</mat-icon>
+                    {{ 'labels.buttons.Waive Charge' | translate }}
+                  </button>
+                }
+              </mat-menu>
+            </div>
+          }
         </td>
       </ng-container>
 
@@ -328,6 +330,7 @@
         [class.row-state-waived]="rowStatus(row) === 'row-state-waived'"
         [class.row-selected]="selection.isSelected(row)"
         [routerLink]="[row.id]"
+        [queryParams]="{ productType: loanProductService.productType.value }"
       ></tr>
     </table>
   </div>

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -523,7 +523,7 @@
             {{ 'labels.inputs.Term Variations' | translate }}
           </a>
         }
-        @if (loanProductService.isLoanProduct && loanDetailsData.overdueCharges.length > 0) {
+        @if (loanProductService.isLoanProduct && loanDetailsData.overdueCharges?.length > 0) {
           <a
             mat-tab-link
             [routerLink]="['./overdue-charges']"

--- a/src/app/loans/loans-view/view-charge/view-charge.component.html
+++ b/src/app/loans/loans-view/view-charge/view-charge.component.html
@@ -6,42 +6,44 @@
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 
-@if (loansAccountData.status.value === 'Active' && chargeData.amountOutstanding !== 0) {
+@if (loansAccountData.status.value === 'Active') {
   <div class="layout-row align-end gap-2percent layout-xs-column container m-b-20">
-    <button
-      mat-raised-button
-      color="primary"
-      *mifosxHasPermission="'WAIVE_SAVINGSACCOUNTCHARGE'"
-      (click)="editCharge()"
-    >
-      <fa-icon icon="flag" class="m-r-10"></fa-icon>
-      {{ 'labels.buttons.Edit' | translate }}
-    </button>
-    @if (allowPayCharge) {
-      <span>
-        <button
-          mat-raised-button
-          color="accent"
-          *mifosxHasPermission="'PAY_SAVINGSACCOUNTCHARGE'"
-          (click)="payCharge()"
-        >
-          <fa-icon icon="dollar-sign" class="m-r-10"></fa-icon>
-          {{ 'labels.buttons.Pay' | translate }}
-        </button>
-      </span>
-    }
-    @if (allowWaive) {
-      <span>
-        <button
-          mat-raised-button
-          color="primary"
-          *mifosxHasPermission="'WAIVE_SAVINGSACCOUNTCHARGE'"
-          (click)="waiveCharge()"
-        >
-          <fa-icon icon="flag" class="m-r-10"></fa-icon>
-          {{ 'labels.buttons.Waive' | translate }}
-        </button>
-      </span>
+    @if (chargeData.amountOutstanding !== 0) {
+      <button
+        mat-raised-button
+        color="primary"
+        *mifosxHasPermission="'WAIVE_SAVINGSACCOUNTCHARGE'"
+        (click)="editCharge()"
+      >
+        <fa-icon icon="flag" class="m-r-10"></fa-icon>
+        {{ 'labels.buttons.Edit' | translate }}
+      </button>
+      @if (allowPayCharge) {
+        <span>
+          <button
+            mat-raised-button
+            color="accent"
+            *mifosxHasPermission="'PAY_SAVINGSACCOUNTCHARGE'"
+            (click)="payCharge()"
+          >
+            <fa-icon icon="dollar-sign" class="m-r-10"></fa-icon>
+            {{ 'labels.buttons.Pay' | translate }}
+          </button>
+        </span>
+      }
+      @if (allowWaive) {
+        <span>
+          <button
+            mat-raised-button
+            color="primary"
+            *mifosxHasPermission="'WAIVE_SAVINGSACCOUNTCHARGE'"
+            (click)="waiveCharge()"
+          >
+            <fa-icon icon="flag" class="m-r-10"></fa-icon>
+            {{ 'labels.buttons.Waive' | translate }}
+          </button>
+        </span>
+      }
     }
     <span>
       <button
@@ -176,7 +178,13 @@
       </div>
 
       <div class="layout-row layout-align-center gap-2percent column-on-mobile">
-        <button type="button" mat-raised-button color="primary" [routerLink]="['../']">
+        <button
+          type="button"
+          mat-raised-button
+          color="primary"
+          [routerLink]="['../']"
+          [queryParams]="{ productType: loanProductService.productType.value }"
+        >
           {{ 'labels.buttons.Back' | translate }}
         </button>
       </div>


### PR DESCRIPTION
## Description

We are adding the functionality to allow the user will be able to do charge adjustment transaction on active loan accounts, even if the Loan Charge is fully paid

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots, if any

https://github.com/user-attachments/assets/9e3de748-6040-4a4c-8d28-56dc7ec429bb

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented template errors when overdue charge data is missing.
* **Behavior Changes**
  * Updated the Charges tab “Actions” area to show only for loan statuses **Active** and **Submitted and pending approval**.
  * Refined charge action visibility for active loans so **Edit/Pay/Waive** only appears when an outstanding amount exists, while **Adjustment** remains available.
* **Navigation Improvements**
  * Preserved loan product context when navigating between loan and charge screens by adding query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->