### PR TITLE
WEB-146: Integrate Codecov coverage upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,26 @@ jobs:
       - name: Run HTMLHint
         run: npx htmlhint "src" --config .htmlhintrc
 
+      - name: Run unit tests with coverage
+        id: unit-tests
+        continue-on-error: true
+        run: |
+          npm run test:ci -- \
+            --coverageReporters=lcov \
+            --coverageReporters=text-summary
+
+      - name: Upload coverage to Codecov
+        if: ${{ always() && steps.unit-tests.outcome != 'skipped' }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/lcov.info
+          disable_search: true
+          flags: unit-tests
+          handle_no_reports_found: true
+          name: web-app
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
       - name: Check file headers
         run: |
           echo "Checking for MPL-2.0 license headers in changed files..."


### PR DESCRIPTION
## Description

Integrates Codecov upload into the existing build workflow. The workflow now runs the Jest CI suite with `lcov` and text-summary coverage reporters, then uploads `coverage/lcov.info` using `codecov/codecov-action@v5`.

The coverage and Codecov steps are non-blocking, so existing Jest failures or upload issues do not fail the build workflow. This keeps the current build behavior intact while still publishing coverage when `lcov.info` is generated.

## Related issues and discussion

Jira: https://mifosforge.jira.com/browse/WEB-146

## Screenshots, if any

No UI changes.

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "yaml_ok"'`
- `actionlint -ignore 'input "GITHUB_TOKEN" is not defined' -ignore 'input "PRESERVE" is not defined' .github/workflows/build.yml`
- `./node_modules/.bin/prettier .github/workflows/build.yml --check`
- `git diff --check origin/dev...HEAD`
- `gitleaks detect --no-banner --redact --source . --log-opts origin/dev..HEAD`
- PR CI confirmed Codecov found `coverage/lcov.info` and queued the upload for processing.
