### PR TITLE
Fix WEB-1068: Enable slab-based Fixed and Recurring Deposit product creation

### DIFF
--- a/src/app/products/deposit-product-interest-rate-chart.util.spec.ts
+++ b/src/app/products/deposit-product-interest-rate-chart.util.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { FormArray, FormControl, FormGroup } from '@angular/forms';
+
+import {
+  depositProductChartSlabsValidator,
+  normalizeDepositProductInterestRateCharts
+} from './deposit-product-interest-rate-chart.util';
+
+function createChartSlabsControl(chartSlabs: any[], isPrimaryGroupingByAmount = false): FormArray {
+  const formArray = new FormArray(
+    chartSlabs.map(
+      (chartSlab) =>
+        new FormGroup(
+          Object.keys(chartSlab).reduce(
+            (controls, key) => ({
+              ...controls,
+              [key]: new FormControl(chartSlab[key])
+            }),
+            {}
+          )
+        )
+    )
+  );
+  formArray.setValidators(depositProductChartSlabsValidator(() => isPrimaryGroupingByAmount));
+  formArray.updateValueAndValidity();
+  return formArray;
+}
+
+describe('Deposit product interest rate chart utils', () => {
+  it('accepts a successful Fixed Deposit creation payload with continuous slabs', () => {
+    const chartSlabs = createChartSlabsControl([
+      {
+        periodType: 2,
+        fromPeriod: 1,
+        toPeriod: 6,
+        annualInterestRate: 5,
+        description: '1 to 6 months'
+      },
+      {
+        periodType: 2,
+        fromPeriod: 7,
+        toPeriod: '',
+        annualInterestRate: 6,
+        description: '7 plus months'
+      }
+    ]);
+
+    expect(chartSlabs.errors).toBeNull();
+  });
+
+  it('accepts a successful Recurring Deposit creation payload with continuous slabs', () => {
+    const chartSlabs = createChartSlabsControl([
+      {
+        periodType: 2,
+        fromPeriod: 1,
+        toPeriod: 6,
+        annualInterestRate: 5,
+        description: '1 to 6 months'
+      },
+      {
+        periodType: 2,
+        fromPeriod: 7,
+        toPeriod: '',
+        annualInterestRate: 6,
+        description: '7 plus months'
+      }
+    ]);
+
+    expect(chartSlabs.errors).toBeNull();
+  });
+
+  it('rejects the reproduced backend gap failure before submit', () => {
+    const chartSlabs = createChartSlabsControl([
+      {
+        periodType: 2,
+        fromPeriod: 1,
+        toPeriod: 6,
+        annualInterestRate: 5,
+        description: '1 to 6 months'
+      },
+      {
+        periodType: 2,
+        fromPeriod: 8,
+        toPeriod: '',
+        annualInterestRate: 6,
+        description: '8 plus months'
+      }
+    ]);
+
+    expect(chartSlabs.errors).toEqual({ slabRange: { type: 'gap' } });
+  });
+
+  it('rejects overlapping period slabs before submit', () => {
+    const chartSlabs = createChartSlabsControl([
+      {
+        periodType: 2,
+        fromPeriod: 1,
+        toPeriod: 6,
+        annualInterestRate: 5,
+        description: '1 to 6 months'
+      },
+      {
+        periodType: 2,
+        fromPeriod: 6,
+        toPeriod: '',
+        annualInterestRate: 6,
+        description: '6 plus months'
+      }
+    ]);
+
+    expect(chartSlabs.errors).toEqual({ slabRange: { type: 'overlap' } });
+  });
+
+  it('rejects a single slab with an inverted range before submit', () => {
+    const chartSlabs = createChartSlabsControl([
+      {
+        periodType: 2,
+        fromPeriod: 10,
+        toPeriod: 5,
+        annualInterestRate: 5,
+        description: 'Invalid single slab'
+      }
+    ]);
+
+    expect(chartSlabs.errors).toEqual({ slabRange: { type: 'invalidRange' } });
+  });
+
+  it('rejects mixed period types in the same chart', () => {
+    const chartSlabs = createChartSlabsControl([
+      {
+        periodType: 2,
+        fromPeriod: 1,
+        toPeriod: 6,
+        annualInterestRate: 5,
+        description: 'Months'
+      },
+      {
+        periodType: 3,
+        fromPeriod: 7,
+        toPeriod: '',
+        annualInterestRate: 6,
+        description: 'Years'
+      }
+    ]);
+
+    expect(chartSlabs.errors).toEqual({ slabRange: { type: 'periodTypeMismatch' } });
+  });
+
+  it('validates primary amount grouping without removing valid zero values', () => {
+    const chartSlabs = createChartSlabsControl(
+      [
+        {
+          periodType: 2,
+          fromPeriod: 1,
+          toPeriod: '',
+          amountRangeFrom: 0,
+          amountRangeTo: 5000,
+          annualInterestRate: 5,
+          description: '0 to 5000'
+        },
+        {
+          periodType: 2,
+          fromPeriod: 1,
+          toPeriod: '',
+          amountRangeFrom: 5001,
+          amountRangeTo: '',
+          annualInterestRate: 6,
+          description: '5001 plus'
+        }
+      ],
+      true
+    );
+
+    expect(chartSlabs.errors).toBeNull();
+  });
+
+  it('normalizes optional blank slab bounds while preserving zeroes', () => {
+    const payload = normalizeDepositProductInterestRateCharts({
+      charts: [
+        {
+          chartSlabs: [
+            {
+              periodType: 2,
+              fromPeriod: 1,
+              toPeriod: '',
+              amountRangeFrom: 0,
+              amountRangeTo: '',
+              annualInterestRate: 5,
+              description: 'Open ended amount range'
+            }
+          ]
+        }
+      ]
+    });
+
+    expect(payload.charts[0].chartSlabs[0]).toEqual({
+      periodType: 2,
+      fromPeriod: 1,
+      amountRangeFrom: 0,
+      annualInterestRate: 5,
+      description: 'Open ended amount range'
+    });
+  });
+});

--- a/src/app/products/deposit-product-interest-rate-chart.util.ts
+++ b/src/app/products/deposit-product-interest-rate-chart.util.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+const OPTIONAL_SLAB_BOUND_FIELDS = [
+  'toPeriod',
+  'amountRangeFrom',
+  'amountRangeTo'
+];
+
+type SlabRangeErrorType =
+  | 'gap'
+  | 'overlap'
+  | 'invalidRange'
+  | 'openEndedRange'
+  | 'missingAmountRangeFrom'
+  | 'periodTypeMismatch';
+
+interface SlabRangeError {
+  type: SlabRangeErrorType;
+}
+
+interface SlabRange {
+  from: number;
+  to: number | null;
+}
+
+export type DepositProductType = 'fixeddeposit' | 'recurringdeposit';
+
+function isBlank(value: any): boolean {
+  return value === '' || value === null || value === undefined;
+}
+
+function toNumber(value: any): number | null {
+  if (isBlank(value)) {
+    return null;
+  }
+  const numericValue = Number(value);
+  return Number.isNaN(numericValue) ? null : numericValue;
+}
+
+function hasValue(value: any): boolean {
+  return !isBlank(value);
+}
+
+function getRange(slab: any, fromField: string, toField: string): SlabRange | null {
+  const from = toNumber(slab[fromField]);
+  if (from === null) {
+    return null;
+  }
+  return {
+    from,
+    to: toNumber(slab[toField])
+  };
+}
+
+function getContinuousRangeError(ranges: SlabRange[]): SlabRangeError | null {
+  const sortedRanges = [...ranges].sort((first, second) => first.from - second.from);
+  for (let index = 0; index < sortedRanges.length; index++) {
+    const range = sortedRanges[index];
+    if (range.to !== null && range.to < range.from) {
+      return { type: 'invalidRange' };
+    }
+    if (range.to === null && index !== sortedRanges.length - 1) {
+      return { type: 'openEndedRange' };
+    }
+
+    const nextRange = sortedRanges[index + 1];
+    if (!nextRange || range.to === null) {
+      continue;
+    }
+    if (nextRange.from <= range.to) {
+      return { type: 'overlap' };
+    }
+    if (nextRange.from > range.to + 1) {
+      return { type: 'gap' };
+    }
+  }
+
+  return null;
+}
+
+function getSlabsRangeError(slabs: any[], isPrimaryGroupingByAmount: boolean): SlabRangeError | null {
+  const periodTypes = new Set(slabs.filter((slab) => hasValue(slab.periodType)).map((slab) => Number(slab.periodType)));
+  if (periodTypes.size > 1) {
+    return { type: 'periodTypeMismatch' };
+  }
+
+  if (isPrimaryGroupingByAmount && slabs.some((slab) => !hasValue(slab.amountRangeFrom))) {
+    return { type: 'missingAmountRangeFrom' };
+  }
+
+  const fromField = isPrimaryGroupingByAmount ? 'amountRangeFrom' : 'fromPeriod';
+  const toField = isPrimaryGroupingByAmount ? 'amountRangeTo' : 'toPeriod';
+  const ranges = slabs.map((slab) => getRange(slab, fromField, toField)).filter((range): range is SlabRange => !!range);
+
+  return getContinuousRangeError(ranges);
+}
+
+export function depositProductChartSlabsValidator(isPrimaryGroupingByAmount: () => boolean): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const slabs = Array.isArray(control.value) ? control.value : [];
+    const error = getSlabsRangeError(slabs, isPrimaryGroupingByAmount());
+    return error ? { slabRange: error } : null;
+  };
+}
+
+export function getDepositProductChartSlabsErrorKey(
+  errors: ValidationErrors | null | undefined,
+  depositProductType: DepositProductType
+): string | null {
+  const slabRangeError = errors?.slabRange as SlabRangeError | undefined;
+  switch (slabRangeError?.type) {
+    case 'gap':
+      return `validation.msg.${depositProductType}.chart.slabs.range.has.gap`;
+    case 'overlap':
+      return `validation.msg.${depositProductType}.chart.slabs.range.overlapping`;
+    case 'invalidRange':
+      return `validation.msg.${depositProductType}.chart.slabs.range.start.incorrect`;
+    case 'openEndedRange':
+      return `validation.msg.${depositProductType}.chart.slabs.range.end.incorrect`;
+    case 'missingAmountRangeFrom':
+      return `validation.msg.${depositProductType}.chart.slabs.amount.range.incomplete`;
+    case 'periodTypeMismatch':
+      return 'validation.msg.interestchart.period.type.is.not.same';
+    default:
+      return null;
+  }
+}
+
+export function normalizeDepositProductInterestRateCharts<T extends { charts?: any[] }>(interestRateChart: T): T {
+  return {
+    ...interestRateChart,
+    charts: interestRateChart.charts?.map((chart) => ({
+      ...chart,
+      chartSlabs: chart.chartSlabs?.map((slab: any) => {
+        const normalizedSlab = { ...slab };
+        OPTIONAL_SLAB_BOUND_FIELDS.forEach((field) => {
+          if (isBlank(normalizedSlab[field])) {
+            delete normalizedSlab[field];
+          }
+        });
+        return normalizedSlab;
+      })
+    }))
+  };
+}

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.html
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.html
@@ -94,6 +94,11 @@
               <h3 class="mat-h3">{{ 'labels.heading.It is required to add at least one Range' | translate }}</h3>
             </div>
           }
+          @if (getChartSlabsErrorKey(chart.controls.chartSlabs)) {
+            <div class="flex-100">
+              <mat-error>{{ getChartSlabsErrorKey(chart.controls.chartSlabs) | translate }}</mat-error>
+            </div>
+          }
           @if (chart.value.chartSlabs.length !== 0) {
             <table
               class="flex-98 mat-elevation-z1"

--- a/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.ts
+++ b/src/app/products/fixed-deposit-products/fixed-deposit-product-stepper/fixed-deposit-product-interest-rate-chart-step/fixed-deposit-product-interest-rate-chart-step.component.ts
@@ -53,6 +53,11 @@ import {
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FindPipe } from '../../../../pipes/find.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import {
+  depositProductChartSlabsValidator,
+  getDepositProductChartSlabsErrorKey,
+  normalizeDepositProductInterestRateCharts
+} from 'app/products/deposit-product-interest-rate-chart.util';
 
 @Component({
   selector: 'mifosx-fixed-deposit-product-interest-rate-chart-step',
@@ -334,7 +339,7 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
   }
 
   createChartForm(): UntypedFormGroup {
-    return this.formBuilder.group({
+    const chartForm = this.formBuilder.group({
       id: [null],
       name: [''],
       description: [''],
@@ -346,6 +351,12 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
       isPrimaryGroupingByAmount: [false],
       chartSlabs: this.formBuilder.array([], Validators.required)
     });
+    const chartSlabs = chartForm.get('chartSlabs') as UntypedFormArray;
+    chartSlabs.setValidators([
+      Validators.required,
+      depositProductChartSlabsValidator(() => chartForm.get('isPrimaryGroupingByAmount')?.value)
+    ]);
+    return chartForm;
   }
 
   addChart() {
@@ -373,6 +384,7 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
               'amountRange'
             ];
         this.chartSlabsDisplayedColumns[chartIndex].push('annualInterestRate', 'description', 'actions');
+        (this.charts.at(chartIndex).get('chartSlabs') as UntypedFormArray).updateValueAndValidity();
       });
   }
 
@@ -436,6 +448,10 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
         formArray.removeAt(index);
       }
     });
+  }
+
+  getChartSlabsErrorKey(chartSlabs: UntypedFormArray): string | null {
+    return getDepositProductChartSlabsErrorKey(chartSlabs.errors, 'fixeddeposit');
   }
 
   getData(formType: string, values?: any) {
@@ -536,7 +552,7 @@ export class FixedDepositProductInterestRateChartStepComponent implements OnInit
         delete chart.id;
       }
     }
-    return fixedDepositProductInterestRateChart;
+    return normalizeDepositProductInterestRateCharts(fixedDepositProductInterestRateChart);
   }
 }
 

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-interest-rate-chart-step/recurring-deposit-product-interest-rate-chart-step.component.html
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-interest-rate-chart-step/recurring-deposit-product-interest-rate-chart-step.component.html
@@ -92,6 +92,11 @@
               <h3 class="mat-h3">{{ 'labels.heading.It is required to add at least one Slab' | translate }}</h3>
             </div>
           }
+          @if (getChartSlabsErrorKey(chart.controls.chartSlabs)) {
+            <div class="flex-100">
+              <mat-error>{{ getChartSlabsErrorKey(chart.controls.chartSlabs) | translate }}</mat-error>
+            </div>
+          }
           @if (chart.value.chartSlabs.length !== 0) {
             <table
               class="flex-98 mat-elevation-z1"

--- a/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-interest-rate-chart-step/recurring-deposit-product-interest-rate-chart-step.component.ts
+++ b/src/app/products/recurring-deposit-products/recurring-deposit-product-stepper/recurring-deposit-product-interest-rate-chart-step/recurring-deposit-product-interest-rate-chart-step.component.ts
@@ -52,6 +52,11 @@ import {
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FindPipe } from '../../../../pipes/find.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import {
+  depositProductChartSlabsValidator,
+  getDepositProductChartSlabsErrorKey,
+  normalizeDepositProductInterestRateCharts
+} from 'app/products/deposit-product-interest-rate-chart.util';
 
 @Component({
   selector: 'mifosx-recurring-deposit-product-interest-rate-chart-step',
@@ -340,7 +345,7 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
   }
 
   createChartForm(): UntypedFormGroup {
-    return this.formBuilder.group({
+    const chartForm = this.formBuilder.group({
       id: [null],
       name: [''],
       description: [''],
@@ -352,6 +357,12 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
       isPrimaryGroupingByAmount: [false],
       chartSlabs: this.formBuilder.array([], Validators.required)
     });
+    const chartSlabs = chartForm.get('chartSlabs') as UntypedFormArray;
+    chartSlabs.setValidators([
+      Validators.required,
+      depositProductChartSlabsValidator(() => chartForm.get('isPrimaryGroupingByAmount')?.value)
+    ]);
+    return chartForm;
   }
 
   addChart() {
@@ -379,6 +390,7 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
               'amountRange'
             ];
         this.chartSlabsDisplayedColumns[chartIndex].push('annualInterestRate', 'description', 'actions');
+        (this.charts.at(chartIndex).get('chartSlabs') as UntypedFormArray).updateValueAndValidity();
       });
   }
 
@@ -439,6 +451,10 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
         formArray.removeAt(index);
       }
     });
+  }
+
+  getChartSlabsErrorKey(chartSlabs: UntypedFormArray): string | null {
+    return getDepositProductChartSlabsErrorKey(chartSlabs.errors, 'recurringdeposit');
   }
 
   getData(formType: string, values?: any) {
@@ -542,6 +558,6 @@ export class RecurringDepositProductInterestRateChartStepComponent implements On
         delete chart.id;
       }
     }
-    return recurringDepositProductInterestRateChart;
+    return normalizeDepositProductInterestRateCharts(recurringDepositProductInterestRateChart);
   }
 }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "Rozpětí období/částky má mezeru pro graf úrokových sazeb",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Překrývající se období/rozpětí částky pro graf úrokových sazeb",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "Začátek období/částkového rozsahu je pro graf úrokových sazeb nesprávný",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "Období účtování fixního vkladu nemůže být kratší než složené období",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Povolit výpočet částečných splátek nelze pro denní výpočet nastavit jako true",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "Variabilní splátka by měla být použita buď s denním výpočtem úroku, nebo povolit výpočet částečného úroku true",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "Der Zeitraum/Betragsbereich weist eine Lücke für das Zinsdiagramm auf",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Perioden-/Betragsbereich überlappen sich für das Zinsdiagramm",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "Der Beginn des Zeitraums/Betragsbereichs ist für das Zinsdiagramm falsch",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "Der Buchungszeitraum für Festgelder darf nicht kürzer als der Zinseszinszeitraum sein",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Teilzahlungsberechnung zulassen kann für die tägliche Berechnung nicht auf „Wahr“ gesetzt werden",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "Variable Ratenzahlung sollte entweder mit täglicher Zinsberechnung verwendet werden oder eine Teilzinsberechnung zulassen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "Period/Amount range has gap for interest rate chart",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Period/Amount range overlapping for interest rate chart",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "Period/Amount range start is incorrect for interest rate chart",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "Fixed Deposit Posting period cannot be less than compounding period",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Allow Partial Installment Calculation cannot be set as true for daily calculation",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "Variable Installment should be used with either daily interest calculation  or allow partial interest calculation true",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "El rango de período/monto tiene un espacio en el gráfico de tasas de interés",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Rango de período/importe superpuesto para el gráfico de tasas de interés",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "El inicio del rango de período/monto es incorrecto para el gráfico de tasas de interés",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "El período de contabilización del Depósito Fijo no puede ser inferior al período de capitalización",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Permitir el cálculo de cuotas parciales no se puede establecer como verdadero para el cálculo diario",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "La cuota variable debe usarse con el cálculo de interés diario o permitir el cálculo de interés parcial.",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "El rango de período/monto tiene un espacio en el gráfico de tasas de interés",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Rango de período/importe superpuesto para el gráfico de tasas de interés",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "El inicio del rango de período/monto es incorrecto para el gráfico de tasas de interés",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "El período de contabilización del Depósito Fijo no puede ser inferior al período de capitalización",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Permitir el cálculo de cuotas parciales no se puede establecer como verdadero para el cálculo diario",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "La cuota variable debe usarse con el cálculo de interés diario o permitir el cálculo de interés parcial.",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "La plage Période/Montant présente un écart pour le graphique des taux d'intérêt",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Plage de périodes/montants se chevauchant pour le graphique des taux d'intérêt",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "Le début de la plage de période/montant est incorrect pour le graphique des taux d'intérêt",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "La période de comptabilisation des dépôts fixes ne peut pas être inférieure à la période de composition",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Autoriser le calcul des versements partiels ne peut pas être défini comme vrai pour le calcul quotidien",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "Le versement variable doit être utilisé avec le calcul des intérêts quotidiens ou permettre le calcul des intérêts partiels.",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "L'intervallo periodo/importo presenta un divario per il grafico del tasso di interesse",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Intervallo di periodo/importo sovrapposto per il grafico del tasso di interesse",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "L'inizio dell'intervallo periodo/importo non è corretto per il grafico del tasso di interesse",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "Il periodo di registrazione del deposito fisso non può essere inferiore al periodo di capitalizzazione",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Consenti calcolo rata parziale non può essere impostato su vero per il calcolo giornaliero",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "La rata variabile deve essere utilizzata con il calcolo dell'interesse giornaliero o con il calcolo dell'interesse parziale vero",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "기간/금액 범위는 금리 차트와 간격이 있습니다.",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "금리 차트의 기간/금액 범위가 중복됩니다.",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "이자율 차트의 기간/금액 범위 시작이 올바르지 않습니다.",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "정기 예금 전기 기간은 복리 기간보다 작을 수 없습니다.",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "일일 계산에서는 부분 할부 계산 허용을 true로 설정할 수 없습니다.",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "변액할부는 일일이자 계산과 함께 사용하거나 부분이자 계산을 허용해야 합니다.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "Laikotarpis / Sumos diapazonas turi spragą palūkanų normų diagramoje",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Palūkanų normos diagramos laikotarpis / sumos diapazonas sutampa",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "Palūkanų normos diagramos laikotarpio/sumos intervalo pradžia neteisinga",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "Fiksuoto indėlio registravimo laikotarpis negali būti trumpesnis nei sudėties laikotarpis",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Leisti dalinį įmokos apskaičiavimą negali būti nustatyta kaip teisinga atliekant kasdienį skaičiavimą",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "Kintamoji įmoka turėtų būti naudojama skaičiuojant kasdienes palūkanas arba leidžiant skaičiuoti dalines palūkanas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "Perioda/summas diapazonā procentu likmju diagrammā ir atstarpe",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Perioda/summas diapazons pārklājas procentu likmju diagrammā",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "Perioda/summas diapazona sākums procentu likmju diagrammai ir nepareizs",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "Fiksētā depozīta grāmatošanas periods nevar būt īsāks par salikšanas periodu",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Atļaut daļējas iemaksas aprēķinu nevar iestatīt kā patiesu ikdienas aprēķinam",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "Mainīgā iemaksa jāizmanto, aprēķinot ikdienas procentus, vai arī pieļaujot daļēju procentu aprēķinu",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "अवधि/राशि दायरा ब्याज दर चार्ट को लागी अन्तर छ",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "ब्याज दर चार्टको लागि अवधि / रकम दायरा ओभरल्यापिङ",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "अवधि/राशि दायरा सुरु ब्याज दर चार्ट को लागी गलत छ",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "फिक्स्ड डिपोजिट पोस्टिङ अवधि चक्रवृद्धि अवधि भन्दा कम हुन सक्दैन",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "अनुमति दिनुहोस् आंशिक किस्ता गणना दैनिक गणनाको लागि सत्यको रूपमा सेट गर्न सकिँदैन",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "चर किस्ता दैनिक ब्याज गणनाको साथ प्रयोग गरिनु पर्छ वा आंशिक ब्याज गणनालाई अनुमति दिनुपर्छ।",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "A faixa Período/Valor tem lacuna no gráfico de taxas de juros",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Intervalo de período/valor sobreposto no gráfico de taxas de juros",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "O início do intervalo de período/valor está incorreto para o gráfico de taxas de juros",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "O período de lançamento de depósito fixo não pode ser inferior ao período composto",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Permitir cálculo de parcela parcial não pode ser definido como verdadeiro para cálculo diário",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "A Parcela Variável deve ser usada com cálculo de juros diários ou permitir cálculo de juros parciais verdadeiro",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -68,6 +68,7 @@
     "validation.msg.fixeddeposit.chart.slabs.range.has.gap": "Masafa ya kipindi/Kiasi ina pengo la chati ya viwango vya riba",
     "validation.msg.fixeddeposit.chart.slabs.range.overlapping": "Masafa ya kipindi/Kiasi kinachopishana kwa chati ya viwango vya riba",
     "validation.msg.fixeddeposit.chart.slabs.range.start.incorrect": "Kipindi/Kiasi cha kuanzia mwanzo si sahihi kwa chati ya viwango vya riba",
+    "validation.msg.interestchart.period.type.is.not.same": "All slabs in a chart must use the same period type.",
     "validation.msg.fixeddepositaccount.posting.period.type.is.less.than.compound.period.type": "Kipindi cha Kuchapisha Amana Isiyobadilika hakiwezi kuwa chini ya kipindi cha kujumuisha",
     "validation.msg.loan.allowPartialPeriodInterestCalculation.not.supported.for.daily.calculations": "Ruhusu Ukokotoaji wa Usawa wa Kiasi hauwezi kuwekwa kuwa kweli kwa hesabu ya kila siku",
     "validation.msg.loan.allowVariableInstallments.not.supported.for.selected.interest.calculation.type": "Malipo ya Kubadilishana yanapaswa kutumiwa pamoja na hesabu ya maslahi ya kila siku au kuruhusu ukokotoaji wa riba kiasi kuwa kweli",


### PR DESCRIPTION
## Description

This PR fixes WEB-1068, where users were unable to create Fixed Deposit and Recurring Deposit products with interest-rate slabs.

The issue was caused by the Web-App allowing slab values that were not correctly validated or normalized before submission. This resulted in invalid slab payloads being rejected by the backend.

### Changes made

* Added validation for Fixed Deposit and Recurring Deposit interest-rate slabs.
* Ensured slab ranges do not contain gaps or overlaps.
* Preserved valid zero values in slab fields.
* Normalized optional blank numeric values before submission.
* Improved validation feedback for invalid slab configurations.
* Added regression tests for creating Fixed and Recurring Deposit products with valid slabs.
* Added tests for invalid slab ranges where applicable.

## Related issue

WEB-1068

## Testing

* Verified Fixed Deposit product creation with slabs.
* Verified Recurring Deposit product creation with slabs.
* Ran relevant unit tests.
* Ran lint successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interest-rate chart slab validation for deposit products, including gap/overlap detection, invalid ranges, and mixed period-type prevention.
  * Displays inline, translated slab error messages in the fixed-deposit and recurring-deposit chart steps.
  * Normalizes chart input by removing optional blank slab bounds while preserving legitimate zero values.
  * Added the new validation message translation key for period-type mismatches.
* **Tests**
  * Added Jest coverage for validator behavior and chart normalization across multiple valid/invalid scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->