### PR TITLE
fix(WEB-1045, WEB-1046): align office address UI with plugin behavior

### DIFF
--- a/src/app/organization/offices/view-office/address-tab/address-tab.component.html
+++ b/src/app/organization/offices/view-office/address-tab/address-tab.component.html
@@ -11,17 +11,19 @@
     <div class="m-b-10">
       <h3>{{ 'labels.heading.Address' | translate }}</h3>
     </div>
-    <div class="action-button m-b-10 gap-25px">
-      <button
-        mat-raised-button
-        color="primary"
-        (click)="addAddress()"
-        [disabled]="isLoading || isSaving || optionsLoadFailed || isPluginUnavailable"
-        *mifosxHasPermission="'CREATE_OFFICE'"
-      >
-        <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
-      </button>
-    </div>
+    @if (!hasOfficeAddress) {
+      <div class="action-button m-b-10 gap-25px">
+        <button
+          mat-raised-button
+          color="primary"
+          (click)="addAddress()"
+          [disabled]="!canAddAddress"
+          *mifosxHasPermission="'CREATE_OFFICE'"
+        >
+          <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}
+        </button>
+      </div>
+    }
   </div>
 
   @if (isLoading) {
@@ -59,7 +61,7 @@
         mat-raised-button
         color="primary"
         (click)="addAddress()"
-        [disabled]="optionsLoadFailed || isPluginUnavailable"
+        [disabled]="!canAddAddress"
         *mifosxHasPermission="'CREATE_OFFICE'"
       >
         <fa-icon icon="plus" class="m-r-10"></fa-icon>{{ 'labels.buttons.Add' | translate }}

--- a/src/app/organization/offices/view-office/address-tab/address-tab.component.spec.ts
+++ b/src/app/organization/offices/view-office/address-tab/address-tab.component.spec.ts
@@ -167,6 +167,20 @@ describe('Office AddressTabComponent', () => {
     const text = fixture.nativeElement.textContent;
     expect(component.officeAddresses).toEqual([]);
     expect(text).toContain('No data found');
+    expect(fixture.nativeElement.querySelector('.action-button button')).not.toBeNull();
+  });
+
+  it('hides the add action and prevents the add dialog when the office already has an address', () => {
+    fixture.detectChanges();
+
+    expect(component.hasOfficeAddress).toBe(true);
+    expect(component.canAddAddress).toBe(false);
+    expect(fixture.nativeElement.querySelector('.action-button button')).toBeNull();
+
+    component.addAddress();
+
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(organizationService.createOfficeAddress).not.toHaveBeenCalled();
   });
 
   it('shows plugin unavailable state when the office address endpoint is not registered', () => {
@@ -197,6 +211,7 @@ describe('Office AddressTabComponent', () => {
   });
 
   it('creates an office address through the plugin endpoint service method', () => {
+    organizationService.getOfficeAddresses.mockReturnValue(of([]));
     fixture.detectChanges();
     dialog.open.mockReturnValue(
       dialogRefWithValue({
@@ -221,6 +236,7 @@ describe('Office AddressTabComponent', () => {
   });
 
   it('shows plugin unavailable state when create returns endpoint not found', () => {
+    organizationService.getOfficeAddresses.mockReturnValue(of([]));
     fixture.detectChanges();
     organizationService.createOfficeAddress.mockReturnValue(throwError(() => endpointNotFoundError()));
     dialog.open.mockReturnValue(
@@ -296,6 +312,21 @@ describe('Office AddressTabComponent', () => {
     expect(organizationService.deleteOfficeAddress).toHaveBeenCalledWith('1', '7');
   });
 
+  it('enables the add action again after the existing address is deleted', () => {
+    organizationService.getOfficeAddresses.mockReturnValueOnce(of([officeAddress])).mockReturnValueOnce(of([]));
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(dialogRefWithDelete());
+
+    component.deleteAddress(officeAddress);
+    fixture.detectChanges();
+
+    expect(organizationService.deleteOfficeAddress).toHaveBeenCalledWith('1', '7');
+    expect(component.officeAddresses).toEqual([]);
+    expect(component.hasOfficeAddress).toBe(false);
+    expect(component.canAddAddress).toBe(true);
+    expect(fixture.nativeElement.querySelector('.action-button button')).not.toBeNull();
+  });
+
   it('uses address validation metadata in the form dialog fields', () => {
     component.addressTemplate = addressTemplate;
 
@@ -335,6 +366,7 @@ describe('Office AddressTabComponent', () => {
 
   it('omits plugin geolocation values from save payloads when the location feature is disabled', () => {
     environment.enableClientAddressLocation = false;
+    organizationService.getOfficeAddresses.mockReturnValue(of([]));
     fixture.detectChanges();
     dialog.open.mockReturnValue(
       dialogRefWithValue({
@@ -351,6 +383,53 @@ describe('Office AddressTabComponent', () => {
     const payload = organizationService.createOfficeAddress.mock.calls[0][1];
     expect(payload.latitude).toBeUndefined();
     expect(payload.longitude).toBeUndefined();
+  });
+
+  it('preserves latitude and longitude in create payloads when the location feature is enabled', () => {
+    organizationService.getOfficeAddresses.mockReturnValue(of([]));
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(
+      dialogRefWithValue({
+        addressTypeId: 1,
+        street: 'Church Street',
+        latitude: '12.9716',
+        longitude: '77.5946',
+        isActive: true
+      })
+    );
+
+    component.addAddress();
+
+    const payload = organizationService.createOfficeAddress.mock.calls[0][1];
+    expect(payload.latitude).toBe('12.9716');
+    expect(payload.longitude).toBe('77.5946');
+  });
+
+  it('preserves latitude and longitude in edit payloads when the location feature is enabled', () => {
+    const officeAddressWithCoordinates = {
+      ...officeAddress,
+      latitude: '12.9716',
+      longitude: '77.5946'
+    };
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(
+      dialogRefWithValue({
+        ...officeAddressWithCoordinates,
+        latitude: '13',
+        longitude: '78'
+      })
+    );
+
+    component.editAddress(officeAddressWithCoordinates);
+
+    expect(organizationService.updateOfficeAddress).toHaveBeenCalledWith(
+      '1',
+      '7',
+      expect.objectContaining({
+        latitude: '13',
+        longitude: '78'
+      })
+    );
   });
 
   it('renders plugin geolocation values and map for returned coordinates when the location feature is enabled', () => {
@@ -370,6 +449,47 @@ describe('Office AddressTabComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('77.5946');
     expect(fixture.nativeElement.querySelector('mifosx-address-location-map')).not.toBeNull();
     expect(L.map).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes displayed coordinates and map position after editing an address location', () => {
+    const initialAddress = {
+      ...officeAddress,
+      latitude: '12.9716',
+      longitude: '77.5946'
+    };
+    const updatedAddress = {
+      ...officeAddress,
+      latitude: '13',
+      longitude: '78'
+    };
+    organizationService.getOfficeAddresses
+      .mockReturnValueOnce(of([initialAddress]))
+      .mockReturnValueOnce(of([updatedAddress]));
+    fixture.detectChanges();
+    dialog.open.mockReturnValue(dialogRefWithValue(updatedAddress));
+
+    component.editAddress(initialAddress);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('13');
+    expect(fixture.nativeElement.textContent).toContain('78');
+    expect(fixture.nativeElement.querySelector('mifosx-address-location-map')).not.toBeNull();
+    expect(mockMapSetView).toHaveBeenCalledWith(
+      [
+        13,
+        78
+      ],
+      15
+    );
+  });
+
+  it('does not render a map when coordinates are missing', () => {
+    organizationService.getOfficeAddresses.mockReturnValue(of([officeAddress]));
+
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('mifosx-address-location-map')).toBeNull();
+    expect(L.map).not.toHaveBeenCalled();
   });
 
   it('hides plugin geolocation values and map for returned coordinates when the location feature is disabled', () => {
@@ -400,5 +520,12 @@ describe('Office AddressTabComponent', () => {
     expect(component.hasError).toBe(true);
     expect(component.isPluginUnavailable).toBe(false);
     expect(component.officeAddresses).toEqual([]);
+    expect(component.canAddAddress).toBe(false);
+    expect(fixture.nativeElement.querySelector('.action-button button:disabled')).not.toBeNull();
+
+    component.addAddress();
+
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(organizationService.createOfficeAddress).not.toHaveBeenCalled();
   });
 });

--- a/src/app/organization/offices/view-office/address-tab/address-tab.component.ts
+++ b/src/app/organization/offices/view-office/address-tab/address-tab.component.ts
@@ -103,6 +103,21 @@ export class AddressTabComponent implements OnInit {
 
   private autoFilledFields = new Set<string>();
 
+  get hasOfficeAddress(): boolean {
+    return this.officeAddresses.length > 0;
+  }
+
+  get canAddAddress(): boolean {
+    return (
+      !this.hasOfficeAddress &&
+      !this.isLoading &&
+      !this.isSaving &&
+      !this.hasError &&
+      !this.optionsLoadFailed &&
+      !this.isPluginUnavailable
+    );
+  }
+
   ngOnInit() {
     this.officeId = this.route.parent.snapshot.paramMap.get('officeId') ?? '';
     this.loadOfficeAddresses();
@@ -150,7 +165,7 @@ export class AddressTabComponent implements OnInit {
   }
 
   addAddress() {
-    if (this.isPluginUnavailable) {
+    if (!this.canAddAddress) {
       return;
     }
 


### PR DESCRIPTION
## Summary

This PR completes the remaining Web-App work for **WEB-1045** and **WEB-1046** by aligning the Office Address UI with the current Savings Plugin implementation and improving the existing address/location experience.

### Changes
- Align the Office Address UI with the plugin's one-address-per-office behavior.
- Prevent users from adding multiple office addresses when one already exists.
- Re-enable address creation after the existing address is deleted.
- Improve the Address tab UX for create, edit, and delete operations.
- Ensure latitude and longitude values are correctly loaded, saved, and updated.
- Improve map rendering and refresh behavior for valid coordinates while handling missing coordinates gracefully.
- Update and extend unit tests for the modified behavior.

No backend or Savings Plugin changes are included in this PR.

## Related issues and discussion

- WEB-1045
- WEB-1046



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hide the “Add Address” action when an office already has an address.
  * Disable “Add Address” during loading/saving/error/option-load-failure states, or when the address feature isn’t available—preventing the dialog from opening and creation from starting.
  * Re-enable “Add Address” after an existing address is deleted.
  * Preserve latitude and longitude when creating or editing addresses.
  * Refresh map positioning after address updates and hide the map when coordinates are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->