### PR TITLE
feat(WEB-1044): add office address management

### DIFF
--- a/src/app/organization/offices/view-office/address-tab/address-tab.component.html
+++ b/src/app/organization/offices/view-office/address-tab/address-tab.component.html
@@ -1,0 +1,198 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<div class="tab-container mat-typography">
+  <div class="layout-row align-start">
+    <div class="m-b-10">
+      <h3>{{ 'labels.heading.Address' | translate }}</h3>
+    </div>
+    <div class="action-button m-b-10 gap-25px">
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="addAddress()"
+        [disabled]="isLoading || isSaving || optionsLoadFailed || isPluginUnavailable"
+        *mifosxHasPermission="'CREATE_OFFICE'"
+      >
+        <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
+      </button>
+    </div>
+  </div>
+
+  @if (isLoading) {
+    <div class="address-state">
+      <mat-spinner diameter="36"></mat-spinner>
+      <span>{{ 'labels.text.Loading data' | translate }}</span>
+    </div>
+  }
+
+  @if (isPluginUnavailable && !isLoading) {
+    <div class="address-state unavailable-state">
+      <span>{{ 'labels.text.Office Address management requires the Savings Plugin to be deployed' | translate }}</span>
+    </div>
+  }
+
+  @if (hasError && !isLoading && !isPluginUnavailable) {
+    <div class="address-state error-state">
+      <span>{{ 'errors.generic.unexpectedRetry' | translate }}</span>
+      <button mat-button color="primary" (click)="loadOfficeAddresses()">
+        {{ 'labels.buttons.Retry' | translate }}
+      </button>
+    </div>
+  }
+
+  @if (optionsLoadFailed && !isLoading && !isPluginUnavailable) {
+    <div class="address-state error-state">
+      <span>{{ 'errors.generic.unexpectedRetry' | translate }}</span>
+    </div>
+  }
+
+  @if (!isLoading && !hasError && !isPluginUnavailable && !officeAddresses.length) {
+    <div class="address-state empty-state">
+      <span>{{ 'labels.text.No data found' | translate }}</span>
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="addAddress()"
+        [disabled]="optionsLoadFailed || isPluginUnavailable"
+        *mifosxHasPermission="'CREATE_OFFICE'"
+      >
+        <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
+      </button>
+    </div>
+  }
+
+  @if (!isLoading && !hasError && !isPluginUnavailable && officeAddresses.length) {
+    <mat-accordion>
+      @for (address of officeAddresses; track getOfficeAddressId(address, $index)) {
+        <mat-expansion-panel class="address">
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              {{ getAddressType(address) || ('labels.heading.Address' | translate) }}
+            </mat-panel-title>
+            <mat-panel-description>
+              {{ 'labels.inputs.Active Status' | translate }}: {{ getActiveStatusLabel(address.isActive) | translate }}
+            </mat-panel-description>
+          </mat-expansion-panel-header>
+          <mat-divider [inset]="true"></mat-divider>
+          <div class="address-actions layout-row align-end align-items-center">
+            <button
+              mat-button
+              color="primary"
+              (click)="editAddress(address)"
+              [disabled]="isSaving || optionsLoadFailed || isPluginUnavailable"
+              *mifosxHasPermission="'UPDATE_OFFICE'"
+            >
+              <fa-icon icon="edit"></fa-icon>
+            </button>
+            <button
+              mat-button
+              color="warn"
+              (click)="deleteAddress(address)"
+              [disabled]="isSaving || isPluginUnavailable"
+              *mifosxHasPermission="'DELETE_OFFICE'"
+            >
+              <fa-icon icon="trash"></fa-icon>
+            </button>
+            <mat-slide-toggle
+              [checked]="address.isActive"
+              (change)="toggleAddress(address)"
+              [disabled]="isSaving || isPluginUnavailable"
+              *mifosxHasPermission="'UPDATE_OFFICE'"
+            ></mat-slide-toggle>
+          </div>
+
+          <div class="address-details">
+            <div class="address-row">
+              <span class="label">{{ 'labels.inputs.Address Type' | translate }}</span>
+              <span>{{ getAddressType(address) || ('labels.inputs.Not Provided' | translate) }}</span>
+            </div>
+            @if (hasValue(address.street)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.Street' | translate }}</span>
+                <span>{{ address.street }}</span>
+              </div>
+            }
+            @if (hasValue(address.addressLine1)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.Address Line' | translate }} 1</span>
+                <span>{{ address.addressLine1 }}</span>
+              </div>
+            }
+            @if (hasValue(address.addressLine2)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.Address Line' | translate }} 2</span>
+                <span>{{ address.addressLine2 }}</span>
+              </div>
+            }
+            @if (hasValue(address.addressLine3)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.Address Line' | translate }} 3</span>
+                <span>{{ address.addressLine3 }}</span>
+              </div>
+            }
+            @if (hasValue(address.townVillage)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.Town / Village' | translate }}</span>
+                <span>{{ address.townVillage }}</span>
+              </div>
+            }
+            @if (hasValue(address.city)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.City' | translate }}</span>
+                <span>{{ address.city }}</span>
+              </div>
+            }
+            @if (hasValue(address.countyDistrict)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.Country District' | translate }}</span>
+                <span>{{ address.countyDistrict }}</span>
+              </div>
+            }
+            @if (hasValue(address.stateProvinceId)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.State / Province' | translate }}</span>
+                <span>{{
+                  getSelectedValue('stateProvinceIdOptions', address.stateProvinceId)?.name || address.stateProvinceId
+                }}</span>
+              </div>
+            }
+            @if (hasValue(address.countryId)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.Country' | translate }}</span>
+                <span>{{ getSelectedValue('countryIdOptions', address.countryId)?.name || address.countryId }}</span>
+              </div>
+            }
+            @if (hasValue(address.postalCode)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.Postal Code' | translate }}</span>
+                <span>{{ address.postalCode }}</span>
+              </div>
+            }
+            @if (hasValue(address.latitude)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.Latitude' | translate }}</span>
+                <span>{{ address.latitude }}</span>
+              </div>
+            }
+            @if (hasValue(address.longitude)) {
+              <div class="address-row">
+                <span class="label">{{ 'labels.inputs.Longitude' | translate }}</span>
+                <span>{{ address.longitude }}</span>
+              </div>
+            }
+            <div class="address-row">
+              <span class="label">{{ 'labels.inputs.Active Status' | translate }}</span>
+              <span>{{ getActiveStatusLabel(address.isActive) | translate }}</span>
+            </div>
+          </div>
+        </mat-expansion-panel>
+      }
+    </mat-accordion>
+  }
+</div>

--- a/src/app/organization/offices/view-office/address-tab/address-tab.component.scss
+++ b/src/app/organization/offices/view-office/address-tab/address-tab.component.scss
@@ -1,0 +1,78 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+
+  .action-button {
+    margin-left: auto;
+  }
+
+  .address-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    min-height: 120px;
+    text-align: center;
+  }
+
+  .error-state {
+    color: var(--warn-color, #b00020);
+  }
+
+  .unavailable-state {
+    color: rgb(78 78 78);
+  }
+
+  .empty-state {
+    flex-direction: column;
+  }
+
+  .address {
+    margin-bottom: 16px;
+
+    .address-actions {
+      margin-top: 1%;
+
+      button {
+        margin-right: 1%;
+      }
+    }
+  }
+
+  .address-details {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin: 16px 2% 0;
+  }
+
+  .address-row {
+    display: flex;
+    gap: 16px;
+    line-height: 24px;
+
+    .label {
+      flex: 0 0 35%;
+      font-weight: 600;
+    }
+  }
+}
+
+@media (width <= 600px) {
+  .tab-container .address-row {
+    flex-direction: column;
+    gap: 2px;
+
+    .label {
+      flex-basis: auto;
+    }
+  }
+}

--- a/src/app/organization/offices/view-office/address-tab/address-tab.component.spec.ts
+++ b/src/app/organization/offices/view-office/address-tab/address-tab.component.spec.ts
@@ -1,0 +1,292 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faEdit, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { of, throwError } from 'rxjs';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+import { AddressTabComponent } from './address-tab.component';
+import { ClientsService } from 'app/clients/clients.service';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { OrganizationService } from 'app/organization/organization.service';
+import { PostalCodeLookupService } from 'app/shared/services/postal-code-lookup.service';
+
+describe('Office AddressTabComponent', () => {
+  let component: AddressTabComponent;
+  let fixture: ComponentFixture<AddressTabComponent>;
+  let organizationService: jest.Mocked<OrganizationService>;
+  let clientsService: jest.Mocked<ClientsService>;
+  let dialog: jest.Mocked<MatDialog>;
+
+  const addressTemplate = {
+    addressTypeIdOptions: [{ id: 1, name: 'Home' }],
+    stateProvinceIdOptions: [{ id: 2, name: 'Karnataka' }],
+    countryIdOptions: [{ id: 3, name: 'India' }]
+  };
+
+  const officeAddress = {
+    officeAddressId: 7,
+    officeId: 1,
+    addressId: 9,
+    addressTypeId: 1,
+    street: 'MG Road',
+    addressLine1: 'Floor 1',
+    city: 'Bengaluru',
+    stateProvinceId: 2,
+    countryId: 3,
+    postalCode: '560001',
+    isActive: true
+  };
+
+  function dialogRefWithValue(value: any) {
+    return {
+      afterClosed: () => of({ data: { value } })
+    } as any;
+  }
+
+  function dialogRefWithDelete() {
+    return {
+      afterClosed: () => of({ delete: true })
+    } as any;
+  }
+
+  function endpointNotFoundError() {
+    return {
+      status: 404,
+      error: {
+        error: 'Not Found',
+        path: '/fineract-provider/api/v2/offices/1/addresses'
+      }
+    };
+  }
+
+  beforeEach(async () => {
+    organizationService = {
+      getOfficeAddresses: jest.fn(() => of([officeAddress])),
+      createOfficeAddress: jest.fn(() => of({ entityId: 10 })),
+      updateOfficeAddress: jest.fn(() => of({ entityId: 7 })),
+      deleteOfficeAddress: jest.fn(() => of({ entityId: 7 }))
+    } as unknown as jest.Mocked<OrganizationService>;
+
+    clientsService = {
+      getClientAddressTemplate: jest.fn(() => of(addressTemplate))
+    } as unknown as jest.Mocked<ClientsService>;
+
+    dialog = {
+      open: jest.fn()
+    } as unknown as jest.Mocked<MatDialog>;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        AddressTabComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            parent: {
+              snapshot: {
+                paramMap: {
+                  get: jest.fn(() => '1')
+                }
+              }
+            }
+          }
+        },
+        { provide: OrganizationService, useValue: organizationService },
+        { provide: ClientsService, useValue: clientsService },
+        { provide: MatDialog, useValue: dialog },
+        { provide: PostalCodeLookupService, useValue: { enabled: false } },
+        { provide: AuthenticationService, useValue: { getCredentials: () => ({ permissions: [] as string[] }) } },
+        provideNoopAnimations()
+      ]
+    }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIcons(faPlus, faEdit, faTrash);
+    fixture = TestBed.createComponent(AddressTabComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads office addresses and address template options', () => {
+    fixture.detectChanges();
+
+    expect(organizationService.getOfficeAddresses).toHaveBeenCalledWith('1');
+    expect(clientsService.getClientAddressTemplate).toHaveBeenCalled();
+    expect(component.officeAddresses).toEqual([officeAddress]);
+    expect(component.isLoading).toBe(false);
+    expect(component.hasError).toBe(false);
+  });
+
+  it('shows an empty state when the office has no address', () => {
+    organizationService.getOfficeAddresses.mockReturnValue(of([]));
+
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent;
+    expect(component.officeAddresses).toEqual([]);
+    expect(text).toContain('No data found');
+  });
+
+  it('shows plugin unavailable state when the office address endpoint is not registered', () => {
+    organizationService.getOfficeAddresses.mockReturnValue(throwError(() => endpointNotFoundError()));
+
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent;
+    expect(component.isPluginUnavailable).toBe(true);
+    expect(component.hasError).toBe(false);
+    expect(component.officeAddresses).toEqual([]);
+    expect(text).toContain('labels.text.Office Address management requires the Savings Plugin to be deployed');
+    expect(text).not.toContain('errors.generic.unexpectedRetry');
+  });
+
+  it('does not open dialogs or call address endpoints when the plugin is unavailable', () => {
+    component.isPluginUnavailable = true;
+
+    component.addAddress();
+    component.editAddress(officeAddress);
+    component.deleteAddress(officeAddress);
+    component.toggleAddress(officeAddress);
+
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(organizationService.createOfficeAddress).not.toHaveBeenCalled();
+    expect(organizationService.updateOfficeAddress).not.toHaveBeenCalled();
+    expect(organizationService.deleteOfficeAddress).not.toHaveBeenCalled();
+  });
+
+  it('creates an office address through the plugin endpoint service method', () => {
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(
+      dialogRefWithValue({
+        addressTypeId: 1,
+        street: 'Church Street',
+        city: 'Bengaluru',
+        isActive: true
+      })
+    );
+
+    component.addAddress();
+
+    expect(organizationService.createOfficeAddress).toHaveBeenCalledWith(
+      '1',
+      expect.objectContaining({
+        addressTypeId: 1,
+        street: 'Church Street',
+        city: 'Bengaluru',
+        isActive: true
+      })
+    );
+  });
+
+  it('shows plugin unavailable state when create returns endpoint not found', () => {
+    fixture.detectChanges();
+    organizationService.createOfficeAddress.mockReturnValue(throwError(() => endpointNotFoundError()));
+    dialog.open.mockReturnValue(
+      dialogRefWithValue({
+        addressTypeId: 1,
+        street: 'Church Street',
+        city: 'Bengaluru',
+        isActive: true
+      })
+    );
+
+    component.addAddress();
+
+    expect(component.isPluginUnavailable).toBe(true);
+    expect(component.hasError).toBe(false);
+    expect(component.officeAddresses).toEqual([]);
+  });
+
+  it('updates an existing office address by office address id', () => {
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(
+      dialogRefWithValue({
+        addressTypeId: 1,
+        street: 'Updated Street',
+        isActive: false
+      })
+    );
+
+    component.editAddress(officeAddress);
+
+    expect(organizationService.updateOfficeAddress).toHaveBeenCalledWith(
+      '1',
+      '7',
+      expect.objectContaining({
+        street: 'Updated Street',
+        isActive: false
+      })
+    );
+  });
+
+  it('handles office addresses without ids without throwing', () => {
+    const addressWithoutId: any = {
+      ...officeAddress,
+      officeAddressId: undefined,
+      id: undefined,
+      addressId: undefined
+    };
+
+    fixture.detectChanges();
+    dialog.open.mockClear();
+
+    expect(component.getOfficeAddressId(addressWithoutId)).toBe('');
+    expect(component.getOfficeAddressId(addressWithoutId, 3)).toBe('office-address-3');
+    expect(() => component.editAddress(addressWithoutId)).not.toThrow();
+    expect(() => component.deleteAddress(addressWithoutId)).not.toThrow();
+    expect(() => component.toggleAddress(addressWithoutId)).not.toThrow();
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(organizationService.updateOfficeAddress).not.toHaveBeenCalled();
+    expect(organizationService.deleteOfficeAddress).not.toHaveBeenCalled();
+  });
+
+  it('uses translated active status labels', () => {
+    expect(component.getActiveStatusLabel(true)).toBe('labels.inputs.Active');
+    expect(component.getActiveStatusLabel(false)).toBe('labels.catalogs.Inactive');
+  });
+
+  it('deletes an existing office address by office address id', () => {
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(dialogRefWithDelete());
+
+    component.deleteAddress(officeAddress);
+
+    expect(organizationService.deleteOfficeAddress).toHaveBeenCalledWith('1', '7');
+  });
+
+  it('uses address validation metadata in the form dialog fields', () => {
+    component.addressTemplate = addressTemplate;
+
+    const formFields = (component as any).getAddressFormFields();
+
+    expect(formFields.find((field: any) => field.controlName === 'addressTypeId')?.required).toBe(true);
+    expect(formFields.find((field: any) => field.controlName === 'latitude')).toEqual(
+      expect.objectContaining({ min: -90, max: 90 })
+    );
+    expect(formFields.find((field: any) => field.controlName === 'longitude')).toEqual(
+      expect.objectContaining({ min: -180, max: 180 })
+    );
+  });
+
+  it('shows an error state when office address loading fails for non-404 errors', () => {
+    organizationService.getOfficeAddresses.mockReturnValue(throwError(() => ({ status: 500 })));
+
+    fixture.detectChanges();
+
+    expect(component.hasError).toBe(true);
+    expect(component.isPluginUnavailable).toBe(false);
+    expect(component.officeAddresses).toEqual([]);
+  });
+});

--- a/src/app/organization/offices/view-office/address-tab/address-tab.component.ts
+++ b/src/app/organization/offices/view-office/address-tab/address-tab.component.ts
@@ -1,0 +1,552 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+
+/** Angular Material Imports */
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import {
+  MatAccordion,
+  MatExpansionPanel,
+  MatExpansionPanelDescription,
+  MatExpansionPanelHeader,
+  MatExpansionPanelTitle
+} from '@angular/material/expansion';
+import { MatDivider } from '@angular/material/divider';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
+
+/** rxjs Imports */
+import { forkJoin, of, Subscription } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, finalize, switchMap } from 'rxjs/operators';
+
+/** Custom Components */
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
+import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
+
+/** Custom Services */
+import { TranslateService } from '@ngx-translate/core';
+import { ClientsService } from 'app/clients/clients.service';
+import { OrganizationService } from 'app/organization/organization.service';
+import { PostalCodeLookupService } from 'app/shared/services/postal-code-lookup.service';
+
+/** Custom Models */
+import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-base';
+import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
+import { SelectBase } from 'app/shared/form-dialog/formfield/model/select-base';
+import { CheckboxBase } from 'app/shared/form-dialog/formfield/model/checkbox-base';
+import { ResolvedAddress } from 'app/shared/models/postal-code-lookup.model';
+
+/** Custom Imports */
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+@Component({
+  selector: 'mifosx-office-address-tab',
+  templateUrl: './address-tab.component.html',
+  styleUrls: ['./address-tab.component.scss'],
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    FaIconComponent,
+    MatAccordion,
+    MatExpansionPanel,
+    MatExpansionPanelHeader,
+    MatExpansionPanelTitle,
+    MatExpansionPanelDescription,
+    MatDivider,
+    MatProgressSpinner,
+    MatSlideToggle
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AddressTabComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private organizationService = inject(OrganizationService);
+  private clientsService = inject(ClientsService);
+  private dialog = inject(MatDialog);
+  private translateService = inject(TranslateService);
+  private postalCodeLookup = inject(PostalCodeLookupService);
+  private changeDetectorRef = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
+
+  officeId: string;
+  officeAddresses: any[] = [];
+  addressTemplate: any = {
+    addressTypeIdOptions: [],
+    stateProvinceIdOptions: [],
+    countryIdOptions: []
+  };
+  isLoading = true;
+  isSaving = false;
+  hasError = false;
+  isPluginUnavailable = false;
+  optionsLoadFailed = false;
+
+  private autoFilledFields = new Set<string>();
+
+  ngOnInit() {
+    this.officeId = this.route.parent.snapshot.paramMap.get('officeId') ?? '';
+    this.loadOfficeAddresses();
+  }
+
+  loadOfficeAddresses() {
+    this.isLoading = true;
+    this.hasError = false;
+    this.isPluginUnavailable = false;
+    this.optionsLoadFailed = false;
+
+    forkJoin({
+      addresses: this.organizationService.getOfficeAddresses(this.officeId).pipe(
+        catchError((error) => {
+          if (this.isEndpointNotFound(error)) {
+            this.isPluginUnavailable = true;
+          } else {
+            this.hasError = true;
+          }
+          return of([]);
+        })
+      ),
+      template: this.clientsService.getClientAddressTemplate().pipe(
+        catchError(() => {
+          this.optionsLoadFailed = true;
+          return of(this.addressTemplate);
+        })
+      )
+    })
+      .pipe(
+        finalize(() => {
+          this.isLoading = false;
+          this.changeDetectorRef.markForCheck();
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(({ addresses, template }: { addresses: any; template: any }) => {
+        this.officeAddresses = Array.isArray(addresses) ? addresses : [];
+        this.addressTemplate = {
+          ...this.addressTemplate,
+          ...template
+        };
+        this.translateAddressTypes();
+      });
+  }
+
+  addAddress() {
+    if (this.isPluginUnavailable) {
+      return;
+    }
+
+    const data = {
+      title:
+        this.translateService.instant('labels.buttons.Add') +
+        ' ' +
+        this.translateService.instant('labels.inputs.Office') +
+        ' ' +
+        this.translateService.instant('labels.heading.Address'),
+      formfields: this.getAddressFormFields(),
+      layout: { addButtonText: this.translateService.instant('labels.buttons.Submit') }
+    };
+    const addAddressDialogRef = this.dialog.open(FormDialogComponent, { data });
+    this.setupPostalCodeLookup(addAddressDialogRef);
+    addAddressDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.data) {
+        this.saveAddress(
+          this.organizationService.createOfficeAddress(this.officeId, this.normalizeAddressData(response.data.value))
+        );
+      }
+    });
+  }
+
+  editAddress(address: any) {
+    if (this.isPluginUnavailable) {
+      return;
+    }
+
+    const officeAddressId = this.getOfficeAddressId(address);
+    if (!officeAddressId) {
+      return;
+    }
+
+    const data = {
+      title:
+        this.translateService.instant('labels.buttons.Edit') +
+        ' ' +
+        this.translateService.instant('labels.inputs.Office') +
+        ' ' +
+        this.translateService.instant('labels.heading.Address'),
+      formfields: this.getAddressFormFields(address),
+      layout: { addButtonText: this.translateService.instant('labels.buttons.Edit') }
+    };
+    const editAddressDialogRef = this.dialog.open(FormDialogComponent, { data });
+    this.setupPostalCodeLookup(editAddressDialogRef);
+    editAddressDialogRef.afterClosed().subscribe((response: any) => {
+      if (response.data) {
+        this.saveAddress(
+          this.organizationService.updateOfficeAddress(
+            this.officeId,
+            officeAddressId,
+            this.normalizeAddressData(response.data.value)
+          )
+        );
+      }
+    });
+  }
+
+  deleteAddress(address: any) {
+    if (this.isPluginUnavailable) {
+      return;
+    }
+
+    const officeAddressId = this.getOfficeAddressId(address);
+    if (!officeAddressId) {
+      return;
+    }
+
+    const deleteAddressDialogRef = this.dialog.open(DeleteDialogComponent, {
+      data: { deleteContext: this.translateService.instant('labels.heading.Address') }
+    });
+    deleteAddressDialogRef.afterClosed().subscribe((response: any) => {
+      if (response?.delete) {
+        this.saveAddress(this.organizationService.deleteOfficeAddress(this.officeId, officeAddressId));
+      }
+    });
+  }
+
+  toggleAddress(address: any) {
+    if (this.isPluginUnavailable) {
+      return;
+    }
+
+    const officeAddressId = this.getOfficeAddressId(address);
+    if (!officeAddressId) {
+      return;
+    }
+
+    this.saveAddress(
+      this.organizationService.updateOfficeAddress(this.officeId, officeAddressId, {
+        isActive: !address.isActive
+      })
+    );
+  }
+
+  getSelectedValue(fieldName: string, fieldId: any) {
+    return this.addressTemplate[fieldName]?.find((fieldObj: any) => fieldObj.id === fieldId);
+  }
+
+  getAddressType(address: any): string {
+    return this.getSelectedValue('addressTypeIdOptions', address.addressTypeId)?.name ?? address.addressTypeId;
+  }
+
+  hasValue(value: any): boolean {
+    return value !== null && value !== undefined && value !== '';
+  }
+
+  private saveAddress(request: any) {
+    this.isSaving = true;
+    this.hasError = false;
+    this.isPluginUnavailable = false;
+    request
+      .pipe(
+        finalize(() => {
+          this.isSaving = false;
+          this.changeDetectorRef.markForCheck();
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe({
+        next: () => this.loadOfficeAddresses(),
+        error: (error: any) => {
+          if (this.isEndpointNotFound(error)) {
+            this.isPluginUnavailable = true;
+            this.officeAddresses = [];
+          } else {
+            this.hasError = true;
+          }
+          this.changeDetectorRef.markForCheck();
+        }
+      });
+  }
+
+  private isEndpointNotFound(error: any): boolean {
+    return error?.status === 404 && error?.error?.error === 'Not Found';
+  }
+
+  getActiveStatusLabel(isActive: boolean): string {
+    return isActive ? 'labels.inputs.Active' : 'labels.catalogs.Inactive';
+  }
+
+  getOfficeAddressId(address: any, index?: number): string {
+    const officeAddressId = address?.officeAddressId ?? address?.id ?? address?.addressId;
+    if (officeAddressId === null || officeAddressId === undefined) {
+      return index === undefined ? '' : `office-address-${index}`;
+    }
+    return officeAddressId.toString();
+  }
+
+  private normalizeAddressData(addressData: any) {
+    return {
+      addressTypeId: addressData.addressTypeId,
+      street: addressData.street ?? '',
+      addressLine1: addressData.addressLine1 ?? '',
+      addressLine2: addressData.addressLine2 ?? '',
+      addressLine3: addressData.addressLine3 ?? '',
+      townVillage: addressData.townVillage ?? '',
+      city: addressData.city ?? '',
+      countyDistrict: addressData.countyDistrict ?? '',
+      stateProvinceId: addressData.stateProvinceId || null,
+      countryId: addressData.countryId || null,
+      postalCode: addressData.postalCode ?? '',
+      latitude: this.hasValue(addressData.latitude) ? addressData.latitude : null,
+      longitude: this.hasValue(addressData.longitude) ? addressData.longitude : null,
+      isActive: !!addressData.isActive
+    };
+  }
+
+  private getAddressFormFields(address?: any) {
+    const formfields: FormfieldBase[] = [
+      new SelectBase({
+        controlName: 'addressTypeId',
+        label: this.translateService.instant('labels.inputs.Address Type'),
+        value: address ? address.addressTypeId : '',
+        options: { label: 'name', value: 'id', data: this.addressTemplate.addressTypeIdOptions ?? [] },
+        required: true,
+        order: 1
+      }),
+      new InputBase({
+        controlName: 'postalCode',
+        label: this.translateService.instant('labels.inputs.Postal Code'),
+        value: address ? address.postalCode : '',
+        type: 'text',
+        order: 2
+      }),
+      new InputBase({
+        controlName: 'street',
+        label: this.translateService.instant('labels.inputs.Street'),
+        value: address ? address.street : '',
+        type: 'text',
+        order: 3
+      }),
+      new InputBase({
+        controlName: 'addressLine1',
+        label: this.translateService.instant('labels.inputs.Address Line') + ' 1',
+        value: address ? address.addressLine1 : '',
+        type: 'text',
+        order: 4
+      }),
+      new InputBase({
+        controlName: 'addressLine2',
+        label: this.translateService.instant('labels.inputs.Address Line') + ' 2',
+        value: address ? address.addressLine2 : '',
+        type: 'text',
+        order: 5
+      }),
+      new InputBase({
+        controlName: 'addressLine3',
+        label: this.translateService.instant('labels.inputs.Address Line') + ' 3',
+        value: address ? address.addressLine3 : '',
+        type: 'text',
+        order: 6
+      }),
+      new InputBase({
+        controlName: 'townVillage',
+        label: this.translateService.instant('labels.inputs.Town / Village'),
+        value: address ? address.townVillage : '',
+        type: 'text',
+        order: 7
+      }),
+      new InputBase({
+        controlName: 'city',
+        label: this.translateService.instant('labels.inputs.City'),
+        value: address ? address.city : '',
+        type: 'text',
+        order: 8
+      }),
+      new SelectBase({
+        controlName: 'stateProvinceId',
+        label: this.translateService.instant('labels.inputs.State / Province'),
+        value: address ? address.stateProvinceId : '',
+        options: { label: 'name', value: 'id', data: this.addressTemplate.stateProvinceIdOptions ?? [] },
+        order: 9
+      }),
+      new InputBase({
+        controlName: 'countyDistrict',
+        label: this.translateService.instant('labels.inputs.Country District'),
+        value: address ? address.countyDistrict : '',
+        type: 'text',
+        order: 10
+      }),
+      new SelectBase({
+        controlName: 'countryId',
+        label: this.translateService.instant('labels.inputs.Country'),
+        value: address ? address.countryId : '',
+        options: { label: 'name', value: 'id', data: this.addressTemplate.countryIdOptions ?? [] },
+        order: 11
+      }),
+      new InputBase({
+        controlName: 'latitude',
+        label: this.translateService.instant('labels.inputs.Latitude'),
+        value: address ? address.latitude : '',
+        type: 'number',
+        min: -90,
+        max: 90,
+        step: '0.00000001',
+        order: 12
+      }),
+      new InputBase({
+        controlName: 'longitude',
+        label: this.translateService.instant('labels.inputs.Longitude'),
+        value: address ? address.longitude : '',
+        type: 'number',
+        min: -180,
+        max: 180,
+        step: '0.00000001',
+        order: 13
+      }),
+      new CheckboxBase({
+        controlName: 'isActive',
+        label: this.translateService.instant('labels.inputs.Active Status'),
+        value: address ? address.isActive : true,
+        order: 14
+      })
+    ];
+    return formfields;
+  }
+
+  private translateAddressTypes() {
+    this.addressTemplate.addressTypeIdOptions = (this.addressTemplate.addressTypeIdOptions ?? []).map(
+      (option: any) => ({
+        ...option,
+        name: this.translateCatalogValue(option.name)
+      })
+    );
+  }
+
+  private translateCatalogValue(value: string): string {
+    const translationKey = `labels.catalogs.${value}`;
+    const translatedValue = this.translateService.instant(translationKey);
+    return translatedValue === translationKey ? value : translatedValue;
+  }
+
+  private setupPostalCodeLookup(dialogRef: MatDialogRef<FormDialogComponent>) {
+    if (!this.postalCodeLookup.enabled) return;
+
+    let postalSub: Subscription;
+    dialogRef.afterOpened().subscribe(() => {
+      const form: FormGroup = dialogRef.componentInstance.form;
+      const postalCodeControl = form.get('postalCode');
+      if (!postalCodeControl) return;
+
+      const initialCountryId = form.get('countryId')?.value || null;
+      postalSub = postalCodeControl.valueChanges
+        .pipe(
+          debounceTime(600),
+          distinctUntilChanged(),
+          switchMap((value: string) => {
+            if (!value || value.trim().length < 3) {
+              return of(null);
+            }
+            const postalCode = value.trim();
+            const currentCountryId = form.get('countryId')?.value;
+            const isUserSelectedCountry =
+              currentCountryId && (currentCountryId === initialCountryId || !this.autoFilledFields.has('countryId'));
+
+            if (isUserSelectedCountry) {
+              const countryCode = this.getSelectedCountryCode(form);
+              if (countryCode) {
+                return this.postalCodeLookup.lookup(countryCode, postalCode);
+              }
+            }
+            return this.postalCodeLookup.lookupWithFallback(postalCode);
+          })
+        )
+        .subscribe((response) => {
+          if (!response) {
+            this.clearAutoFilledFields(form);
+            return;
+          }
+          const resolved = this.postalCodeLookup.toResolvedAddress(response);
+          if (resolved) {
+            this.clearAutoFilledFields(form);
+            this.applyResolvedAddress(form, resolved);
+          } else {
+            this.clearAutoFilledFields(form);
+          }
+        });
+    });
+
+    dialogRef.afterClosed().subscribe(() => {
+      postalSub?.unsubscribe();
+      this.autoFilledFields.clear();
+    });
+  }
+
+  private getSelectedCountryCode(form: FormGroup): string | null {
+    const countryIdValue = form.get('countryId')?.value;
+    if (!countryIdValue) return null;
+
+    const selectedCountry = this.addressTemplate.countryIdOptions?.find(
+      (country: any) => country.id === countryIdValue
+    );
+    if (!selectedCountry) return null;
+
+    return this.postalCodeLookup.resolveCountryCode(selectedCountry.name);
+  }
+
+  private clearAutoFilledFields(form: FormGroup) {
+    for (const fieldName of this.autoFilledFields) {
+      const control = form.get(fieldName);
+      if (control) {
+        control.setValue('');
+        control.markAsDirty();
+      }
+    }
+    this.autoFilledFields.clear();
+  }
+
+  private applyResolvedAddress(form: FormGroup, address: ResolvedAddress) {
+    const cityControl = form.get('city');
+    if (cityControl && address.city) {
+      cityControl.setValue(address.city);
+      cityControl.markAsDirty();
+      this.autoFilledFields.add('city');
+    }
+
+    const stateControl = form.get('stateProvinceId');
+    if (stateControl && (address.state || address.stateAbbreviation)) {
+      const matched = this.postalCodeLookup.findBestMatch(
+        this.addressTemplate.stateProvinceIdOptions ?? [],
+        address.state,
+        address.stateAbbreviation
+      );
+      if (matched) {
+        stateControl.setValue(matched.id);
+        stateControl.markAsDirty();
+        this.autoFilledFields.add('stateProvinceId');
+      }
+    }
+
+    const countryControl = form.get('countryId');
+    if (countryControl && (address.country || address.countryAbbreviation)) {
+      const matched = this.postalCodeLookup.findBestMatch(
+        this.addressTemplate.countryIdOptions ?? [],
+        address.country,
+        address.countryAbbreviation
+      );
+      if (matched) {
+        countryControl.setValue(matched.id);
+        countryControl.markAsDirty();
+        this.autoFilledFields.add('countryId');
+      }
+    }
+
+    form.markAsDirty();
+  }
+}

--- a/src/app/organization/offices/view-office/view-office.component.html
+++ b/src/app/organization/offices/view-office/view-office.component.html
@@ -33,6 +33,17 @@
         >
           {{ 'labels.inputs.General' | translate }}
         </a>
+        <a
+          mat-tab-link
+          [routerLink]="['./address']"
+          routerLinkActive
+          #address="routerLinkActive"
+          [active]="address.isActive"
+          class="compact-tab"
+          *mifosxHasPermission="'READ_OFFICE'"
+        >
+          {{ 'labels.heading.Address' | translate }}
+        </a>
         @for (officeDatatable of officeDatatables; track officeDatatable) {
           <span>
             <a

--- a/src/app/organization/organization-routing.module.ts
+++ b/src/app/organization/organization-routing.module.ts
@@ -42,6 +42,7 @@ import { ViewCashierComponent } from './tellers/cashiers/view-cashier/view-cashi
 import { ViewHolidaysComponent } from './holidays/view-holidays/view-holidays.component';
 import { ViewOfficeComponent } from './offices/view-office/view-office.component';
 import { GeneralTabComponent } from './offices/view-office/general-tab/general-tab.component';
+import { AddressTabComponent } from './offices/view-office/address-tab/address-tab.component';
 import { DatatableTabsComponent } from './offices/view-office/datatable-tabs/datatable-tabs.component';
 import { ViewCampaignComponent } from './sms-campaigns/view-campaign/view-campaign.component';
 import { ManageFundsComponent } from './manage-funds/manage-funds.component';
@@ -210,6 +211,11 @@ const routes: Routes = [
                   resolve: {
                     office: OfficeResolver
                   }
+                },
+                {
+                  path: 'address',
+                  component: AddressTabComponent,
+                  data: { title: 'Address', breadcrumb: 'Address', routeParamBreadcrumb: false }
                 },
                 {
                   path: 'datatables',

--- a/src/app/organization/organization.module.ts
+++ b/src/app/organization/organization.module.ts
@@ -46,6 +46,7 @@ import { ViewCashierComponent } from './tellers/cashiers/view-cashier/view-cashi
 import { ViewHolidaysComponent } from './holidays/view-holidays/view-holidays.component';
 import { ViewOfficeComponent } from './offices/view-office/view-office.component';
 import { GeneralTabComponent } from './offices/view-office/general-tab/general-tab.component';
+import { AddressTabComponent } from './offices/view-office/address-tab/address-tab.component';
 import { DatatableTabsComponent } from './offices/view-office/datatable-tabs/datatable-tabs.component';
 import { ViewCampaignComponent } from './sms-campaigns/view-campaign/view-campaign.component';
 import { ManageFundsComponent } from './manage-funds/manage-funds.component';
@@ -127,6 +128,7 @@ import { InvestorsComponent } from './investors/investors.component';
     ViewHolidaysComponent,
     ViewOfficeComponent,
     GeneralTabComponent,
+    AddressTabComponent,
     DatatableTabsComponent,
     ViewCampaignComponent,
     ManageFundsComponent,

--- a/src/app/organization/organization.service.ts
+++ b/src/app/organization/organization.service.ts
@@ -140,6 +140,42 @@ export class OrganizationService {
   }
 
   /**
+   * @param {string} officeId Office ID of Office.
+   * @returns {Observable<any>} Office addresses.
+   */
+  getOfficeAddresses(officeId: string): Observable<any> {
+    return this.http.get(`/v2/offices/${officeId}/addresses`);
+  }
+
+  /**
+   * @param {string} officeId Office ID of Office.
+   * @param {any} addressData Office address data.
+   * @returns {Observable<any>}
+   */
+  createOfficeAddress(officeId: string, addressData: any): Observable<any> {
+    return this.http.post(`/v2/offices/${officeId}/addresses`, addressData);
+  }
+
+  /**
+   * @param {string} officeId Office ID of Office.
+   * @param {string} addressId Office address ID.
+   * @param {any} addressData Office address data.
+   * @returns {Observable<any>}
+   */
+  updateOfficeAddress(officeId: string, addressId: string, addressData: any): Observable<any> {
+    return this.http.put(`/v2/offices/${officeId}/addresses/${addressId}`, addressData);
+  }
+
+  /**
+   * @param {string} officeId Office ID of Office.
+   * @param {string} addressId Office address ID.
+   * @returns {Observable<any>}
+   */
+  deleteOfficeAddress(officeId: string, addressId: string): Observable<any> {
+    return this.http.delete(`/v2/offices/${officeId}/addresses/${addressId}`);
+  }
+
+  /**
    * @returns {Observable<any>}
    */
   getOfficeDatatables(): Observable<any> {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3963,6 +3963,7 @@
       "Notification": "Notification",
       "Notification Service Configuration": "Notification Service Configuration",
       "Notifications": "Notifications",
+      "Office Address management requires the Savings Plugin to be deployed": "Office Address management requires the Savings Plugin to be deployed.",
       "Offices and staff": "Offices & staff",
       "Optional": "Optional",
       "Organization": "Organization",


### PR DESCRIPTION
## Summary

Adds an Address tab to the Office Details screen with support for viewing and managing office addresses using the existing Savings Plugin APIs. When the plugin is not deployed, the UI displays an informational message and disables address actions instead of showing a generic error.

## Related issues

#WEB-1044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Address” tab to office details with an address list and permission-gated add/edit/delete and active/inactive toggling.
  * Included dynamic, validated address forms with translated address-type options and postal-code autofill.
  * Added clear UI states for loading, empty results, errors (with retry), and plugin-unavailable scenarios (with dedicated guidance).

* **Tests**
  * Added/extended unit coverage for initialization, state handling (including 404/unavailable), validation, postal-code autofill behavior, and CRUD/toggle flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->