### PR TITLE
feat(WEB-1048): add office working hours management UI

### DIFF
--- a/src/app/organization/offices/view-office/schedules-tab/schedules-tab.component.html
+++ b/src/app/organization/offices/view-office/schedules-tab/schedules-tab.component.html
@@ -1,0 +1,112 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<div class="tab-container mat-typography">
+  <div class="layout-row align-start">
+    <div class="m-b-10">
+      <h3>{{ 'labels.heading.Schedules' | translate }}</h3>
+    </div>
+  </div>
+
+  @if (isLoading) {
+    <div class="schedule-state">
+      <mat-spinner diameter="36"></mat-spinner>
+      <span>{{ 'labels.text.Loading data' | translate }}</span>
+    </div>
+  }
+
+  @if (isPluginUnavailable && !isLoading) {
+    <div class="schedule-state unavailable-state">
+      <span>{{
+        'labels.text.Office Schedules management requires the Savings Plugin to be deployed' | translate
+      }}</span>
+    </div>
+  }
+
+  @if (hasError && !isLoading && !isPluginUnavailable) {
+    <div class="schedule-state error-state">
+      <span>{{ 'errors.generic.unexpectedRetry' | translate }}</span>
+      <button mat-button color="primary" (click)="loadOfficeSchedules()">
+        {{ 'labels.buttons.Retry' | translate }}
+      </button>
+    </div>
+  }
+
+  @if (saveError && !isLoading && !isPluginUnavailable) {
+    <div class="schedule-state error-state compact-state">
+      <span>{{ 'errors.generic.unexpectedRetry' | translate }}</span>
+    </div>
+  }
+
+  @if (!isLoading && !hasError && !isPluginUnavailable) {
+    <form [formGroup]="schedulesForm" (ngSubmit)="submit()">
+      <div class="schedule-table" formArrayName="days">
+        <div class="schedule-header">
+          <span class="day-column">{{ 'labels.inputs.Day' | translate }}</span>
+          <span class="enabled-column">{{ 'labels.inputs.Enabled' | translate }}</span>
+          <span class="time-column">{{ 'labels.inputs.Opening Time' | translate }}</span>
+          <span class="time-column">{{ 'labels.inputs.Closing Time' | translate }}</span>
+        </div>
+
+        @for (dayControl of days.controls; track dayControl.get('weekday')?.value) {
+          <div class="schedule-row" [formGroupName]="$index">
+            <div class="weekday-label day-column">
+              {{ getWeekdayLabelKey(dayControl) | translate }}
+            </div>
+            <mat-checkbox
+              class="enabled-column"
+              formControlName="enabled"
+              (change)="setDayEnabled(dayControl, $event.checked)"
+              [attr.aria-label]="'labels.inputs.Enabled' | translate"
+            ></mat-checkbox>
+            <mat-form-field appearance="outline" class="time-column">
+              <mat-label>{{ 'labels.inputs.Opening Time' | translate }}</mat-label>
+              <input
+                matInput
+                type="time"
+                formControlName="openingTime"
+                [readonly]="isSaving"
+                (input)="refreshClosingTime(dayControl)"
+              />
+              @if (hasTimeRequiredError(dayControl, 'openingTime')) {
+                <mat-error>{{
+                  'errors.validation.requiredField' | translate: { label: ('labels.inputs.Opening Time' | translate) }
+                }}</mat-error>
+              }
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="time-column">
+              <mat-label>{{ 'labels.inputs.Closing Time' | translate }}</mat-label>
+              <input matInput type="time" formControlName="closingTime" [readonly]="isSaving" />
+              @if (hasTimeRequiredError(dayControl, 'closingTime')) {
+                <mat-error>{{
+                  'errors.validation.requiredField' | translate: { label: ('labels.inputs.Closing Time' | translate) }
+                }}</mat-error>
+              }
+              @if (hasTimeOrderError(dayControl)) {
+                <mat-error>{{ 'errors.validation.openingTimeBeforeClosingTime' | translate }}</mat-error>
+              }
+            </mat-form-field>
+          </div>
+        }
+      </div>
+
+      <div class="schedule-actions">
+        <button
+          mat-raised-button
+          color="primary"
+          type="submit"
+          [disabled]="schedulesForm.invalid || isSaving"
+          *mifosxHasPermission="'UPDATE_OFFICE'"
+        >
+          <fa-icon icon="save" class="m-r-10"></fa-icon>
+          {{ 'labels.buttons.Save Changes' | translate }}
+        </button>
+      </div>
+    </form>
+  }
+</div>

--- a/src/app/organization/offices/view-office/schedules-tab/schedules-tab.component.scss
+++ b/src/app/organization/offices/view-office/schedules-tab/schedules-tab.component.scss
@@ -1,0 +1,106 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+
+  .schedule-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    min-height: 120px;
+    text-align: center;
+  }
+
+  .compact-state {
+    min-height: 40px;
+    justify-content: flex-start;
+  }
+
+  .error-state {
+    color: var(--warn-color, #b00020);
+  }
+
+  .unavailable-state {
+    color: rgb(78 78 78);
+  }
+
+  .schedule-table {
+    display: grid;
+    gap: 8px;
+  }
+
+  .schedule-header,
+  .schedule-row {
+    display: grid;
+    grid-template-columns: minmax(96px, 26%) 76px minmax(0, calc(37% - 53px)) minmax(0, calc(37% - 53px));
+    align-items: center;
+    column-gap: 10px;
+  }
+
+  .schedule-header {
+    min-height: 36px;
+    font-weight: 500;
+    color: rgb(0 0 0 / 60%);
+  }
+
+  .schedule-row {
+    min-height: 72px;
+  }
+
+  .weekday-label {
+    font-weight: 500;
+  }
+
+  .schedule-header span,
+  .weekday-label {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .enabled-column {
+    justify-self: center;
+  }
+
+  .time-column {
+    min-width: 0;
+  }
+
+  .schedule-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 16px;
+  }
+
+  mat-form-field {
+    width: 100%;
+  }
+
+  @media (width <= 720px) {
+    .schedule-header,
+    .schedule-row {
+      grid-template-columns: minmax(96px, calc(100% - 74px)) 64px;
+      row-gap: 8px;
+      padding: 8px 0;
+    }
+
+    .schedule-row {
+      border-bottom: 1px solid rgb(0 0 0 / 12%);
+    }
+
+    .schedule-header .time-column {
+      display: none;
+    }
+
+    .schedule-row .time-column {
+      grid-column: 1 / -1;
+    }
+  }
+}

--- a/src/app/organization/offices/view-office/schedules-tab/schedules-tab.component.spec.ts
+++ b/src/app/organization/offices/view-office/schedules-tab/schedules-tab.component.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faSave } from '@fortawesome/free-solid-svg-icons';
+import { of, throwError } from 'rxjs';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+import { SchedulesTabComponent } from './schedules-tab.component';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { OrganizationService } from 'app/organization/organization.service';
+
+describe('Office SchedulesTabComponent', () => {
+  let component: SchedulesTabComponent;
+  let fixture: ComponentFixture<SchedulesTabComponent>;
+  let organizationService: jest.Mocked<OrganizationService>;
+
+  const officeSchedule = {
+    days: [
+      {
+        weekday: 'MONDAY',
+        enabled: true,
+        openingTime: '09:00',
+        closingTime: '17:00'
+      },
+      {
+        weekday: 'TUESDAY',
+        enabled: false
+      }
+    ]
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    organizationService = {
+      getOfficeSchedules: jest.fn(() => of(officeSchedule)),
+      updateOfficeSchedules: jest.fn(() => of({ resourceId: 1 }))
+    } as unknown as jest.Mocked<OrganizationService>;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        SchedulesTabComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            parent: {
+              snapshot: {
+                paramMap: {
+                  get: jest.fn(() => '1')
+                }
+              }
+            }
+          }
+        },
+        { provide: OrganizationService, useValue: organizationService },
+        { provide: AuthenticationService, useValue: { getCredentials: () => ({ permissions: ['UPDATE_OFFICE'] }) } },
+        provideNoopAnimations()
+      ]
+    }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIcons(faSave);
+    fixture = TestBed.createComponent(SchedulesTabComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('loads office schedules into weekday rows', () => {
+    fixture.detectChanges();
+
+    expect(organizationService.getOfficeSchedules).toHaveBeenCalledWith('1');
+    expect(component.days.length).toBe(7);
+    expect(component.days.at(0).getRawValue()).toEqual({
+      weekday: 'MONDAY',
+      weekdayLabelKey: 'labels.inputs.Monday',
+      enabled: true,
+      openingTime: '09:00',
+      closingTime: '17:00'
+    });
+    expect(component.days.at(1).get('openingTime').disabled).toBe(true);
+    expect(component.isLoading).toBe(false);
+    expect(fixture.nativeElement.textContent).toContain('Monday');
+  });
+
+  it('initializes seven disabled weekdays when the backend returns an empty schedule', () => {
+    organizationService.getOfficeSchedules.mockReturnValue(of({ days: [] }));
+
+    fixture.detectChanges();
+
+    expect(component.days.length).toBe(7);
+    expect(component.days.getRawValue().every((day: any) => day.enabled === false)).toBe(true);
+    expect(component.days.controls.every((day) => day.get('openingTime').disabled)).toBe(true);
+    expect(component.getSchedulePayload()).toEqual({
+      days: [
+        { weekday: 'MONDAY', enabled: false },
+        { weekday: 'TUESDAY', enabled: false },
+        { weekday: 'WEDNESDAY', enabled: false },
+        { weekday: 'THURSDAY', enabled: false },
+        { weekday: 'FRIDAY', enabled: false },
+        { weekday: 'SATURDAY', enabled: false },
+        { weekday: 'SUNDAY', enabled: false }
+      ]
+    });
+  });
+
+  it('submits the complete weekly schedule payload', () => {
+    organizationService.getOfficeSchedules.mockReturnValue(of({ days: [] }));
+    fixture.detectChanges();
+
+    const monday = component.days.at(0);
+    monday.get('enabled').setValue(true);
+    component.setDayEnabled(monday, true);
+    monday.patchValue({
+      openingTime: '08:30',
+      closingTime: '16:30'
+    });
+
+    component.submit();
+
+    expect(organizationService.updateOfficeSchedules).toHaveBeenCalledWith('1', {
+      days: [
+        {
+          weekday: 'MONDAY',
+          enabled: true,
+          openingTime: '08:30',
+          closingTime: '16:30'
+        },
+        { weekday: 'TUESDAY', enabled: false },
+        { weekday: 'WEDNESDAY', enabled: false },
+        { weekday: 'THURSDAY', enabled: false },
+        { weekday: 'FRIDAY', enabled: false },
+        { weekday: 'SATURDAY', enabled: false },
+        { weekday: 'SUNDAY', enabled: false }
+      ]
+    });
+  });
+
+  it('prevents invalid submissions when opening time is not before closing time', () => {
+    organizationService.getOfficeSchedules.mockReturnValue(of({ days: [] }));
+    fixture.detectChanges();
+
+    const monday = component.days.at(0);
+    monday.get('enabled').setValue(true);
+    component.setDayEnabled(monday, true);
+    monday.patchValue({
+      openingTime: '17:00',
+      closingTime: '09:00'
+    });
+
+    component.submit();
+
+    expect(monday.get('closingTime').hasError('timeOrder')).toBe(true);
+    expect(organizationService.updateOfficeSchedules).not.toHaveBeenCalled();
+  });
+
+  it('requires both times for enabled days', () => {
+    organizationService.getOfficeSchedules.mockReturnValue(of({ days: [] }));
+    fixture.detectChanges();
+
+    const monday = component.days.at(0);
+    monday.get('enabled').setValue(true);
+    component.setDayEnabled(monday, true);
+    monday.patchValue({
+      openingTime: '09:00',
+      closingTime: ''
+    });
+
+    component.submit();
+
+    expect(monday.get('closingTime').hasError('required')).toBe(true);
+    expect(organizationService.updateOfficeSchedules).not.toHaveBeenCalled();
+  });
+
+  it('disables and clears time controls when a day is unchecked', () => {
+    fixture.detectChanges();
+
+    const monday = component.days.at(0);
+    monday.get('enabled').setValue(false);
+    component.setDayEnabled(monday, false);
+
+    expect(monday.get('openingTime').disabled).toBe(true);
+    expect(monday.get('closingTime').disabled).toBe(true);
+    expect(monday.getRawValue()).toEqual({
+      weekday: 'MONDAY',
+      weekdayLabelKey: 'labels.inputs.Monday',
+      enabled: false,
+      openingTime: '',
+      closingTime: ''
+    });
+    expect(monday.valid).toBe(true);
+  });
+
+  it('shows plugin unavailable state when the office schedules endpoint is not registered', () => {
+    organizationService.getOfficeSchedules.mockReturnValue(
+      throwError(() => ({
+        status: 404,
+        error: {
+          error: 'Not Found'
+        }
+      }))
+    );
+
+    fixture.detectChanges();
+
+    expect(component.isPluginUnavailable).toBe(true);
+    expect(component.hasError).toBe(false);
+    expect(component.days.length).toBe(7);
+    expect(fixture.nativeElement.textContent).toContain(
+      'labels.text.Office Schedules management requires the Savings Plugin to be deployed'
+    );
+  });
+});

--- a/src/app/organization/offices/view-office/schedules-tab/schedules-tab.component.ts
+++ b/src/app/organization/offices/view-office/schedules-tab/schedules-tab.component.ts
@@ -1,0 +1,319 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  AbstractControl,
+  UntypedFormArray,
+  UntypedFormBuilder,
+  UntypedFormGroup,
+  ValidationErrors,
+  ValidatorFn,
+  Validators
+} from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+
+/** Angular Material Imports */
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+
+/** rxjs Imports */
+import { of } from 'rxjs';
+import { catchError, finalize } from 'rxjs/operators';
+
+/** Custom Components */
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+
+/** Custom Services */
+import { OrganizationService } from 'app/organization/organization.service';
+
+/** Custom Imports */
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+interface OfficeScheduleDay {
+  weekday: string;
+  enabled: boolean;
+  openingTime?: string | null;
+  closingTime?: string | null;
+}
+
+interface OfficeScheduleWeekday extends OfficeScheduleDay {
+  labelKey: string;
+}
+
+@Component({
+  selector: 'mifosx-office-schedules-tab',
+  templateUrl: './schedules-tab.component.html',
+  styleUrls: ['./schedules-tab.component.scss'],
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    FaIconComponent,
+    MatProgressSpinner
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SchedulesTabComponent implements OnInit {
+  private route = inject(ActivatedRoute);
+  private formBuilder = inject(UntypedFormBuilder);
+  private organizationService = inject(OrganizationService);
+  private changeDetectorRef = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
+
+  readonly weekdays: OfficeScheduleWeekday[] = [
+    { weekday: 'MONDAY', labelKey: 'labels.inputs.Monday', enabled: false },
+    { weekday: 'TUESDAY', labelKey: 'labels.inputs.Tuesday', enabled: false },
+    { weekday: 'WEDNESDAY', labelKey: 'labels.inputs.Wednesday', enabled: false },
+    { weekday: 'THURSDAY', labelKey: 'labels.inputs.Thursday', enabled: false },
+    { weekday: 'FRIDAY', labelKey: 'labels.inputs.Friday', enabled: false },
+    { weekday: 'SATURDAY', labelKey: 'labels.inputs.Saturday', enabled: false },
+    { weekday: 'SUNDAY', labelKey: 'labels.inputs.Sunday', enabled: false }
+  ];
+
+  officeId: string;
+  schedulesForm = this.formBuilder.group({
+    days: this.formBuilder.array([])
+  });
+  isLoading = true;
+  isSaving = false;
+  hasError = false;
+  saveError = false;
+  isPluginUnavailable = false;
+
+  get days(): UntypedFormArray {
+    return this.schedulesForm.get('days') as UntypedFormArray;
+  }
+
+  ngOnInit() {
+    this.officeId = this.route.parent.snapshot.paramMap.get('officeId') ?? '';
+    this.loadOfficeSchedules();
+  }
+
+  loadOfficeSchedules() {
+    this.isLoading = true;
+    this.hasError = false;
+    this.saveError = false;
+    this.isPluginUnavailable = false;
+
+    this.organizationService
+      .getOfficeSchedules(this.officeId)
+      .pipe(
+        catchError((error) => {
+          if (this.isEndpointNotFound(error)) {
+            this.isPluginUnavailable = true;
+          } else {
+            this.hasError = true;
+          }
+          return of({ days: [] });
+        }),
+        finalize(() => {
+          this.isLoading = false;
+          this.changeDetectorRef.markForCheck();
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((schedule: any) => {
+        this.setScheduleDays(this.normalizeScheduleResponse(schedule));
+      });
+  }
+
+  submit() {
+    if (this.isPluginUnavailable || this.isLoading || this.isSaving) {
+      return;
+    }
+
+    this.schedulesForm.markAllAsTouched();
+    if (this.schedulesForm.invalid) {
+      return;
+    }
+
+    this.isSaving = true;
+    this.hasError = false;
+    this.saveError = false;
+    this.isPluginUnavailable = false;
+
+    this.organizationService
+      .updateOfficeSchedules(this.officeId, this.getSchedulePayload())
+      .pipe(
+        finalize(() => {
+          this.isSaving = false;
+          this.changeDetectorRef.markForCheck();
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe({
+        next: () => this.loadOfficeSchedules(),
+        error: (error: any) => {
+          if (this.isEndpointNotFound(error)) {
+            this.isPluginUnavailable = true;
+          } else {
+            this.saveError = true;
+          }
+          this.changeDetectorRef.markForCheck();
+        }
+      });
+  }
+
+  setDayEnabled(dayControl: AbstractControl, enabled: boolean) {
+    const openingTime = dayControl.get('openingTime');
+    const closingTime = dayControl.get('closingTime');
+
+    if (enabled) {
+      openingTime?.enable();
+      closingTime?.enable();
+    } else {
+      openingTime?.reset('');
+      closingTime?.reset('');
+      openingTime?.disable();
+      closingTime?.disable();
+    }
+
+    this.updateTimeValidators(dayControl);
+    dayControl.updateValueAndValidity();
+    this.changeDetectorRef.markForCheck();
+  }
+
+  getSchedulePayload() {
+    return {
+      days: this.days.getRawValue().map((day: OfficeScheduleDay) => {
+        const scheduleDay: OfficeScheduleDay = {
+          weekday: day.weekday,
+          enabled: !!day.enabled
+        };
+
+        if (scheduleDay.enabled) {
+          scheduleDay.openingTime = day.openingTime;
+          scheduleDay.closingTime = day.closingTime;
+        }
+
+        return scheduleDay;
+      })
+    };
+  }
+
+  getWeekdayLabelKey(dayControl: AbstractControl): string {
+    return dayControl.get('weekdayLabelKey')?.value ?? '';
+  }
+
+  hasTimeRequiredError(dayControl: AbstractControl, controlName: string): boolean {
+    const timeControl = dayControl.get(controlName);
+    return !!timeControl?.hasError('required') && (timeControl.touched || timeControl.dirty);
+  }
+
+  hasTimeOrderError(dayControl: AbstractControl): boolean {
+    const closingTime = dayControl.get('closingTime');
+    return !!closingTime?.hasError('timeOrder') && (closingTime.touched || closingTime.dirty);
+  }
+
+  refreshClosingTime(dayControl: AbstractControl) {
+    dayControl.get('closingTime')?.updateValueAndValidity();
+    dayControl.updateValueAndValidity();
+  }
+
+  private setScheduleDays(scheduleDays: OfficeScheduleDay[]) {
+    this.days.clear();
+    this.mergeWeekdays(scheduleDays).forEach((day) => this.days.push(this.createDayForm(day)));
+  }
+
+  private createDayForm(day: OfficeScheduleDay): UntypedFormGroup {
+    const scheduleDay = day as OfficeScheduleWeekday;
+    const dayGroup = this.formBuilder.group(
+      {
+        weekday: [day.weekday],
+        weekdayLabelKey: [scheduleDay.labelKey ?? this.getWeekdayLabelKeyFromValue(day.weekday)],
+        enabled: [!!day.enabled],
+        openingTime: [{ value: day.openingTime ?? '', disabled: !day.enabled }],
+        closingTime: [{ value: day.closingTime ?? '', disabled: !day.enabled }]
+      },
+      { validators: this.scheduleDayValidator() }
+    );
+
+    this.updateTimeValidators(dayGroup);
+    return dayGroup;
+  }
+
+  private normalizeScheduleResponse(schedule: any): OfficeScheduleDay[] {
+    const days = Array.isArray(schedule) ? schedule : schedule?.days;
+    return Array.isArray(days) ? days : [];
+  }
+
+  private mergeWeekdays(scheduleDays: OfficeScheduleDay[]): OfficeScheduleWeekday[] {
+    return this.weekdays.map((weekday) => {
+      const scheduleDay = scheduleDays.find((day) => this.normalizeWeekday(day?.weekday) === weekday.weekday);
+
+      return {
+        weekday: weekday.weekday,
+        labelKey: weekday.labelKey,
+        enabled: !!scheduleDay?.enabled,
+        openingTime: scheduleDay?.openingTime ?? '',
+        closingTime: scheduleDay?.closingTime ?? ''
+      };
+    });
+  }
+
+  private getWeekdayLabelKeyFromValue(weekday: string): string {
+    return this.weekdays.find((day) => day.weekday === this.normalizeWeekday(weekday))?.labelKey ?? '';
+  }
+
+  private normalizeWeekday(weekday: string): string {
+    return weekday?.replace('labels.inputs.', '').toUpperCase();
+  }
+
+  private scheduleDayValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const enabled = !!control.get('enabled')?.value;
+      const openingTime = control.get('openingTime')?.value;
+      const closingTime = control.get('closingTime')?.value;
+
+      if (!enabled) {
+        return null;
+      }
+
+      if (!openingTime || !closingTime) {
+        return { timesRequired: true };
+      }
+
+      return openingTime < closingTime ? null : { timeOrder: true };
+    };
+  }
+
+  private updateTimeValidators(dayControl: AbstractControl) {
+    const enabled = !!dayControl.get('enabled')?.value;
+    const openingTime = dayControl.get('openingTime');
+    const closingTime = dayControl.get('closingTime');
+
+    openingTime?.setValidators(enabled ? [Validators.required] : []);
+    closingTime?.setValidators(
+      enabled ? [
+            Validators.required,
+            this.closingAfterOpeningValidator()
+          ] : []
+    );
+    openingTime?.updateValueAndValidity({ emitEvent: false });
+    closingTime?.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private closingAfterOpeningValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const dayControl = control.parent;
+      const enabled = !!dayControl?.get('enabled')?.value;
+      const openingTime = dayControl?.get('openingTime')?.value;
+      const closingTime = control.value;
+
+      if (!enabled || !openingTime || !closingTime) {
+        return null;
+      }
+
+      return openingTime < closingTime ? null : { timeOrder: true };
+    };
+  }
+
+  private isEndpointNotFound(error: any): boolean {
+    return error?.status === 404 && error?.error?.error === 'Not Found';
+  }
+}

--- a/src/app/organization/offices/view-office/view-office.component.html
+++ b/src/app/organization/offices/view-office/view-office.component.html
@@ -55,6 +55,17 @@
         >
           {{ 'labels.heading.Services' | translate }}
         </a>
+        <a
+          mat-tab-link
+          [routerLink]="['./schedules']"
+          routerLinkActive
+          #schedules="routerLinkActive"
+          [active]="schedules.isActive"
+          class="compact-tab"
+          *mifosxHasPermission="'READ_OFFICE'"
+        >
+          {{ 'labels.heading.Schedules' | translate }}
+        </a>
         @for (officeDatatable of officeDatatables; track officeDatatable) {
           <span>
             <a

--- a/src/app/organization/organization-routing.module.ts
+++ b/src/app/organization/organization-routing.module.ts
@@ -44,6 +44,7 @@ import { ViewOfficeComponent } from './offices/view-office/view-office.component
 import { GeneralTabComponent } from './offices/view-office/general-tab/general-tab.component';
 import { AddressTabComponent } from './offices/view-office/address-tab/address-tab.component';
 import { ServicesTabComponent } from './offices/view-office/services-tab/services-tab.component';
+import { SchedulesTabComponent } from './offices/view-office/schedules-tab/schedules-tab.component';
 import { DatatableTabsComponent } from './offices/view-office/datatable-tabs/datatable-tabs.component';
 import { ViewCampaignComponent } from './sms-campaigns/view-campaign/view-campaign.component';
 import { ManageFundsComponent } from './manage-funds/manage-funds.component';
@@ -222,6 +223,11 @@ const routes: Routes = [
                   path: 'services',
                   component: ServicesTabComponent,
                   data: { title: 'Services', breadcrumb: 'Services', routeParamBreadcrumb: false }
+                },
+                {
+                  path: 'schedules',
+                  component: SchedulesTabComponent,
+                  data: { title: 'Schedules', breadcrumb: 'Schedules', routeParamBreadcrumb: false }
                 },
                 {
                   path: 'datatables',

--- a/src/app/organization/organization.module.ts
+++ b/src/app/organization/organization.module.ts
@@ -48,6 +48,7 @@ import { ViewOfficeComponent } from './offices/view-office/view-office.component
 import { GeneralTabComponent } from './offices/view-office/general-tab/general-tab.component';
 import { AddressTabComponent } from './offices/view-office/address-tab/address-tab.component';
 import { ServicesTabComponent } from './offices/view-office/services-tab/services-tab.component';
+import { SchedulesTabComponent } from './offices/view-office/schedules-tab/schedules-tab.component';
 import { DatatableTabsComponent } from './offices/view-office/datatable-tabs/datatable-tabs.component';
 import { ViewCampaignComponent } from './sms-campaigns/view-campaign/view-campaign.component';
 import { ManageFundsComponent } from './manage-funds/manage-funds.component';
@@ -131,6 +132,7 @@ import { InvestorsComponent } from './investors/investors.component';
     GeneralTabComponent,
     AddressTabComponent,
     ServicesTabComponent,
+    SchedulesTabComponent,
     DatatableTabsComponent,
     ViewCampaignComponent,
     ManageFundsComponent,

--- a/src/app/organization/organization.service.ts
+++ b/src/app/organization/organization.service.ts
@@ -185,6 +185,23 @@ export class OrganizationService {
 
   /**
    * @param {string} officeId Office ID of Office.
+   * @returns {Observable<any>} Office schedules.
+   */
+  getOfficeSchedules(officeId: string): Observable<any> {
+    return this.http.get(`/v2/offices/${officeId}/schedules`);
+  }
+
+  /**
+   * @param {string} officeId Office ID of Office.
+   * @param {any} scheduleData Office schedule data.
+   * @returns {Observable<any>}
+   */
+  updateOfficeSchedules(officeId: string, scheduleData: any): Observable<any> {
+    return this.http.put(`/v2/offices/${officeId}/schedules`, scheduleData);
+  }
+
+  /**
+   * @param {string} officeId Office ID of Office.
    * @param {any} serviceData Office service data.
    * @returns {Observable<any>}
    */

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -428,7 +428,8 @@
     "validation.emailInvalid": "Email not valid",
     "validation.requiredField": "{{label}} is a required field.",
     "validation.mustBeAtLeast": "{{field}} must be at least {{min}}",
-    "validation.mustBePositive": "{{field}} must be a positive number."
+    "validation.mustBePositive": "{{field}} must be a positive number.",
+    "validation.openingTimeBeforeClosingTime": "Opening time must be before closing time."
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -1612,7 +1613,8 @@
       "No Breach Actions": "No Breach Actions",
       "Pause Timeline": "Pause Timeline",
       "Location Map": "Location Map",
-      "Services": "Services"
+      "Services": "Services",
+      "Schedules": "Schedules"
     },
     "inputs": {
       "Breach Actions": "Breach Actions",
@@ -1870,6 +1872,7 @@
       "Closed on Date": "Closed on Date",
       "Closing Date": "Closing Date",
       "Closing Entries": "Closing Entries",
+      "Closing Time": "Closing Time",
       "Closure Creation Date": "Closure Creation Date",
       "Closure Date": "Closure Date",
       "Closure Reason": "Closure Reason",
@@ -1962,6 +1965,7 @@
       "Date of Birth": "Date of Birth",
       "Date of Deposit": "Date of Deposit",
       "DateTime": "DateTime",
+      "Day": "Day",
       "Days": "Days",
       "Days From": "Days From",
       "Days Till": "Days Till",
@@ -2196,6 +2200,7 @@
       "Frequency Type": "Frequency Type",
       "Frequency for compounding": "Frequency for compounding",
       "Frequency for recalculate Outstanding Principal": "Frequency for recalculate Outstanding Principal",
+      "Friday": "Friday",
       "From": "From",
       "From Account": "From Account",
       "From Account ID": "From Account ID",
@@ -2614,6 +2619,7 @@
       "Opening Balances Contra Account": "Opening Balances Contra Account",
       "Opening Balances Date": "Opening Balances Date",
       "Opening Date": "Opening Date",
+      "Opening Time": "Opening Time",
       "Option": "Option",
       "Order": "Order",
       "Original": "Original",
@@ -2859,6 +2865,7 @@
       "Role": "Role",
       "Role Description": "Role Description",
       "Schedule": "Schedule",
+      "Schedules": "Schedules",
       "System": "System",
       "This role provides all application permissions": "This role provides all application permissions.",
       "Role Name": "Role Name",
@@ -4017,6 +4024,7 @@
       "Notification Service Configuration": "Notification Service Configuration",
       "Notifications": "Notifications",
       "Office Address management requires the Savings Plugin to be deployed": "Office Address management requires the Savings Plugin to be deployed.",
+      "Office Schedules management requires the Savings Plugin to be deployed": "Office Schedules management requires the Savings Plugin to be deployed.",
       "Office Services management requires the Savings Plugin to be deployed": "Office Services management requires the Savings Plugin to be deployed.",
       "Offices and staff": "Offices & staff",
       "Optional": "Optional",


### PR DESCRIPTION
## Description

Adds the Office Working Hours management UI for WEB-1048.

This PR introduces a new **Schedules** tab in the Office management screen, allowing users to configure weekly working hours for an office.

### Changes
- Added Office Schedules tab.
- Integrated with the Savings Plugin schedules API.
- Displayed all seven weekdays with:
  - Enable/Disable toggle
  - Opening time
  - Closing time
- Added client-side validation:
  - Opening time must be before closing time.
  - Enabled days require both opening and closing times.
  - Disabled days allow empty times.
- Handles empty schedules returned by the backend.
- Added loading, saving, and error handling.
- Added/updated unit tests.

## Related Issue

WEB-1048

## Dependencies

Requires the Savings Plugin with the Office Working Hours API deployed.

## Screenshots
<img width="1408" height="769" alt="Screenshot 2026-07-25 at 12 55 37 PM" src="https://github.com/user-attachments/assets/9d59a590-aaf6-477b-ba92-2673c89cb7d5" />

<img width="990" height="733" alt="Screenshot 2026-07-25 at 12 55 50 PM" src="https://github.com/user-attachments/assets/691dd25a-1ed6-4148-98a8-dae06d4c5a4c" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Office Schedules tab for viewing and editing weekly opening hours.
  - Configure enabled days, opening times, and closing times.
  - Added validation for required times and valid opening/closing order.
  - Added responsive schedule layout for smaller screens.
  - Added loading, error, retry, and unavailable-plugin states.
- **Translations**
  - Added English labels and messages for schedules, weekdays, times, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->