### PR TITLE
WEB-657: Fix wc loan undo command

### DIFF
--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
@@ -434,28 +434,29 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;
     const loanId = this.route.parent.parent.snapshot.params['loanId'];
+    const isLoanProduct = this.loanProductService.isLoanProduct;
     let command = 'undo';
     let operationDate = this.dateUtils.parseDate(transaction.date);
-    let payload = {};
+    let payload: any = {};
+    // Working capital loan undo only accepts locale/dateFormat/note/reversalExternalId;
+    // transactionDate/transactionAmount are required only by the generic loan adjust endpoint.
+    const undoPayload = isLoanProduct
+      ? {
+          transactionDate: this.dateUtils.formatDate(operationDate && new Date(operationDate), dateFormat),
+          transactionAmount: 0,
+          dateFormat,
+          locale
+        }
+      : { dateFormat, locale };
     if (this.isChargeOff(transaction.type)) {
       command = 'undo-charge-off';
       operationDate = this.settingsService.businessDate;
       payload = {};
     } else if (this.isWriteOff(transaction.type)) {
       command = 'undowriteoff';
-      payload = {
-        transactionDate: this.dateUtils.formatDate(operationDate && new Date(operationDate), dateFormat),
-        transactionAmount: 0,
-        dateFormat,
-        locale
-      };
+      payload = undoPayload;
     } else {
-      payload = {
-        transactionDate: this.dateUtils.formatDate(operationDate && new Date(operationDate), dateFormat),
-        transactionAmount: 0,
-        dateFormat,
-        locale
-      };
+      payload = undoPayload;
     }
 
     const undoTransactionAccountDialogRef = this.dialog.open(ConfirmationDialogComponent, {

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
@@ -170,6 +170,10 @@ export class ViewTransactionComponent extends LoanAccountActionsBaseComponent im
       ) {
         this.allowUndo = false;
       }
+      if (this.isWorkingCapital) {
+        this.allowEdition = false;
+        this.allowChargeback = false;
+      }
     });
     this.clientId = this.route.snapshot.params['clientId'];
     this.loanId = this.route.snapshot.params['loanId'];
@@ -291,27 +295,34 @@ export class ViewTransactionComponent extends LoanAccountActionsBaseComponent im
         if (response.confirm) {
           const locale = this.settingsService.language.code;
           const dateFormat = this.settingsService.dateFormat;
-          const data = {
-            transactionDate: this.dateUtils.formatDate(
-              this.transactionData.date && new Date(this.transactionData.date),
-              dateFormat
-            ),
-            transactionAmount: 0,
-            dateFormat,
-            locale
-          };
           const command = this.isWriteOff(this.transactionType) ? 'undowriteoff' : 'undo';
-          const transactionId = command === 'undowriteoff' ? null : this.transactionData.id;
-          this.loansService
-            .executeLoansAccountTransactionsCommand(accountId, command, data, transactionId)
-            .subscribe(() => {
-              this.router.navigate(['../'], {
-                queryParams: {
-                  productType: this.loanProductService.productType.value
-                },
-                relativeTo: this.route
-              });
+          const navigateBack = () =>
+            this.router.navigate(['../'], {
+              queryParams: {
+                productType: this.loanProductService.productType.value
+              },
+              relativeTo: this.route
             });
+          if (this.isWorkingCapital) {
+            const payload = { dateFormat, locale };
+            this.loansService
+              .applyWorkingCapitalLoanActionCommand(accountId, payload, command, this.transactionData.id)
+              .subscribe(navigateBack);
+          } else {
+            const data = {
+              transactionDate: this.dateUtils.formatDate(
+                this.transactionData.date && new Date(this.transactionData.date),
+                dateFormat
+              ),
+              transactionAmount: 0,
+              dateFormat,
+              locale
+            };
+            const transactionId = command === 'undowriteoff' ? null : this.transactionData.id;
+            this.loansService
+              .executeLoansAccountTransactionsCommand(accountId, command, data, transactionId)
+              .subscribe(navigateBack);
+          }
         }
       });
     }


### PR DESCRIPTION
## Description

Currently the transaction reversal is broken for Working Capital loans. 

- If a user tries to revert a transaction from the 3 dot menu on the transactions table, the UI application sends `transactionDate` and `transactionAmount` unsupported parameters as well. 

- If a user clicks on the transaction to go to the details screen and tries to undo the transaction through that button the request is sent to the generic adjustLoanTransaction endpoint, which does not support Working Capital loans. 

In case of working capital loan products the unsupported parameters aren't being sent, the undo button on the details view calls the right endpoint and the other two buttons are disabled, as WC loans currently don't permit editing a transaction and chargebacks. These can be enabled later as desired.

## Related issues and discussion

#{WEB-657}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction undo and write-off handling for working-capital accounts.
  - Prevented unsupported editing and chargeback actions for working-capital transactions.
  - Ensured transaction dates, amounts, locale, and date formats are applied correctly when reversing transactions.
  - Improved navigation after completing undo, write-off, and charge-off actions.
  - Preserved confirmation prompts before transactions are reversed.
  - Applied the correct transaction identifiers when processing write-offs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->