### PR TITLE
WEB-657: Working Capital loan - Payout Refund transaction

### DIFF
--- a/src/app/clients/clients-view/dispute-management/dispute-management.component.ts
+++ b/src/app/clients/clients-view/dispute-management/dispute-management.component.ts
@@ -14,7 +14,6 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { MatIcon } from '@angular/material/icon';
 import { MatDivider } from '@angular/material/divider';
-import { MatProgressBar } from '@angular/material/progress-bar';
 import { FormsModule } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -39,7 +38,6 @@ import { DisputeCase, CbildRole, CBILD_ROLE_LABELS } from 'app/credit-bureau/cre
     ...STANDALONE_SHARED_IMPORTS,
     MatIcon,
     MatDivider,
-    MatProgressBar,
     FormsModule
   ]
 })

--- a/src/app/loans/common-resolvers/loan-action-button.resolver.ts
+++ b/src/app/loans/common-resolvers/loan-action-button.resolver.ts
@@ -50,7 +50,9 @@ export class LoanActionButtonResolver {
     } else if (loanActionButton === 'Interest Payment Waiver') {
       return this.loansService.getLoanActionTemplate(loanId, 'interestPaymentWaiver');
     } else if (loanActionButton === 'Payout Refund') {
-      return this.loansService.getLoanActionTemplate(loanId, 'payoutRefund');
+      return this.loanProductService.isLoanProduct
+        ? this.loansService.getLoanActionTemplate(loanId, 'payoutRefund')
+        : this.loansService.getWorkingCapitalLoanActionTemplate(loanId, 'repayment');
     } else if (loanActionButton === 'Merchant Issued Refund') {
       return this.loansService.getLoanActionTemplate(loanId, 'merchantIssuedRefund');
     } else if (loanActionButton === 'Credit Balance Refund') {

--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.html
@@ -74,7 +74,7 @@
               <input matInput formControlName="externalId" />
             </mat-form-field>
 
-            @if (isCapitalizedIncome() || isBuyDownFee()) {
+            @if (isCapitalizedIncome() || isBuyDownFee() || (isWorkingCapital && classificationOptions?.length)) {
               <mat-form-field>
                 <mat-label>{{ 'labels.inputs.Classification' | translate }}</mat-label>
                 <mat-select formControlName="classificationId">

--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
@@ -99,6 +99,9 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
   }
 
   get requiredPermission(): string {
+    if (this.loanProductService.isWorkingCapital && this.command === 'payoutRefund') {
+      return 'PAYOUTREFUND_WORKINGCAPITALLOAN';
+    }
     const map: Record<string, string> = {
       repayment: 'REPAYMENT_LOAN',
       goodwillCredit: 'CREATE_GOODWILL_TRANSACTION',
@@ -141,7 +144,7 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
 
     this.repaymentLoanForm.addControl('transactionAmount', new FormControl(0, []));
     this.updateTransactionAmountValidators(false);
-    if (this.isCapitalizedIncome() || this.isBuyDownFee()) {
+    if (this.isCapitalizedIncome() || this.isBuyDownFee() || this.isWorkingCapital) {
       this.repaymentLoanForm.addControl('classificationId', new FormControl(null));
     }
   }
@@ -149,7 +152,7 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
   setRepaymentLoanDetails() {
     this.paymentTypes = this.dataObject.paymentTypeOptions;
     this.classificationOptions = this.dataObject.classificationOptions;
-    this.originalAmount = Number(this.dataObject.amount) || 0;
+    this.originalAmount = Number(this.dataObject.amount ?? this.dataObject.expectedAmount) || 0;
     if (this.repaymentLoanForm) {
       this.repaymentLoanForm.patchValue({
         transactionAmount: this.originalAmount
@@ -365,17 +368,29 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
     delete payload.skipInterestRefund;
 
     if (this.loanProductService.isWorkingCapital) {
-      if (payload['paymentTypeId'] === null) {
-        delete payload['paymentTypeId'];
-      } else {
-        if ('paymentDetails' in payload) {
-          payload['paymentDetails']['paymentTypeId'] = payload['paymentTypeId'];
-        } else {
-          payload['paymentDetails'] = {
-            paymentTypeId: payload['paymentTypeId']
-          };
+      if (payload['classificationId'] == null) {
+        delete payload['classificationId'];
+      }
+      // Working capital expects payment data nested in a paymentDetails object
+      const paymentDetails: any = 'paymentDetails' in payload ? payload['paymentDetails'] : {};
+      if (payload['paymentTypeId'] != null) {
+        paymentDetails['paymentTypeId'] = payload['paymentTypeId'];
+      }
+      delete payload['paymentTypeId'];
+      [
+        'accountNumber',
+        'checkNumber',
+        'routingCode',
+        'receiptNumber',
+        'bankNumber'
+      ].forEach((field: string) => {
+        if (payload[field]) {
+          paymentDetails[field] = payload[field];
         }
-        delete payload['paymentTypeId'];
+        delete payload[field];
+      });
+      if (Object.keys(paymentDetails).length > 0) {
+        payload['paymentDetails'] = paymentDetails;
       }
     }
 

--- a/src/app/loans/loans-view/loan-accounts-button-config.ts
+++ b/src/app/loans/loans-view/loan-accounts-button-config.ts
@@ -200,6 +200,11 @@ export class LoansAccountButtonConfiguration {
             taskPermissionName: 'REPAYMENT_LOAN'
           },
           {
+            name: 'Payout Refund',
+            icon: 'coins',
+            taskPermissionName: 'PAYOUTREFUND_WORKINGCAPITALLOAN'
+          },
+          {
             name: 'Undo Disbursal',
             icon: 'undo',
             taskPermissionName: 'DISBURSALUNDO_LOAN'
@@ -212,6 +217,20 @@ export class LoansAccountButtonConfiguration {
             name: 'Goodwill Credit',
             icon: 'coins',
             taskPermissionName: 'CREATE_GOODWILL_TRANSACTION'
+          },
+          {
+            name: 'Payout Refund',
+            icon: 'coins',
+            taskPermissionName: 'PAYOUTREFUND_WORKINGCAPITALLOAN'
+          }
+        ];
+        break;
+      case 'Overpaid':
+        this.buttonsArray = [
+          {
+            name: 'Payout Refund',
+            icon: 'coins',
+            taskPermissionName: 'PAYOUTREFUND_WORKINGCAPITALLOAN'
           }
         ];
         break;

--- a/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.html
+++ b/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.html
@@ -302,7 +302,7 @@
       </table>
     </div>
   }
-  @if (wcLoanDelinquencyRangeSchedule.length > 0) {
+  @if (wcLoanDelinquencyRangeSchedule?.length > 0) {
     <div class="m-t-10">
       <h3>{{ 'labels.heading.Loan Delinquency Range Schedule' | translate }}</h3>
       <table mat-table [dataSource]="wcLoanDelinquencyRangeSchedule">

--- a/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.ts
+++ b/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.ts
@@ -285,7 +285,7 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
           if (loanDelinquencyDataResponse?.product) {
             this.loanProductId = loanDelinquencyDataResponse.product.id;
           }
-          this.wcLoanDelinquencyRangeSchedule = data.wcLoanDelinquencyRangeSchedule;
+          this.wcLoanDelinquencyRangeSchedule = data.wcLoanDelinquencyRangeSchedule || [];
           this.cdr.markForCheck();
         }
       );

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -370,20 +370,6 @@
               {{ 'labels.inputs.Breach Schedule' | translate }}
             </a>
           }
-          @if (loanDetailsData.breach || loanDetailsData.nearBreach) {
-            <a
-              mat-tab-link
-              [routerLink]="['./breach-actions']"
-              [queryParams]="{
-                productType: loanProductService.productType.value
-              }"
-              routerLinkActive
-              #breachActions="routerLinkActive"
-              [active]="breachActions.isActive"
-            >
-              {{ 'labels.inputs.Breach Actions' | translate }}
-            </a>
-          }
         }
         @if (loanProductService.isWorkingCapital || loanDetailsData.transactions?.length) {
           <a

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
@@ -295,34 +295,30 @@ export class ViewTransactionComponent extends LoanAccountActionsBaseComponent im
         if (response.confirm) {
           const locale = this.settingsService.language.code;
           const dateFormat = this.settingsService.dateFormat;
-          const command = this.isWriteOff(this.transactionType) ? 'undowriteoff' : 'undo';
-          const navigateBack = () =>
+          const data = this.loanProductService.isLoanProduct
+            ? {
+                transactionDate: this.dateUtils.formatDate(
+                  this.transactionData.date && new Date(this.transactionData.date),
+                  dateFormat
+                ),
+                transactionAmount: 0,
+                dateFormat,
+                locale
+              }
+            : {};
+          const command = this.transactionType && this.isWriteOff(this.transactionType) ? 'undowriteoff' : 'undo';
+          const transactionId = command === 'undowriteoff' ? null : this.transactionData.id;
+          const undoRequest = this.loanProductService.isWorkingCapital
+            ? this.loansService.applyWorkingCapitalLoanActionCommand(accountId, data, command, transactionId)
+            : this.loansService.executeLoansAccountTransactionsCommand(accountId, command, data, transactionId);
+          undoRequest.subscribe(() => {
             this.router.navigate(['../'], {
               queryParams: {
                 productType: this.loanProductService.productType.value
               },
               relativeTo: this.route
             });
-          if (this.isWorkingCapital) {
-            const payload = { dateFormat, locale };
-            this.loansService
-              .applyWorkingCapitalLoanActionCommand(accountId, payload, command, this.transactionData.id)
-              .subscribe(navigateBack);
-          } else {
-            const data = {
-              transactionDate: this.dateUtils.formatDate(
-                this.transactionData.date && new Date(this.transactionData.date),
-                dateFormat
-              ),
-              transactionAmount: 0,
-              dateFormat,
-              locale
-            };
-            const transactionId = command === 'undowriteoff' ? null : this.transactionData.id;
-            this.loansService
-              .executeLoansAccountTransactionsCommand(accountId, command, data, transactionId)
-              .subscribe(navigateBack);
-          }
+          });
         }
       });
     }

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.html
@@ -193,7 +193,7 @@
                   <span class="date-cell">{{ row.startDateObj | dateFormat }}</span>
                 </td>
                 <td>
-                  @if (row.action !== 'RESUME') {
+                  @if (row.hasEndDate) {
                     @if (row.endDateObj) {
                       <span class="date-cell">{{ row.endDateObj | dateFormat }}</span>
                     } @else {

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.ts
@@ -49,6 +49,8 @@ interface BreachActionRow {
   endDate: number[];
   startDateObj: Date;
   endDateObj: Date | null;
+  /** Whether the action type defines an end date at all (RESUME and RESCHEDULE do not) */
+  hasEndDate: boolean;
   status: BreachActionStatus;
   statusLabelKey: string;
   isOngoing: boolean;
@@ -133,11 +135,16 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
     const businessDate = this.settingsService.businessDate;
     return this.breachActions().map((item, index) => {
       const isResumeAction = item.action === 'RESUME';
+      const isRescheduleAction = item.action === 'RESCHEDULE';
       const isResumedPause = item.action === 'PAUSE' && !!item.effectiveEndDate;
       const start = this.dateUtils.parseDate(item.startDate);
       const end = isResumeAction ? null : this.dateUtils.parseDate(item.effectiveEndDate ?? item.endDate);
       const reference = end ?? businessDate;
-      const durationDays = Math.max(1, Math.round((reference.getTime() - start.getTime()) / MS_PER_DAY));
+      // Both boundary dates count: a pause from Jul 1st to Jul 16th lasts 16 days, not 15.
+      // A pause closed by a RESUME is the exception: the loan is already active on the resume
+      // date, so that day is not a paused day and must not be added.
+      const elapsedDays = Math.round((reference.getTime() - start.getTime()) / MS_PER_DAY);
+      const durationDays = Math.max(1, isResumedPause ? elapsedDays : elapsedDays + 1);
 
       let status: BreachActionStatus;
       if (isResumeAction) {
@@ -159,6 +166,7 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
         endDate: item.endDate,
         startDateObj: start,
         endDateObj: end,
+        hasEndDate: !isResumeAction && !isRescheduleAction,
         status,
         statusLabelKey: this.statusKey(status),
         isOngoing: !end && status === 'active',

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -670,6 +670,16 @@ export class LoansService {
     return this.http.get(`/working-capital-loans/${loanId}/template`, { params: httpParams });
   }
 
+  getWorkingCapitalLoanPayoutTemplate(loanId: string, actionName: string): Observable<any> {
+    const httpParams = new HttpParams().set('templateType', actionName);
+    return this.http.get(`/workingcapitalloans/${loanId}/template`, { params: httpParams });
+  }
+
+  getWorkingCapitalLoanTransactionTemplate(loanId: string, actionName: string): Observable<any> {
+    const httpParams = new HttpParams().set('command', actionName);
+    return this.http.get(`/working-capital-loans/${loanId}/transactions/template`, { params: httpParams });
+  }
+
   guarantorAccountResource(loanId: string, clientId: any): Observable<any> {
     const httpParams = new HttpParams().set('clientId', clientId);
     return this.http.get(`/loans/${loanId}/guarantors/accounts/template`, { params: httpParams });

--- a/src/app/products/manage-delinquency-buckets/delinquency-bucket/create-bucket/create-bucket.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-bucket/create-bucket/create-bucket.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
@@ -65,6 +65,7 @@ export class CreateBucketComponent extends DelinquencyBucketBaseComponent implem
   private router = inject(Router);
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private changeDetectorRef = inject(ChangeDetectorRef);
 
   /** Delinquency Bucket form. */
   bucketForm: UntypedFormGroup;
@@ -183,9 +184,11 @@ export class CreateBucketComponent extends DelinquencyBucketBaseComponent implem
     };
     const rangeDialogRef = this.dialog.open(FormDialogComponent, { data });
     rangeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         this.rangesDataSource = this.rangesDataSource.concat(response.data.value);
         this.delinquencyRangesIds.push(response.data.value.rangeId);
+        // The dialog close event does not mark this OnPush view as dirty
+        this.changeDetectorRef.markForCheck();
       }
     });
   }
@@ -198,10 +201,12 @@ export class CreateBucketComponent extends DelinquencyBucketBaseComponent implem
       data: { deleteContext: this.translateService.instant('labels.text.this') }
     });
     dialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.delinquencyRangesIds.splice(index, 1);
         this.rangesDataSource.splice(index, 1);
         this.rangesDataSource = this.rangesDataSource.concat([]);
+        // The dialog close event does not mark this OnPush view as dirty
+        this.changeDetectorRef.markForCheck();
       }
     });
   }

--- a/src/app/products/manage-delinquency-buckets/delinquency-bucket/edit-bucket/edit-bucket.component.ts
+++ b/src/app/products/manage-delinquency-buckets/delinquency-bucket/edit-bucket/edit-bucket.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { MatDialog } from '@angular/material/dialog';
 import { Router } from '@angular/router';
@@ -65,6 +65,7 @@ export class EditBucketComponent extends DelinquencyBucketBaseComponent implemen
   private router = inject(Router);
   dialog = inject(MatDialog);
   private translateService = inject(TranslateService);
+  private changeDetectorRef = inject(ChangeDetectorRef);
 
   /** Delinquency Bucket form. */
   bucketForm: UntypedFormGroup;
@@ -197,7 +198,7 @@ export class EditBucketComponent extends DelinquencyBucketBaseComponent implemen
     };
     const rangeDialogRef = this.dialog.open(FormDialogComponent, { data });
     rangeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const itemSelected = response.data.value;
         const item = this.delinquencyRangesData.filter((range: any) => {
           return range.id === itemSelected.rangeId;
@@ -205,6 +206,8 @@ export class EditBucketComponent extends DelinquencyBucketBaseComponent implemen
         this.rangesDataSource = this.rangesDataSource.concat(item);
         this.delinquencyRangesIds.push(item.id);
         this.dataWasChanged = true;
+        // The dialog close event does not mark this OnPush view as dirty
+        this.changeDetectorRef.markForCheck();
       }
     });
   }
@@ -217,11 +220,13 @@ export class EditBucketComponent extends DelinquencyBucketBaseComponent implemen
       data: { deleteContext: this.translateService.instant('labels.text.this') }
     });
     dialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.delinquencyRangesIds.splice(index, 1);
         this.rangesDataSource.splice(index, 1);
         this.rangesDataSource = this.rangesDataSource.concat([]);
         this.dataWasChanged = true;
+        // The dialog close event does not mark this OnPush view as dirty
+        this.changeDetectorRef.markForCheck();
       }
     });
   }


### PR DESCRIPTION
## Description

User should be able to add a Payout refund transaction on active and closed loan accounts

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots, if any

https://github.com/user-attachments/assets/df00f4bd-7ee5-462d-b877-e491296ef060


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added “Payout Refund” actions for eligible working-capital loan accounts.
* Added working-capital transaction handling for payout refunds and repayments.
* Enhanced repayment forms with classification options and organized payment details.

## Bug Fixes

* Corrected refund templates, permissions, and repayment amount handling for working-capital products.
* Improved transaction undo behavior across loan product types.
* Removed the working-capital breach-actions tab where it was no longer applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->