### PR TITLE
fix(WEB-1044): decouple savings geolocation from Fineract field configuration (Part 2)

### DIFF
--- a/src/app/organization/offices/view-office/address-tab/address-tab.component.html
+++ b/src/app/organization/offices/view-office/address-tab/address-tab.component.html
@@ -174,13 +174,13 @@
                 <span>{{ address.postalCode }}</span>
               </div>
             }
-            @if (hasValue(address.latitude)) {
+            @if (clientAddressLocationEnabled && hasValue(address.latitude)) {
               <div class="address-row">
                 <span class="label">{{ 'labels.inputs.Latitude' | translate }}</span>
                 <span>{{ address.latitude }}</span>
               </div>
             }
-            @if (hasValue(address.longitude)) {
+            @if (clientAddressLocationEnabled && hasValue(address.longitude)) {
               <div class="address-row">
                 <span class="label">{{ 'labels.inputs.Longitude' | translate }}</span>
                 <span>{{ address.longitude }}</span>
@@ -191,6 +191,9 @@
               <span>{{ getActiveStatusLabel(address.isActive) | translate }}</span>
             </div>
           </div>
+          @if (clientAddressLocationEnabled && hasValidCoordinatePair(address.latitude, address.longitude)) {
+            <mifosx-address-location-map [latitude]="address.latitude" [longitude]="address.longitude" />
+          }
         </mat-expansion-panel>
       }
     </mat-accordion>

--- a/src/app/organization/offices/view-office/address-tab/address-tab.component.spec.ts
+++ b/src/app/organization/offices/view-office/address-tab/address-tab.component.spec.ts
@@ -15,12 +15,39 @@ import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
 import { faEdit, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { of, throwError } from 'rxjs';
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import * as L from 'leaflet';
 
 import { AddressTabComponent } from './address-tab.component';
 import { ClientsService } from 'app/clients/clients.service';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
 import { OrganizationService } from 'app/organization/organization.service';
 import { PostalCodeLookupService } from 'app/shared/services/postal-code-lookup.service';
+import { environment } from 'environments/environment';
+
+const mockMapRemove = jest.fn();
+const mockMapSetView = jest.fn().mockReturnThis();
+const mockMapInvalidateSize = jest.fn();
+const mockMarkerSetLatLng = jest.fn();
+const mockTileLayerAddTo = jest.fn().mockReturnThis();
+const mockTileLayerOn = jest.fn().mockReturnValue({ addTo: mockTileLayerAddTo, on: jest.fn() });
+const mockMarkerAddTo = jest.fn().mockReturnThis();
+
+jest.mock('leaflet', () => ({
+  icon: jest.fn(() => ({})),
+  map: jest.fn(() => ({
+    setView: mockMapSetView,
+    invalidateSize: mockMapInvalidateSize,
+    remove: mockMapRemove
+  })),
+  tileLayer: jest.fn(() => ({
+    addTo: mockTileLayerAddTo,
+    on: mockTileLayerOn
+  })),
+  marker: jest.fn(() => ({
+    addTo: mockMarkerAddTo,
+    setLatLng: mockMarkerSetLatLng
+  }))
+}));
 
 describe('Office AddressTabComponent', () => {
   let component: AddressTabComponent;
@@ -72,6 +99,9 @@ describe('Office AddressTabComponent', () => {
   }
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+    environment.enableClientAddressLocation = true;
+
     organizationService = {
       getOfficeAddresses: jest.fn(() => of([officeAddress])),
       createOfficeAddress: jest.fn(() => of({ entityId: 10 })),
@@ -278,6 +308,88 @@ describe('Office AddressTabComponent', () => {
     expect(formFields.find((field: any) => field.controlName === 'longitude')).toEqual(
       expect.objectContaining({ min: -180, max: 180 })
     );
+  });
+
+  it('shows plugin geolocation fields when the location feature is enabled even if Fineract field config disables them', () => {
+    component.addressTemplate = addressTemplate;
+    (component as any).clientAddressFieldConfig = [
+      { field: 'latitude', isEnabled: false },
+      { field: 'longitude', isEnabled: false }
+    ];
+
+    const formFields = (component as any).getAddressFormFields();
+
+    expect(formFields.some((field: any) => field.controlName === 'latitude')).toBe(true);
+    expect(formFields.some((field: any) => field.controlName === 'longitude')).toBe(true);
+  });
+
+  it('hides plugin geolocation fields when the location feature is disabled', () => {
+    environment.enableClientAddressLocation = false;
+    component.addressTemplate = addressTemplate;
+
+    const formFields = (component as any).getAddressFormFields();
+
+    expect(formFields.some((field: any) => field.controlName === 'latitude')).toBe(false);
+    expect(formFields.some((field: any) => field.controlName === 'longitude')).toBe(false);
+  });
+
+  it('omits plugin geolocation values from save payloads when the location feature is disabled', () => {
+    environment.enableClientAddressLocation = false;
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(
+      dialogRefWithValue({
+        addressTypeId: 1,
+        street: 'Church Street',
+        latitude: '12.9716',
+        longitude: '77.5946',
+        isActive: true
+      })
+    );
+
+    component.addAddress();
+
+    const payload = organizationService.createOfficeAddress.mock.calls[0][1];
+    expect(payload.latitude).toBeUndefined();
+    expect(payload.longitude).toBeUndefined();
+  });
+
+  it('renders plugin geolocation values and map for returned coordinates when the location feature is enabled', () => {
+    organizationService.getOfficeAddresses.mockReturnValue(
+      of([
+        {
+          ...officeAddress,
+          latitude: '12.9716',
+          longitude: '77.5946'
+        }
+      ])
+    );
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('12.9716');
+    expect(fixture.nativeElement.textContent).toContain('77.5946');
+    expect(fixture.nativeElement.querySelector('mifosx-address-location-map')).not.toBeNull();
+    expect(L.map).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides plugin geolocation values and map for returned coordinates when the location feature is disabled', () => {
+    environment.enableClientAddressLocation = false;
+    organizationService.getOfficeAddresses.mockReturnValue(
+      of([
+        {
+          ...officeAddress,
+          latitude: '12.9716',
+          longitude: '77.5946'
+        }
+      ])
+    );
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('12.9716');
+    expect(fixture.nativeElement.textContent).not.toContain('77.5946');
+    expect(fixture.nativeElement.querySelector('mifosx-address-location-map')).toBeNull();
+    expect(L.map).not.toHaveBeenCalled();
   });
 
   it('shows an error state when office address loading fails for non-404 errors', () => {

--- a/src/app/organization/offices/view-office/address-tab/address-tab.component.ts
+++ b/src/app/organization/offices/view-office/address-tab/address-tab.component.ts
@@ -33,12 +33,14 @@ import { catchError, debounceTime, distinctUntilChanged, finalize, switchMap } f
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
 import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
+import { AddressLocationMapComponent } from 'app/clients/clients-view/address-tab/address-location-map/address-location-map.component';
 
 /** Custom Services */
 import { TranslateService } from '@ngx-translate/core';
 import { ClientsService } from 'app/clients/clients.service';
 import { OrganizationService } from 'app/organization/organization.service';
 import { PostalCodeLookupService } from 'app/shared/services/postal-code-lookup.service';
+import { environment } from 'environments/environment';
 
 /** Custom Models */
 import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-base';
@@ -49,6 +51,7 @@ import { ResolvedAddress } from 'app/shared/models/postal-code-lookup.model';
 
 /** Custom Imports */
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { hasValidCoordinatePair } from 'app/clients/utils/address-coordinate.util';
 
 @Component({
   selector: 'mifosx-office-address-tab',
@@ -64,11 +67,18 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatExpansionPanelDescription,
     MatDivider,
     MatProgressSpinner,
-    MatSlideToggle
+    MatSlideToggle,
+    AddressLocationMapComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AddressTabComponent implements OnInit {
+  readonly hasValidCoordinatePair = hasValidCoordinatePair;
+
+  get clientAddressLocationEnabled(): boolean {
+    return environment.enableClientAddressLocation;
+  }
+
   private route = inject(ActivatedRoute);
   private organizationService = inject(OrganizationService);
   private clientsService = inject(ClientsService);
@@ -292,7 +302,7 @@ export class AddressTabComponent implements OnInit {
   }
 
   private normalizeAddressData(addressData: any) {
-    return {
+    const normalizedAddressData: any = {
       addressTypeId: addressData.addressTypeId,
       street: addressData.street ?? '',
       addressLine1: addressData.addressLine1 ?? '',
@@ -304,10 +314,15 @@ export class AddressTabComponent implements OnInit {
       stateProvinceId: addressData.stateProvinceId || null,
       countryId: addressData.countryId || null,
       postalCode: addressData.postalCode ?? '',
-      latitude: this.hasValue(addressData.latitude) ? addressData.latitude : null,
-      longitude: this.hasValue(addressData.longitude) ? addressData.longitude : null,
       isActive: !!addressData.isActive
     };
+
+    if (this.clientAddressLocationEnabled) {
+      normalizedAddressData.latitude = this.hasValue(addressData.latitude) ? addressData.latitude : null;
+      normalizedAddressData.longitude = this.hasValue(addressData.longitude) ? addressData.longitude : null;
+    }
+
+    return normalizedAddressData;
   }
 
   private getAddressFormFields(address?: any) {
@@ -390,26 +405,30 @@ export class AddressTabComponent implements OnInit {
         options: { label: 'name', value: 'id', data: this.addressTemplate.countryIdOptions ?? [] },
         order: 11
       }),
-      new InputBase({
-        controlName: 'latitude',
-        label: this.translateService.instant('labels.inputs.Latitude'),
-        value: address ? address.latitude : '',
-        type: 'number',
-        min: -90,
-        max: 90,
-        step: '0.00000001',
-        order: 12
-      }),
-      new InputBase({
-        controlName: 'longitude',
-        label: this.translateService.instant('labels.inputs.Longitude'),
-        value: address ? address.longitude : '',
-        type: 'number',
-        min: -180,
-        max: 180,
-        step: '0.00000001',
-        order: 13
-      }),
+      ...(this.clientAddressLocationEnabled
+        ? [
+            new InputBase({
+              controlName: 'latitude',
+              label: this.translateService.instant('labels.inputs.Latitude'),
+              value: address ? address.latitude : '',
+              type: 'number',
+              min: -90,
+              max: 90,
+              step: '0.00000001',
+              order: 12
+            }),
+            new InputBase({
+              controlName: 'longitude',
+              label: this.translateService.instant('labels.inputs.Longitude'),
+              value: address ? address.longitude : '',
+              type: 'number',
+              min: -180,
+              max: 180,
+              step: '0.00000001',
+              order: 13
+            })
+          ]
+        : []),
       new CheckboxBase({
         controlName: 'isActive',
         label: this.translateService.instant('labels.inputs.Active Status'),


### PR DESCRIPTION
## Description

This is **Part 2** of the WEB-1044 work.

The Savings Plugin should not depend on Apache Fineract's `/fieldconfiguration/ADDRESS` endpoint to determine whether geolocation fields are displayed.

This PR removes that dependency for the Savings Plugin flow and relies on the geolocation feature flag (`MIFOS_ENABLE_CLIENT_ADDRESS_LOCATION`) together with the plugin's address data instead.

The change preserves existing functionality while ensuring geolocation is available for Savings Plugin users without requiring latitude/longitude to be enabled in Fineract's field configuration.

## Related issues and discussion

- WEB-1044 (Part 2)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional latitude/longitude inputs for office addresses when the client address location feature is enabled.
  * Address details now render the location map only when valid coordinate pairs are available.
* **Bug Fixes**
  * Prevented latitude/longitude from appearing in address details or being included in saved payloads when the feature is disabled.
* **Tests**
  * Expanded unit tests to verify map rendering and payload/UI behavior for enabled vs. disabled location settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->