### PR TITLE
fix(WEB-1054): allow updating zero-interest loan products

### DIFF
--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.spec.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
+import { ProcessingStrategyService } from '../../services/processing-strategy.service';
+import { LoanProductService } from '../../services/loan-product.service';
+import { LoanProductTermsStepComponent } from './loan-product-terms-step.component';
+
+describe('LoanProductTermsStepComponent', () => {
+  function baseTemplate(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      minPrincipal: 1000,
+      principal: 10000,
+      maxPrincipal: 50000,
+      minNumberOfRepayments: 1,
+      numberOfRepayments: 12,
+      maxNumberOfRepayments: 36,
+      isLinkedToFloatingInterestRates: false,
+      minInterestRatePerPeriod: 0,
+      interestRatePerPeriod: 0,
+      maxInterestRatePerPeriod: 0,
+      floatingRateId: null,
+      interestRateDifferential: null,
+      isFloatingInterestRateCalculationAllowed: false,
+      allowApprovedDisbursedAmountsOverApplied: false,
+      minDifferentialLendingRate: null,
+      defaultDifferentialLendingRate: null,
+      maxDifferentialLendingRate: null,
+      useBorrowerCycle: false,
+      repaymentEvery: 1,
+      minimumDaysBetweenDisbursalAndFirstRepayment: null,
+      interestRecognitionOnDisbursementDate: false,
+      interestRateFrequencyType: { id: 3 },
+      repaymentFrequencyType: { id: 2 },
+      repaymentStartDateType: { id: 1 },
+      principalVariationsForBorrowerCycle: [],
+      numberOfRepaymentVariationsForBorrowerCycle: [],
+      interestRateVariationsForBorrowerCycle: [],
+      valueConditionTypeOptions: [{ id: 1, value: 'Equal' }],
+      floatingRateOptions: [],
+      interestRateFrequencyTypeOptions: [{ id: 3, value: 'Per year' }],
+      repaymentFrequencyTypeOptions: [{ id: 2, value: 'Months' }],
+      repaymentStartDateTypeOptions: [{ id: 1, value: 'Disbursement date' }],
+      fixedLength: null,
+      ...overrides
+    };
+  }
+
+  function createComponent(template: Record<string, unknown>): LoanProductTermsStepComponent {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Router, useValue: { navigate: jest.fn(), url: '' } },
+        { provide: LoanProductService, useValue: { isLoanProduct: true, isWorkingCapital: false } },
+        {
+          provide: ProcessingStrategyService,
+          useValue: { advancedTransactionProcessingStrategy: of(false) }
+        },
+        { provide: MatDialog, useValue: { open: jest.fn() } },
+        { provide: TranslateService, useValue: { instant: (key: string): string => key } }
+      ]
+    });
+
+    return TestBed.runInInjectionContext(() => {
+      const component = new LoanProductTermsStepComponent();
+      component.loanProductsTemplate = template;
+      component.ngOnInit();
+      return component;
+    });
+  }
+
+  it('does not keep zero max interest when editing a zero-interest product to positive interest', () => {
+    const component = createComponent(baseTemplate());
+
+    component.zeroInterest.setValue(false);
+    component.loanProductTermsForm.get('interestRatePerPeriod')!.setValue(5);
+
+    expect(component.loanProductTerms).toEqual(
+      expect.objectContaining({
+        minInterestRatePerPeriod: '',
+        interestRatePerPeriod: 5,
+        maxInterestRatePerPeriod: ''
+      })
+    );
+  });
+
+  it('preserves configured min and max interest values for positive-interest products', () => {
+    const component = createComponent(
+      baseTemplate({
+        minInterestRatePerPeriod: 0,
+        interestRatePerPeriod: 12,
+        maxInterestRatePerPeriod: 30
+      })
+    );
+
+    component.loanProductTermsForm.get('interestRatePerPeriod')!.setValue(15);
+
+    expect(component.loanProductTerms).toEqual(
+      expect.objectContaining({
+        minInterestRatePerPeriod: 0,
+        interestRatePerPeriod: 15,
+        maxInterestRatePerPeriod: 30
+      })
+    );
+  });
+
+  it('keeps unchanged zero-interest products at zero interest', () => {
+    const component = createComponent(baseTemplate());
+
+    expect(component.loanProductTerms).toEqual(
+      expect.objectContaining({
+        minInterestRatePerPeriod: 0,
+        interestRatePerPeriod: 0,
+        maxInterestRatePerPeriod: 0
+      })
+    );
+  });
+});

--- a/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
+++ b/src/app/products/loan-products/loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component.ts
@@ -482,17 +482,12 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
           this.loanProductTermsForm.get('maxInterestRatePerPeriod')!.patchValue(0);
           this.loanProductTermsForm.get('maxInterestRatePerPeriod')!.disable();
         } else {
-          this.loanProductTermsForm
-            .get('minInterestRatePerPeriod')!
-            .patchValue(this.loanProductsTemplate.minInterestRatePerPeriod);
+          const interestRateValues = this.getInterestRateValues();
+          this.loanProductTermsForm.get('minInterestRatePerPeriod')!.patchValue(interestRateValues.min);
           this.loanProductTermsForm.get('minInterestRatePerPeriod')!.enable();
-          this.loanProductTermsForm
-            .get('interestRatePerPeriod')!
-            .patchValue(this.loanProductsTemplate.interestRatePerPeriod);
+          this.loanProductTermsForm.get('interestRatePerPeriod')!.patchValue(interestRateValues.default);
           this.loanProductTermsForm.get('interestRatePerPeriod')!.enable();
-          this.loanProductTermsForm
-            .get('maxInterestRatePerPeriod')!
-            .patchValue(this.loanProductsTemplate.maxInterestRatePerPeriod);
+          this.loanProductTermsForm.get('maxInterestRatePerPeriod')!.patchValue(interestRateValues.max);
           this.loanProductTermsForm.get('maxInterestRatePerPeriod')!.enable();
         }
         this.validateAdvancedPaymentStrategyControls();
@@ -659,5 +654,29 @@ export class LoanProductTermsStepComponent extends LoanProductBaseComponent impl
     } else {
       this.loanProductTermsForm.get('fixedLength')!.patchValue(null);
     }
+  }
+
+  private getInterestRateValues(): { min: any; default: any; max: any } {
+    if (this.isZeroInterestTemplate()) {
+      return {
+        min: '',
+        default: '',
+        max: ''
+      };
+    }
+
+    return {
+      min: this.loanProductsTemplate.minInterestRatePerPeriod,
+      default: this.loanProductsTemplate.interestRatePerPeriod,
+      max: this.loanProductsTemplate.maxInterestRatePerPeriod
+    };
+  }
+
+  private isZeroInterestTemplate(): boolean {
+    return (
+      this.loanProductsTemplate.minInterestRatePerPeriod === 0 &&
+      this.loanProductsTemplate.interestRatePerPeriod === 0 &&
+      this.loanProductsTemplate.maxInterestRatePerPeriod === 0
+    );
   }
 }


### PR DESCRIPTION
## Summary

Fixes WEB-1054 by correcting the Loan/Credit Product edit flow when updating a product that was originally created with a 0% interest rate.

The update request now sends consistent interest-rate values, allowing the product to be modified successfully when changing the interest rate from zero to a positive value while preserving existing behavior for other loan products.

## Related Issue

WEB-1054



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zero-interest loan product handling when switching between zero and standard interest rates.
  * Preserved configured minimum and maximum interest rates when updating a product’s interest rate.
  * Ensured interest-rate fields display consistent blank or numeric values based on the selected configuration.

* **Tests**
  * Added coverage for zero-interest initialization and interest-rate updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->