### PR TITLE
feat(WEB-1047): add office services management

### DIFF
--- a/src/app/organization/offices/view-office/services-tab/services-tab.component.html
+++ b/src/app/organization/offices/view-office/services-tab/services-tab.component.html
@@ -1,0 +1,115 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<div class="tab-container mat-typography">
+  <div class="layout-row align-start">
+    <div class="m-b-10">
+      <h3>{{ 'labels.heading.Services' | translate }}</h3>
+    </div>
+    <div class="action-button m-b-10 gap-25px">
+      <button
+        mat-raised-button
+        color="primary"
+        (click)="addService()"
+        [disabled]="isLoading || isSaving || isPluginUnavailable"
+        *mifosxHasPermission="'CREATE_OFFICE'"
+      >
+        <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
+      </button>
+    </div>
+  </div>
+
+  @if (isLoading) {
+    <div class="service-state">
+      <mat-spinner diameter="36"></mat-spinner>
+      <span>{{ 'labels.text.Loading data' | translate }}</span>
+    </div>
+  }
+
+  @if (isPluginUnavailable && !isLoading) {
+    <div class="service-state unavailable-state">
+      <span>{{ 'labels.text.Office Services management requires the Savings Plugin to be deployed' | translate }}</span>
+    </div>
+  }
+
+  @if (hasError && !isLoading && !isPluginUnavailable) {
+    <div class="service-state error-state">
+      <span>{{ 'errors.generic.unexpectedRetry' | translate }}</span>
+      <button mat-button color="primary" (click)="loadOfficeServices()">
+        {{ 'labels.buttons.Retry' | translate }}
+      </button>
+    </div>
+  }
+
+  @if (!isLoading && !hasError && !isPluginUnavailable && !officeServices.length) {
+    <div class="service-state empty-state">
+      <span>{{ 'labels.text.No data found' | translate }}</span>
+      <button mat-raised-button color="primary" (click)="addService()" *mifosxHasPermission="'CREATE_OFFICE'">
+        <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
+      </button>
+    </div>
+  }
+
+  @if (!isLoading && !hasError && !isPluginUnavailable && officeServices.length) {
+    <div class="mat-elevation-z1 table-container">
+      <table mat-table [dataSource]="officeServices">
+        <ng-container matColumnDef="serviceName">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Service Name' | translate }}</th>
+          <td mat-cell *matCellDef="let service">
+            {{ service.serviceName || ('labels.inputs.Not Provided' | translate) }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="serviceExternalId">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.External Id' | translate }}</th>
+          <td mat-cell *matCellDef="let service">
+            {{ service.serviceExternalId || ('labels.inputs.Not Provided' | translate) }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="workingHours">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Working Hours' | translate }}</th>
+          <td mat-cell *matCellDef="let service">
+            {{ service.workingHours || ('labels.inputs.Not Provided' | translate) }}
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
+          <td mat-cell *matCellDef="let service">
+            <button
+              mat-button
+              color="primary"
+              (click)="editService(service)"
+              [disabled]="isSaving || isPluginUnavailable"
+              matTooltip="{{ 'labels.buttons.Edit' | translate }}"
+              [attr.aria-label]="'labels.buttons.Edit' | translate"
+              *mifosxHasPermission="'UPDATE_OFFICE'"
+            >
+              <fa-icon icon="edit"></fa-icon>
+            </button>
+            <button
+              mat-button
+              color="warn"
+              (click)="deleteService(service)"
+              [disabled]="isSaving || isPluginUnavailable"
+              matTooltip="{{ 'labels.buttons.Delete' | translate }}"
+              [attr.aria-label]="'labels.buttons.Delete' | translate"
+              *mifosxHasPermission="'DELETE_OFFICE'"
+            >
+              <fa-icon icon="trash"></fa-icon>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      </table>
+    </div>
+  }
+</div>

--- a/src/app/organization/offices/view-office/services-tab/services-tab.component.scss
+++ b/src/app/organization/offices/view-office/services-tab/services-tab.component.scss
@@ -1,0 +1,45 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+
+  .action-button {
+    margin-left: auto;
+  }
+
+  .service-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    min-height: 120px;
+    text-align: center;
+  }
+
+  .error-state {
+    color: var(--warn-color, #b00020);
+  }
+
+  .unavailable-state {
+    color: rgb(78 78 78);
+  }
+
+  .empty-state {
+    flex-direction: column;
+  }
+
+  .table-container {
+    overflow: auto;
+  }
+
+  table {
+    width: 100%;
+  }
+}

--- a/src/app/organization/offices/view-office/services-tab/services-tab.component.spec.ts
+++ b/src/app/organization/offices/view-office/services-tab/services-tab.component.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faEdit, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { of, throwError } from 'rxjs';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+import { ServicesTabComponent } from './services-tab.component';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { OrganizationService } from 'app/organization/organization.service';
+
+describe('Office ServicesTabComponent', () => {
+  let component: ServicesTabComponent;
+  let fixture: ComponentFixture<ServicesTabComponent>;
+  let organizationService: jest.Mocked<OrganizationService>;
+  let dialog: jest.Mocked<MatDialog>;
+
+  const officeService = {
+    officeServiceId: 7,
+    officeId: 1,
+    serviceName: 'Cash Deposit',
+    serviceExternalId: 'cash-deposit',
+    workingHours: '09:00-17:00'
+  };
+
+  function dialogRefWithValue(value: any) {
+    return {
+      afterClosed: () => of({ data: { value } })
+    } as any;
+  }
+
+  function dialogRefWithDelete() {
+    return {
+      afterClosed: () => of({ delete: true })
+    } as any;
+  }
+
+  function endpointNotFoundError() {
+    return {
+      status: 404,
+      error: {
+        error: 'Not Found',
+        path: '/fineract-provider/api/v2/offices/1/services'
+      }
+    };
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    organizationService = {
+      getOfficeServices: jest.fn(() => of([officeService])),
+      createOfficeService: jest.fn(() => of({ entityId: 10 })),
+      updateOfficeService: jest.fn(() => of({ entityId: 7 })),
+      deleteOfficeService: jest.fn(() => of({ entityId: 7 }))
+    } as unknown as jest.Mocked<OrganizationService>;
+
+    dialog = {
+      open: jest.fn()
+    } as unknown as jest.Mocked<MatDialog>;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ServicesTabComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            parent: {
+              snapshot: {
+                paramMap: {
+                  get: jest.fn(() => '1')
+                }
+              }
+            }
+          }
+        },
+        { provide: OrganizationService, useValue: organizationService },
+        { provide: MatDialog, useValue: dialog },
+        { provide: AuthenticationService, useValue: { getCredentials: () => ({ permissions: [] as string[] }) } },
+        provideNoopAnimations()
+      ]
+    }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIcons(faPlus, faEdit, faTrash);
+    fixture = TestBed.createComponent(ServicesTabComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads and renders office services', () => {
+    fixture.detectChanges();
+
+    expect(organizationService.getOfficeServices).toHaveBeenCalledWith('1');
+    expect(component.officeServices).toEqual([officeService]);
+    expect(component.isLoading).toBe(false);
+    expect(fixture.nativeElement.textContent).toContain('Cash Deposit');
+    expect(fixture.nativeElement.textContent).toContain('cash-deposit');
+    expect(fixture.nativeElement.textContent).toContain('09:00-17:00');
+  });
+
+  it('shows an empty state when the office has no services', () => {
+    organizationService.getOfficeServices.mockReturnValue(of([]));
+
+    fixture.detectChanges();
+
+    expect(component.officeServices).toEqual([]);
+    expect(fixture.nativeElement.textContent).toContain('No data found');
+  });
+
+  it('shows plugin unavailable state when the office services endpoint is not registered', () => {
+    organizationService.getOfficeServices.mockReturnValue(throwError(() => endpointNotFoundError()));
+
+    fixture.detectChanges();
+
+    expect(component.isPluginUnavailable).toBe(true);
+    expect(component.hasError).toBe(false);
+    expect(component.officeServices).toEqual([]);
+    expect(fixture.nativeElement.textContent).toContain(
+      'labels.text.Office Services management requires the Savings Plugin to be deployed'
+    );
+  });
+
+  it('shows an error state when office services loading fails for non-404 errors', () => {
+    organizationService.getOfficeServices.mockReturnValue(throwError(() => ({ status: 500 })));
+
+    fixture.detectChanges();
+
+    expect(component.hasError).toBe(true);
+    expect(component.isPluginUnavailable).toBe(false);
+    expect(component.officeServices).toEqual([]);
+  });
+
+  it('does not open dialogs or call service endpoints when the plugin is unavailable', () => {
+    component.isPluginUnavailable = true;
+
+    component.addService();
+    component.editService(officeService);
+    component.deleteService(officeService);
+
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(organizationService.createOfficeService).not.toHaveBeenCalled();
+    expect(organizationService.updateOfficeService).not.toHaveBeenCalled();
+    expect(organizationService.deleteOfficeService).not.toHaveBeenCalled();
+  });
+
+  it('creates an office service through the plugin endpoint service method', () => {
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(
+      dialogRefWithValue({
+        serviceName: 'ATM',
+        serviceExternalId: 'atm',
+        workingHours: '24 hours'
+      })
+    );
+
+    component.addService();
+
+    expect(organizationService.createOfficeService).toHaveBeenCalledWith('1', {
+      serviceName: 'ATM',
+      serviceExternalId: 'atm',
+      workingHours: '24 hours'
+    });
+  });
+
+  it('updates an existing office service by office service id', () => {
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(
+      dialogRefWithValue({
+        serviceName: 'Updated Cash Deposit',
+        serviceExternalId: 'updated-cash-deposit',
+        workingHours: '10:00-16:00'
+      })
+    );
+
+    component.editService(officeService);
+
+    expect(organizationService.updateOfficeService).toHaveBeenCalledWith('1', '7', {
+      serviceName: 'Updated Cash Deposit',
+      serviceExternalId: 'updated-cash-deposit',
+      workingHours: '10:00-16:00'
+    });
+  });
+
+  it('deletes an existing office service by office service id', () => {
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(dialogRefWithDelete());
+
+    component.deleteService(officeService);
+
+    expect(organizationService.deleteOfficeService).toHaveBeenCalledWith('1', '7');
+  });
+
+  it('handles office services without ids without throwing', () => {
+    const serviceWithoutId: any = {
+      ...officeService,
+      officeServiceId: undefined,
+      id: undefined,
+      serviceId: undefined
+    };
+
+    fixture.detectChanges();
+    dialog.open.mockClear();
+
+    expect(component.getOfficeServiceId(serviceWithoutId)).toBe('');
+    expect(component.getOfficeServiceId(serviceWithoutId, 3)).toBe('office-service-3');
+    expect(() => component.editService(serviceWithoutId)).not.toThrow();
+    expect(() => component.deleteService(serviceWithoutId)).not.toThrow();
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(organizationService.updateOfficeService).not.toHaveBeenCalled();
+    expect(organizationService.deleteOfficeService).not.toHaveBeenCalled();
+  });
+
+  it('shows plugin unavailable state when create returns endpoint not found', () => {
+    fixture.detectChanges();
+    organizationService.createOfficeService.mockReturnValue(throwError(() => endpointNotFoundError()));
+    dialog.open.mockReturnValue(
+      dialogRefWithValue({
+        serviceName: 'ATM',
+        serviceExternalId: 'atm',
+        workingHours: '24 hours'
+      })
+    );
+
+    component.addService();
+
+    expect(component.isPluginUnavailable).toBe(true);
+    expect(component.hasError).toBe(false);
+    expect(component.officeServices).toEqual([]);
+  });
+});

--- a/src/app/organization/offices/view-office/services-tab/services-tab.component.ts
+++ b/src/app/organization/offices/view-office/services-tab/services-tab.component.ts
@@ -1,0 +1,283 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+
+/** Angular Material Imports */
+import { MatDialog } from '@angular/material/dialog';
+import {
+  MatTable,
+  MatColumnDef,
+  MatHeaderCellDef,
+  MatHeaderCell,
+  MatCellDef,
+  MatCell,
+  MatHeaderRowDef,
+  MatHeaderRow,
+  MatRowDef,
+  MatRow
+} from '@angular/material/table';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatTooltip } from '@angular/material/tooltip';
+
+/** rxjs Imports */
+import { of } from 'rxjs';
+import { catchError, finalize } from 'rxjs/operators';
+
+/** Custom Components */
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
+import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
+
+/** Custom Services */
+import { TranslateService } from '@ngx-translate/core';
+import { OrganizationService } from 'app/organization/organization.service';
+
+/** Custom Models */
+import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-base';
+import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
+
+/** Custom Imports */
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+interface OfficeServiceData {
+  officeServiceId?: string | number;
+  serviceId?: string | number;
+  id?: string | number;
+  serviceName?: string;
+  serviceExternalId?: string;
+  workingHours?: string;
+}
+
+@Component({
+  selector: 'mifosx-office-services-tab',
+  templateUrl: './services-tab.component.html',
+  styleUrls: ['./services-tab.component.scss'],
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    FaIconComponent,
+    MatTable,
+    MatColumnDef,
+    MatHeaderCellDef,
+    MatHeaderCell,
+    MatCellDef,
+    MatCell,
+    MatHeaderRowDef,
+    MatHeaderRow,
+    MatRowDef,
+    MatRow,
+    MatProgressSpinner,
+    MatTooltip
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ServicesTabComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private organizationService = inject(OrganizationService);
+  private dialog = inject(MatDialog);
+  private translateService = inject(TranslateService);
+  private changeDetectorRef = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
+
+  officeId: string;
+  officeServices: OfficeServiceData[] = [];
+  displayedColumns: string[] = [
+    'serviceName',
+    'serviceExternalId',
+    'workingHours',
+    'actions'
+  ];
+  isLoading = true;
+  isSaving = false;
+  hasError = false;
+  isPluginUnavailable = false;
+
+  ngOnInit() {
+    this.officeId = this.route.parent.snapshot.paramMap.get('officeId') ?? '';
+    this.loadOfficeServices();
+  }
+
+  loadOfficeServices() {
+    this.isLoading = true;
+    this.hasError = false;
+    this.isPluginUnavailable = false;
+
+    this.organizationService
+      .getOfficeServices(this.officeId)
+      .pipe(
+        catchError((error) => {
+          if (this.isEndpointNotFound(error)) {
+            this.isPluginUnavailable = true;
+          } else {
+            this.hasError = true;
+          }
+          return of([]);
+        }),
+        finalize(() => {
+          this.isLoading = false;
+          this.changeDetectorRef.markForCheck();
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((services: OfficeServiceData[]) => {
+        this.officeServices = Array.isArray(services) ? services : [];
+      });
+  }
+
+  addService() {
+    if (this.isPluginUnavailable) {
+      return;
+    }
+
+    const data = {
+      title:
+        this.translateService.instant('labels.buttons.Add') +
+        ' ' +
+        this.translateService.instant('labels.heading.Services'),
+      formfields: this.getServiceFormFields(),
+      layout: { addButtonText: this.translateService.instant('labels.buttons.Submit') }
+    };
+    const addServiceDialogRef = this.dialog.open(FormDialogComponent, { data });
+    addServiceDialogRef.afterClosed().subscribe((response: any) => {
+      if (response?.data) {
+        this.saveService(
+          this.organizationService.createOfficeService(this.officeId, this.normalizeServiceData(response.data.value))
+        );
+      }
+    });
+  }
+
+  editService(service: OfficeServiceData) {
+    if (this.isPluginUnavailable) {
+      return;
+    }
+
+    const officeServiceId = this.getOfficeServiceId(service);
+    if (!officeServiceId) {
+      return;
+    }
+
+    const data = {
+      title:
+        this.translateService.instant('labels.buttons.Edit') +
+        ' ' +
+        this.translateService.instant('labels.heading.Services'),
+      formfields: this.getServiceFormFields(service),
+      layout: { addButtonText: this.translateService.instant('labels.buttons.Edit') }
+    };
+    const editServiceDialogRef = this.dialog.open(FormDialogComponent, { data });
+    editServiceDialogRef.afterClosed().subscribe((response: any) => {
+      if (response?.data) {
+        this.saveService(
+          this.organizationService.updateOfficeService(
+            this.officeId,
+            officeServiceId,
+            this.normalizeServiceData(response.data.value)
+          )
+        );
+      }
+    });
+  }
+
+  deleteService(service: OfficeServiceData) {
+    if (this.isPluginUnavailable) {
+      return;
+    }
+
+    const officeServiceId = this.getOfficeServiceId(service);
+    if (!officeServiceId) {
+      return;
+    }
+
+    const deleteServiceDialogRef = this.dialog.open(DeleteDialogComponent, {
+      data: { deleteContext: this.translateService.instant('labels.heading.Services') }
+    });
+    deleteServiceDialogRef.afterClosed().subscribe((response: any) => {
+      if (response?.delete) {
+        this.saveService(this.organizationService.deleteOfficeService(this.officeId, officeServiceId));
+      }
+    });
+  }
+
+  getOfficeServiceId(service: OfficeServiceData, index?: number): string {
+    const officeServiceId = service?.officeServiceId ?? service?.id ?? service?.serviceId;
+    if (officeServiceId === null || officeServiceId === undefined) {
+      return index === undefined ? '' : `office-service-${index}`;
+    }
+    return officeServiceId.toString();
+  }
+
+  private saveService(request: any) {
+    this.isSaving = true;
+    this.hasError = false;
+    this.isPluginUnavailable = false;
+    request
+      .pipe(
+        finalize(() => {
+          this.isSaving = false;
+          this.changeDetectorRef.markForCheck();
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe({
+        next: () => this.loadOfficeServices(),
+        error: (error: any) => {
+          if (this.isEndpointNotFound(error)) {
+            this.isPluginUnavailable = true;
+            this.officeServices = [];
+          } else {
+            this.hasError = true;
+          }
+          this.changeDetectorRef.markForCheck();
+        }
+      });
+  }
+
+  private getServiceFormFields(service?: OfficeServiceData) {
+    const formfields: FormfieldBase[] = [
+      new InputBase({
+        controlName: 'serviceName',
+        label: this.translateService.instant('labels.inputs.Service Name'),
+        value: service ? service.serviceName : '',
+        type: 'text',
+        required: true,
+        order: 1
+      }),
+      new InputBase({
+        controlName: 'serviceExternalId',
+        label: this.translateService.instant('labels.inputs.External Id'),
+        value: service ? service.serviceExternalId : '',
+        type: 'text',
+        order: 2
+      }),
+      new InputBase({
+        controlName: 'workingHours',
+        label: this.translateService.instant('labels.inputs.Working Hours'),
+        value: service ? service.workingHours : '',
+        type: 'text',
+        order: 3
+      })
+    ];
+    return formfields;
+  }
+
+  private normalizeServiceData(serviceData: any) {
+    return {
+      serviceName: serviceData.serviceName ?? '',
+      serviceExternalId: serviceData.serviceExternalId ?? '',
+      workingHours: serviceData.workingHours ?? ''
+    };
+  }
+
+  private isEndpointNotFound(error: any): boolean {
+    return error?.status === 404 && error?.error?.error === 'Not Found';
+  }
+}

--- a/src/app/organization/offices/view-office/view-office.component.html
+++ b/src/app/organization/offices/view-office/view-office.component.html
@@ -44,6 +44,17 @@
         >
           {{ 'labels.heading.Address' | translate }}
         </a>
+        <a
+          mat-tab-link
+          [routerLink]="['./services']"
+          routerLinkActive
+          #services="routerLinkActive"
+          [active]="services.isActive"
+          class="compact-tab"
+          *mifosxHasPermission="'READ_OFFICE'"
+        >
+          {{ 'labels.heading.Services' | translate }}
+        </a>
         @for (officeDatatable of officeDatatables; track officeDatatable) {
           <span>
             <a

--- a/src/app/organization/organization-routing.module.ts
+++ b/src/app/organization/organization-routing.module.ts
@@ -43,6 +43,7 @@ import { ViewHolidaysComponent } from './holidays/view-holidays/view-holidays.co
 import { ViewOfficeComponent } from './offices/view-office/view-office.component';
 import { GeneralTabComponent } from './offices/view-office/general-tab/general-tab.component';
 import { AddressTabComponent } from './offices/view-office/address-tab/address-tab.component';
+import { ServicesTabComponent } from './offices/view-office/services-tab/services-tab.component';
 import { DatatableTabsComponent } from './offices/view-office/datatable-tabs/datatable-tabs.component';
 import { ViewCampaignComponent } from './sms-campaigns/view-campaign/view-campaign.component';
 import { ManageFundsComponent } from './manage-funds/manage-funds.component';
@@ -216,6 +217,11 @@ const routes: Routes = [
                   path: 'address',
                   component: AddressTabComponent,
                   data: { title: 'Address', breadcrumb: 'Address', routeParamBreadcrumb: false }
+                },
+                {
+                  path: 'services',
+                  component: ServicesTabComponent,
+                  data: { title: 'Services', breadcrumb: 'Services', routeParamBreadcrumb: false }
                 },
                 {
                   path: 'datatables',

--- a/src/app/organization/organization.module.ts
+++ b/src/app/organization/organization.module.ts
@@ -47,6 +47,7 @@ import { ViewHolidaysComponent } from './holidays/view-holidays/view-holidays.co
 import { ViewOfficeComponent } from './offices/view-office/view-office.component';
 import { GeneralTabComponent } from './offices/view-office/general-tab/general-tab.component';
 import { AddressTabComponent } from './offices/view-office/address-tab/address-tab.component';
+import { ServicesTabComponent } from './offices/view-office/services-tab/services-tab.component';
 import { DatatableTabsComponent } from './offices/view-office/datatable-tabs/datatable-tabs.component';
 import { ViewCampaignComponent } from './sms-campaigns/view-campaign/view-campaign.component';
 import { ManageFundsComponent } from './manage-funds/manage-funds.component';
@@ -129,6 +130,7 @@ import { InvestorsComponent } from './investors/investors.component';
     ViewOfficeComponent,
     GeneralTabComponent,
     AddressTabComponent,
+    ServicesTabComponent,
     DatatableTabsComponent,
     ViewCampaignComponent,
     ManageFundsComponent,

--- a/src/app/organization/organization.service.ts
+++ b/src/app/organization/organization.service.ts
@@ -176,6 +176,42 @@ export class OrganizationService {
   }
 
   /**
+   * @param {string} officeId Office ID of Office.
+   * @returns {Observable<any>} Office services.
+   */
+  getOfficeServices(officeId: string): Observable<any> {
+    return this.http.get(`/v2/offices/${officeId}/services`);
+  }
+
+  /**
+   * @param {string} officeId Office ID of Office.
+   * @param {any} serviceData Office service data.
+   * @returns {Observable<any>}
+   */
+  createOfficeService(officeId: string, serviceData: any): Observable<any> {
+    return this.http.post(`/v2/offices/${officeId}/services`, serviceData);
+  }
+
+  /**
+   * @param {string} officeId Office ID of Office.
+   * @param {string} serviceId Office service ID.
+   * @param {any} serviceData Office service data.
+   * @returns {Observable<any>}
+   */
+  updateOfficeService(officeId: string, serviceId: string, serviceData: any): Observable<any> {
+    return this.http.put(`/v2/offices/${officeId}/services/${serviceId}`, serviceData);
+  }
+
+  /**
+   * @param {string} officeId Office ID of Office.
+   * @param {string} serviceId Office service ID.
+   * @returns {Observable<any>}
+   */
+  deleteOfficeService(officeId: string, serviceId: string): Observable<any> {
+    return this.http.delete(`/v2/offices/${officeId}/services/${serviceId}`);
+  }
+
+  /**
    * @returns {Observable<any>}
    */
   getOfficeDatatables(): Observable<any> {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1611,7 +1611,8 @@
       "Loan Breach Actions": "Loan Breach Actions",
       "No Breach Actions": "No Breach Actions",
       "Pause Timeline": "Pause Timeline",
-      "Location Map": "Location Map"
+      "Location Map": "Location Map",
+      "Services": "Services"
     },
     "inputs": {
       "Breach Actions": "Breach Actions",
@@ -2920,6 +2921,7 @@
       "Sender": "Sender",
       "Sender Name": "Sender Name",
       "Sender Registry": "Sender Registry",
+      "Service Name": "Service Name",
       "Sent By": "Sent By",
       "Server": "Server",
       "Server Key": "Server Key",
@@ -3145,6 +3147,7 @@
       "Within Bank": "Within Bank",
       "Workflow Jobs": "Workflow Jobs",
       "Working Days": "Working Days",
+      "Working Hours": "Working Hours",
       "Write Off Date": "Write Off Date",
       "Write off on": "Write off on",
       "Write-off": "Write-off",
@@ -4014,6 +4017,7 @@
       "Notification Service Configuration": "Notification Service Configuration",
       "Notifications": "Notifications",
       "Office Address management requires the Savings Plugin to be deployed": "Office Address management requires the Savings Plugin to be deployed.",
+      "Office Services management requires the Savings Plugin to be deployed": "Office Services management requires the Savings Plugin to be deployed.",
       "Offices and staff": "Offices & staff",
       "Optional": "Optional",
       "Organization": "Organization",


### PR DESCRIPTION
## Description

Implements the Office Services management interface for branch offices in the Web-App.

This change adds the Services tab to the Office Details page and integrates it with the existing Savings Plugin APIs to allow branch administrators to manage the services provided by a branch.

## Changes

- Added the Services tab to the Office Details view.
- Integrated with existing Office Services plugin APIs.
- Implemented service listing for the selected office.
- Added support for registering new branch services.
- Reused existing routing, services, Material components, and UI patterns.
- Added required translations and tests.
- No Apache Fineract Core or plugin changes.

## Related Issue

- WEB-1047

##Screenshots



https://github.com/user-attachments/assets/4df36a46-e540-4458-83bd-900d89f49ca0





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a permission-gated **Services** tab to office details, with a dedicated child route.
  * Added full UI to view services and manage them via **Add/Edit/Delete** dialogs.
* **UI States / Improvements**
  * Added loading, empty, and error-with-retry states.
  * When services endpoints are unavailable, the UI shows a notice and disables create/update/delete.
* **Translations**
  * Updated service-related labels and messaging, including plugin-unavailable copy.
* **Tests**
  * Added unit tests for loading, empty/error/unavailable states, permissions, and CRUD dialog flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->