### PR TITLE
WEB-1072: Add support for Two Wheeler, Education and Agricultural loan products

### DIFF
--- a/src/app/products/loan-products/create-loan-product-classic/create-loan-product-classic.component.ts
+++ b/src/app/products/loan-products/create-loan-product-classic/create-loan-product-classic.component.ts
@@ -368,14 +368,15 @@ export class CreateLoanProductClassicComponent extends LoanProductBaseComponent 
       .subscribe((response: any) => {
         this.router.navigate(
           [
-            '../',
+            '/',
+            'products',
+            'loan-products',
             response.resourceId
           ],
           {
             queryParams: {
               productType: this.loanProductService.productType.value
-            },
-            relativeTo: this.route
+            }
           }
         );
       });
@@ -387,13 +388,12 @@ export class CreateLoanProductClassicComponent extends LoanProductBaseComponent 
     this.productsService
       .createLoanProduct(this.loanProductService.loanProductPath, loanProduct)
       .subscribe((response: any) => {
-        this.router.navigate(
-          [
-            '../',
-            response.resourceId
-          ],
-          { relativeTo: this.route }
-        );
+        this.router.navigate([
+          '/',
+          'products',
+          'loan-products',
+          response.resourceId
+        ]);
       });
   }
 

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.html
@@ -7,10 +7,11 @@
 -->
 
 <div class="container">
-  <h1>{{ pageTitle }}</h1>
+  <h1>{{ pageTitle | translate }}</h1>
   <mifosx-loan-product-wizard
     [loanProductsTemplate]="loanProductsTemplate"
     [itemsByDefault]="itemsByDefault"
     [profileMode]="profileMode"
+    [accountingRuleData]="accountingRuleData"
   ></mifosx-loan-product-wizard>
 </div>

--- a/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
+++ b/src/app/products/loan-products/create-loan-product/create-loan-product.component.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
-import { LoanWizardProfileMode } from '../wizard/loan-product.config';
+import { LoanWizardProfileMode, profileForRoutePath } from '../wizard/loan-product.config';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -39,7 +39,8 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
   accountingRuleData: string[] = [];
   itemsByDefault: any[] = [];
   profileMode: LoanWizardProfileMode = 'personal';
-  pageTitle = 'Create Personal Loan';
+  /** Translation key for the page heading, resolved from the matched route. */
+  pageTitle = 'labels.heading.Create Personal Loan';
 
   constructor() {
     super();
@@ -48,10 +49,9 @@ export class CreateLoanProductComponent extends LoanProductBaseComponent impleme
     const productType = this.route.snapshot.queryParamMap.get('productType') || 'loan';
     this.loanProductService.initialize(productType);
 
-    const routePath = this.route.snapshot.routeConfig?.path;
-    this.profileMode = routePath === 'custom-advanced' ? 'custom-advanced' : 'personal';
-    this.pageTitle =
-      this.profileMode === 'custom-advanced' ? 'Custom / Advanced Loan Configuration' : 'Create Personal Loan';
+    const routeProfile = profileForRoutePath(this.route.snapshot.routeConfig?.path);
+    this.profileMode = routeProfile.profileMode;
+    this.pageTitle = routeProfile.pageTitle;
 
     this.route.data.subscribe((data) => {
       this.loanProductsTemplate = data['loanProductsTemplate'];

--- a/src/app/products/loan-products/loan-products.component.html
+++ b/src/app/products/loan-products/loan-products.component.html
@@ -27,15 +27,17 @@
         <fa-icon icon="calendar-alt" class="m-r-10"></fa-icon>
         {{ 'labels.buttons.Create Loan Product (Classic)' | translate }}
       </button>
-      <button
-        mat-menu-item
-        [routerLink]="['create']"
-        [queryParams]="{ productType: 'loan' }"
-        *mifosxHasPermission="'CREATE_LOANPRODUCT'"
-      >
-        <fa-icon icon="calendar-check" class="m-r-10"></fa-icon>
-        {{ 'labels.buttons.Create Loan Product (Convenient)' | translate }}
-      </button>
+      @if (!productionMode) {
+        <button
+          mat-menu-item
+          [routerLink]="['create']"
+          [queryParams]="{ productType: 'loan' }"
+          *mifosxHasPermission="'CREATE_LOANPRODUCT'"
+        >
+          <fa-icon icon="calendar-check" class="m-r-10"></fa-icon>
+          {{ 'labels.buttons.Create Loan Product (Convenient)' | translate }}
+        </button>
+      }
       <button
         mat-menu-item
         [routerLink]="['create/classic']"

--- a/src/app/products/loan-products/loan-products.component.ts
+++ b/src/app/products/loan-products/loan-products.component.ts
@@ -54,6 +54,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { UntypedFormControl } from '@angular/forms';
 import { LOAN_PRODUCT_TYPE, PRODUCT_TYPES } from './models/loan-product.model';
 import { LoanProductBaseComponent } from './common/loan-product-base.component';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'mifosx-loan-products',
@@ -94,6 +95,12 @@ export class LoanProductsComponent extends LoanProductBaseComponent implements O
   private errorHandler = inject(ErrorHandlerService);
 
   loanProductSelector = new UntypedFormControl();
+
+  /**
+   * Production mode (MIFOS_PRODUCTION_MODE) - hides the Convenient loan product creation flow,
+   * leaving Classic as the only way to create a loan product.
+   */
+  productionMode = environment.productionMode === true;
 
   loanProductsData: any;
   displayedColumns: string[] = [

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.html
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.html
@@ -9,7 +9,7 @@
 <div class="wizard-shell">
   <div class="wizard-shell__header">
     <div>
-      <p class="landing-page__eyebrow">{{ profileLabel }}</p>
+      <p class="landing-page__eyebrow">{{ profileLabel | translate }}</p>
       <h2>{{ 'labels.heading.Multi-step form' | translate }}</h2>
     </div>
   </div>
@@ -43,7 +43,24 @@
           </div>
         </ng-container>
 
-        <ng-container *ngIf="step.kind !== 'payment-allocation' && step.kind !== 'charges' && step.kind !== 'review'">
+        <ng-container *ngIf="step.kind === 'accounting' && loanProductsTemplate">
+          <div class="wizard-accounting">
+            <mifosx-loan-product-accounting-step
+              [loanProductsTemplate]="loanProductsTemplate"
+              [accountingRuleData]="accountingRuleData"
+              [loanProductFormValid]="form.valid"
+            ></mifosx-loan-product-accounting-step>
+          </div>
+        </ng-container>
+
+        <ng-container
+          *ngIf="
+            step.kind !== 'payment-allocation' &&
+            step.kind !== 'charges' &&
+            step.kind !== 'accounting' &&
+            step.kind !== 'review'
+          "
+        >
           <div class="field-grid">
             <ng-container *ngFor="let field of visibleFields(step); trackBy: trackByFieldKey">
               <mat-form-field *ngIf="field.type !== 'checkbox'" appearance="outline">
@@ -138,6 +155,25 @@
               </div>
             </div>
           </ng-container>
+
+          <!--
+            Accounting summary, driven by the reused Classic accounting step and rendered with the same
+            atomic mifosx-gl-account-display component Classic uses — so the selected GL accounts appear
+            exactly as they do in the Classic preview.
+          -->
+          <div class="review-section" *ngIf="accountingReview">
+            <p class="review-section__title">{{ 'labels.heading.Accounting' | translate }}</p>
+            <div class="review-row">
+              <span class="review-row__label">{{ 'labels.inputs.Type' | translate }}</span>
+              <span class="review-row__value">{{ accountingReview.ruleLabel }}</span>
+            </div>
+            <mifosx-gl-account-display
+              *ngFor="let account of accountingReview.accounts; trackBy: trackByAccountTitle"
+              [accountTitle]="account.title"
+              [glAccount]="account.glAccount"
+              [withTitle]="'47%'"
+            ></mifosx-gl-account-display>
+          </div>
 
           <div class="review-defaults-pill">
             <div>

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
@@ -697,4 +697,742 @@ describe('LoanProductWizardComponent', () => {
       expect(component.formattedPrincipal).toContain('60,000');
     });
   });
+
+  describe('golden parity: visible fields, steps and seeded form state per profile', () => {
+    // These locks pin the exact wizard surface (which fields/steps render) and the exact form
+    // seeding (what getInitialFormState + syncTemplateDefaults leave in the controls) for the
+    // existing profile modes. Any refactor of visibility or seeding shows up as an explicit,
+    // reviewable diff in these literal objects — only an intentional UX change may update them.
+
+    function personalComponent(): LoanProductWizardComponent {
+      const component = createComponent();
+      component.profileMode = 'personal';
+      component.loanProductsTemplate = {
+        currencyOptions: [{ code: 'INR' }],
+        transactionProcessingStrategyOptions: [
+          { code: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced Payment Allocation' }
+        ]
+      };
+      component.ngOnInit();
+      return component;
+    }
+
+    function customAdvancedComponent(): LoanProductWizardComponent {
+      const component = createComponent();
+      component.profileMode = 'custom-advanced';
+      component.loanProductsTemplate = {
+        currencyOptions: [{ code: 'INR' }],
+        transactionProcessingStrategyOptions: [
+          { code: 'mifos-standard-strategy', name: 'Mifos standard' },
+          { code: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced Payment Allocation' }
+        ]
+      };
+      component.ngOnInit();
+      return component;
+    }
+
+    function visibleKeysByStep(component: LoanProductWizardComponent): Record<string, string[]> {
+      return Object.fromEntries(
+        component.steps
+          .filter((step) => (step.kind ?? 'fields') === 'fields')
+          .map((step) => [
+            step.title,
+            component.visibleFields(step).map((field) => field.key)
+          ])
+      );
+    }
+
+    it('locks the Personal Loan visible field set', () => {
+      expect(visibleKeysByStep(personalComponent())).toEqual({
+        Details: [
+          'name',
+          'shortName',
+          'externalId'
+        ],
+        Currency: ['currencyCode'],
+        Terms: [
+          'principal',
+          'numberOfRepayments',
+          'interestRatePerPeriod',
+          'interestRateFrequencyType',
+          'repaymentEvery',
+          'repaymentFrequencyType'
+        ],
+        Settings: [
+          'amortizationType',
+          'interestType',
+          'interestCalculationPeriodType',
+          'transactionProcessingStrategyCode',
+          'graceOnPrincipalPayment',
+          'graceOnInterestPayment',
+          'interestFreePeriod'
+        ],
+        'Advanced Configuration': []
+      });
+    });
+
+    it('locks the Custom/Advanced visible field set', () => {
+      expect(visibleKeysByStep(customAdvancedComponent())).toEqual({
+        Details: [
+          'name',
+          'shortName',
+          'externalId',
+          'description',
+          'startDate',
+          'closeDate',
+          'includeInBorrowerCycle'
+        ],
+        Currency: [
+          'currencyCode',
+          'digitsAfterDecimal',
+          'inMultiplesOf',
+          'installmentAmountInMultiplesOf',
+          'useBorrowerCycle'
+        ],
+        Terms: [
+          'principal',
+          'numberOfRepayments',
+          'interestRatePerPeriod',
+          'interestRateFrequencyType',
+          'repaymentEvery',
+          'repaymentFrequencyType',
+          'isLinkedToFloatingInterestRates',
+          'allowApprovedDisbursedAmountsOverApplied',
+          'overAppliedCalculationType',
+          'overAppliedNumber',
+          'minimumDaysBetweenDisbursalAndFirstRepayment',
+          'interestRecognitionOnDisbursementDate'
+        ],
+        Settings: [
+          'amortizationType',
+          'interestType',
+          'calculateInterestForExactDays',
+          'isEqualAmortization',
+          'interestCalculationPeriodType',
+          'loanScheduleType',
+          'transactionProcessingStrategyCode',
+          'graceOnPrincipalPayment',
+          'graceOnInterestPayment',
+          'interestFreePeriod',
+          'daysInYearType',
+          'daysInMonthType',
+          'principalThresholdForLastInstallment',
+          'canUseForTopup',
+          'isInterestRecalculationEnabled',
+          'delinquencyBucketId',
+          'canDefineInstallmentAmount',
+          'allowVariableInstallments',
+          'multiDisburseLoan',
+          'inArrearsTolerance',
+          'graceOnArrearsAgeing',
+          'overdueDaysForNPA',
+          'accountMovesOutOfNPAOnlyOnArrearsCompletion',
+          'holdGuaranteeFunds',
+          'outstandingLoanBalance',
+          'disallowExpectedDisbursements',
+          'allowAttributeOverrides.amortizationType',
+          'allowAttributeOverrides.interestType',
+          'allowAttributeOverrides.transactionProcessingStrategyCode',
+          'allowAttributeOverrides.interestCalculationPeriodType',
+          'allowAttributeOverrides.inArrearsTolerance',
+          'allowAttributeOverrides.repaymentEvery',
+          'allowAttributeOverrides.graceOnPrincipalAndInterestPayment',
+          'allowAttributeOverrides.graceOnArrearsAgeing',
+          'enableDownPayment',
+          'enableInstallmentLevelDelinquency',
+          'enableIncomeCapitalization',
+          'enableBuydownFees'
+        ],
+        'Advanced Configuration': [
+          'useGlobalConfigForRepaymentEvent',
+          'dueDaysForRepaymentEvent',
+          'overDueDaysForRepaymentEvent'
+        ]
+      });
+    });
+
+    it('locks the Personal Loan visible step sequence', () => {
+      expect(personalComponent().visibleSteps.map((step) => step.title)).toEqual([
+        'Details',
+        'Currency',
+        'Terms',
+        'Settings',
+        'Payment Allocation',
+        'Charges',
+        'Accounting',
+        'Review'
+      ]);
+    });
+
+    it('locks the Custom/Advanced visible step sequence', () => {
+      expect(customAdvancedComponent().visibleSteps.map((step) => step.title)).toEqual([
+        'Details',
+        'Currency',
+        'Terms',
+        'Settings',
+        'Charges',
+        'Accounting',
+        'Advanced Configuration',
+        'Review'
+      ]);
+    });
+
+    it('locks the Personal Loan form seeding when the template omits the seeded fields', () => {
+      // The stub template carries no principal/rate/repayments, so every value below comes from
+      // getInitialFormState + the syncTemplateDefaults fallbacks — the exact code paths a
+      // profile-aware seeding refactor touches.
+      expect(personalComponent().form.getRawValue()).toMatchObject({
+        principal: '',
+        numberOfRepayments: 12,
+        interestRatePerPeriod: '',
+        interestRateFrequencyType: 2,
+        repaymentEvery: 1,
+        repaymentFrequencyType: 2,
+        transactionProcessingStrategyCode: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+        loanScheduleType: 'Progressive',
+        multiDisburseLoan: true,
+        allowVariableInstallments: true,
+        enableDownPayment: false,
+        disbursedAmountPercentageForDownPayment: 35,
+        currencyCode: 'INR'
+      });
+    });
+
+    it('locks the Custom/Advanced form seeding when the template omits the seeded fields', () => {
+      expect(customAdvancedComponent().form.getRawValue()).toMatchObject({
+        principal: '',
+        numberOfRepayments: 12,
+        interestRatePerPeriod: '',
+        transactionProcessingStrategyCode: 'interest-principal-penalties-fees-order-strategy',
+        loanScheduleType: 'Progressive',
+        multiDisburseLoan: false,
+        allowVariableInstallments: false,
+        enableDownPayment: false,
+        disbursedAmountPercentageForDownPayment: 35,
+        currencyCode: 'INR'
+      });
+    });
+  });
+
+  describe('Two Wheeler profile', () => {
+    function twoWheelerComponent(templateExtras: Record<string, unknown> = {}): LoanProductWizardComponent {
+      const component = createComponent();
+      component.profileMode = 'two-wheeler';
+      component.loanProductsTemplate = {
+        currencyOptions: [{ code: 'INR' }],
+        transactionProcessingStrategyOptions: [
+          { code: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced Payment Allocation' }
+        ],
+        advancedPaymentAllocationTransactionTypes: [{ id: 1, code: 'DEFAULT', value: 'Default' }],
+        advancedPaymentAllocationTypes: [
+          { id: 1, code: 'PENALTY', value: 'Penalty' },
+          { id: 2, code: 'FEE', value: 'Fee' },
+          { id: 3, code: 'INTEREST', value: 'Interest' },
+          { id: 4, code: 'PRINCIPAL', value: 'Principal' }
+        ],
+        advancedPaymentAllocationFutureInstallmentAllocationRules: [
+          { id: 1, code: 'NEXT_INSTALLMENT', value: 'Next installment' }
+        ],
+        ...templateExtras
+      };
+      component.ngOnInit();
+      return component;
+    }
+
+    function visibleKeysByStep(component: LoanProductWizardComponent): Record<string, string[]> {
+      return Object.fromEntries(
+        component.steps
+          .filter((step) => (step.kind ?? 'fields') === 'fields')
+          .map((step) => [
+            step.title,
+            component.visibleFields(step).map((field) => field.key)
+          ])
+      );
+    }
+
+    it('locks the Two Wheeler visible field set: Personal plus the editable down payment %', () => {
+      expect(visibleKeysByStep(twoWheelerComponent())).toEqual({
+        Details: [
+          'name',
+          'shortName',
+          'externalId'
+        ],
+        Currency: ['currencyCode'],
+        Terms: [
+          'principal',
+          'numberOfRepayments',
+          'interestRatePerPeriod',
+          'interestRateFrequencyType',
+          'repaymentEvery',
+          'repaymentFrequencyType'
+        ],
+        Settings: [
+          'amortizationType',
+          'interestType',
+          'interestCalculationPeriodType',
+          'transactionProcessingStrategyCode',
+          'graceOnPrincipalPayment',
+          'graceOnInterestPayment',
+          'interestFreePeriod',
+          'delinquencyBucketId',
+          'disbursedAmountPercentageForDownPayment'
+        ],
+        'Advanced Configuration': []
+      });
+    });
+
+    it('keeps the down payment toggle and auto-repayment flag hidden (forced by the profile)', () => {
+      const settingsKeys = visibleKeysByStep(twoWheelerComponent()).Settings;
+
+      expect(settingsKeys).not.toContain('enableDownPayment');
+      expect(settingsKeys).not.toContain('enableAutoRepaymentForDownPayment');
+    });
+
+    it('shows the same guided step sequence as Personal, including Payment Allocation', () => {
+      expect(twoWheelerComponent().visibleSteps.map((step) => step.title)).toEqual([
+        'Details',
+        'Currency',
+        'Terms',
+        'Settings',
+        'Payment Allocation',
+        'Charges',
+        'Accounting',
+        'Review'
+      ]);
+    });
+
+    it('seeds the curated Two Wheeler prefills when the template omits those fields', () => {
+      expect(twoWheelerComponent().form.getRawValue()).toMatchObject({
+        principal: 80000,
+        numberOfRepayments: 36,
+        interestRatePerPeriod: 14,
+        interestRateFrequencyType: 3,
+        enableDownPayment: true,
+        disbursedAmountPercentageForDownPayment: 20,
+        transactionProcessingStrategyCode: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+        loanScheduleType: 'Progressive',
+        currencyCode: 'INR'
+      });
+    });
+
+    it('lets the curated prefills win over the generic backend template defaults', () => {
+      // The template's generic defaults (e.g. per-month rate frequency) would turn "14% per year"
+      // into "14% per month" — a very different product. Curated profile prefills must win for
+      // exactly the overridden keys; non-overridden keys keep their template-first behavior.
+      const component = twoWheelerComponent({
+        interestRateFrequencyType: { id: 2 },
+        numberOfRepayments: 12,
+        repaymentEvery: 4,
+        daysInMonthType: { id: 1, code: 'DaysInMonthType.actual', value: 'Same as in year' }
+      });
+
+      expect(component.form.getRawValue()).toMatchObject({
+        interestRateFrequencyType: 3,
+        numberOfRepayments: 36,
+        // Not a curated key: the template still wins over INITIAL_FORM_STATE.
+        repaymentEvery: 4,
+        daysInMonthType: 1
+      });
+    });
+
+    it('submits the Personal-shaped guided payload with the Two Wheeler down payment deltas', () => {
+      const component = twoWheelerComponent();
+      const payload = component.buildPayloadForSubmit();
+
+      expect(payload.transactionProcessingStrategyCode).toBe(LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
+      expect(payload.loanScheduleType).toBe('PROGRESSIVE');
+      expect(Array.isArray(payload.paymentAllocation)).toBe(true);
+      expect((payload.paymentAllocation as unknown[]).length).toBeGreaterThan(0);
+      expect(payload.enableDownPayment).toBe(true);
+      expect(payload.disbursedAmountPercentageForDownPayment).toBe(20);
+      expect(payload.enableAutoRepaymentForDownPayment).toBe(true);
+      expect(payload.description).toBe('Two Wheeler Loan Product');
+      expect(payload.multiDisburseLoan).toBeUndefined();
+      expect(payload.maxTrancheCount).toBeUndefined();
+    });
+
+    it('submits a user-edited down payment percentage instead of the prefill', () => {
+      const component = twoWheelerComponent();
+      component.form.patchValue({ disbursedAmountPercentageForDownPayment: 25 });
+
+      expect(component.buildPayloadForSubmit().disbursedAmountPercentageForDownPayment).toBe(25);
+    });
+
+    it('exposes one profile label translation key per mode', () => {
+      const component = twoWheelerComponent();
+      expect(component.profileLabel).toBe('labels.text.Two Wheeler Loan');
+
+      component.profileMode = 'personal';
+      expect(component.profileLabel).toBe('labels.text.Personal Loan');
+
+      component.profileMode = 'custom-advanced';
+      expect(component.profileLabel).toBe('labels.text.Custom / Advanced');
+
+      component.profileMode = 'education';
+      expect(component.profileLabel).toBe('labels.text.Education Loan');
+
+      component.profileMode = 'agriculture';
+      expect(component.profileLabel).toBe('labels.text.Agriculture Loan');
+    });
+  });
+
+  describe('Education profile', () => {
+    function educationComponent(templateExtras: Record<string, unknown> = {}): LoanProductWizardComponent {
+      const component = createComponent();
+      component.profileMode = 'education';
+      component.loanProductsTemplate = {
+        currencyOptions: [{ code: 'INR' }],
+        transactionProcessingStrategyOptions: [
+          { code: 'mifos-standard-strategy', name: 'Mifos standard' },
+          { code: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced Payment Allocation' }
+        ],
+        ...templateExtras
+      };
+      component.ngOnInit();
+      return component;
+    }
+
+    function visibleKeysByStep(component: LoanProductWizardComponent): Record<string, string[]> {
+      return Object.fromEntries(
+        component.steps
+          .filter((step) => (step.kind ?? 'fields') === 'fields')
+          .map((step) => [
+            step.title,
+            component.visibleFields(step).map((field) => field.key)
+          ])
+      );
+    }
+
+    it('locks the Education visible field set: the moratorium and tranche controls headline Settings', () => {
+      expect(visibleKeysByStep(educationComponent())).toEqual({
+        Details: [
+          'name',
+          'shortName',
+          'externalId'
+        ],
+        Currency: ['currencyCode'],
+        Terms: [
+          'principal',
+          'numberOfRepayments',
+          'interestRatePerPeriod',
+          'interestRateFrequencyType',
+          'repaymentEvery',
+          'repaymentFrequencyType'
+        ],
+        Settings: [
+          'graceOnPrincipalPayment',
+          'graceOnInterestPayment',
+          'delinquencyBucketId',
+          'maxTrancheCount'
+        ],
+        'Advanced Configuration': []
+      });
+    });
+
+    it('hides the Payment Allocation step: Education runs on the Cumulative + standard-strategy stack', () => {
+      const component = educationComponent();
+
+      expect(component.isAdvancedPaymentStrategy).toBe(false);
+      expect(component.visibleSteps.map((step) => step.title)).toEqual([
+        'Details',
+        'Currency',
+        'Terms',
+        'Settings',
+        'Charges',
+        'Accounting',
+        'Review'
+      ]);
+    });
+
+    it('seeds the curated Education prefills when the template omits those fields', () => {
+      expect(educationComponent().form.getRawValue()).toMatchObject({
+        principal: 500000,
+        numberOfRepayments: 120,
+        interestRatePerPeriod: 10.5,
+        interestRateFrequencyType: 3,
+        graceOnPrincipalPayment: 24,
+        maxTrancheCount: 8,
+        multiDisburseLoan: true,
+        transactionProcessingStrategyCode: 'mifos-standard-strategy',
+        loanScheduleType: 'Cumulative',
+        currencyCode: 'INR'
+      });
+    });
+
+    it('lets the curated prefills win over the generic backend template defaults', () => {
+      const component = educationComponent({
+        graceOnPrincipalPayment: 0,
+        numberOfRepayments: 12,
+        interestRateFrequencyType: { id: 2 },
+        // Not a curated key: the template still wins over INITIAL_FORM_STATE.
+        repaymentEvery: 4
+      });
+
+      expect(component.form.getRawValue()).toMatchObject({
+        graceOnPrincipalPayment: 24,
+        numberOfRepayments: 120,
+        interestRateFrequencyType: 3,
+        repaymentEvery: 4
+      });
+    });
+
+    it('submits the Cumulative-stack payload with the moratorium and tranches, and no allocation', () => {
+      const component = educationComponent();
+      const payload = component.buildPayloadForSubmit();
+
+      expect(payload.loanScheduleType).toBe('CUMULATIVE');
+      expect(payload.transactionProcessingStrategyCode).toBe('mifos-standard-strategy');
+      expect(payload.interestCalculationPeriodType).toBe(0);
+      expect(payload.graceOnPrincipalPayment).toBe(24);
+      expect(payload.multiDisburseLoan).toBe(true);
+      expect(payload.maxTrancheCount).toBe(8);
+      expect(payload.enableDownPayment).toBe(false);
+      expect(payload.description).toBe('Education Loan Product');
+      expect(payload.paymentAllocation).toBeUndefined();
+      expect(payload.creditAllocation).toBeUndefined();
+      expect(payload.chargeOffBehaviour).toBeUndefined();
+      expect(payload.outstandingLoanBalance).toBeUndefined();
+    });
+
+    it('submits a user-edited moratorium and tranche count instead of the prefills', () => {
+      const component = educationComponent();
+      component.form.patchValue({ graceOnPrincipalPayment: 36, maxTrancheCount: 10 });
+
+      const payload = component.buildPayloadForSubmit();
+
+      expect(payload.graceOnPrincipalPayment).toBe(36);
+      expect(payload.maxTrancheCount).toBe(10);
+    });
+  });
+
+  describe('Agriculture profile', () => {
+    function agricultureComponent(templateExtras: Record<string, unknown> = {}): LoanProductWizardComponent {
+      const component = createComponent();
+      component.profileMode = 'agriculture';
+      component.loanProductsTemplate = {
+        currencyOptions: [{ code: 'INR' }],
+        transactionProcessingStrategyOptions: [
+          {
+            code: 'principal-interest-penalties-fees-order-strategy',
+            name: 'Principal → Interest → Penalties → Fees'
+          },
+          { code: 'mifos-standard-strategy', name: 'Mifos standard' },
+          { code: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced Payment Allocation' }
+        ],
+        ...templateExtras
+      };
+      component.ngOnInit();
+      return component;
+    }
+
+    function visibleKeysByStep(component: LoanProductWizardComponent): Record<string, string[]> {
+      return Object.fromEntries(
+        component.steps
+          .filter((step) => (step.kind ?? 'fields') === 'fields')
+          .map((step) => [
+            step.title,
+            component.visibleFields(step).map((field) => field.key)
+          ])
+      );
+    }
+
+    it('locks the Agriculture visible field set: the season terms plus the NPA clock', () => {
+      expect(visibleKeysByStep(agricultureComponent())).toEqual({
+        Details: [
+          'name',
+          'shortName',
+          'externalId'
+        ],
+        Currency: ['currencyCode'],
+        Terms: [
+          'principal',
+          'numberOfRepayments',
+          'interestRatePerPeriod',
+          'interestRateFrequencyType',
+          'repaymentEvery',
+          'repaymentFrequencyType'
+        ],
+        Settings: [
+          'delinquencyBucketId',
+          'overdueDaysForNPA'
+        ],
+        'Advanced Configuration': []
+      });
+    });
+
+    it('hides the Payment Allocation step: Agriculture runs on the Cumulative + principal-first stack', () => {
+      const component = agricultureComponent();
+
+      expect(component.isAdvancedPaymentStrategy).toBe(false);
+      expect(component.visibleSteps.map((step) => step.title)).toEqual([
+        'Details',
+        'Currency',
+        'Terms',
+        'Settings',
+        'Charges',
+        'Accounting',
+        'Review'
+      ]);
+    });
+
+    it('seeds the curated Agriculture prefills when the template omits those fields', () => {
+      expect(agricultureComponent().form.getRawValue()).toMatchObject({
+        principal: 100000,
+        numberOfRepayments: 1,
+        repaymentEvery: 12,
+        interestRatePerPeriod: 7,
+        interestRateFrequencyType: 3,
+        overdueDaysForNPA: 180,
+        transactionProcessingStrategyCode: 'principal-interest-penalties-fees-order-strategy',
+        loanScheduleType: 'Cumulative',
+        currencyCode: 'INR'
+      });
+    });
+
+    it('lets the curated prefills win over the generic backend template defaults', () => {
+      const component = agricultureComponent({
+        overdueDaysForNPA: 90,
+        numberOfRepayments: 12,
+        interestRateFrequencyType: { id: 2 },
+        // Not a curated key: the template still wins over INITIAL_FORM_STATE.
+        graceOnArrearsAgeing: 10
+      });
+
+      expect(component.form.getRawValue()).toMatchObject({
+        overdueDaysForNPA: 180,
+        numberOfRepayments: 1,
+        interestRateFrequencyType: 3,
+        graceOnArrearsAgeing: 10
+      });
+    });
+
+    it('submits the bullet payload: one installment, flat interest, no allocation, no tranches', () => {
+      const component = agricultureComponent();
+      const payload = component.buildPayloadForSubmit();
+
+      expect(payload.numberOfRepayments).toBe(1);
+      expect(payload.repaymentEvery).toBe(12);
+      expect(payload.interestType).toBe(1);
+      expect(payload.loanScheduleType).toBe('CUMULATIVE');
+      expect(payload.transactionProcessingStrategyCode).toBe('principal-interest-penalties-fees-order-strategy');
+      expect(payload.overdueDaysForNPA).toBe(180);
+      expect(payload.enableDownPayment).toBe(false);
+      expect(payload.description).toBe('Agriculture Loan Product');
+      expect(payload.paymentAllocation).toBeUndefined();
+      expect(payload.creditAllocation).toBeUndefined();
+      expect(payload.multiDisburseLoan).toBeUndefined();
+      expect(payload.chargeOffBehaviour).toBeUndefined();
+    });
+
+    it('submits a user-tuned season: NPA days and cycle structure instead of the prefills', () => {
+      const component = agricultureComponent();
+      component.form.patchValue({ overdueDaysForNPA: 360, numberOfRepayments: 2, repaymentEvery: 6 });
+
+      const payload = component.buildPayloadForSubmit();
+
+      expect(payload.overdueDaysForNPA).toBe(360);
+      expect(payload.numberOfRepayments).toBe(2);
+      expect(payload.repaymentEvery).toBe(6);
+    });
+  });
+
+  describe('Accounting step reuse (Classic parity)', () => {
+    // Minimal stub of the reused Classic accounting step: exposes the same `loanProductAccounting`
+    // raw value and `loanProductAccountingForm` the real component does, which is all the wizard reads.
+    function accountingStepStub(loanProductAccounting: Record<string, unknown>, invalid = false): any {
+      return { loanProductAccounting, loanProductAccountingForm: { invalid, markAllAsTouched: jest.fn() } };
+    }
+
+    function personalComponent(): LoanProductWizardComponent {
+      const component = createComponent();
+      component.profileMode = 'personal';
+      component.loanProductsTemplate = {
+        currencyOptions: [{ code: 'INR' }],
+        transactionProcessingStrategyOptions: [
+          { code: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced Payment Allocation' }
+        ],
+        accountingMappingOptions: {
+          assetAccountOptions: [{ id: 4, name: 'Fund', glCode: '1001' }],
+          incomeAccountOptions: [{ id: 7, name: 'Interest income', glCode: '4001' }],
+          expenseAccountOptions: [{ id: 9, name: 'Write off', glCode: '5001' }],
+          liabilityAccountOptions: [{ id: 12, name: 'Overpayment', glCode: '2001' }]
+        }
+      };
+      component.ngOnInit();
+      return component;
+    }
+
+    it('folds the Cash GL account ids from the reused accounting step into the payload and overrides the rule', () => {
+      const component = personalComponent();
+      component.loanProductAccountingStep = accountingStepStub({
+        accountingRule: 2,
+        fundSourceAccountId: 4,
+        loanPortfolioAccountId: 5,
+        interestOnLoanAccountId: 7,
+        writeOffAccountId: 9,
+        overpaymentLiabilityAccountId: 12
+      });
+
+      const payload = component.buildPayloadForSubmit();
+
+      // The seeded INITIAL_FORM_STATE accountingRule (2) is overridden by the step's value, and every
+      // mandatory GL account id the step collected is present — the ids Fineract was rejecting before.
+      expect(payload.accountingRule).toBe(2);
+      expect(payload.fundSourceAccountId).toBe(4);
+      expect(payload.loanPortfolioAccountId).toBe(5);
+      expect(payload.interestOnLoanAccountId).toBe(7);
+      expect(payload.writeOffAccountId).toBe(9);
+      expect(payload.overpaymentLiabilityAccountId).toBe(12);
+    });
+
+    it('lets the accounting step drive the rule to None (1) so an untouched form needs no GL accounts', () => {
+      const component = personalComponent();
+      component.loanProductAccountingStep = accountingStepStub({ accountingRule: 1 });
+
+      const payload = component.buildPayloadForSubmit();
+
+      expect(payload.accountingRule).toBe(1);
+      expect(payload.fundSourceAccountId).toBeUndefined();
+    });
+
+    it('blocks submit when the reused accounting form is invalid (Cash without accounts)', () => {
+      const component = personalComponent();
+      component.form.patchValue({ name: 'LP', shortName: 'LP', principal: 1000, interestRatePerPeriod: 12 });
+      const step = accountingStepStub({ accountingRule: 2 }, true);
+      component.loanProductAccountingStep = step;
+      productsServiceStub.createLoanProduct.mockClear();
+
+      component.submit();
+
+      expect(step.loanProductAccountingForm.markAllAsTouched).toHaveBeenCalled();
+      expect(productsServiceStub.createLoanProduct).not.toHaveBeenCalled();
+    });
+
+    it('resolves the selected accounts for the Review exactly like Classic (gl-account-display objects)', () => {
+      const component = personalComponent();
+      component.loanProductAccountingStep = accountingStepStub({
+        accountingRule: 2,
+        fundSourceAccountId: 4,
+        writeOffAccountId: 9
+      });
+
+      const review = component.accountingReview;
+
+      expect(review?.ruleLabel).toBe('Cash-based');
+      expect(review?.accounts).toEqual([
+        { title: 'Fund source', glAccount: { id: 4, name: 'Fund', glCode: '1001' } },
+        { title: 'Losses written off', glAccount: { id: 9, name: 'Write off', glCode: '5001' } }
+      ]);
+    });
+
+    it('shows only the rule (no accounts) in the Review when accounting is None', () => {
+      const component = personalComponent();
+      component.loanProductAccountingStep = accountingStepStub({ accountingRule: 1 });
+
+      const review = component.accountingReview;
+
+      expect(review?.ruleLabel).toBe('None');
+      expect(review?.accounts).toEqual([]);
+    });
+  });
 });

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
@@ -11,10 +11,15 @@ import { FormBuilder, FormGroup, UntypedFormControl, ValidatorFn, Validators } f
 import { Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import {
-  HIDDEN_DEFAULTS,
   FORM_STEPS,
   INITIAL_FORM_STATE,
+  PROFILE_EXTRA_VISIBLE_FIELDS,
+  PROFILE_INITIAL_OVERRIDES,
+  PROFILE_LABEL_KEYS,
   buildPayload,
+  forcesProgressiveStack,
+  hiddenDefaultsFor,
+  isGuidedProfileMode,
   VALUE_MAP,
   SelectOption,
   LoanWizardProfileMode,
@@ -32,6 +37,8 @@ import {
 } from '../loan-product-stepper/loan-product-payment-strategy-step/payment-allocation-model';
 import { LoanProductPaymentStrategyStepComponent } from '../loan-product-stepper/loan-product-payment-strategy-step/loan-product-payment-strategy-step.component';
 import { LoanProductChargesStepComponent } from '../loan-product-stepper/loan-product-charges-step/loan-product-charges-step.component';
+import { LoanProductAccountingStepComponent } from '../loan-product-stepper/loan-product-accounting-step/loan-product-accounting-step.component';
+import { GlAccountDisplayComponent } from '../../../shared/accounting/gl-account-display/gl-account-display.component';
 import { LoanProductService } from '../services/loan-product.service';
 import { Router } from '@angular/router';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -43,6 +50,37 @@ import { SettingsService } from 'app/settings/settings.service';
 /** Currency symbols rendered in the Review banner, keyed by ISO currency code. */
 const CURRENCY_SYMBOLS: Record<string, string> = { INR: '₹', USD: '$', EUR: '€', GBP: '£' };
 
+/**
+ * The GL account controls the reused Classic accounting step collects for a Cash/Accrual loan
+ * product, each paired with the exact account title Classic's summary renders. Used only to build the
+ * Review's accounting section (via the reused `mifosx-gl-account-display`); the payload itself is
+ * driven entirely by the step's raw form value. Receivable accounts appear only for Accrual and are
+ * simply absent from the step's value for Cash, so a single presence filter covers both rules.
+ */
+const ACCOUNTING_REVIEW_ACCOUNTS: ReadonlyArray<{ key: string; title: string }> = [
+  { key: 'fundSourceAccountId', title: 'Fund source' },
+  { key: 'loanPortfolioAccountId', title: 'Loan portfolio' },
+  { key: 'transfersInSuspenseAccountId', title: 'Transfer in suspense' },
+  { key: 'receivableInterestAccountId', title: 'Interest Receivable' },
+  { key: 'receivableFeeAccountId', title: 'Fees Receivable' },
+  { key: 'receivablePenaltyAccountId', title: 'Penalties Receivable' },
+  { key: 'interestOnLoanAccountId', title: 'Income from Interest' },
+  { key: 'incomeFromFeeAccountId', title: 'Income from fees' },
+  { key: 'incomeFromPenaltyAccountId', title: 'Income from penalties' },
+  { key: 'incomeFromRecoveryAccountId', title: 'Income from Recovery Repayments' },
+  { key: 'incomeFromChargeOffInterestAccountId', title: 'Income from ChargeOff Interest' },
+  { key: 'incomeFromChargeOffFeesAccountId', title: 'Income from ChargeOff Fees' },
+  { key: 'incomeFromChargeOffPenaltyAccountId', title: 'Income from ChargeOff Penalty' },
+  { key: 'incomeFromGoodwillCreditInterestAccountId', title: 'Income from Goodwill Credit Interest' },
+  { key: 'incomeFromGoodwillCreditFeesAccountId', title: 'Income from Goodwill Credit Fees' },
+  { key: 'incomeFromGoodwillCreditPenaltyAccountId', title: 'Income from Goodwill Credit Penalty' },
+  { key: 'writeOffAccountId', title: 'Losses written off' },
+  { key: 'goodwillCreditAccountId', title: 'Expenses from Goodwill Credit' },
+  { key: 'chargeOffExpenseAccountId', title: 'ChargeOff Expense' },
+  { key: 'chargeOffFraudExpenseAccountId', title: 'ChargeOff Fraud Expense' },
+  { key: 'overpaymentLiabilityAccountId', title: 'Over payment liability' }
+];
+
 @Component({
   selector: 'mifosx-loan-product-wizard',
   standalone: true,
@@ -51,7 +89,9 @@ const CURRENCY_SYMBOLS: Record<string, string> = { INR: '₹', USD: '$', EUR: '�
     MatStepperModule,
     MatButtonModule,
     LoanProductPaymentStrategyStepComponent,
-    LoanProductChargesStepComponent
+    LoanProductChargesStepComponent,
+    LoanProductAccountingStepComponent,
+    GlAccountDisplayComponent
   ],
   templateUrl: './loan-product-wizard.component.html',
   styleUrls: ['./loan-product-wizard.component.scss']
@@ -68,7 +108,11 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
   private readonly translateService = inject(TranslateService);
   private readonly dateUtils = inject(Dates);
   private readonly settingsService = inject(SettingsService);
-  private readonly hiddenFieldKeys = new Set(Object.keys(HIDDEN_DEFAULTS));
+  // Hidden-key set derived from the ACTIVE profile's hidden defaults (Two Wheeler, for example,
+  // removes the down payment % from its defaults so it can be a visible control). Computed lazily
+  // and memoised per mode because `profileMode` is an @Input, not yet set when class fields
+  // initialize.
+  private hiddenFieldKeysCache?: { profileMode: LoanWizardProfileMode; keys: Set<string> };
   // Single source of truth for each control's config, so the `required`/`maxLength` metadata declared
   // in FORM_STEPS is wired into real Angular Validators instead of only decorating the template.
   private readonly fieldConfigByKey = new Map<string, FormField>(
@@ -81,10 +125,19 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
   @Input() loanProductsTemplate: any;
   @Input() itemsByDefault: any[] = [];
   @Input() profileMode: LoanWizardProfileMode = 'personal';
+  // The accounting-rule display names (NONE / CASH_BASED / ACCRUAL_PERIODIC / ACCRUAL_UPFRONT) the
+  // reused Classic accounting step renders as radio options — resolved by the host from the shared
+  // `Accounting` util, identical to Classic.
+  @Input() accountingRuleData: any[] = [];
 
   // Reused Classic Charges step. Rendered for the `kind: 'charges'` step; read at submit time to fold the
   // selected charge objects into the payload — mirrors Classic's `@ViewChild(LoanProductChargesStepComponent)`.
   @ViewChild(LoanProductChargesStepComponent) loanProductChargesStep?: LoanProductChargesStepComponent;
+
+  // Reused Classic Accounting step. Rendered for the `kind: 'accounting'` step; it owns the accounting
+  // rule and — for Cash/Accrual — every mandatory GL account selector, validator and advanced mapping
+  // rule. Read at submit time so its collected values are folded into the payload exactly like Classic.
+  @ViewChild(LoanProductAccountingStepComponent) loanProductAccountingStep?: LoanProductAccountingStepComponent;
 
   steps = FORM_STEPS;
   valueMap = VALUE_MAP;
@@ -118,9 +171,32 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
     this.formValueChangesSubscription?.unsubscribe();
   }
 
-  /** Human-readable name of the active profile, shown in the wizard header. */
+  /** Translation key for the active profile's name, shown in the wizard header. */
   get profileLabel(): string {
-    return this.profileMode === 'custom-advanced' ? 'Custom / Advanced' : 'Personal Loan';
+    return PROFILE_LABEL_KEYS[this.profileMode];
+  }
+
+  private get hiddenFieldKeys(): Set<string> {
+    if (this.hiddenFieldKeysCache?.profileMode !== this.profileMode) {
+      this.hiddenFieldKeysCache = {
+        profileMode: this.profileMode,
+        keys: new Set(Object.keys(hiddenDefaultsFor(this.profileMode)))
+      };
+    }
+    return this.hiddenFieldKeysCache.keys;
+  }
+
+  private get isGuidedProfile(): boolean {
+    return isGuidedProfileMode(this.profileMode);
+  }
+
+  private get forcesProgressiveStack(): boolean {
+    return forcesProgressiveStack(this.profileMode);
+  }
+
+  /** Keys the active profile re-exposes even though the guided-hidden lists would hide them. */
+  private isProfileExtraVisibleField(key: string): boolean {
+    return (PROFILE_EXTRA_VISIBLE_FIELDS[this.profileMode] ?? []).includes(key);
   }
 
   /**
@@ -142,6 +218,9 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
         return this.isAdvancedPaymentStrategy;
       }
       if (step.kind === 'charges') {
+        return true;
+      }
+      if (step.kind === 'accounting') {
         return true;
       }
       return this.visibleFields(step).length > 0;
@@ -190,6 +269,10 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
     return row.label;
   }
 
+  trackByAccountTitle(_index: number, account: { title: string }): string {
+    return account.title;
+  }
+
   visibleFields(step: FormStep): FormField[] {
     return step.fields
       .map((field) => {
@@ -211,7 +294,11 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
           return false;
         }
 
-        if (this.profileMode === 'personal' && this.hiddenFieldKeys.has(field.key)) {
+        if (
+          this.isGuidedProfile &&
+          this.hiddenFieldKeys.has(field.key) &&
+          !this.isProfileExtraVisibleField(field.key)
+        ) {
           return false;
         }
 
@@ -230,7 +317,7 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
           return false;
         }
 
-        if (this.profileMode === 'personal' && this.isCustomOnlyField(field.key)) {
+        if (this.isGuidedProfile && this.isCustomOnlyField(field.key) && !this.isProfileExtraVisibleField(field.key)) {
           return false;
         }
 
@@ -317,6 +404,14 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
     formValue.charges = this.selectedCharges;
     const merged = buildPayload(formValue, this.profileMode, this.loanProductsTemplate);
     this.applyAdvancedPaymentAllocation(merged);
+    // Fold in the accounting rule + GL account mappings collected by the reused Classic accounting
+    // step, mirroring Classic's `...this.loanProductAccountingStep.loanProductAccounting` spread. For
+    // None it overrides the seeded `accountingRule` with 1; for Cash/Accrual it also supplies every
+    // mandatory account id (fundSourceAccountId, loanPortfolioAccountId, …) so Fineract accepts the
+    // request. Guarded so unit tests that invoke the builder without rendering the step are unchanged.
+    if (this.loanProductAccountingStep) {
+      Object.assign(merged, this.loanProductAccountingStep.loanProductAccounting);
+    }
     return this.loanProducts.buildPayload(merged, this.itemsByDefault || []);
   }
 
@@ -520,6 +615,46 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   /**
+   * Accounting summary for the Review, driven by the reused Classic accounting step's collected
+   * values and rendered with the atomic Classic `mifosx-gl-account-display` (identical GL-code + name
+   * formatting). Each selected account id is resolved to its GL account object from the template's
+   * account options — account ids are globally unique in Fineract, so one union lookup covers every
+   * field without duplicating Classic's per-category mapping. Returns just the rule for None (or when
+   * the step has not been rendered), matching Classic's "Type: <rule>" summary line.
+   */
+  get accountingReview(): { ruleLabel: string; accounts: Array<{ title: string; glAccount: unknown }> } | null {
+    const accounting = this.loanProductAccountingStep?.loanProductAccounting;
+    if (!accounting) {
+      return null;
+    }
+    const ruleLabel = this.formatValue('accountingRule', accounting.accountingRule);
+    const ruleId = Number(accounting.accountingRule);
+    if (!(ruleId >= 2 && ruleId <= 4)) {
+      return { ruleLabel, accounts: [] };
+    }
+    const options = this.loanProductsTemplate?.accountingMappingOptions ?? {};
+    const glAccounts: any[] = [
+      ...(options.assetAccountOptions ?? []),
+      ...(options.incomeAccountOptions ?? []),
+      ...(options.expenseAccountOptions ?? []),
+      ...(options.liabilityAccountOptions ?? [])
+    ];
+    const accounts = ACCOUNTING_REVIEW_ACCOUNTS.map((field) => {
+      const id = (accounting as Record<string, unknown>)[field.key];
+      if (id === null || id === undefined || id === '') {
+        return null;
+      }
+      // Compared as strings: the control's value is a `mat-option` [value] binding of the numeric
+      // `GLAccount.id` today, but the guard above already tolerates a string (''), so a strict `===`
+      // would silently drop a row if any caller ever seeded the step with string ids. Both sides come
+      // from the same id space, so stringifying cannot introduce a false match.
+      const glAccount = glAccounts.find((account) => String(account.id) === String(id)) ?? null;
+      return glAccount ? { title: field.title, glAccount } : null;
+    }).filter((row): row is { title: string; glAccount: unknown } => row !== null);
+    return { ruleLabel, accounts };
+  }
+
+  /**
    * Formats a single visible field's current form value for the Review, reusing the field's own
    * configuration (its resolved `options` for selects). No payload/defaults logic is involved.
    */
@@ -604,10 +739,14 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
 
   submit(): void {
     // Every required field is visible in both profiles, so an invalid form means the user left a
-    // required control blank (or exceeded a maxLength). Surface the errors instead of POSTing a
-    // payload the backend would reject.
-    if (this.form.invalid) {
+    // required control blank (or exceeded a maxLength). The reused Classic accounting step keeps its
+    // own FormGroup (with the mandatory GL account validators for Cash/Accrual), so it must be checked
+    // alongside the wizard form — otherwise a Cash product with unselected accounts would POST and the
+    // backend would reject it with "fundSourceAccountId is mandatory". Surface the errors instead.
+    const accountingForm = this.loanProductAccountingStep?.loanProductAccountingForm;
+    if (this.form.invalid || accountingForm?.invalid) {
       this.form.markAllAsTouched();
+      accountingForm?.markAllAsTouched();
       return;
     }
     const final = this.buildPayloadForSubmit();
@@ -665,16 +804,16 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
         interestCalculationPeriodType:
           this.loanProductsTemplate.interestCalculationPeriodType?.id ??
           INITIAL_FORM_STATE.interestCalculationPeriodType,
-        // Personal Loan always uses Progressive schedule type - never let template override this
-        loanScheduleType:
-          this.profileMode === 'personal'
-            ? INITIAL_FORM_STATE.loanScheduleType
-            : (this.loanProductsTemplate.loanScheduleType?.value ?? INITIAL_FORM_STATE.loanScheduleType),
-        transactionProcessingStrategyCode:
-          this.profileMode === 'personal'
-            ? LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
-            : (this.loanProductsTemplate.transactionProcessingStrategyCode ??
-              INITIAL_FORM_STATE.transactionProcessingStrategyCode),
+        // Progressive-stack profiles pin the schedule type and strategy - never let the template
+        // override them. Education pins its Cumulative stack via PROFILE_INITIAL_OVERRIDES instead
+        // (spread last below), so it intentionally falls through this branch.
+        loanScheduleType: this.forcesProgressiveStack
+          ? INITIAL_FORM_STATE.loanScheduleType
+          : (this.loanProductsTemplate.loanScheduleType?.value ?? INITIAL_FORM_STATE.loanScheduleType),
+        transactionProcessingStrategyCode: this.forcesProgressiveStack
+          ? LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
+          : (this.loanProductsTemplate.transactionProcessingStrategyCode ??
+            INITIAL_FORM_STATE.transactionProcessingStrategyCode),
         loanScheduleProcessingType:
           this.loanProductsTemplate.loanScheduleProcessingType?.value ?? INITIAL_FORM_STATE.loanScheduleProcessingType,
         graceOnPrincipalPayment:
@@ -703,17 +842,18 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
           this.loanProductsTemplate.canDefineInstallmentAmount ?? INITIAL_FORM_STATE.canDefineInstallmentAmount,
         // Fineract rejects multiDisburseLoan/allowVariableInstallments unless the product uses daily
         // interest calculation or the advanced-payment-allocation repayment strategy
-        // (LoanProductDataValidator: "not.supported.for.selected.interest.calculation.type"). Personal
-        // Loan always forces the advanced strategy (see transactionProcessingStrategyCode below), so it
-        // keeps the existing checked-by-default template/INITIAL_FORM_STATE value. Custom/Advanced
-        // defaults to the standard repayment strategy, so it must default both to false here, same as
-        // the Classic stepper (loan-product-settings-step.component.ts).
+        // (LoanProductDataValidator: "not.supported.for.selected.interest.calculation.type"). Guided
+        // profiles satisfy the rule either way — Personal/Two Wheeler force the advanced strategy,
+        // Education pins daily interest calculation — so they keep the checked-by-default
+        // template/INITIAL_FORM_STATE value. Custom/Advanced defaults to the standard repayment
+        // strategy, so it must default both to false here, same as the Classic stepper
+        // (loan-product-settings-step.component.ts).
         allowVariableInstallments:
           this.loanProductsTemplate.allowVariableInstallments ??
-          (this.profileMode === 'personal' ? INITIAL_FORM_STATE.allowVariableInstallments : false),
+          (this.isGuidedProfile ? INITIAL_FORM_STATE.allowVariableInstallments : false),
         multiDisburseLoan:
           this.loanProductsTemplate.multiDisburseLoan ??
-          (this.profileMode === 'personal' ? INITIAL_FORM_STATE.multiDisburseLoan : false),
+          (this.isGuidedProfile ? INITIAL_FORM_STATE.multiDisburseLoan : false),
         maxTrancheCount: this.loanProductsTemplate.maxTrancheCount ?? INITIAL_FORM_STATE.maxTrancheCount,
         allowFullTermForTranche:
           this.loanProductsTemplate.allowFullTermForTranche ?? INITIAL_FORM_STATE.allowFullTermForTranche,
@@ -722,7 +862,13 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
         overdueDaysForNPA: this.loanProductsTemplate.overdueDaysForNPA ?? INITIAL_FORM_STATE.overdueDaysForNPA,
         chargeName: this.loanProductsTemplate.chargeName ?? INITIAL_FORM_STATE.chargeName,
         overdueCharge: this.loanProductsTemplate.overdueCharge ?? INITIAL_FORM_STATE.overdueCharge,
-        accountingRule: this.loanProductsTemplate.accountingRule ?? INITIAL_FORM_STATE.accountingRule
+        accountingRule: this.loanProductsTemplate.accountingRule ?? INITIAL_FORM_STATE.accountingRule,
+        // Curated profile prefills win over the generic backend template for exactly the overridden
+        // keys (e.g. the Two Wheeler product quotes 14% per YEAR, while the template would reset the
+        // frequency to per month — a very different product). Every other key keeps its
+        // template-first behavior above. Spread order: template-derived entries first, profile
+        // overrides last.
+        ...PROFILE_INITIAL_OVERRIDES[this.profileMode]
       },
       { emitEvent: false }
     );
@@ -746,19 +892,21 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   private getInitialFormState(): typeof INITIAL_FORM_STATE {
+    // Profile prefills layer between the shared seed and the template/profile-forced entries below:
+    // INITIAL_FORM_STATE < PROFILE_INITIAL_OVERRIDES < the explicit entries in the return object.
+    const state = { ...INITIAL_FORM_STATE, ...PROFILE_INITIAL_OVERRIDES[this.profileMode] };
     return {
-      ...INITIAL_FORM_STATE,
+      ...state,
       currencyCode: this.getDefaultCurrencyCode(),
-      principal: this.loanProductsTemplate?.principal ?? INITIAL_FORM_STATE.principal,
-      transactionProcessingStrategyCode:
-        this.profileMode === 'personal'
-          ? LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
-          : INITIAL_FORM_STATE.transactionProcessingStrategyCode,
+      principal: this.loanProductsTemplate?.principal ?? state.principal,
+      transactionProcessingStrategyCode: this.forcesProgressiveStack
+        ? LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
+        : state.transactionProcessingStrategyCode,
       // See the matching comment in syncTemplateDefaults(): Custom/Advanced defaults to the standard
       // repayment strategy, so multiDisburseLoan/allowVariableInstallments must default to false there
-      // to satisfy the same Fineract validation rule. Personal Loan is unaffected.
-      multiDisburseLoan: this.profileMode === 'personal' ? INITIAL_FORM_STATE.multiDisburseLoan : false,
-      allowVariableInstallments: this.profileMode === 'personal' ? INITIAL_FORM_STATE.allowVariableInstallments : false
+      // to satisfy the same Fineract validation rule. Guided profiles are unaffected.
+      multiDisburseLoan: this.isGuidedProfile ? state.multiDisburseLoan : false,
+      allowVariableInstallments: this.isGuidedProfile ? state.allowVariableInstallments : false
     };
   }
 

--- a/src/app/products/loan-products/wizard/loan-product.config.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product.config.spec.ts
@@ -7,7 +7,13 @@
  */
 
 import { LoanProducts } from '../loan-products';
-import { buildPayload, PRODUCT_CARDS } from './loan-product.config';
+import {
+  buildPayload,
+  INITIAL_FORM_STATE,
+  PRODUCT_CARDS,
+  PROFILE_INITIAL_OVERRIDES,
+  profileForRoutePath
+} from './loan-product.config';
 
 describe('loan-product.config buildPayload', () => {
   it('removes unsupported hidden defaults from the personal loan payload', () => {
@@ -433,12 +439,733 @@ describe('loan-product.config buildPayload', () => {
   });
 });
 
+describe('loan-product.config buildPayload golden parity', () => {
+  // These two tests pin the COMPLETE create payload for the existing profile modes. Unlike the
+  // focused key-by-key tests above, `toEqual` on the whole object also fails when a key is ADDED,
+  // so any refactor of the shared payload path shows up as an explicit, reviewable diff here.
+  // Only an intentional product-behavior change may update these expected objects.
+
+  it('produces the exact Personal Loan create payload for an untouched wizard form', () => {
+    // The wizard form's raw value for a user who only filled the required fields: every other
+    // control still carries its INITIAL_FORM_STATE seed.
+    const formState = {
+      ...INITIAL_FORM_STATE,
+      name: 'Personal Loan – Standard',
+      shortName: 'PLS',
+      currencyCode: 'INR',
+      principal: 50000,
+      interestRatePerPeriod: 12
+    };
+
+    const payload = buildPayload(formState, 'personal', {
+      currencyCode: { id: 'INR' },
+      digitsAfterDecimal: { id: 2 },
+      inMultiplesOf: { id: 1 },
+      installmentAmountInMultiplesOf: { id: 10 },
+      amortizationType: { id: 1 },
+      interestType: { id: 0 },
+      interestCalculationPeriodType: { id: 1 },
+      repaymentFrequencyType: { id: 2 },
+      interestRateFrequencyType: { id: 2 },
+      repaymentStartDateType: { id: 1 },
+      accountingRule: { id: 2 },
+      daysInMonthType: { id: 30 },
+      daysInYearType: { id: 360 },
+      loanScheduleType: { value: 'Progressive' },
+      loanScheduleProcessingType: { value: 'Horizontal' },
+      transactionProcessingStrategyCode: { value: 'interest-principal-penalties-fees-order-strategy' }
+    });
+
+    expect(payload).toEqual({
+      name: 'Personal Loan – Standard',
+      shortName: 'PLS',
+      externalId: '',
+      description: 'Personal Loan Product',
+      startDate: '',
+      closeDate: '',
+      includeInBorrowerCycle: true,
+      currencyCode: 'INR',
+      digitsAfterDecimal: 2,
+      inMultiplesOf: 1,
+      installmentAmountInMultiplesOf: 10,
+      useBorrowerCycle: false,
+      principal: 50000,
+      numberOfRepayments: 12,
+      interestRatePerPeriod: 12,
+      interestRateFrequencyType: 2,
+      repaymentEvery: 1,
+      repaymentFrequencyType: 2,
+      isLinkedToFloatingInterestRates: false,
+      allowApprovedDisbursedAmountsOverApplied: false,
+      overAppliedCalculationType: null,
+      overAppliedNumber: null,
+      minimumDaysBetweenDisbursalAndFirstRepayment: 5,
+      interestRecognitionOnDisbursementDate: false,
+      repaymentStartDateType: 1,
+      amortizationType: 1,
+      interestType: 0,
+      isEqualAmortization: false,
+      interestCalculationPeriodType: 1,
+      loanScheduleType: 'PROGRESSIVE',
+      transactionProcessingStrategyCode: 'interest-principal-penalties-fees-order-strategy',
+      loanScheduleProcessingType: 'HORIZONTAL',
+      graceOnPrincipalPayment: 0,
+      graceOnInterestPayment: 0,
+      graceOnInterestCharged: 0,
+      daysInYearType: 360,
+      daysInMonthType: 30,
+      principalThresholdForLastInstallment: 5,
+      canUseForTopup: false,
+      isInterestRecalculationEnabled: false,
+      delinquencyBucketId: null,
+      canDefineInstallmentAmount: true,
+      inArrearsTolerance: 50,
+      graceOnArrearsAgeing: 5,
+      overdueDaysForNPA: 90,
+      accountMovesOutOfNPAOnlyOnArrearsCompletion: true,
+      holdGuaranteeFunds: false,
+      enableDownPayment: true,
+      disbursedAmountPercentageForDownPayment: 35,
+      enableAutoRepaymentForDownPayment: true,
+      enableInstallmentLevelDelinquency: false,
+      dueDaysForRepaymentEvent: 1,
+      overDueDaysForRepaymentEvent: 1,
+      enableIncomeCapitalization: false,
+      enableBuyDownFee: false,
+      accountingRule: 2,
+      principalVariationsForBorrowerCycle: [],
+      numberOfRepaymentVariationsForBorrowerCycle: [],
+      interestRateVariationsForBorrowerCycle: [],
+      charges: [],
+      allowAttributeOverrides: {
+        amortizationType: true,
+        interestType: true,
+        transactionProcessingStrategyCode: true,
+        interestCalculationPeriodType: true,
+        inArrearsTolerance: true,
+        repaymentEvery: true,
+        graceOnPrincipalAndInterestPayment: true,
+        graceOnArrearsAgeing: true
+      }
+    });
+  });
+
+  it('produces the exact Custom/Advanced create payload for an untouched wizard form', () => {
+    const formState = {
+      ...INITIAL_FORM_STATE,
+      name: 'Custom LP',
+      shortName: 'CLP',
+      currencyCode: 'INR',
+      principal: 50000,
+      interestRatePerPeriod: 12
+    };
+
+    const payload = buildPayload(formState, 'custom-advanced');
+
+    expect(payload).toEqual({
+      name: 'Custom LP',
+      shortName: 'CLP',
+      externalId: '',
+      description: '',
+      startDate: '',
+      closeDate: '',
+      includeInBorrowerCycle: false,
+      currencyCode: 'INR',
+      digitsAfterDecimal: 2,
+      inMultiplesOf: 1,
+      installmentAmountInMultiplesOf: 1,
+      useBorrowerCycle: false,
+      principal: 50000,
+      numberOfRepayments: 12,
+      interestRatePerPeriod: 12,
+      interestRateFrequencyType: 2,
+      repaymentEvery: 1,
+      repaymentFrequencyType: 2,
+      isLinkedToFloatingInterestRates: false,
+      allowApprovedDisbursedAmountsOverApplied: false,
+      overAppliedCalculationType: '',
+      overAppliedNumber: null,
+      minimumDaysBetweenDisbursalAndFirstRepayment: 5,
+      interestRecognitionOnDisbursementDate: false,
+      repaymentStartDateType: 1,
+      amortizationType: 1,
+      interestType: 0,
+      isEqualAmortization: false,
+      interestCalculationPeriodType: 1,
+      loanScheduleType: 'PROGRESSIVE',
+      transactionProcessingStrategyCode: 'interest-principal-penalties-fees-order-strategy',
+      loanScheduleProcessingType: 'HORIZONTAL',
+      graceOnPrincipalPayment: 0,
+      graceOnInterestPayment: 0,
+      graceOnInterestCharged: 0,
+      daysInYearType: 360,
+      daysInMonthType: 30,
+      principalThresholdForLastInstallment: 5,
+      canUseForTopup: false,
+      isInterestRecalculationEnabled: false,
+      delinquencyBucketId: '',
+      canDefineInstallmentAmount: true,
+      allowVariableInstallments: true,
+      multiDisburseLoan: true,
+      maxTrancheCount: 4,
+      allowFullTermForTranche: false,
+      inArrearsTolerance: 50,
+      graceOnArrearsAgeing: 5,
+      overdueDaysForNPA: 90,
+      accountMovesOutOfNPAOnlyOnArrearsCompletion: true,
+      holdGuaranteeFunds: false,
+      outstandingLoanBalance: 100000,
+      disallowExpectedDisbursements: true,
+      enableDownPayment: false,
+      chargeOffBehaviour: 'REGULAR',
+      enableInstallmentLevelDelinquency: false,
+      dueDaysForRepaymentEvent: 1,
+      overDueDaysForRepaymentEvent: 1,
+      enableIncomeCapitalization: false,
+      enableBuyDownFee: false,
+      accountingRule: 2,
+      principalVariationsForBorrowerCycle: [],
+      numberOfRepaymentVariationsForBorrowerCycle: [],
+      interestRateVariationsForBorrowerCycle: [],
+      charges: [],
+      allowAttributeOverrides: {
+        amortizationType: true,
+        interestType: true,
+        transactionProcessingStrategyCode: true,
+        interestCalculationPeriodType: true,
+        inArrearsTolerance: true,
+        repaymentEvery: true,
+        graceOnPrincipalAndInterestPayment: true,
+        graceOnArrearsAgeing: true
+      }
+    });
+  });
+});
+
+describe('loan-product.config buildPayload for the two-wheeler profile', () => {
+  /**
+   * The raw form value the wizard actually submits for Two Wheeler: the shared seed, the profile's
+   * curated prefills, and the guided-profile strategy forced by getInitialFormState — plus the two
+   * required fields the user types.
+   */
+  function twoWheelerFormState(edits: Record<string, unknown> = {}): typeof INITIAL_FORM_STATE {
+    return {
+      ...INITIAL_FORM_STATE,
+      ...PROFILE_INITIAL_OVERRIDES['two-wheeler'],
+      name: 'Two Wheeler Loan – Standard',
+      shortName: 'TWL',
+      currencyCode: 'INR',
+      transactionProcessingStrategyCode: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+      ...edits
+    };
+  }
+
+  it('produces the exact Two Wheeler create payload for an untouched wizard form', () => {
+    // Identical contract to the Personal Loan golden above except for the profile's deltas:
+    // curated principal/tenure/rate prefills, per-year rate quoting, the 20% down payment carried
+    // by the (visible, editable) form control, and the product description.
+    expect(buildPayload(twoWheelerFormState(), 'two-wheeler')).toEqual({
+      name: 'Two Wheeler Loan – Standard',
+      shortName: 'TWL',
+      externalId: '',
+      description: 'Two Wheeler Loan Product',
+      startDate: '',
+      closeDate: '',
+      includeInBorrowerCycle: true,
+      currencyCode: 'INR',
+      digitsAfterDecimal: 2,
+      inMultiplesOf: 1,
+      installmentAmountInMultiplesOf: 10,
+      useBorrowerCycle: false,
+      principal: 80000,
+      numberOfRepayments: 36,
+      interestRatePerPeriod: 14,
+      interestRateFrequencyType: 3,
+      repaymentEvery: 1,
+      repaymentFrequencyType: 2,
+      isLinkedToFloatingInterestRates: false,
+      allowApprovedDisbursedAmountsOverApplied: false,
+      overAppliedCalculationType: null,
+      overAppliedNumber: null,
+      minimumDaysBetweenDisbursalAndFirstRepayment: 5,
+      interestRecognitionOnDisbursementDate: false,
+      repaymentStartDateType: 1,
+      amortizationType: 1,
+      interestType: 0,
+      isEqualAmortization: false,
+      interestCalculationPeriodType: 1,
+      loanScheduleType: 'PROGRESSIVE',
+      transactionProcessingStrategyCode: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+      loanScheduleProcessingType: 'HORIZONTAL',
+      graceOnPrincipalPayment: 0,
+      graceOnInterestPayment: 0,
+      graceOnInterestCharged: 0,
+      daysInYearType: 360,
+      daysInMonthType: 30,
+      principalThresholdForLastInstallment: 5,
+      canUseForTopup: false,
+      isInterestRecalculationEnabled: false,
+      delinquencyBucketId: null,
+      canDefineInstallmentAmount: true,
+      inArrearsTolerance: 50,
+      graceOnArrearsAgeing: 5,
+      overdueDaysForNPA: 90,
+      accountMovesOutOfNPAOnlyOnArrearsCompletion: true,
+      holdGuaranteeFunds: false,
+      enableDownPayment: true,
+      disbursedAmountPercentageForDownPayment: 20,
+      enableAutoRepaymentForDownPayment: true,
+      chargeOffBehaviour: 'REGULAR',
+      enableInstallmentLevelDelinquency: false,
+      dueDaysForRepaymentEvent: 1,
+      overDueDaysForRepaymentEvent: 1,
+      enableIncomeCapitalization: false,
+      enableBuyDownFee: false,
+      accountingRule: 2,
+      principalVariationsForBorrowerCycle: [],
+      numberOfRepaymentVariationsForBorrowerCycle: [],
+      interestRateVariationsForBorrowerCycle: [],
+      charges: [],
+      allowAttributeOverrides: {
+        amortizationType: true,
+        interestType: true,
+        transactionProcessingStrategyCode: true,
+        interestCalculationPeriodType: true,
+        inArrearsTolerance: true,
+        repaymentEvery: true,
+        graceOnPrincipalAndInterestPayment: true,
+        graceOnArrearsAgeing: true
+      }
+    });
+  });
+
+  it('lets the user-edited down payment percentage win over the profile prefill', () => {
+    // disbursedAmountPercentageForDownPayment is REMOVED from the two-wheeler hidden defaults, so
+    // the guided "defaults win" merge must not clobber the visible control's value.
+    const payload = buildPayload(twoWheelerFormState({ disbursedAmountPercentageForDownPayment: 25 }), 'two-wheeler');
+
+    expect(payload.disbursedAmountPercentageForDownPayment).toBe(25);
+    expect(payload.enableDownPayment).toBe(true);
+    expect(payload.enableAutoRepaymentForDownPayment).toBe(true);
+  });
+
+  it('forces down payment on even if the form control was somehow toggled off', () => {
+    // enableDownPayment is the product's identity: it stays in the two-wheeler hidden defaults,
+    // which are spread last for guided profiles, so a stray false in the (hidden) control cannot
+    // turn the product into a personal loan.
+    const payload = buildPayload(twoWheelerFormState({ enableDownPayment: false }), 'two-wheeler');
+
+    expect(payload.enableDownPayment).toBe(true);
+    expect(payload.disbursedAmountPercentageForDownPayment).toBe(20);
+  });
+
+  it('omits the multi-disburse field family, matching the Personal Loan payload contract', () => {
+    const payload = buildPayload(twoWheelerFormState(), 'two-wheeler');
+
+    expect(payload.multiDisburseLoan).toBeUndefined();
+    expect(payload.maxTrancheCount).toBeUndefined();
+    expect(payload.allowFullTermForTranche).toBeUndefined();
+    expect(payload.outstandingLoanBalance).toBeUndefined();
+    expect(payload.disallowExpectedDisbursements).toBeUndefined();
+    expect(payload.allowVariableInstallments).toBeUndefined();
+  });
+
+  it('drops grace periods that are not shorter than the repayment count, like Personal', () => {
+    const payload = buildPayload(twoWheelerFormState({ graceOnPrincipalPayment: 36 }), 'two-wheeler');
+
+    expect(payload.graceOnPrincipalPayment).toBeUndefined();
+  });
+
+  it('lets a user-selected delinquency bucket win, and normalizes the None option to null', () => {
+    // delinquencyBucketId is REMOVED from the two-wheeler hidden defaults (spreadsheet marks it
+    // Applicable), so the visible select's value must survive the guided "defaults win" merge; the
+    // None option ('') is normalized back to the null contract Personal sends from its hidden default.
+    expect(buildPayload(twoWheelerFormState({ delinquencyBucketId: '1' }), 'two-wheeler').delinquencyBucketId).toBe(
+      '1'
+    );
+    expect(
+      buildPayload(twoWheelerFormState({ delinquencyBucketId: '' }), 'two-wheeler').delinquencyBucketId
+    ).toBeNull();
+  });
+});
+
+describe('loan-product.config buildPayload for the education profile', () => {
+  /**
+   * The raw form value the wizard actually submits for Education: the shared seed plus the
+   * profile's curated prefills (which include the pinned Cumulative-stack control values), plus
+   * the two required fields the user types.
+   */
+  function educationFormState(edits: Record<string, unknown> = {}): typeof INITIAL_FORM_STATE {
+    return {
+      ...INITIAL_FORM_STATE,
+      ...PROFILE_INITIAL_OVERRIDES['education'],
+      name: 'Education Loan – Domestic',
+      shortName: 'EDU',
+      currencyCode: 'INR',
+      ...edits
+    };
+  }
+
+  it('produces the exact Education create payload for an untouched wizard form', () => {
+    // Education is the first guided profile OFF the Progressive stack: Fineract's progressive
+    // schedule generator has no grace/moratorium support, so the moratorium product runs on the
+    // Classic Cumulative + standard-strategy + daily-interest configuration, and it is the only
+    // profile that transmits the multi-disburse family (semester tranches).
+    expect(buildPayload(educationFormState(), 'education')).toEqual({
+      name: 'Education Loan – Domestic',
+      shortName: 'EDU',
+      externalId: '',
+      description: 'Education Loan Product',
+      startDate: '',
+      closeDate: '',
+      includeInBorrowerCycle: true,
+      currencyCode: 'INR',
+      digitsAfterDecimal: 2,
+      inMultiplesOf: 1,
+      installmentAmountInMultiplesOf: 10,
+      useBorrowerCycle: false,
+      principal: 500000,
+      numberOfRepayments: 120,
+      interestRatePerPeriod: 10.5,
+      interestRateFrequencyType: 3,
+      repaymentEvery: 1,
+      repaymentFrequencyType: 2,
+      isLinkedToFloatingInterestRates: false,
+      allowApprovedDisbursedAmountsOverApplied: false,
+      overAppliedCalculationType: null,
+      overAppliedNumber: null,
+      minimumDaysBetweenDisbursalAndFirstRepayment: 30,
+      interestRecognitionOnDisbursementDate: false,
+      repaymentStartDateType: 1,
+      amortizationType: 1,
+      interestType: 0,
+      isEqualAmortization: false,
+      interestCalculationPeriodType: 0,
+      loanScheduleType: 'CUMULATIVE',
+      transactionProcessingStrategyCode: 'mifos-standard-strategy',
+      loanScheduleProcessingType: 'HORIZONTAL',
+      graceOnPrincipalPayment: 24,
+      graceOnInterestPayment: 0,
+      graceOnInterestCharged: 0,
+      daysInYearType: 360,
+      daysInMonthType: 30,
+      principalThresholdForLastInstallment: 5,
+      canUseForTopup: true,
+      isInterestRecalculationEnabled: false,
+      delinquencyBucketId: null,
+      canDefineInstallmentAmount: true,
+      multiDisburseLoan: true,
+      maxTrancheCount: 8,
+      allowFullTermForTranche: false,
+      disallowExpectedDisbursements: true,
+      inArrearsTolerance: 50,
+      graceOnArrearsAgeing: 5,
+      overdueDaysForNPA: 90,
+      accountMovesOutOfNPAOnlyOnArrearsCompletion: true,
+      holdGuaranteeFunds: false,
+      enableDownPayment: false,
+      enableInstallmentLevelDelinquency: false,
+      dueDaysForRepaymentEvent: 1,
+      overDueDaysForRepaymentEvent: 1,
+      enableIncomeCapitalization: false,
+      enableBuyDownFee: false,
+      accountingRule: 2,
+      principalVariationsForBorrowerCycle: [],
+      numberOfRepaymentVariationsForBorrowerCycle: [],
+      interestRateVariationsForBorrowerCycle: [],
+      charges: [],
+      allowAttributeOverrides: {
+        amortizationType: true,
+        interestType: true,
+        transactionProcessingStrategyCode: true,
+        interestCalculationPeriodType: true,
+        inArrearsTolerance: true,
+        repaymentEvery: true,
+        graceOnPrincipalAndInterestPayment: true,
+        graceOnArrearsAgeing: true
+      }
+    });
+  });
+
+  it('never forces the Progressive stack: schedule, strategy and interest calc stay pinned Cumulative', () => {
+    // Even if the (hidden) controls somehow carried Progressive-stack values, the education hidden
+    // defaults are spread last and must win — a Progressive education product would silently drop
+    // its moratorium at schedule generation.
+    const payload = buildPayload(
+      educationFormState({
+        loanScheduleType: 'Progressive',
+        transactionProcessingStrategyCode: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+        interestCalculationPeriodType: 1
+      }),
+      'education'
+    );
+
+    expect(payload.loanScheduleType).toBe('CUMULATIVE');
+    expect(payload.transactionProcessingStrategyCode).toBe('mifos-standard-strategy');
+    expect(payload.interestCalculationPeriodType).toBe(0);
+    expect(payload.supportedInterestRefundTypes).toBeUndefined();
+    expect(payload.chargeOffBehaviour).toBeUndefined();
+  });
+
+  it('transmits the multi-disburse family but never the outstanding-balance cap', () => {
+    const payload = buildPayload(educationFormState(), 'education');
+
+    expect(payload.multiDisburseLoan).toBe(true);
+    expect(payload.maxTrancheCount).toBe(8);
+    expect(payload.allowFullTermForTranche).toBe(false);
+    expect(payload.disallowExpectedDisbursements).toBe(true);
+    expect(payload.outstandingLoanBalance).toBeUndefined();
+  });
+
+  it('lets the user-edited tranche count win over the profile prefill', () => {
+    expect(buildPayload(educationFormState({ maxTrancheCount: 12 }), 'education').maxTrancheCount).toBe(12);
+  });
+
+  it('floors an emptied or below-minimum tranche count instead of sending an invalid cap', () => {
+    // The control is a visible, optional number input: clearing it leaves the FormControl at null and
+    // 0/1 are typeable, but Fineract rejects `multiDisburseLoan: true` without a cap of 2 or more.
+    [
+      null,
+      undefined,
+      '',
+      0,
+      1
+    ].forEach((maxTrancheCount) => {
+      expect(buildPayload(educationFormState({ maxTrancheCount }), 'education').maxTrancheCount).toBe(2);
+    });
+  });
+
+  it('sends no down-payment fields (overrides the base hidden enableDownPayment: true)', () => {
+    const payload = buildPayload(educationFormState(), 'education');
+
+    expect(payload.enableDownPayment).toBe(false);
+    expect(payload.disbursedAmountPercentageForDownPayment).toBeUndefined();
+    expect(payload.enableAutoRepaymentForDownPayment).toBeUndefined();
+  });
+
+  it('keeps the moratorium while it is shorter than the repayment count and drops it otherwise', () => {
+    expect(buildPayload(educationFormState(), 'education').graceOnPrincipalPayment).toBe(24);
+    expect(
+      buildPayload(educationFormState({ graceOnPrincipalPayment: 120 }), 'education').graceOnPrincipalPayment
+    ).toBeUndefined();
+  });
+});
+
+describe('loan-product.config buildPayload for the agriculture profile', () => {
+  /**
+   * The raw form value the wizard actually submits for Agriculture: the shared seed plus the
+   * profile's curated prefills (which include the pinned Cumulative-stack control values), plus
+   * the two required fields the user types.
+   */
+  function agricultureFormState(edits: Record<string, unknown> = {}): typeof INITIAL_FORM_STATE {
+    return {
+      ...INITIAL_FORM_STATE,
+      ...PROFILE_INITIAL_OVERRIDES['agriculture'],
+      name: 'Agriculture Loan – Kharif',
+      shortName: 'AGR',
+      currencyCode: 'INR',
+      ...edits
+    };
+  }
+
+  it('produces the exact Agriculture create payload for an untouched wizard form', () => {
+    // The bullet crop loan: one installment (all principal + interest) at the end of the crop
+    // cycle, flat interest, Cumulative schedule, principal-first settlement ordering, seasonal
+    // arrears/NPA settings — and no down payment, tranches or progressive-only fields.
+    expect(buildPayload(agricultureFormState(), 'agriculture')).toEqual({
+      name: 'Agriculture Loan – Kharif',
+      shortName: 'AGR',
+      externalId: '',
+      description: 'Agriculture Loan Product',
+      startDate: '',
+      closeDate: '',
+      includeInBorrowerCycle: true,
+      currencyCode: 'INR',
+      digitsAfterDecimal: 2,
+      inMultiplesOf: 1,
+      installmentAmountInMultiplesOf: 10,
+      useBorrowerCycle: false,
+      principal: 100000,
+      numberOfRepayments: 1,
+      interestRatePerPeriod: 7,
+      interestRateFrequencyType: 3,
+      repaymentEvery: 12,
+      repaymentFrequencyType: 2,
+      isLinkedToFloatingInterestRates: false,
+      allowApprovedDisbursedAmountsOverApplied: false,
+      overAppliedCalculationType: null,
+      overAppliedNumber: null,
+      minimumDaysBetweenDisbursalAndFirstRepayment: 5,
+      interestRecognitionOnDisbursementDate: false,
+      repaymentStartDateType: 1,
+      amortizationType: 1,
+      interestType: 1,
+      isEqualAmortization: false,
+      interestCalculationPeriodType: 1,
+      loanScheduleType: 'CUMULATIVE',
+      transactionProcessingStrategyCode: 'principal-interest-penalties-fees-order-strategy',
+      loanScheduleProcessingType: 'HORIZONTAL',
+      graceOnPrincipalPayment: 0,
+      graceOnInterestPayment: 0,
+      graceOnInterestCharged: 0,
+      daysInYearType: 360,
+      daysInMonthType: 30,
+      principalThresholdForLastInstallment: 5,
+      canUseForTopup: false,
+      isInterestRecalculationEnabled: false,
+      delinquencyBucketId: null,
+      canDefineInstallmentAmount: false,
+      inArrearsTolerance: 100,
+      graceOnArrearsAgeing: 30,
+      overdueDaysForNPA: 180,
+      accountMovesOutOfNPAOnlyOnArrearsCompletion: true,
+      holdGuaranteeFunds: false,
+      enableDownPayment: false,
+      enableInstallmentLevelDelinquency: false,
+      dueDaysForRepaymentEvent: 1,
+      overDueDaysForRepaymentEvent: 1,
+      enableIncomeCapitalization: false,
+      enableBuyDownFee: false,
+      accountingRule: 2,
+      principalVariationsForBorrowerCycle: [],
+      numberOfRepaymentVariationsForBorrowerCycle: [],
+      interestRateVariationsForBorrowerCycle: [],
+      charges: [],
+      allowAttributeOverrides: {
+        amortizationType: true,
+        interestType: true,
+        transactionProcessingStrategyCode: true,
+        interestCalculationPeriodType: true,
+        inArrearsTolerance: true,
+        repaymentEvery: true,
+        graceOnPrincipalAndInterestPayment: true,
+        graceOnArrearsAgeing: true
+      }
+    });
+  });
+
+  it('keeps the pinned bullet stack even if the hidden controls carried other values', () => {
+    // Flat interest, Cumulative schedule, principal-first strategy and zero grace are the
+    // product's identity: the agriculture hidden defaults are spread last and must win over any
+    // stray control values (all of these controls are hidden for this profile).
+    const payload = buildPayload(
+      agricultureFormState({
+        interestType: 0,
+        loanScheduleType: 'Progressive',
+        transactionProcessingStrategyCode: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
+        graceOnPrincipalPayment: 6
+      }),
+      'agriculture'
+    );
+
+    expect(payload.interestType).toBe(1);
+    expect(payload.loanScheduleType).toBe('CUMULATIVE');
+    expect(payload.transactionProcessingStrategyCode).toBe('principal-interest-penalties-fees-order-strategy');
+    expect(payload.graceOnPrincipalPayment).toBe(0);
+    expect(payload.chargeOffBehaviour).toBeUndefined();
+    expect(payload.supportedInterestRefundTypes).toBeUndefined();
+  });
+
+  it('lets the user tune the seasonal NPA clock and the cycle structure', () => {
+    // overdueDaysForNPA (visible/editable) and the Terms fields are the operator's levers:
+    // 360 ≈ two crop seasons; 2 × 6 months is the two-season bullet variant.
+    const payload = buildPayload(
+      agricultureFormState({ overdueDaysForNPA: 360, numberOfRepayments: 2, repaymentEvery: 6 }),
+      'agriculture'
+    );
+
+    expect(payload.overdueDaysForNPA).toBe(360);
+    expect(payload.numberOfRepayments).toBe(2);
+    expect(payload.repaymentEvery).toBe(6);
+  });
+
+  it('omits the multi-disburse family and every down-payment field', () => {
+    const payload = buildPayload(agricultureFormState(), 'agriculture');
+
+    expect(payload.multiDisburseLoan).toBeUndefined();
+    expect(payload.maxTrancheCount).toBeUndefined();
+    expect(payload.allowFullTermForTranche).toBeUndefined();
+    expect(payload.disallowExpectedDisbursements).toBeUndefined();
+    expect(payload.outstandingLoanBalance).toBeUndefined();
+    expect(payload.disbursedAmountPercentageForDownPayment).toBeUndefined();
+    expect(payload.enableAutoRepaymentForDownPayment).toBeUndefined();
+  });
+});
+
+describe('loan-product.config profileForRoutePath', () => {
+  it('maps each wizard route to its profile and page title key', () => {
+    expect(profileForRoutePath('personal-loan')).toEqual({
+      profileMode: 'personal',
+      pageTitle: 'labels.heading.Create Personal Loan'
+    });
+    expect(profileForRoutePath('custom-advanced')).toEqual({
+      profileMode: 'custom-advanced',
+      pageTitle: 'labels.heading.Custom / Advanced Loan Configuration'
+    });
+    expect(profileForRoutePath('two-wheeler-loan')).toEqual({
+      profileMode: 'two-wheeler',
+      pageTitle: 'labels.heading.Create Two Wheeler Loan'
+    });
+    expect(profileForRoutePath('education-loan')).toEqual({
+      profileMode: 'education',
+      pageTitle: 'labels.heading.Create Education Loan'
+    });
+    expect(profileForRoutePath('agriculture-loan')).toEqual({
+      profileMode: 'agriculture',
+      pageTitle: 'labels.heading.Create Agriculture Loan'
+    });
+  });
+
+  it('falls back to the Personal Loan profile for unknown or missing paths', () => {
+    expect(profileForRoutePath('no-such-route').profileMode).toBe('personal');
+    expect(profileForRoutePath(undefined).profileMode).toBe('personal');
+  });
+});
+
 describe('loan-product.config PRODUCT_CARDS', () => {
   it('gives every product card a non-empty icon', () => {
     PRODUCT_CARDS.forEach((product) => {
       expect(product.icon).toBeDefined();
       expect(typeof product.icon).toBe('string');
       expect(product.icon.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('activates the Two Wheeler Loan card with its wizard route', () => {
+    const card = PRODUCT_CARDS.find((product) => product.name === 'Two Wheeler Loan')!;
+
+    expect(card.active).toBe(true);
+    expect(card.disabled).toBe(false);
+    expect(card.route).toBe('two-wheeler-loan');
+  });
+
+  it('activates the Education Loan card with its wizard route', () => {
+    const card = PRODUCT_CARDS.find((product) => product.name === 'Education Loan')!;
+
+    expect(card.active).toBe(true);
+    expect(card.disabled).toBe(false);
+    expect(card.route).toBe('education-loan');
+  });
+
+  it('activates the Agriculture Loan card with its wizard route', () => {
+    const card = PRODUCT_CARDS.find((product) => product.name === 'Agriculture Loan')!;
+
+    expect(card.active).toBe(true);
+    expect(card.disabled).toBe(false);
+    expect(card.route).toBe('agriculture-loan');
+  });
+
+  it('routes every active card to a route a wizard profile claims', () => {
+    // The selection grid renders a Create button for every active card; a card whose route no
+    // profile claims would silently fall back to the Personal Loan wizard.
+    PRODUCT_CARDS.filter((product) => product.active).forEach((product) => {
+      expect([
+        'personal-loan',
+        'custom-advanced',
+        'two-wheeler-loan',
+        'education-loan',
+        'agriculture-loan'
+      ]).toContain(product.route);
     });
   });
 });

--- a/src/app/products/loan-products/wizard/loan-product.config.ts
+++ b/src/app/products/loan-products/wizard/loan-product.config.ts
@@ -112,7 +112,7 @@ export interface FormField {
  *   only while the selected repayment strategy is the advanced payment allocation strategy.
  * - `review`: the summary/confirmation step.
  */
-export type FormStepKind = 'fields' | 'payment-allocation' | 'charges' | 'review';
+export type FormStepKind = 'fields' | 'payment-allocation' | 'charges' | 'accounting' | 'review';
 export interface FormStep {
   id: number;
   title: string;
@@ -146,9 +146,12 @@ export const PRODUCT_CARDS: ProductCard[] = [
   },
   {
     name: 'Two Wheeler Loan',
-    description: 'Finance for new or used two-wheelers with quick approval and flexible down payment options.',
-    active: false,
-    disabled: true,
+    // Fully qualified translation key, same pattern as the Custom/Advanced card above.
+    description:
+      'labels.text.Finance for new or used two-wheelers with quick approval and flexible down payment options',
+    active: true,
+    disabled: false,
+    route: 'two-wheeler-loan',
     icon: 'pedal_bike'
   },
   {
@@ -161,10 +164,12 @@ export const PRODUCT_CARDS: ProductCard[] = [
   },
   {
     name: 'Education Loan',
+    // Fully qualified translation key, same pattern as the Custom/Advanced card above.
     description:
-      'Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration.',
-    active: false,
-    disabled: true,
+      'labels.text.Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration',
+    active: true,
+    disabled: false,
+    route: 'education-loan',
     icon: 'school'
   },
   {
@@ -182,11 +187,15 @@ export const PRODUCT_CARDS: ProductCard[] = [
     icon: 'home_work'
   },
   {
-    name: 'Agri Loan',
+    // Renamed from 'Agri Loan' to match the template's full product name everywhere else
+    // (profile label, breadcrumb, page title).
+    name: 'Agriculture Loan',
+    // Fully qualified translation key, same pattern as the Custom/Advanced card above.
     description:
-      'Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles.',
-    active: false,
-    disabled: true,
+      'labels.text.Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles',
+    active: true,
+    disabled: false,
+    route: 'agriculture-loan',
     icon: 'agriculture'
   },
   {
@@ -697,30 +706,17 @@ export const FORM_STEPS: FormStep[] = [
     fields: []
   },
   {
-    // Item 4 — Accounting is intentionally kept as its own self-contained, optional wizard step: a
-    // single `accountingRule` control with no cross-field dependencies on any other step. This is the
-    // decoupling seam. A richer accounting module (e.g. reusing the Classic
-    // `LoanProductAccountingStepComponent` for advanced GL-account mappings) can be plugged in behind
-    // this step later WITHOUT touching payload generation (`buildPayload` only reads `accountingRule`
-    // from form state) or any other step. Left as a documented future enhancement here to avoid a
-    // structural rewrite; behaviour is unchanged.
+    // Reuses the Classic `LoanProductAccountingStepComponent` (rendered by the wizard for
+    // `kind: 'accounting'`). It owns the accounting rule radio AND — when Cash/Accrual is selected —
+    // the full set of mandatory GL account selectors, validators and advanced mapping rules, exactly
+    // like Classic. The wizard folds its collected values (`loanProductAccounting`) into the payload
+    // in buildPayloadForSubmit, mirroring Classic's `...loanProductAccountingStep.loanProductAccounting`
+    // spread, so Cash / Accrual (periodic) / Accrual (upfront) all send every required account id.
     id: 6,
     title: 'Accounting',
     icon: 'ti-report',
-    fields: [
-      {
-        label: 'Accounting rule',
-        key: 'accountingRule',
-        type: 'select',
-        required: true,
-        options: [
-          { value: 1, label: 'None' },
-          { value: 2, label: 'Cash-based' },
-          { value: 3, label: 'Accrual (periodic)' },
-          { value: 4, label: 'Accrual (upfront)' }
-        ]
-      }
-    ]
+    kind: 'accounting',
+    fields: []
   },
   {
     id: 7,
@@ -828,9 +824,276 @@ export const INITIAL_FORM_STATE: Record<string, string | number | boolean | null
   accountingRule: 2
 };
 
-export type LoanWizardProfileMode = 'personal' | 'custom-advanced';
+export type LoanWizardProfileMode = 'personal' | 'custom-advanced' | 'two-wheeler' | 'education' | 'agriculture';
 
 export type FormState = typeof INITIAL_FORM_STATE;
+
+/**
+ * Guided template modes (Personal, Two Wheeler) hide the HIDDEN_DEFAULTS long-tail, force the
+ * Progressive + advanced-payment-allocation stack and run the guided payload transforms in
+ * {@link buildPayload}. Only Custom/Advanced exposes every control and lets the form win the merge.
+ */
+export function isGuidedProfileMode(profileMode: LoanWizardProfileMode): boolean {
+  return profileMode !== 'custom-advanced';
+}
+
+/**
+ * Guided profiles that pin the Progressive + advanced-payment-allocation stack (buildPayload forces
+ * schedule/strategy; the wizard seeds the strategy control to the advanced strategy).
+ *
+ * Education deliberately is NOT on this list: its defining feature is the principal moratorium
+ * (graceOnPrincipalPayment), and Fineract's ProgressiveLoanScheduleGenerator does not implement
+ * grace periods at all — the create API accepts them on a Progressive product but the generated
+ * schedule silently ignores them. Education therefore runs on the Classic Cumulative stack, pinned
+ * through its hidden defaults (CUMULATIVE + standard strategy + daily interest calculation).
+ *
+ * Agriculture is NOT on this list either: a bullet crop loan is the classic Cumulative pattern
+ * (numberOfRepayments: 1 with repaymentEvery = the crop-cycle length); Progressive is EMI-oriented
+ * and would drag in the advanced-allocation requirement for no benefit.
+ */
+export function forcesProgressiveStack(profileMode: LoanWizardProfileMode): boolean {
+  return profileMode === 'personal' || profileMode === 'two-wheeler';
+}
+
+/**
+ * Guided profiles whose payload transmits the multi-disburse family (multiDisburseLoan,
+ * maxTrancheCount, allowFullTermForTranche, disallowExpectedDisbursements). Every other guided
+ * profile omits all of them — the proven Personal Loan contract. Education needs them: education
+ * loans disburse in semester-wise tranches paid to the institution.
+ */
+export function sendsMultiDisburseFields(profileMode: LoanWizardProfileMode): boolean {
+  return profileMode === 'education';
+}
+
+/** Fewest tranches a `multiDisburseLoan: true` product can be created with — used as the floor and
+ * the empty-value fallback for `maxTrancheCount` in {@link buildPayload}. */
+export const MIN_TRANCHE_COUNT = 2;
+
+/**
+ * The hidden, always-sent defaults for a profile mode. Guided profiles hide every key of the
+ * returned object in the UI and spread it LAST in {@link buildPayload}'s merge, so a key must be
+ * removed here (not just overridden) the moment a profile exposes it as an editable control —
+ * otherwise the default would clobber the user's input.
+ */
+export function hiddenDefaultsFor(profileMode: LoanWizardProfileMode): Record<string, unknown> {
+  if (profileMode === 'two-wheeler') {
+    const defaults: Record<string, unknown> = { ...HIDDEN_DEFAULTS, description: 'Two Wheeler Loan Product' };
+    // The down payment percentage is THE commercial lever of a two wheeler product (it is how
+    // lenders control loan-to-value on a fast-depreciating asset), so this profile exposes it as a
+    // visible, editable Settings control — see PROFILE_EXTRA_VISIBLE_FIELDS. `enableDownPayment`
+    // itself stays hidden and forced true: turning it off would make the product a personal loan.
+    delete defaults.disbursedAmountPercentageForDownPayment;
+    // The delinquency bucket is an editable risk control for this template (spreadsheet marks it
+    // Applicable for Two Wheeler): drop it from the hidden defaults so the visible select's value
+    // wins the guided "defaults win" merge. buildPayload normalizes the None option ('') back to
+    // null, keeping the same payload contract Personal sends from its hidden null default.
+    delete defaults.delinquencyBucketId;
+    return defaults;
+  }
+  if (profileMode === 'education') {
+    const defaults: Record<string, unknown> = {
+      ...HIDDEN_DEFAULTS,
+      description: 'Education Loan Product',
+      // No down payment concept in an education loan — overrides the base hidden true. The sanitize
+      // step then drops the two down-payment dependents exactly as it does for Classic.
+      enableDownPayment: false,
+      // Follow-on funding for higher studies is a real pattern; cheap to allow.
+      canUseForTopup: true,
+      // First (interest) installment a month after the first tranche reaches the institution.
+      minimumDaysBetweenDisbursalAndFirstRepayment: 30,
+      // The Cumulative stack (see forcesProgressiveStack): Fineract's Progressive schedule
+      // generator has no grace/moratorium support, so the moratorium product must run on the
+      // Classic Cumulative path. Daily interest calculation keeps the tranche-friendly
+      // configuration Classic uses for multi-disbursal products, and the standard strategy avoids
+      // the advanced-allocation requirement that would drag Progressive back in.
+      loanScheduleType: 'Cumulative',
+      transactionProcessingStrategyCode: 'mifos-standard-strategy',
+      interestCalculationPeriodType: 0,
+      // Universal for education loans: declining balance, fixed EMI after the moratorium. Pinned
+      // (and therefore hidden) so the operator's surface stays "course length → moratorium →
+      // repayment years".
+      interestType: 0,
+      amortizationType: 1,
+      // Banks charge interest from day one; an interest-free moratorium would be a pricing
+      // giveaway. Hidden to avoid confusion with the two real grace fields, which stay visible as
+      // this template's headline controls.
+      interestFreePeriod: 0
+    };
+    // Semester-wise tranche count is the product lever operators actually tune, so it is a
+    // visible, editable control (its default comes from PROFILE_INITIAL_OVERRIDES). It must leave
+    // the hidden defaults or the guided "defaults win" merge would clobber the user's input.
+    // (The rest of the multi-disburse family stays pinned here and is transmitted — see
+    // sendsMultiDisburseFields in buildPayload; the outstanding-balance cap is dropped there for
+    // every guided profile. loanScheduleProcessingType stays HORIZONTAL like every other profile —
+    // Fineract only restricts VERTICAL to the advanced strategy.)
+    delete defaults.maxTrancheCount;
+    // Editable delinquency bucket (spreadsheet marks it Applicable for Education): see the
+    // Two Wheeler branch — dropped from hidden defaults so the visible select drives the payload.
+    delete defaults.delinquencyBucketId;
+    return defaults;
+  }
+  if (profileMode === 'agriculture') {
+    const defaults: Record<string, unknown> = {
+      ...HIDDEN_DEFAULTS,
+      description: 'Agriculture Loan Product',
+      // Production credit carries no down payment concept — overrides the base hidden true; the
+      // sanitize step then drops the two down-payment dependents.
+      enableDownPayment: false,
+      // Bullet repayment at harvest is the classic Cumulative pattern (see forcesProgressiveStack).
+      // At settlement, clear principal first, then interest — the borrower-friendly ordering for
+      // partial harvest-time payments.
+      loanScheduleType: 'Cumulative',
+      transactionProcessingStrategyCode: 'principal-interest-penalties-fees-order-strategy',
+      // With a single installment, flat = simple interest on the full principal for the term —
+      // exactly how crop-loan interest is quoted and how subvention is computed. One period, one
+      // interest amount: daily calculation adds nothing; amortization is meaningless with N=1 and
+      // is pinned to a valid value.
+      interestType: 1,
+      amortizationType: 1,
+      interestCalculationPeriodType: 1,
+      // A bullet product has nothing to moratorium: Fineract requires grace < numberOfRepayments
+      // (= 1), so all three grace controls are pinned to 0 and hidden. The guided grace guard in
+      // buildPayload would drop any value >= 1 anyway; hiding removes the invalid states entirely.
+      graceOnPrincipalPayment: 0,
+      graceOnInterestPayment: 0,
+      interestFreePeriod: 0,
+      // Seasonal arrears behavior: post-harvest sale proceeds take weeks to arrive, so don't age
+      // arrears instantly, and tolerate small rounding/short-payments at settlement.
+      graceOnArrearsAgeing: 30,
+      inArrearsTolerance: 100,
+      // One fixed installment; nothing for the borrower to define or vary.
+      canDefineInstallmentAmount: false
+    };
+    // The seasonal NPA clock is the one risk lever Fineract exposes for the RBI "crop seasons"
+    // norm, so it is a visible, editable Settings control (default 180 ≈ one season, via
+    // PROFILE_INITIAL_OVERRIDES). It must leave the hidden defaults or the guided "defaults win"
+    // merge would clobber the user's input.
+    delete defaults.overdueDaysForNPA;
+    // Editable delinquency bucket (spreadsheet marks it Applicable for Agriculture): see the
+    // Two Wheeler branch — dropped from hidden defaults so the visible select drives the payload.
+    delete defaults.delinquencyBucketId;
+    return defaults;
+  }
+  if (profileMode === 'custom-advanced') {
+    const d: Record<string, unknown> = { ...HIDDEN_DEFAULTS };
+    delete d.canDefineInstallmentAmount;
+    delete d.allowVariableInstallments;
+    delete d.multiDisburseLoan;
+    delete d.maxTrancheCount;
+    delete d.allowFullTermForTranche;
+    delete d.inArrearsTolerance;
+    delete d.graceOnArrearsAgeing;
+    delete d.overdueDaysForNPA;
+    // `daysInYearType` and `daysInYearCustomStrategy` are visible, user-editable selects in the
+    // Custom/Advanced settings step (same as Classic). Leaving them in HIDDEN_DEFAULTS would
+    // force `daysInYearType` to 360 / `daysInYearCustomStrategy` to 'Full Leap Year' regardless
+    // of the user's choice, so the form value would never reach the payload. Drop them here so
+    // the form drives both, matching Classic — the gate in `sanitizeCreateLoanProductPayload`
+    // then removes `daysInYearCustomStrategy` for any non-ACTUAL type, exactly as Classic does.
+    delete d.daysInYearType;
+    delete d.daysInYearCustomStrategy;
+    return d;
+  }
+  return { ...HIDDEN_DEFAULTS };
+}
+
+/**
+ * Visible-control prefills that differ from INITIAL_FORM_STATE per profile. They seed the
+ * FormGroup AND win over the generic backend template in the wizard's `syncTemplateDefaults` —
+ * a curated product template deliberately overrides the template's generic defaults (e.g. two
+ * wheeler rates are quoted per YEAR, while the backend template defaults the frequency to
+ * per month; 14 per month would be a very different product).
+ */
+export const PROFILE_INITIAL_OVERRIDES: Partial<Record<LoanWizardProfileMode, Partial<FormState>>> = {
+  'two-wheeler': {
+    principal: 80000, // mid-range new two-wheeler on-road price
+    numberOfRepayments: 36, // standard 3-year EMI plan
+    interestRatePerPeriod: 14, // mid-market two-wheeler rate
+    interestRateFrequencyType: 3, // per year — how the product is quoted and sold
+    // Down payment is the product's defining feature. The `enableDownPayment` payload value is
+    // forced true via hiddenDefaultsFor, but the FormControl must ALSO be seeded true because the
+    // down payment %'s visibility gates on the control's value (see the wizard's visibleFields).
+    enableDownPayment: true,
+    disbursedAmountPercentageForDownPayment: 20 // ≈ 80% LTV, the industry midpoint
+  },
+  education: {
+    principal: 500000, // typical domestic education loan ticket
+    numberOfRepayments: 120, // 10-year repayment phase after the moratorium
+    interestRatePerPeriod: 10.5, // mid-market education loan rate
+    interestRateFrequencyType: 3, // per year — how the product is quoted
+    // The headline field: principal moratorium ≈ 2-year course + buffer, in monthly periods.
+    // Editable because it tracks the borrower's actual course length; stays < numberOfRepayments
+    // or the guided grace guard drops it (Fineract requires grace < numberOfRepayments).
+    graceOnPrincipalPayment: 24,
+    // 8 semester tranches cover a 4-year course. Editable; visibility of the control gates on the
+    // multiDisburseLoan control, which INITIAL_FORM_STATE already seeds true for guided profiles.
+    maxTrancheCount: 8,
+    // Seed the controls to the pinned Cumulative stack so the wizard UI agrees with the payload:
+    // the Payment Allocation step hides itself for a non-advanced strategy, exactly as intended.
+    loanScheduleType: 'Cumulative',
+    transactionProcessingStrategyCode: 'mifos-standard-strategy'
+  },
+  agriculture: {
+    principal: 100000, // typical scale-of-finance ticket
+    // THE bullet: one installment containing all principal and interest at cycle end. Editable so
+    // a two-season variant (2 × 6 months) stays possible without leaving the template.
+    numberOfRepayments: 1,
+    // Crop-cycle length — the field the product manager actually tunes (6 = single kharif/rabi
+    // season, 12 = annual, 18 = sugarcane).
+    repaymentEvery: 12,
+    interestRatePerPeriod: 7, // subvented crop-loan headline rate; fully policy-driven
+    interestRateFrequencyType: 3, // per year
+    // Day-based proxy for the RBI "one/two crop seasons" NPA norm: 180 ≈ one season,
+    // 360 ≈ two seasons for short-duration crops. Visible and editable per crop profile.
+    overdueDaysForNPA: 180,
+    // Seed the controls to the pinned Cumulative stack so the wizard UI agrees with the payload.
+    loanScheduleType: 'Cumulative',
+    transactionProcessingStrategyCode: 'principal-interest-penalties-fees-order-strategy'
+  }
+};
+
+/**
+ * Keys from the guided-hidden lists (hidden defaults / custom-only fields) that a specific profile
+ * exposes as an editable control. `disbursedAmountPercentageForDownPayment` sits in the wizard's
+ * custom-only list, which hides it for every guided profile; Two Wheeler surfaces it as its
+ * headline field.
+ */
+export const PROFILE_EXTRA_VISIBLE_FIELDS: Partial<Record<LoanWizardProfileMode, readonly string[]>> = {
+  'two-wheeler': ['disbursedAmountPercentageForDownPayment']
+};
+
+/** Wizard header eyebrow, one translation key per profile. */
+export const PROFILE_LABEL_KEYS: Record<LoanWizardProfileMode, string> = {
+  personal: 'labels.text.Personal Loan',
+  'custom-advanced': 'labels.text.Custom / Advanced',
+  'two-wheeler': 'labels.text.Two Wheeler Loan',
+  education: 'labels.text.Education Loan',
+  agriculture: 'labels.text.Agriculture Loan'
+};
+
+/** Route path (under products/loan-products) → wizard profile and the page heading it renders. */
+const PROFILE_ROUTES: Record<string, { profileMode: LoanWizardProfileMode; pageTitle: string }> = {
+  'personal-loan': { profileMode: 'personal', pageTitle: 'labels.heading.Create Personal Loan' },
+  'custom-advanced': {
+    profileMode: 'custom-advanced',
+    pageTitle: 'labels.heading.Custom / Advanced Loan Configuration'
+  },
+  'two-wheeler-loan': { profileMode: 'two-wheeler', pageTitle: 'labels.heading.Create Two Wheeler Loan' },
+  'education-loan': { profileMode: 'education', pageTitle: 'labels.heading.Create Education Loan' },
+  'agriculture-loan': { profileMode: 'agriculture', pageTitle: 'labels.heading.Create Agriculture Loan' }
+};
+
+/**
+ * Resolves the wizard profile (and its page title translation key) from the matched route path,
+ * falling back to the Personal Loan profile for unknown paths — the same fallback the route
+ * mapping had when it was a `path === 'custom-advanced'` ternary.
+ */
+export function profileForRoutePath(routePath: string | undefined): {
+  profileMode: LoanWizardProfileMode;
+  pageTitle: string;
+} {
+  return PROFILE_ROUTES[routePath ?? ''] ?? PROFILE_ROUTES['personal-loan'];
+}
 
 /**
  * Fields that should use template defaults when not explicitly provided by user.
@@ -1134,37 +1397,18 @@ export function buildPayload(
   profileMode: LoanWizardProfileMode = 'personal',
   template?: unknown
 ): Record<string, unknown> {
-  const defaults =
-    profileMode === 'custom-advanced'
-      ? (() => {
-          const d = { ...HIDDEN_DEFAULTS };
-          delete d.canDefineInstallmentAmount;
-          delete d.allowVariableInstallments;
-          delete d.multiDisburseLoan;
-          delete d.maxTrancheCount;
-          delete d.allowFullTermForTranche;
-          delete d.inArrearsTolerance;
-          delete d.graceOnArrearsAgeing;
-          delete d.overdueDaysForNPA;
-          // `daysInYearType` and `daysInYearCustomStrategy` are visible, user-editable selects in the
-          // Custom/Advanced settings step (same as Classic). Leaving them in HIDDEN_DEFAULTS would
-          // force `daysInYearType` to 360 / `daysInYearCustomStrategy` to 'Full Leap Year' regardless
-          // of the user's choice, so the form value would never reach the payload. Drop them here so
-          // the form drives both, matching Classic — the gate in `sanitizeCreateLoanProductPayload`
-          // then removes `daysInYearCustomStrategy` for any non-ACTUAL type, exactly as Classic does.
-          delete d.daysInYearType;
-          delete d.daysInYearCustomStrategy;
-          return d;
-        })()
-      : { ...HIDDEN_DEFAULTS };
+  const defaults = hiddenDefaultsFor(profileMode);
 
-  /* Apply template defaults if template is provided for Personal Loan */
+  /* Apply template defaults if template is provided for a guided profile */
   const formValuesWithTemplateDefaults = template ? mergeTemplateDefaults(formState, template) : formState;
 
   // Merge order is profile-dependent:
-  // - Personal Loan hides every HIDDEN_DEFAULTS field in the UI (see the `hiddenFieldKeys` filter in
-  //   loan-product-wizard.component.ts), so those controls only ever carry their INITIAL_FORM_STATE
-  //   seed. The product-specific hidden defaults must therefore win — `defaults` is spread last.
+  // - Guided profiles (Personal, Two Wheeler) hide every key of their hidden defaults in the UI
+  //   (see the `hiddenFieldKeys` filter in loan-product-wizard.component.ts), so those controls only
+  //   ever carry their INITIAL_FORM_STATE seed. The product-specific hidden defaults must therefore
+  //   win — `defaults` is spread last. Any field a guided profile exposes as editable is REMOVED
+  //   from its hidden defaults in `hiddenDefaultsFor` (e.g. Two Wheeler's down payment %), so the
+  //   form value survives this spread.
   // - Custom/Advanced exposes those same fields as editable controls, so the user's form values must
   //   win. Spreading `defaults` first lets it fill in only the genuinely hidden, backend-only fields
   //   the form never carries (e.g. the borrower-cycle variation arrays) without clobbering visible
@@ -1174,23 +1418,33 @@ export function buildPayload(
       ? { ...defaults, ...formValuesWithTemplateDefaults }
       : { ...formValuesWithTemplateDefaults, ...defaults };
 
-  // Personal Loan specific transformations
-  if (profileMode === 'personal') {
+  // Guided-profile transformations: fold charges, validate grace, and normalize the payload to the
+  // contract the Personal Loan template has always sent. Profiles on the Progressive stack
+  // (Personal, Two Wheeler) additionally force the Progressive + advanced-payment-allocation pair;
+  // Education runs on the Classic Cumulative stack (its hidden defaults pin schedule/strategy), so
+  // no forcing happens and the progressive-only branches below turn themselves off.
+  if (isGuidedProfileMode(profileMode)) {
     const formValues = formState as Record<string, unknown>;
     const selectedTransactionProcessingStrategyCode = formValues.transactionProcessingStrategyCode;
+    const numberOfRepayments = toFiniteNumber(merged.numberOfRepayments);
+
+    if (forcesProgressiveStack(profileMode)) {
+      merged.transactionProcessingStrategyCode =
+        typeof selectedTransactionProcessingStrategyCode === 'string' &&
+        selectedTransactionProcessingStrategyCode !== ''
+          ? selectedTransactionProcessingStrategyCode
+          : LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
+      merged.loanScheduleType = LoanProducts.LOAN_SCHEDULE_TYPE_PROGRESSIVE;
+    }
+
+    // Computed AFTER any stack forcing so the progressive-only branches below key off the strategy
+    // and schedule the payload will actually carry.
     const transactionProcessingStrategyCode = merged.transactionProcessingStrategyCode;
     const supportsAdvancedPaymentAllocation =
       typeof transactionProcessingStrategyCode === 'string' &&
       LoanProducts.isAdvancedPaymentAllocationStrategy(transactionProcessingStrategyCode);
     const supportsProgressiveLoanFeatures =
       supportsAdvancedPaymentAllocation && isProgressiveLoanSchedule(merged.loanScheduleType);
-    const numberOfRepayments = toFiniteNumber(merged.numberOfRepayments);
-
-    merged.transactionProcessingStrategyCode =
-      typeof selectedTransactionProcessingStrategyCode === 'string' && selectedTransactionProcessingStrategyCode !== ''
-        ? selectedTransactionProcessingStrategyCode
-        : LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY;
-    merged.loanScheduleType = LoanProducts.LOAN_SCHEDULE_TYPE_PROGRESSIVE;
 
     // Map interest-free period to the backend field name used by the classic payload contract.
     if ('interestFreePeriod' in merged) {
@@ -1202,6 +1456,15 @@ export function buildPayload(
 
     delete merged.chargeName;
     delete merged.overdueCharge;
+
+    // Normalize the delinquency bucket "None" option ('') to null, mirroring the Classic Settings
+    // step (loan-product-settings-step.component.ts, which converts '' -> null before submit). For
+    // profiles that expose it as an editable select (Two Wheeler, Education, Agriculture) this keeps
+    // the untouched-form payload on the same `null` contract Personal sends from its hidden default;
+    // for profiles that keep it hidden the value is already null, so this is a no-op.
+    if (merged.delinquencyBucketId === '') {
+      merged.delinquencyBucketId = null;
+    }
 
     // Preserve backend field names expected by the classic payload contract.
     if ('enableBuydownFees' in merged) {
@@ -1231,11 +1494,29 @@ export function buildPayload(
     delete merged.allowVariableInstallments;
     delete merged.minimumGap;
     delete merged.maximumGap;
-    delete merged.multiDisburseLoan;
-    delete merged.maxTrancheCount;
-    delete merged.allowFullTermForTranche;
+
+    // Profiles without tranches omit the entire multi-disburse family (the proven Personal Loan
+    // contract — the backend then applies its own defaults). Education transmits it: semester-wise
+    // tranche disbursement is intrinsic to the product, `multiDisburseLoan: true` is pinned in its
+    // hidden defaults and `maxTrancheCount` is a visible, editable control. The outstanding-balance
+    // cap is omitted for every guided profile — the form seeds it with the base 100000, which no
+    // guided product wants as an actual cap.
     delete merged.outstandingLoanBalance;
-    delete merged.disallowExpectedDisbursements;
+    if (!sendsMultiDisburseFields(profileMode)) {
+      delete merged.multiDisburseLoan;
+      delete merged.maxTrancheCount;
+      delete merged.allowFullTermForTranche;
+      delete merged.disallowExpectedDisbursements;
+    } else {
+      // The tranche cap is a visible, optional number control (Education), so clearing it leaves the
+      // FormControl at null and typing 0/1 is equally accepted by the input. Fineract rejects
+      // `multiDisburseLoan: true` without a valid cap, and a "multi"-disburse product needs at least
+      // two tranches, so coerce anything below the minimum back to it rather than shipping the
+      // invalid value.
+      const trancheCount = toFiniteNumber(merged.maxTrancheCount);
+      merged.maxTrancheCount =
+        trancheCount !== null && trancheCount >= MIN_TRANCHE_COUNT ? trancheCount : MIN_TRANCHE_COUNT;
+    }
 
     if (!hasValidGracePeriod(merged.graceOnPrincipalPayment, numberOfRepayments)) {
       delete merged.graceOnPrincipalPayment;
@@ -1256,7 +1537,8 @@ export function buildPayload(
     templateOnlyFieldsNotAcceptedByCreateApi.forEach((field) => {
       delete merged[field];
     });
-  } else if (profileMode === 'custom-advanced') {
+  } else {
+    // Custom/Advanced only.
     // Advanced Payment Allocation parity with Classic: `supportedInterestRefundTypes` is only ever
     // populated from the template's default list (there is no dedicated Interest Refund UI in either
     // wizard profile, same as Personal Loan above), and only once the advanced strategy + Progressive

--- a/src/app/products/products-routing.module.ts
+++ b/src/app/products/products-routing.module.ts
@@ -209,6 +209,33 @@ const routes: Routes = [
               }
             },
             {
+              path: 'two-wheeler-loan',
+              component: CreateLoanProductComponent,
+              data: { title: 'Create Two Wheeler Loan', breadcrumb: 'Two Wheeler Loan' },
+              resolve: {
+                loanProductsTemplate: LoanProductsTemplateResolver,
+                configurations: GlobalConfigurationsResolver
+              }
+            },
+            {
+              path: 'education-loan',
+              component: CreateLoanProductComponent,
+              data: { title: 'Create Education Loan', breadcrumb: 'Education Loan' },
+              resolve: {
+                loanProductsTemplate: LoanProductsTemplateResolver,
+                configurations: GlobalConfigurationsResolver
+              }
+            },
+            {
+              path: 'agriculture-loan',
+              component: CreateLoanProductComponent,
+              data: { title: 'Create Agriculture Loan', breadcrumb: 'Agriculture Loan' },
+              resolve: {
+                loanProductsTemplate: LoanProductsTemplateResolver,
+                configurations: GlobalConfigurationsResolver
+              }
+            },
+            {
               path: ':productId',
               component: ViewLoanProductComponent,
               resolve: {

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1131,6 +1131,11 @@
       "NotEqual": "Nerovná se"
     },
     "heading": {
+      "Create Agriculture Loan": "Vytvořit zemědělský úvěr",
+      "Create Education Loan": "Vytvořit studentský úvěr",
+      "Create Personal Loan": "Vytvořit osobní úvěr",
+      "Create Two Wheeler Loan": "Vytvořit úvěr na motocykly a skútry",
+      "Custom / Advanced Loan Configuration": "Vlastní / pokročilá konfigurace úvěru",
       "Breach Actions": "Porušení Akce",
       "Delinquency & Breach": "Delikvence a porušení",
       "Interest": "Úrok",
@@ -3453,6 +3458,14 @@
       "undo_account_transfer": "Opravdu chcete vrátit tento převod účtu?"
     },
     "text": {
+      "Agriculture Loan": "Zemědělský úvěr",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Úvěr na potřeby spojené se zemědělstvím, jako je rostlinná výroba, technika nebo zúrodnění půdy, obvykle navázaný na zemědělské cykly.",
+      "Education Loan": "Studentský úvěr",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Financování školného a souvisejících výdajů při studiu v tuzemsku i zahraničí, se splácením přizpůsobeným délce studia.",
+      "Personal Loan": "Osobní úvěr",
+      "Custom / Advanced": "Vlastní / pokročilé",
+      "Two Wheeler Loan": "Úvěr na motocykly a skútry",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Financování nových i ojetých motocyklů a skútrů s rychlým schválením a flexibilní zálohou.",
       "Max": "Max",
       "Hidden variables and predefined values are included in the final payload automatically.": "Skryté proměnné a předdefinované hodnoty jsou automaticky zahrnuty do konečného payloadu.",
       "No Breach Actions": "Žádné Porušení Akce",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1132,6 +1132,11 @@
       "NotEqual": "Ungleich"
     },
     "heading": {
+      "Create Agriculture Loan": "Agrarkredit erstellen",
+      "Create Education Loan": "Bildungskredit erstellen",
+      "Create Personal Loan": "Privatkredit erstellen",
+      "Create Two Wheeler Loan": "Zweiradkredit erstellen",
+      "Custom / Advanced Loan Configuration": "Benutzerdefinierte / erweiterte Kreditkonfiguration",
       "Breach Actions": "Verstoßaktionen",
       "Delinquency & Breach": "Verzug & Verstoß",
       "Interest": "Zinsen",
@@ -3455,6 +3460,14 @@
       "undo_account_transfer": "Möchten Sie diesen Kontotransfer wirklich rückgängig machen?"
     },
     "text": {
+      "Agriculture Loan": "Agrarkredit",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Kredit für landwirtschaftliche Zwecke wie Pflanzenbau, Maschinen oder Flächenerschließung, meist an die landwirtschaftlichen Zyklen gekoppelt.",
+      "Education Loan": "Bildungskredit",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Finanzierung von Studiengebühren und damit verbundenen Kosten für ein Studium im In- oder Ausland, mit an die Studiendauer angepassten Rückzahlungsoptionen.",
+      "Personal Loan": "Privatkredit",
+      "Custom / Advanced": "Benutzerdefiniert / Erweitert",
+      "Two Wheeler Loan": "Zweiradkredit",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Finanzierung neuer oder gebrauchter Zweiräder mit schneller Zusage und flexibler Anzahlung.",
       "Max": "Max",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Keine Verstoßaktionen",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1145,6 +1145,11 @@
       "NotEqual": "Not equal"
     },
     "heading": {
+      "Create Agriculture Loan": "Create Agriculture Loan",
+      "Create Education Loan": "Create Education Loan",
+      "Create Personal Loan": "Create Personal Loan",
+      "Create Two Wheeler Loan": "Create Two Wheeler Loan",
+      "Custom / Advanced Loan Configuration": "Custom / Advanced Loan Configuration",
       "Breach Actions": "Breach Actions",
       "Delinquency & Breach": "Delinquency & Breach",
       "Interest": "Interest",
@@ -3482,6 +3487,14 @@
       "the Transaction Type": "the Transaction Type"
     },
     "text": {
+      "Agriculture Loan": "Agriculture Loan",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles.",
+      "Education Loan": "Education Loan",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration.",
+      "Personal Loan": "Personal Loan",
+      "Custom / Advanced": "Custom / Advanced",
+      "Two Wheeler Loan": "Two Wheeler Loan",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Finance for new or used two-wheelers with quick approval and flexible down payment options.",
       "Max": "Max",
       "Min": "Min",
       "Any": "Any",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1129,6 +1129,11 @@
       "NotEqual": "No igual"
     },
     "heading": {
+      "Create Agriculture Loan": "Crear Crédito Agrícola",
+      "Create Education Loan": "Crear Crédito Educativo",
+      "Create Personal Loan": "Crear Crédito Personal",
+      "Create Two Wheeler Loan": "Crear Crédito para Motos",
+      "Custom / Advanced Loan Configuration": "Configuración de Crédito Personalizada / Avanzada",
       "Breach Actions": "Acciones de Incumplimiento",
       "Delinquency & Breach": "Morosidad e Incumplimiento",
       "Interest": "Interés",
@@ -3454,6 +3459,14 @@
       "undo_account_transfer": "¿Está seguro de que desea revertir esta transferencia de cuenta?"
     },
     "text": {
+      "Agriculture Loan": "Crédito Agrícola",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Crédito para necesidades agrícolas como la producción de cultivos, maquinaria o habilitación de terrenos, generalmente ajustado a los ciclos agrícolas.",
+      "Education Loan": "Crédito Educativo",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Financiamiento de matrícula y gastos asociados para estudios nacionales o internacionales, con opciones de pago ajustadas a la duración de la carrera.",
+      "Personal Loan": "Crédito Personal",
+      "Custom / Advanced": "Personalizado / Avanzado",
+      "Two Wheeler Loan": "Crédito para Motos",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Financiamiento de motos nuevas o usadas, con aprobación rápida y opciones flexibles de pago inicial.",
       "Max": "Máx",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Sin acciones de incumplimiento",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1134,6 +1134,11 @@
       "NotEqual": "No igual"
     },
     "heading": {
+      "Create Agriculture Loan": "Crear Crédito Agrícola",
+      "Create Education Loan": "Crear Crédito Educativo",
+      "Create Personal Loan": "Crear Crédito Personal",
+      "Create Two Wheeler Loan": "Crear Crédito para Motos",
+      "Custom / Advanced Loan Configuration": "Configuración de Crédito Personalizada / Avanzada",
       "Breach Actions": "Acciones de Incumplimiento",
       "Delinquency & Breach": "Morosidad e Incumplimiento",
       "Interest": "Interés",
@@ -3458,6 +3463,14 @@
       "undo_account_transfer": "¿Está seguro de que desea revertir esta transferencia de cuenta?"
     },
     "text": {
+      "Agriculture Loan": "Crédito Agrícola",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Crédito para necesidades agrícolas como la producción de cultivos, maquinaria o habilitación de terrenos, generalmente ajustado a los ciclos agrícolas.",
+      "Education Loan": "Crédito Educativo",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Financiamiento de matrícula y gastos asociados para estudios nacionales o internacionales, con opciones de pago ajustadas a la duración de la carrera.",
+      "Personal Loan": "Crédito Personal",
+      "Custom / Advanced": "Personalizado / Avanzado",
+      "Two Wheeler Loan": "Crédito para Motos",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Financiamiento de motos nuevas o usadas, con aprobación rápida y opciones flexibles de pago inicial.",
       "Max": "Máx",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Sin acciones de incumplimiento",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1133,6 +1133,11 @@
       "NotEqual": "Différent de"
     },
     "heading": {
+      "Create Agriculture Loan": "Créer un prêt agricole",
+      "Create Education Loan": "Créer un prêt étudiant",
+      "Create Personal Loan": "Créer un prêt personnel",
+      "Create Two Wheeler Loan": "Créer un prêt deux-roues",
+      "Custom / Advanced Loan Configuration": "Configuration de prêt personnalisée / avancée",
       "Breach Actions": "Actions de violation",
       "Delinquency & Breach": "Délinquance et violation",
       "Interest": "Intérêts",
@@ -3456,6 +3461,14 @@
       "undo_account_transfer": "Êtes-vous sûr de vouloir annuler ce transfert de compte ?"
     },
     "text": {
+      "Agriculture Loan": "Prêt agricole",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Crédit destiné aux besoins agricoles tels que la production végétale, le matériel ou l'aménagement foncier, généralement aligné sur les cycles agricoles.",
+      "Education Loan": "Prêt étudiant",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Financement des frais de scolarité et des dépenses associées pour des études dans le pays ou à l'étranger, avec des options de remboursement adaptées à la durée du cursus.",
+      "Personal Loan": "Prêt personnel",
+      "Custom / Advanced": "Personnalisé / Avancé",
+      "Two Wheeler Loan": "Prêt deux-roues",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Financement de deux-roues neufs ou d'occasion, avec accord rapide et acompte modulable.",
       "Max": "Max",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Aucune action de violation",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1130,6 +1130,11 @@
       "NotEqual": "Diverso da"
     },
     "heading": {
+      "Create Agriculture Loan": "Crea prestito agricolo",
+      "Create Education Loan": "Crea prestito per studi",
+      "Create Personal Loan": "Crea prestito personale",
+      "Create Two Wheeler Loan": "Crea prestito per veicoli a due ruote",
+      "Custom / Advanced Loan Configuration": "Configurazione prestito personalizzata / avanzata",
       "Breach Actions": "Azioni di violazione",
       "Delinquency & Breach": "Delinquenza e violazione",
       "Interest": "Interessi",
@@ -3452,6 +3457,14 @@
       "undo_account_transfer": "Sei sicuro di voler annullare questo trasferimento conto?"
     },
     "text": {
+      "Agriculture Loan": "Prestito agricolo",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Credito per esigenze agricole come la produzione di colture, i macchinari o la sistemazione dei terreni, generalmente legato ai cicli agricoli.",
+      "Education Loan": "Prestito per studi",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Finanziamento delle tasse scolastiche e delle spese correlate per studi in Italia o all'estero, con opzioni di rimborso allineate alla durata del corso.",
+      "Personal Loan": "Prestito personale",
+      "Custom / Advanced": "Personalizzato / Avanzato",
+      "Two Wheeler Loan": "Prestito per veicoli a due ruote",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Finanziamento di veicoli a due ruote nuovi o usati, con approvazione rapida e acconto flessibile.",
       "Max": "Max",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Nessuna azione di violazione",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1130,6 +1130,11 @@
       "NotEqual": "같지 않음"
     },
     "heading": {
+      "Create Agriculture Loan": "농업 대출 생성",
+      "Create Education Loan": "교육 대출 생성",
+      "Create Personal Loan": "개인 대출 생성",
+      "Create Two Wheeler Loan": "이륜차 대출 생성",
+      "Custom / Advanced Loan Configuration": "사용자 지정 / 고급 대출 구성",
       "Breach Actions": "위반 행위",
       "Delinquency & Breach": "연체 및 위반",
       "Interest": "이자",
@@ -3452,6 +3457,14 @@
       "undo_account_transfer": "이 계좌 이체를 취소하시겠습니까?"
     },
     "text": {
+      "Agriculture Loan": "농업 대출",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "작물 생산, 장비, 농지 개발 등 영농 관련 자금을 지원하며, 일반적으로 영농 주기에 맞춰 운영되는 대출입니다.",
+      "Education Loan": "교육 대출",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "국내외 학업의 등록금 및 관련 비용을 지원하며, 학업 기간에 맞춘 상환 옵션을 제공합니다.",
+      "Personal Loan": "개인 대출",
+      "Custom / Advanced": "사용자 지정 / 고급",
+      "Two Wheeler Loan": "이륜차 대출",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "신차 및 중고 이륜차 구입 자금을 빠른 승인과 유연한 계약금 옵션으로 지원합니다.",
       "Max": "최대",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "위반 행위 없음",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1129,6 +1129,11 @@
       "NotEqual": "Nelygu"
     },
     "heading": {
+      "Create Agriculture Loan": "Sukurti žemės ūkio paskolą",
+      "Create Education Loan": "Sukurti studijų paskolą",
+      "Create Personal Loan": "Sukurti vartojimo paskolą",
+      "Create Two Wheeler Loan": "Sukurti motociklų ir motorolerių paskolą",
+      "Custom / Advanced Loan Configuration": "Pasirinktinė / išplėstinė paskolos konfigūracija",
       "Breach Actions": "Pažeidimas Veiksmai",
       "Delinquency & Breach": "Delinkvencija ir pažeidimas",
       "Interest": "Palūkanos",
@@ -3452,6 +3457,14 @@
       "undo_account_transfer": "Ar tikrai norite atšaukti šį sąskaitos pervedimą?"
     },
     "text": {
+      "Agriculture Loan": "Žemės ūkio paskola",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Kreditas žemės ūkio poreikiams, tokiems kaip augalininkystė, technika ar žemės gerinimas, paprastai derinamas prie žemės ūkio ciklų.",
+      "Education Loan": "Studijų paskola",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Studijų mokesčio ir kitų susijusių išlaidų finansavimas mokantis šalyje ar užsienyje, su studijų trukmei pritaikytomis grąžinimo galimybėmis.",
+      "Personal Loan": "Vartojimo paskola",
+      "Custom / Advanced": "Pasirinktinė / išplėstinė",
+      "Two Wheeler Loan": "Motociklų ir motorolerių paskola",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Naujų ar naudotų motociklų ir motorolerių finansavimas su greitu patvirtinimu ir lanksčia pradine įmoka.",
       "Max": "Maks",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Nėra Pažeidimas Veiksmai",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1130,6 +1130,11 @@
       "NotEqual": "Nevienāds"
     },
     "heading": {
+      "Create Agriculture Loan": "Izveidot lauksaimniecības aizdevumu",
+      "Create Education Loan": "Izveidot studiju aizdevumu",
+      "Create Personal Loan": "Izveidot patēriņa aizdevumu",
+      "Create Two Wheeler Loan": "Izveidot divriteņu transportlīdzekļa aizdevumu",
+      "Custom / Advanced Loan Configuration": "Pielāgota / paplašināta aizdevuma konfigurācija",
       "Breach Actions": "Pārkāpums Darbības",
       "Delinquency & Breach": "Kavējumi un pārkāpums",
       "Interest": "Procenti",
@@ -3452,6 +3457,14 @@
       "undo_account_transfer": "Vai tiešām vēlaties atcelt šo konta pārskaitījumu?"
     },
     "text": {
+      "Agriculture Loan": "Lauksaimniecības aizdevums",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Kredīts lauksaimniecības vajadzībām, piemēram, kultūraugu audzēšanai, tehnikai vai zemes uzlabošanai, parasti saistīts ar lauksaimniecības cikliem.",
+      "Education Loan": "Studiju aizdevums",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Mācību maksas un ar to saistīto izdevumu finansējums studijām valstī vai ārzemēs ar studiju ilgumam pielāgotām atmaksas iespējām.",
+      "Personal Loan": "Patēriņa aizdevums",
+      "Custom / Advanced": "Pielāgots / paplašināts",
+      "Two Wheeler Loan": "Divriteņu transportlīdzekļa aizdevums",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Jaunu vai lietotu divriteņu transportlīdzekļu finansējums ar ātru apstiprinājumu un elastīgu pirmo iemaksu.",
       "Max": "Maks",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Nav Pārkāpums Darbības",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1129,6 +1129,11 @@
       "NotEqual": "बराबर छैन"
     },
     "heading": {
+      "Create Agriculture Loan": "कृषि ऋण सिर्जना गर्नुहोस्",
+      "Create Education Loan": "शैक्षिक ऋण सिर्जना गर्नुहोस्",
+      "Create Personal Loan": "व्यक्तिगत ऋण सिर्जना गर्नुहोस्",
+      "Create Two Wheeler Loan": "दुई पाङ्ग्रे सवारी ऋण सिर्जना गर्नुहोस्",
+      "Custom / Advanced Loan Configuration": "अनुकूलित / उन्नत ऋण कन्फिगरेसन",
       "Breach Actions": "उल्लंघन कार्यहरू",
       "Delinquency & Breach": "अपराध र उल्लंघन",
       "Interest": "ब्याज",
@@ -3452,6 +3457,14 @@
       "undo_account_transfer": "के तपाईं यो खाता स्थानान्तरण रद्द गर्न निश्चित हुनुहुन्छ?"
     },
     "text": {
+      "Agriculture Loan": "कृषि ऋण",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "बाली उत्पादन, कृषि उपकरण वा जग्गा विकास जस्ता कृषिसम्बन्धी आवश्यकताका लागि ऋण, जुन प्रायः कृषि चक्रसँग मिलाइएको हुन्छ।",
+      "Education Loan": "शैक्षिक ऋण",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "स्वदेश वा विदेशमा अध्ययनका लागि शुल्क र सम्बन्धित खर्चको वित्तीय सहायता, पाठ्यक्रम अवधिअनुसार मिलाइएका भुक्तानी विकल्पसहित।",
+      "Personal Loan": "व्यक्तिगत ऋण",
+      "Custom / Advanced": "अनुकूलित / उन्नत",
+      "Two Wheeler Loan": "दुई पाङ्ग्रे सवारी ऋण",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "नयाँ वा प्रयोग भइसकेका दुई पाङ्ग्रे सवारीका लागि छिटो स्वीकृति र लचिलो डाउन पेमेन्ट विकल्पसहितको वित्तीय सुविधा।",
       "Max": "अधिकतम",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "कुनै उल्लंघन कार्यहरू छैन",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1130,6 +1130,11 @@
       "NotEqual": "Diferente de"
     },
     "heading": {
+      "Create Agriculture Loan": "Criar empréstimo agrícola",
+      "Create Education Loan": "Criar empréstimo para estudos",
+      "Create Personal Loan": "Criar empréstimo pessoal",
+      "Create Two Wheeler Loan": "Criar empréstimo para veículos de duas rodas",
+      "Custom / Advanced Loan Configuration": "Configuração de empréstimo personalizada / avançada",
       "Breach Actions": "Ações de violação",
       "Delinquency & Breach": "Inadimplência e Violação",
       "Interest": "Juros",
@@ -3452,6 +3457,14 @@
       "undo_account_transfer": "Tem a certeza de que pretende reverter esta transferência de conta?"
     },
     "text": {
+      "Agriculture Loan": "Empréstimo agrícola",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Crédito para necessidades agrícolas como a produção de culturas, equipamento ou valorização de terrenos, geralmente ajustado aos ciclos agrícolas.",
+      "Education Loan": "Empréstimo para estudos",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Financiamento de propinas e despesas associadas para estudos no país ou no estrangeiro, com opções de reembolso ajustadas à duração do curso.",
+      "Personal Loan": "Empréstimo pessoal",
+      "Custom / Advanced": "Personalizado / Avançado",
+      "Two Wheeler Loan": "Empréstimo para veículos de duas rodas",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Financiamento de veículos de duas rodas novos ou usados, com aprovação rápida e pagamento inicial flexível.",
       "Max": "Máx",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Nenhuma ação de violação",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1128,6 +1128,11 @@
       "NotEqual": "Sio sawa"
     },
     "heading": {
+      "Create Agriculture Loan": "Unda Mkopo wa Kilimo",
+      "Create Education Loan": "Unda Mkopo wa Elimu",
+      "Create Personal Loan": "Unda Mkopo wa Binafsi",
+      "Create Two Wheeler Loan": "Unda Mkopo wa Pikipiki",
+      "Custom / Advanced Loan Configuration": "Usanidi wa Mkopo Maalum / wa Kina",
       "Breach Actions": "Ukiukaji Vitendo",
       "Delinquency & Breach": "Uhalifu na Ukiukaji",
       "Interest": "Riba",
@@ -3449,6 +3454,14 @@
       "undo_account_transfer": "Una uhakika unataka kufuta uhamisho huu wa akaunti?"
     },
     "text": {
+      "Agriculture Loan": "Mkopo wa Kilimo",
+      "Credit for farming-related needs such as crop production, equipment, or land development, often tied to agricultural cycles": "Mkopo kwa mahitaji ya kilimo kama vile uzalishaji wa mazao, vifaa au uendelezaji wa ardhi, ambao mara nyingi hufungamanishwa na misimu ya kilimo.",
+      "Education Loan": "Mkopo wa Elimu",
+      "Funding for tuition and related expenses for domestic or international studies, with repayment options aligned to course duration": "Ufadhili wa ada na gharama zinazohusiana kwa masomo ya ndani au ya nje ya nchi, wenye chaguo za ulipaji zinazolingana na muda wa kozi.",
+      "Personal Loan": "Mkopo wa Binafsi",
+      "Custom / Advanced": "Maalum / wa Kina",
+      "Two Wheeler Loan": "Mkopo wa Pikipiki",
+      "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Ufadhili wa pikipiki mpya au zilizotumika wenye idhini ya haraka na chaguo nyumbufu za malipo ya awali.",
       "Max": "Upeo",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Hakuna Ukiukaji Vitendo",


### PR DESCRIPTION
## Description

This PR extends the template-based loan product creation workflow by introducing support for three additional loan product templates:

- Two Wheeler Loan
- Education Loan
- Agricultural Loan

Each template is configured with loan-specific defaults, field visibility, editability, and validation rules to simplify product creation while aligning with the expected business requirements for each loan type. The changes provide a more guided and consistent experience for creating commonly used loan products without affecting the existing Personal Loan, Advanced Loan, or Classic loan product creation flows.

No additional dependencies are required.

## Related issues and discussion

# WEB-1072

## Screenshots, if any

<img width="1918" height="970" alt="image" src="https://github.com/user-attachments/assets/ba3a212e-4802-404e-9e82-a7f573859788" />

https://github.com/user-attachments/assets/d0d41c16-9857-41f1-aa9e-50793374e345

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added loan product creation routes and wizard flows for Two Wheeler, Education, and Agriculture, with guided, mode-aware defaults and localized headings/descriptions.
  * Introduced a reusable Accounting step in the loan product wizard, including GL account selection and an Accounting section on the Review screen.
* **Bug Fixes**
  * Improved wizard submission validation to block when the Accounting step is invalid, and refined step rendering so Accounting appears only when applicable.
* **Tests**
  * Expanded golden parity and wizard-flow tests to lock step sequences, payload shapes, Accounting reuse/overrides, and invalid-state submission blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->