### PR TITLE
fix(WEB-1051): implement responsive visualization for dynamic datatables

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.html
@@ -48,7 +48,7 @@
             <ng-container [matColumnDef]="datatableColumn">
               @if (i === 0) {
                 <th mat-header-cell *matHeaderCellDef class="checkbox-column"></th>
-                <td mat-cell *matCellDef="let data">
+                <td mat-cell *matCellDef="let data" class="selection-cell">
                   <mat-checkbox
                     class="center"
                     (click)="$event.stopPropagation()"
@@ -60,8 +60,15 @@
               }
               @if (i > 0) {
                 <th mat-header-cell class="right" *matHeaderCellDef>{{ getInputName(datatableColumn) }}</th>
-                <td mat-cell class="right" *matCellDef="let data" [ngClass]="isToDelete(data)">
-                  {{ formatValue(data, datatableColumn) }}
+                <td
+                  mat-cell
+                  class="right responsive-data-cell"
+                  *matCellDef="let data"
+                  [ngClass]="isToDelete(data)"
+                  [attr.data-label]="getInputName(datatableColumn)"
+                >
+                  <span class="mobile-cell-label">{{ getInputName(datatableColumn) }}</span>
+                  <span class="cell-value">{{ formatValue(data, datatableColumn) }}</span>
                 </td>
               }
             </ng-container>

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
@@ -62,6 +62,14 @@
       overflow-wrap: anywhere;
     }
 
+    .mobile-cell-label {
+      display: none;
+    }
+
+    .cell-value {
+      overflow-wrap: anywhere;
+    }
+
     .data-row {
       transition: background-color 0.2s ease;
       cursor: pointer;
@@ -82,6 +90,119 @@
       width: 60px;
       min-width: 60px;
       max-width: 60px;
+    }
+  }
+}
+
+@media (width <= 768px) {
+  .tab-container {
+    .layout-row {
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .action-button {
+      width: 100%;
+      margin-left: 0;
+      flex-wrap: wrap;
+    }
+
+    .data-table-card {
+      box-shadow: none;
+
+      mat-card-content {
+        background: transparent;
+      }
+
+      .table-scroll-wrapper {
+        overflow-x: visible;
+      }
+    }
+
+    table {
+      display: block;
+      min-width: 0;
+      width: 100%;
+      border-radius: 0;
+      background: transparent;
+      box-shadow: none;
+
+      .mat-mdc-header-row {
+        display: none;
+      }
+
+      .mat-mdc-row {
+        display: block;
+        width: 100%;
+        margin-bottom: 16px;
+        overflow: hidden;
+        border: 1px solid rgb(0 0 0 / 12%);
+        border-radius: 8px;
+        background: var(--mat-card-background-color, var(--card-background, #fff));
+      }
+
+      td {
+        width: 100%;
+        max-width: none;
+        min-width: 0;
+        box-sizing: border-box;
+        text-align: left;
+      }
+
+      .selection-cell,
+      .mat-column-select {
+        display: flex;
+        justify-content: flex-end;
+        width: 100%;
+        max-width: none;
+        min-width: 0;
+        padding: 8px 16px;
+        background-color: rgb(0 0 0 / 3%);
+      }
+
+      .responsive-data-cell {
+        display: grid;
+        grid-template-columns: minmax(7rem, 38%) minmax(0, 1fr); /* stylelint-disable-line unit-allowed-list */
+        gap: 16px;
+        align-items: start;
+        padding: 16px;
+      }
+
+      .mobile-cell-label {
+        display: block;
+        color: rgb(0 0 0 / 60%);
+        font-size: 0.8125rem;
+        font-weight: 600;
+        line-height: 1.4;
+        overflow-wrap: anywhere;
+      }
+
+      .cell-value {
+        min-width: 0;
+        line-height: 1.45;
+      }
+    }
+  }
+}
+
+:host-context(.dark-theme) {
+  @media (width <= 768px) {
+    .tab-container {
+      table {
+        .mat-mdc-row {
+          border-color: rgb(255 255 255 / 12%);
+          background: var(--mat-card-background-color, var(--card-background, #424242));
+        }
+
+        .selection-cell,
+        .mat-column-select {
+          background-color: rgb(255 255 255 / 8%);
+        }
+
+        .mobile-cell-label {
+          color: rgb(255 255 255 / 70%);
+        }
+      }
     }
   }
 }

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DatePipe, DecimalPipe } from '@angular/common';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { of } from 'rxjs';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { SystemService } from 'app/system/system.service';
+import { DateFormatPipe } from 'app/pipes/date-format.pipe';
+import { DatetimeFormatPipe } from 'app/pipes/datetime-format.pipe';
+import { DatatableMultiRowComponent } from './datatable-multi-row.component';
+
+describe('DatatableMultiRowComponent', () => {
+  let fixture: ComponentFixture<DatatableMultiRowComponent>;
+  let component: DatatableMultiRowComponent;
+
+  const dataObject = {
+    columnHeaders: [
+      { columnName: 'id', columnDisplayType: 'INTEGER' },
+      { columnName: 'client_id', columnDisplayType: 'INTEGER' },
+      { columnName: 'first_name', columnDisplayType: 'STRING' },
+      { columnName: 'last_name', columnDisplayType: 'STRING' },
+      { columnName: 'notes', columnDisplayType: 'TEXT' },
+      { columnName: 'empty_value', columnDisplayType: 'STRING' }
+    ],
+    data: [
+      {
+        row: [
+          7,
+          99,
+          'Ada',
+          'Lovelace',
+          'A long datatable value that should remain readable when rendered in the responsive mobile row.',
+          null
+        ]
+      }
+    ]
+  };
+
+  beforeEach(async () => {
+    const translateService = {
+      instant: jest.fn((key: string) => key),
+      get: jest.fn((key: string) => of(key)),
+      onLangChange: of({ lang: 'en' }),
+      onTranslationChange: of({}),
+      onDefaultLangChange: of({ lang: 'en' })
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        DatatableMultiRowComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ datatableName: 'client_extra_data' })
+          }
+        },
+        {
+          provide: AuthenticationService,
+          useValue: { getCredentials: jest.fn(() => ({ permissions: ['ALL_FUNCTIONS'] })) }
+        },
+        { provide: MatDialog, useValue: { open: jest.fn() } },
+        DatePipe,
+        DecimalPipe,
+        DateFormatPipe,
+        DatetimeFormatPipe,
+        { provide: SystemService, useValue: { getEntityDatatable: jest.fn() } },
+        {
+          provide: SettingsService,
+          useValue: {
+            language: { code: 'en' },
+            dateFormat: 'dd MMMM yyyy',
+            datetimeFormat: 'dd MMMM yyyy HH:mm'
+          }
+        },
+        { provide: TranslateService, useValue: translateService }
+      ]
+    }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIcons(faPlus, faTrash);
+
+    fixture = TestBed.createComponent(DatatableMultiRowComponent);
+    component = fixture.componentInstance;
+    component.dataObject = dataObject;
+    component.entityId = '99';
+    component.entityType = 'Client';
+    fixture.detectChanges();
+  });
+
+  it('adds responsive labels to dynamic data cells', () => {
+    const dataCells = fixture.nativeElement.querySelectorAll('td.responsive-data-cell');
+    const labels = Array.from(dataCells).map((cell: Element) => cell.getAttribute('data-label'));
+    const mobileLabels = Array.from(dataCells).map((cell: Element) =>
+      cell.querySelector('.mobile-cell-label')?.textContent?.trim()
+    );
+
+    expect(labels).toEqual([
+      'Id',
+      'First name',
+      'Last name',
+      'Notes',
+      'Empty value'
+    ]);
+    expect(mobileLabels).toEqual(labels);
+  });
+
+  it('does not add responsive data labels to the selection column', () => {
+    const selectionCell = fixture.nativeElement.querySelector('td.selection-cell');
+
+    expect(selectionCell).toBeTruthy();
+    expect(selectionCell.getAttribute('data-label')).toBeNull();
+    expect(selectionCell.querySelector('.mobile-cell-label')).toBeNull();
+    expect(selectionCell.querySelector('mat-checkbox')).toBeTruthy();
+  });
+
+  it('preserves the existing displayed columns and desktop table structure', () => {
+    const table = fixture.nativeElement.querySelector('table[mat-table]');
+    const headerCells = fixture.nativeElement.querySelectorAll('th[mat-header-cell]');
+
+    expect(table).toBeTruthy();
+    expect(component.datatableColumns).toEqual([
+      'select',
+      'id',
+      'first_name',
+      'last_name',
+      'notes',
+      'empty_value'
+    ]);
+    expect(component.datatableColumns).not.toContain('client_id');
+    expect(headerCells.length).toBe(component.datatableColumns.length);
+  });
+
+  it('keeps empty values renderable inside labeled responsive cells', () => {
+    const emptyValueCell = fixture.nativeElement.querySelector('td[data-label="Empty value"]');
+    const emptyValue = emptyValueCell.querySelector('.cell-value');
+
+    expect(emptyValueCell).toBeTruthy();
+    expect(emptyValue).toBeTruthy();
+    expect(emptyValue.textContent.trim()).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

This PR improves the responsive visualization of the shared dynamic datatable renderer used across the Web-App.

Previously, multi-row datatables primarily relied on horizontal scrolling on smaller screens, making them difficult to read on mobile devices. This change enhances the responsive experience while preserving the existing desktop and tablet table layout.

The implementation is limited to the shared datatable renderer and does not modify backend APIs, business logic, or entity-specific components.

### Changes

- Improved responsive visualization for multi-row datatables.
- Preserved the existing desktop/tablet Material table layout.
- Enhanced mobile readability with responsive row presentation.
- Kept horizontal scrolling available for large datasets where appropriate.
- Preserved selection, actions, and existing datatable functionality.
- Scoped all styling changes to the shared datatable component to avoid impacting other Material tables.

## Related issues and discussion

- WEB-1051


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved responsive rendering of the multi-row data table with a card-like mobile layout.
  * Added per-cell mobile labels using `data-label`, tightened value wrapping, and ensured empty/null values display consistently.
  * Updated selection column presentation for responsive layouts, including improved dark-theme contrast.
* **Tests**
  * Added unit tests validating responsive label attributes/text, selection-cell behavior, expected desktop column set, and empty/null value rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->