### PR TITLE
fix(WEB-1069): make third-party services configurable

### DIFF
--- a/src/app/system/external-services/external-services.component.html
+++ b/src/app/system/external-services/external-services.component.html
@@ -8,88 +8,44 @@
 
 <div class="container">
   <mat-card>
-    <div class="layout-row responsive-column gap-20px">
-      <div class="flex-50">
-        <mat-nav-list>
-          <mat-list-item [routerLink]="['amazon-s3']">
-            <mat-icon matListIcon [routerLink]="['amazon-s3']">
-              <fa-icon icon="cloud" size="sm"></fa-icon>
-            </mat-icon>
-            <h4 matLine [routerLink]="['amazon-s3']">{{ 'labels.heading.S3 Amazon External Service' | translate }}</h4>
-            @if (!arrowBooleans[0]) {
-              <fa-icon (click)="arrowBooleansToggle(0); $event.stopPropagation()" icon="arrow-down" size="md"></fa-icon>
-            }
-            @if (arrowBooleans[0]) {
-              <fa-icon (click)="arrowBooleansToggle(0); $event.stopPropagation()" icon="arrow-up" size="md"></fa-icon>
-            }
-            @if (arrowBooleans[0]) {
-              <p matLine [routerLink]="['amazon-s3']">
-                {{ 'labels.text.S3 Amazon Service Configuration' | translate }}
-              </p>
-            }
-          </mat-list-item>
-
-          <mat-list-item [routerLink]="['sms']">
-            <mat-icon matListIcon [routerLink]="['sms']">
-              <fa-icon icon="comment-alt" size="sm"></fa-icon>
-            </mat-icon>
-            <h4 matLine [routerLink]="['sms']">{{ 'labels.heading.SMS External Service' | translate }}</h4>
-            @if (!arrowBooleans[1]) {
-              <fa-icon (click)="arrowBooleansToggle(1); $event.stopPropagation()" icon="arrow-down" size="md"></fa-icon>
-            }
-            @if (arrowBooleans[1]) {
-              <fa-icon (click)="arrowBooleansToggle(1); $event.stopPropagation()" icon="arrow-up" size="md"></fa-icon>
-            }
-            @if (arrowBooleans[1]) {
-              <p matLine [routerLink]="['sms']">
-                {{ 'labels.text.SMS Service Configuration' | translate }}
-              </p>
-            }
-          </mat-list-item>
-        </mat-nav-list>
+    @if (serviceColumns.length) {
+      <div class="layout-row responsive-column gap-20px">
+        @for (column of serviceColumns; track $index) {
+          <div class="flex-50">
+            <mat-nav-list>
+              @for (service of column; track service.id) {
+                <mat-list-item [routerLink]="service.route">
+                  <mat-icon matListIcon [routerLink]="service.route">
+                    <fa-icon [icon]="service.icon" size="sm"></fa-icon>
+                  </mat-icon>
+                  <h4 matLine [routerLink]="service.route">{{ service.label | translate }}</h4>
+                  <button
+                    mat-icon-button
+                    type="button"
+                    [attr.aria-expanded]="isServiceDescriptionVisible(service.id)"
+                    [attr.aria-label]="service.label | translate"
+                    (click)="toggleServiceDescription(service.id); $event.stopPropagation()"
+                  >
+                    @if (!isServiceDescriptionVisible(service.id)) {
+                      <fa-icon icon="arrow-down" size="lg"></fa-icon>
+                    }
+                    @if (isServiceDescriptionVisible(service.id)) {
+                      <fa-icon icon="arrow-up" size="lg"></fa-icon>
+                    }
+                  </button>
+                  @if (isServiceDescriptionVisible(service.id)) {
+                    <p matLine [routerLink]="service.route">
+                      {{ service.description | translate }}
+                    </p>
+                  }
+                </mat-list-item>
+              }
+            </mat-nav-list>
+          </div>
+        }
       </div>
-
-      <div class="flex-50">
-        <mat-nav-list>
-          <mat-list-item [routerLink]="['email']">
-            <mat-icon matListIcon [routerLink]="['email']">
-              <fa-icon icon="envelope" size="sm"></fa-icon>
-            </mat-icon>
-            <h4 matLine [routerLink]="['email']">{{ 'labels.heading.Email External Service' | translate }}</h4>
-            @if (!arrowBooleans[2]) {
-              <fa-icon (click)="arrowBooleansToggle(2); $event.stopPropagation()" icon="arrow-down" size="md"></fa-icon>
-            }
-            @if (arrowBooleans[2]) {
-              <fa-icon (click)="arrowBooleansToggle(2); $event.stopPropagation()" icon="arrow-up" size="md"></fa-icon>
-            }
-            @if (arrowBooleans[2]) {
-              <p matLine [routerLink]="['email']">
-                {{ 'labels.text.Email Service Configuration' | translate }}
-              </p>
-            }
-          </mat-list-item>
-
-          <mat-list-item [routerLink]="['notification']">
-            <mat-icon matListIcon [routerLink]="['notification']">
-              <fa-icon icon="bell" size="sm"></fa-icon>
-            </mat-icon>
-            <h4 matLine [routerLink]="['notification']">
-              {{ 'labels.heading.Notification External Service' | translate }}
-            </h4>
-            @if (!arrowBooleans[3]) {
-              <fa-icon (click)="arrowBooleansToggle(3); $event.stopPropagation()" icon="arrow-down" size="md"></fa-icon>
-            }
-            @if (arrowBooleans[3]) {
-              <fa-icon (click)="arrowBooleansToggle(3); $event.stopPropagation()" icon="arrow-up" size="md"></fa-icon>
-            }
-            @if (arrowBooleans[3]) {
-              <p matLine [routerLink]="['notification']">
-                {{ 'labels.text.Notification Service Configuration' | translate }}
-              </p>
-            }
-          </mat-list-item>
-        </mat-nav-list>
-      </div>
-    </div>
+    } @else {
+      <p>{{ 'labels.text.No data found' | translate }}</p>
+    }
   </mat-card>
 </div>

--- a/src/app/system/external-services/external-services.component.spec.ts
+++ b/src/app/system/external-services/external-services.component.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import {
+  faArrowDown,
+  faArrowUp,
+  faBell,
+  faCloud,
+  faCommentAlt,
+  faEnvelope,
+  faKey
+} from '@fortawesome/free-solid-svg-icons';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { ExternalServicesComponent } from './external-services.component';
+import {
+  EXTERNAL_SERVICE_REGISTRY,
+  ExternalServiceConfiguration,
+  getVisibleExternalServices
+} from './external-services.config';
+
+describe('ExternalServicesComponent', () => {
+  let component: ExternalServicesComponent;
+  let fixture: ComponentFixture<ExternalServicesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ExternalServicesComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        {
+          provide: AuthenticationService,
+          useValue: { getCredentials: () => ({ permissions: ['ALL_FUNCTIONS'] }) }
+        }
+      ]
+    }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIcons(faArrowDown, faArrowUp, faBell, faCloud, faCommentAlt, faEnvelope, faKey);
+
+    fixture = TestBed.createComponent(ExternalServicesComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('renders configured SMTP, SMS, and Amazon S3 services', () => {
+    fixture.detectChanges();
+
+    const textContent = fixture.nativeElement.textContent;
+
+    expect(textContent).toContain('labels.heading.Email External Service');
+    expect(textContent).toContain('labels.heading.SMS External Service');
+    expect(textContent).toContain('labels.heading.S3 Amazon External Service');
+    expect(component.externalServices.map((service: ExternalServiceConfiguration) => service.id)).toEqual([
+      'amazon-s3',
+      'sms',
+      'email',
+      'notification'
+    ]);
+  });
+
+  it('renders from the service registry instead of service-specific template blocks', () => {
+    const customService: ExternalServiceConfiguration = {
+      id: 'custom',
+      label: 'labels.heading.Custom External Service',
+      description: 'labels.text.Custom External Service Configuration',
+      icon: 'key',
+      route: ['custom']
+    };
+
+    component.externalServices = [customService];
+    component.serviceColumns = component.getServiceColumns(component.externalServices);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('labels.heading.Custom External Service');
+    expect(component.serviceColumns).toEqual([[customService]]);
+  });
+
+  it('keeps the configured route selection for existing deep links', () => {
+    expect(EXTERNAL_SERVICE_REGISTRY.find((service) => service.id === 'amazon-s3')?.route).toEqual(['amazon-s3']);
+    expect(EXTERNAL_SERVICE_REGISTRY.find((service) => service.id === 'sms')?.route).toEqual(['sms']);
+    expect(EXTERNAL_SERVICE_REGISTRY.find((service) => service.id === 'email')?.route).toEqual(['email']);
+  });
+
+  it('filters services by configured permission when RBAC is enabled', () => {
+    const registry: ExternalServiceConfiguration[] = [
+      {
+        id: 'visible',
+        label: 'Visible',
+        description: 'Visible description',
+        icon: 'key',
+        route: ['visible'],
+        requiredPermission: 'READ_VISIBLE_SERVICE'
+      },
+      {
+        id: 'hidden',
+        label: 'Hidden',
+        description: 'Hidden description',
+        icon: 'key',
+        route: ['hidden'],
+        requiredPermission: 'UPDATE_HIDDEN_SERVICE'
+      }
+    ];
+
+    expect(getVisibleExternalServices(registry, {}, ['ALL_FUNCTIONS_READ'], true).map((service) => service.id)).toEqual(
+      [
+        'visible'
+      ]
+    );
+  });
+
+  it('does not apply configured permissions when RBAC is disabled', () => {
+    const registry: ExternalServiceConfiguration[] = [
+      {
+        id: 'legacy-visible',
+        label: 'Legacy visible',
+        description: 'Legacy visible description',
+        icon: 'key',
+        route: ['legacy-visible'],
+        requiredPermission: 'UPDATE_LEGACY_SERVICE'
+      }
+    ];
+
+    expect(getVisibleExternalServices(registry, {}, [], false).map((service) => service.id)).toEqual([
+      'legacy-visible'
+    ]);
+  });
+
+  it('filters services by availability when a registry entry has an existing availability context', () => {
+    const registry: ExternalServiceConfiguration[] = [
+      {
+        id: 'enabled',
+        label: 'Enabled',
+        description: 'Enabled description',
+        icon: 'key',
+        route: ['enabled'],
+        isAvailable: (context) => context['enabled'] === true
+      },
+      {
+        id: 'disabled',
+        label: 'Disabled',
+        description: 'Disabled description',
+        icon: 'key',
+        route: ['disabled'],
+        isAvailable: (context) => context['enabled'] === false
+      }
+    ];
+
+    expect(getVisibleExternalServices(registry, { enabled: true }, [], false).map((service) => service.id)).toEqual([
+      'enabled'
+    ]);
+  });
+
+  it('shows an empty state when no services are visible', () => {
+    component.externalServices = [];
+    component.serviceColumns = component.getServiceColumns(component.externalServices);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('labels.text.No data found');
+  });
+
+  it('toggles a service description from the generated row action', () => {
+    fixture.detectChanges();
+
+    expect(component.isServiceDescriptionVisible('sms')).toBe(false);
+
+    const expandButtons = fixture.nativeElement.querySelectorAll('button[mat-icon-button]');
+    expandButtons[1].click();
+    fixture.detectChanges();
+
+    expect(component.isServiceDescriptionVisible('sms')).toBe(true);
+    expect(fixture.nativeElement.textContent).toContain('labels.text.SMS Service Configuration');
+  });
+});

--- a/src/app/system/external-services/external-services.component.ts
+++ b/src/app/system/external-services/external-services.component.ts
@@ -7,12 +7,21 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatIconButton } from '@angular/material/button';
 import { MatNavList, MatListItem } from '@angular/material/list';
 import { MatIcon } from '@angular/material/icon';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatLine } from '@angular/material/grid-list';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { environment } from 'environments/environment';
+import {
+  EXTERNAL_SERVICE_REGISTRY,
+  ExternalServiceAvailabilityContext,
+  ExternalServiceConfiguration,
+  getVisibleExternalServices
+} from './external-services.config';
 
 /**
  * External Services component.
@@ -25,24 +34,56 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatNavList,
     MatListItem,
     MatIcon,
+    MatIconButton,
     FaIconComponent,
     MatLine
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ExternalServicesComponent {
-  // Initialize an array of 4 boolean values, all set to false
-  arrowBooleans: boolean[] = new Array(4).fill(false);
+  private readonly authenticationService = inject(AuthenticationService);
+  private readonly availabilityContext: ExternalServiceAvailabilityContext = {};
+  private readonly userPermissions: string[];
+  private readonly expandedServiceIds = new Set<string>();
 
-  constructor() {}
+  externalServices: ExternalServiceConfiguration[];
+  serviceColumns: ExternalServiceConfiguration[][];
+
+  constructor() {
+    this.userPermissions = this.authenticationService.getCredentials()?.permissions ?? [];
+    this.externalServices = getVisibleExternalServices(
+      EXTERNAL_SERVICE_REGISTRY,
+      this.availabilityContext,
+      this.userPermissions,
+      environment.productionModeEnableRBAC
+    );
+    this.serviceColumns = this.getServiceColumns(this.externalServices);
+  }
+
+  getServiceColumns(services: ExternalServiceConfiguration[]): ExternalServiceConfiguration[][] {
+    const columnSize = Math.ceil(services.length / 2);
+    if (!columnSize) {
+      return [];
+    }
+    return [
+      services.slice(0, columnSize),
+      services.slice(columnSize)
+    ].filter((column: ExternalServiceConfiguration[]) => column.length > 0);
+  }
 
   /**
-   * Popover function
-   * @param arrowNumber - The index of the boolean value to toggle.
+   * Toggles a service description.
+   * @param serviceId Service identifier.
    */
+  toggleServiceDescription(serviceId: string): void {
+    if (this.expandedServiceIds.has(serviceId)) {
+      this.expandedServiceIds.delete(serviceId);
+    } else {
+      this.expandedServiceIds.add(serviceId);
+    }
+  }
 
-  arrowBooleansToggle(arrowNumber: number) {
-    // Toggle the boolean value at the given index
-    this.arrowBooleans[arrowNumber] = !this.arrowBooleans[arrowNumber];
+  isServiceDescriptionVisible(serviceId: string): boolean {
+    return this.expandedServiceIds.has(serviceId);
   }
 }

--- a/src/app/system/external-services/external-services.config.ts
+++ b/src/app/system/external-services/external-services.config.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+export interface ExternalServiceAvailabilityContext {
+  [key: string]: unknown;
+}
+
+export interface ExternalServiceConfiguration {
+  id: string;
+  label: string;
+  description: string;
+  icon: string;
+  route: string[];
+  requiredPermission?: string | string[];
+  isAvailable?: (context: ExternalServiceAvailabilityContext) => boolean;
+}
+
+export const EXTERNAL_SERVICE_REGISTRY: readonly ExternalServiceConfiguration[] = [
+  {
+    id: 'amazon-s3',
+    label: 'labels.heading.S3 Amazon External Service',
+    description: 'labels.text.S3 Amazon Service Configuration',
+    icon: 'cloud',
+    route: ['amazon-s3']
+  },
+  {
+    id: 'sms',
+    label: 'labels.heading.SMS External Service',
+    description: 'labels.text.SMS Service Configuration',
+    icon: 'comment-alt',
+    route: ['sms']
+  },
+  {
+    id: 'email',
+    label: 'labels.heading.Email External Service',
+    description: 'labels.text.Email Service Configuration',
+    icon: 'envelope',
+    route: ['email']
+  },
+  {
+    id: 'notification',
+    label: 'labels.heading.Notification External Service',
+    description: 'labels.text.Notification Service Configuration',
+    icon: 'bell',
+    route: ['notification']
+  }
+];
+
+export function hasExternalServicePermission(
+  service: ExternalServiceConfiguration,
+  userPermissions: string[],
+  rbacEnabled: boolean
+): boolean {
+  if (!service.requiredPermission || !rbacEnabled) {
+    return true;
+  }
+
+  if (userPermissions.includes('ALL_FUNCTIONS')) {
+    return true;
+  }
+
+  const requiredPermissions = Array.isArray(service.requiredPermission)
+    ? service.requiredPermission
+    : [service.requiredPermission];
+
+  return requiredPermissions.some((permission: string) => {
+    const trimmedPermission = permission.trim();
+    return (
+      trimmedPermission !== '' &&
+      (userPermissions.includes(trimmedPermission) ||
+        (trimmedPermission.startsWith('READ_') && userPermissions.includes('ALL_FUNCTIONS_READ')))
+    );
+  });
+}
+
+export function isExternalServiceAvailable(
+  service: ExternalServiceConfiguration,
+  context: ExternalServiceAvailabilityContext
+): boolean {
+  return service.isAvailable ? service.isAvailable(context) : true;
+}
+
+export function getVisibleExternalServices(
+  registry: readonly ExternalServiceConfiguration[],
+  context: ExternalServiceAvailabilityContext,
+  userPermissions: string[],
+  rbacEnabled: boolean
+): ExternalServiceConfiguration[] {
+  return registry.filter(
+    (service: ExternalServiceConfiguration) =>
+      isExternalServiceAvailable(service, context) &&
+      hasExternalServicePermission(service, userPermissions, rbacEnabled)
+  );
+}


### PR DESCRIPTION
## Summary

Refactor the Third Party Services page to use a configuration-driven approach instead of relying on hardcoded service definitions.

This change preserves the existing functionality for SMTP, SMS, and S3 while making the page easier to extend with additional third-party services in the future. The implementation follows the existing Web-App architecture without introducing backend changes or altering current behavior.

## Related Issues

Closes #WEB-1069



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External services are now rendered dynamically based on user access permissions and service availability.
  * Service items now support dynamic links, icons, and expandable descriptions, presented in an automatic two-column layout.
  * Added a translated empty state (“No data found”) when no services are available.
* **Bug Fixes**
  * Preserves correct service ordering and deep-link navigation.
  * Ensures permission/availability filtering behaves consistently, including when RBAC is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->