### PR TITLE
Web 1068 playwright loan savings account types and factories

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -134,7 +134,9 @@ export default defineConfig({
       testMatch: [
         /playwright\/utils\/.*\.spec\.ts/,
         /playwright\/pages\/.*\.spec\.ts/,
-        /playwright\/factories\/client\.spec\.ts/
+        /playwright\/fixtures\/.*\.spec\.ts/,
+        /playwright\/factories\/client\.spec\.ts/,
+        /playwright\/factories\/_shared\.spec\.ts/
       ],
       testDir: '.',
       use: { storageState: { cookies: [], origins: [] } }

--- a/playwright/factories/_shared.spec.ts
+++ b/playwright/factories/_shared.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Unit coverage for the pure helpers in `_shared.ts`.
+ *
+ * `resolveDefaultOfficeId` needs an `ApiSetupManager` and is exercised
+ * by the integration specs; `resolveProductId` is pure, so it is
+ * pinned here where it costs nothing to run.
+ */
+
+import { test, expect } from '@playwright/test';
+import { resolveProductId } from './_shared';
+
+test.describe('resolveProductId', () => {
+  test('reads the `id` spelling returned by ensure*Product', () => {
+    expect(resolveProductId({ id: 42, name: 'E2E Loan Product' }, 'loan.factory')).toBe(42);
+  });
+
+  test('reads the `resourceId` spelling returned by create-* envelopes', () => {
+    expect(resolveProductId({ resourceId: 7 }, 'savings.factory')).toBe(7);
+  });
+
+  test('prefers `id` when a payload carries both spellings', () => {
+    // Fineract product-list rows carry `id`; a create envelope merged on
+    // top could add `resourceId`. `id` is the canonical product key.
+    expect(resolveProductId({ id: 3, resourceId: 99 }, 'loan.factory')).toBe(3);
+  });
+
+  test('accepts id 0 rather than treating it as absent', () => {
+    // Guards against a `||` regression — 0 is falsy but a valid id.
+    expect(resolveProductId({ id: 0 }, 'loan.factory')).toBe(0);
+  });
+
+  test('falls back to a numeric resourceId when id is present but not numeric', () => {
+    // `id ?? resourceId` would latch onto the non-numeric `id` and throw,
+    // discarding a perfectly good `resourceId`. Selection must be by type,
+    // not merely by presence.
+    expect(resolveProductId({ id: 'invalid', resourceId: 7 }, 'savings.factory')).toBe(7);
+  });
+
+  test('throws a caller-tagged error when neither spelling is numeric', () => {
+    // The silent failure this replaces was an account POSTed with
+    // `productId: undefined`, which Fineract rejects with an opaque 400.
+    expect(() => resolveProductId({ name: 'no id here' }, 'savings.factory')).toThrow(
+      /savings\.factory: product payload missing a numeric id\/resourceId/
+    );
+  });
+
+  test('throws on a string id instead of silently coercing it', () => {
+    expect(() => resolveProductId({ id: '42' }, 'loan.factory')).toThrow(/loan\.factory/);
+  });
+
+  test('throws on null and undefined payloads', () => {
+    expect(() => resolveProductId(null, 'loan.factory')).toThrow(/loan\.factory/);
+    expect(() => resolveProductId(undefined, 'loan.factory')).toThrow(/loan\.factory/);
+  });
+});

--- a/playwright/factories/_shared.ts
+++ b/playwright/factories/_shared.ts
@@ -38,3 +38,35 @@ export const FIRST_OFFICE_CACHE_KEY = 'office:first';
 export async function resolveDefaultOfficeId(setup: ApiSetupManager): Promise<number> {
   return setup.dedupe(FIRST_OFFICE_CACHE_KEY, () => setup.api.getFirstOfficeId());
 }
+
+/**
+ * Normalise a Fineract product payload down to its numeric id.
+ *
+ * `ensureMinimalLoanProduct` / `ensureMinimalSavingsProduct` return
+ * either an existing product straight off the product-list endpoint or
+ * a freshly-built `{ id, name, shortName }` projection. Both spell the
+ * key `id`, whereas the create-* envelope used everywhere else in this
+ * suite spells it `resourceId` — so a factory that reaches for
+ * `product.resourceId` silently gets `undefined` and posts an account
+ * with no product attached. Reading both spellings in one place stops
+ * every future product-backed factory from re-discovering that.
+ *
+ * @param product - Payload returned by an `ensure*Product` call.
+ * @param caller  - Factory name, used to make the failure traceable.
+ * @returns The numeric product id.
+ * @throws When neither `id` nor `resourceId` is a number.
+ */
+export function resolveProductId(product: unknown, caller: string): number {
+  const candidate = product as { id?: unknown; resourceId?: unknown } | null | undefined;
+  // Prefer a numeric `id`, then fall back to `resourceId`. Selecting on
+  // nullishness alone (`id ?? resourceId`) would latch onto a
+  // present-but-non-numeric `id` and reject a payload whose `resourceId`
+  // is a perfectly good number.
+  const id = typeof candidate?.id === 'number' ? candidate.id : candidate?.resourceId;
+
+  if (typeof id !== 'number') {
+    throw new Error(`${caller}: product payload missing a numeric id/resourceId, got ${JSON.stringify(product)}`);
+  }
+
+  return id;
+}

--- a/playwright/factories/client.factory.spec.ts
+++ b/playwright/factories/client.factory.spec.ts
@@ -140,6 +140,24 @@ test.describe('createActiveTestClient() against live Fineract', () => {
     expect(cleanupGuard.size()).toBe(0);
   });
 
+  test('pins the wire date protocol even when extra supplies a conflicting dateFormat', async ({
+    apiSetup,
+    cleanupGuard
+  }) => {
+    // The factory's dates are `dd MMMM yyyy` and `assertDateNotBefore`
+    // validates them as such. A caller who slips a different
+    // `dateFormat` into `extra` must not be able to desync the protocol
+    // from those values — otherwise Fineract tries to parse
+    // `02 January 2024` under `yyyy-MM-dd` and rejects the create. The
+    // create succeeding here proves `dateFormat` stayed pinned.
+    const client = await createActiveTestClient(apiSetup, cleanupGuard, {
+      extra: { dateFormat: 'yyyy-MM-dd' }
+    });
+
+    const fetched = await apiSetup.api.getClient(client.resourceId);
+    expect(fetched.active).toBe(true);
+  });
+
   test('exposes an account-opening date after the activation date', () => {
     // Guards the constant chain itself: a future edit that bumps the
     // activation date past the account-opening date would silently

--- a/playwright/factories/client.factory.ts
+++ b/playwright/factories/client.factory.ts
@@ -163,17 +163,30 @@ export interface CreateActiveTestClientOverrides extends Omit<CreateTestClientOv
   /**
    * Override the default activation date. MUST NOT precede
    * `submittedOnDate` — Fineract rejects the create outright.
+   *
+   * ⚠️ Downstream monotonicity: the loan and savings factories default
+   * their account dates to {@link DEFAULT_ACCOUNT_OPENING_DATE}. An
+   * `activationDate` later than that constant produces a client whose
+   * activation postdates a default-dated account, and Fineract rejects
+   * that account. When you set a later activation, also pass matching
+   * `submittedOnDate` / `approvedOnDate` / `activatedOnDate` to those
+   * factories — the safe default (`02 January 2024`) already precedes
+   * `DEFAULT_ACCOUNT_OPENING_DATE`, so callers that take the defaults
+   * on both sides never hit this.
    */
   activationDate?: string;
   /**
    * Extra payload fields merged BEFORE this factory's own invariants.
    *
-   * `active`, `activationDate`, and `submittedOnDate` are always
-   * applied last and cannot be overridden here — they are the fields
-   * this factory validates, and letting `extra` replace them would
-   * mean validating one value while sending another to Fineract. Use
-   * the dedicated `submittedOnDate` / `activationDate` options
-   * instead, which go through {@link assertDateNotBefore}.
+   * `active`, `activationDate`, `submittedOnDate`, `dateFormat`, and
+   * `locale` are always applied last and cannot be overridden here.
+   * The first three are the values this factory validates; `dateFormat`
+   * and `locale` are the wire protocol those values are written in, and
+   * {@link assertDateNotBefore} assumes English `dd MMMM yyyy`. Letting
+   * `extra` replace any of them would mean validating one thing while
+   * sending another to Fineract. Use the dedicated `submittedOnDate` /
+   * `activationDate` options instead, which go through
+   * {@link assertDateNotBefore}.
    */
   extra?: Record<string, unknown>;
 }
@@ -227,13 +240,20 @@ export async function createActiveTestClient(
       // Caller extras first, invariants last. `createTestClient`
       // spreads this object after its own defaults, so anything left
       // in here wins — including `submittedOnDate`. Ordering the
-      // spread this way keeps the three validated fields
-      // authoritative: otherwise the guard above could pass on one
-      // date pair while Fineract received another.
+      // spread this way keeps the validated fields authoritative:
+      // otherwise the guard above could pass on one date pair while
+      // Fineract received another.
       ...overrides.extra,
       active: true,
       activationDate,
-      submittedOnDate
+      submittedOnDate,
+      // `dateFormat`/`locale` are the wire protocol the dates above are
+      // written in and that `assertDateNotBefore` assumes (`dd MMMM
+      // yyyy`, English). Pin them last so `extra` cannot desync the
+      // format from the values just validated — otherwise the guard
+      // checks one protocol while Fineract parses under another.
+      dateFormat: DEFAULT_DATE_FORMAT,
+      locale: DEFAULT_LOCALE
     }
   });
 }

--- a/playwright/factories/index.ts
+++ b/playwright/factories/index.ts
@@ -50,6 +50,15 @@ export {
   type CreateActiveTestClientOverrides
 } from './client.factory';
 
+export { createTestLoan, createApprovedLoan, createActiveLoan, type CreateTestLoanOverrides } from './loan.factory';
+
+export {
+  createTestSavingsAccount,
+  createApprovedSavingsAccount,
+  createActiveSavingsAccount,
+  type CreateTestSavingsAccountOverrides
+} from './savings.factory';
+
 // ── Pure payload builders (no network) ─────────────────────────────
 
 export {
@@ -63,4 +72,4 @@ export {
 
 // ── Shared resolvers ───────────────────────────────────────────────
 
-export { resolveDefaultOfficeId, FIRST_OFFICE_CACHE_KEY } from './_shared';
+export { resolveDefaultOfficeId, resolveProductId, FIRST_OFFICE_CACHE_KEY } from './_shared';

--- a/playwright/factories/loan.factory.spec.ts
+++ b/playwright/factories/loan.factory.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '../fixtures/test-fixtures';
+import { createActiveTestClient } from './client.factory';
+import { createTestLoan, createApprovedLoan, createActiveLoan } from './loan.factory';
+
+// Live-backend specs — `integration` Playwright project. No browser.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('createTestLoan() against live Fineract', () => {
+  test('creates a loan in Submitted and pending approval', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const loan = await createTestLoan(apiSetup, cleanupGuard, client.resourceId);
+
+    expect(typeof loan.resourceId).toBe('number');
+    expect(loan.resourceId).toBeGreaterThan(0);
+    expect(loan.clientId).toBe(client.resourceId);
+    // Regression guard: `ensureMinimalLoanProduct` spells the key `id`,
+    // not `resourceId`. Reading the wrong one used to yield `undefined`
+    // and POST a loan with no product attached.
+    expect(loan.loanProductId).toBeGreaterThan(0);
+
+    const fetched = await apiSetup.api.getLoan(loan.resourceId);
+    expect(fetched.id).toBe(loan.resourceId);
+    expect(fetched.status?.value).toBe('Submitted and pending approval');
+    expect(fetched.loanProductId).toBe(loan.loanProductId);
+  });
+
+  test('registers deleters for both the loan and its client', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    await createTestLoan(apiSetup, cleanupGuard, client.resourceId);
+
+    // Client first, loan second — the guard drains LIFO so the loan is
+    // deleted before its owning client, which is the only order
+    // Fineract's foreign keys accept.
+    expect(cleanupGuard.size()).toBe(2);
+  });
+
+  test('hard-deletes a pending loan on flush', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const loan = await createTestLoan(apiSetup, cleanupGuard, client.resourceId);
+
+    const summary = await cleanupGuard.flush();
+    // Scoped to the loan deleter on purpose. The owning client is
+    // ACTIVE, and Fineract only hard-deletes clients in Pending state,
+    // so that entry is an expected failure and asserting an empty
+    // `failed` array would be asserting the wrong thing.
+    expect(summary.failed.some((entry) => entry.label === `loan:${loan.resourceId}`)).toBe(false);
+    await expect(apiSetup.api.getLoan(loan.resourceId)).rejects.toThrow(/404|not found/i);
+  });
+});
+
+test.describe('createApprovedLoan() against live Fineract', () => {
+  test('returns server state rather than the command envelope', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const loan = await createApprovedLoan(apiSetup, cleanupGuard, client.resourceId);
+
+    // Fineract's approve response is a thin `{ loanId, changes }`
+    // envelope with no status/timeline/principal. These assertions only
+    // pass because the factory re-reads the loan afterwards.
+    expect(loan.status?.value).toBe('Approved');
+    expect(loan.timeline?.approvedOnDate).toBeTruthy();
+    expect(loan.principal).toBeGreaterThan(0);
+  });
+});
+
+test.describe('createActiveLoan() against live Fineract', () => {
+  test('disburses the loan and reports Active status', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const loan = await createActiveLoan(apiSetup, cleanupGuard, client.resourceId);
+
+    expect(loan.status?.value).toBe('Active');
+    expect(loan.timeline?.actualDisbursementDate).toBeTruthy();
+
+    const fetched = await apiSetup.api.getLoan(loan.resourceId);
+    expect(fetched.status?.value).toBe('Active');
+    // The disbursed amount must match the approved principal — the
+    // earlier projection bug silently disbursed 0 here.
+    expect(fetched.summary?.principalDisbursed).toBe(loan.principal);
+  });
+
+  test('records the expected-to-fail deleter without throwing', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const loan = await createActiveLoan(apiSetup, cleanupGuard, client.resourceId);
+
+    // Fineract refuses to hard-delete a disbursed loan. The guard is
+    // expected to surface that as a recorded failure, not an exception
+    // that would mask the real test result. Scope the assertion to the
+    // loan's own deleter — the active client also fails to delete, so a
+    // bare `failed.length > 0` would still pass if the loan deleter were
+    // missing or had unexpectedly succeeded.
+    const summary = await cleanupGuard.flush();
+    expect(summary.failed.some((entry) => entry.label === `loan:${loan.resourceId}`)).toBe(true);
+  });
+});

--- a/playwright/factories/loan.factory.ts
+++ b/playwright/factories/loan.factory.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Factory for a Fineract loan owned by the current Playwright test.
+ *
+ * Three state variants are exported, each building on the previous
+ * one so a spec only pays for the transitions it actually needs:
+ *
+ *  - {@link createTestLoan} — "Submitted and pending approval".
+ *  - {@link createApprovedLoan} — approved, not yet disbursed.
+ *  - {@link createActiveLoan} — approved AND disbursed (Active).
+ *
+ * Every variant requires an ACTIVE client — Fineract rejects a loan
+ * application against a pending client — so callers are expected to
+ * have already produced one via `createActiveTestClient` (see
+ * `playwright/factories/client.factory.ts`). The client's activation
+ * date bounds this factory's default dates through
+ * `DEFAULT_ACCOUNT_OPENING_DATE`; passing an earlier `submittedOnDate`
+ * risks a validation error that names neither field.
+ *
+ * Cleanup caveat: Fineract only hard-deletes a loan while it is still
+ * "Submitted and pending approval". The deleter registered by
+ * {@link createApprovedLoan} and {@link createActiveLoan} will
+ * therefore FAIL, and the `CleanupGuard` records that without
+ * throwing — same accepted trade-off as `createActiveTestClient`.
+ *
+ * Portability note: this module imports only from the in-tree
+ * `ApiSetupManager` and `CleanupGuard` types. The React port can adopt
+ * it verbatim once it has its own `FineractApiClient` (or a
+ * structural equivalent).
+ */
+
+import type { ApiSetupManager } from '../utils/api-setup-manager';
+import type { CleanupGuard } from '../utils/cleanup-guard';
+import type { TestLoan } from '../types/test-data.types';
+import { DEFAULT_ACCOUNT_OPENING_DATE } from './client.factory';
+import { resolveProductId } from './_shared';
+
+/** Caller-supplied tweaks accepted by every loan factory in this module. */
+export interface CreateTestLoanOverrides {
+  /** Fineract loan product id. Defaults to the shared minimal E2E product. */
+  loanProductId?: number;
+  /**
+   * Submitted-on date. Defaults to {@link DEFAULT_ACCOUNT_OPENING_DATE}
+   * so a loan submitted with no overrides is always dated after the
+   * client's default activation date.
+   */
+  submittedOnDate?: string;
+  /** Expected/actual disbursement date. Defaults to `submittedOnDate`. */
+  disbursementDate?: string;
+}
+
+/**
+ * Resolve (and cache) the shared minimal loan product id.
+ *
+ * A thin wrapper so every loan factory in this module shares the same
+ * `ApiSetupManager`-deduped product lookup instead of each calling
+ * `ensureMinimalLoanProduct` directly and depending on its own dedupe
+ * behaviour matching the others by coincidence.
+ */
+async function resolveLoanProductId(setup: ApiSetupManager, overrides: CreateTestLoanOverrides): Promise<number> {
+  if (overrides.loanProductId !== undefined) {
+    return overrides.loanProductId;
+  }
+  return resolveProductId(await setup.ensureMinimalLoanProduct(), 'loan.factory');
+}
+
+/**
+ * Re-read a loan after a state transition and project it.
+ *
+ * Fineract's command responses (`approve`, `disburse`, ...) return only
+ * a thin `{ officeId, clientId, loanId, resourceId, changes }`
+ * envelope — no `status`, no `timeline`, no `principal`. Projecting
+ * straight off that envelope produced a `TestLoan` whose `principal`
+ * silently fell back to `0`, which then got passed as the disbursement
+ * amount. Re-fetching costs one GET and keeps the returned projection
+ * true to server state.
+ */
+async function refetchLoan(
+  setup: ApiSetupManager,
+  loanId: number,
+  clientId: number,
+  loanProductId: number
+): Promise<TestLoan> {
+  const loan = await setup.api.getLoan(loanId);
+  return {
+    resourceId: loanId,
+    displayName: `Loan #${loanId}`,
+    clientId,
+    loanProductId,
+    principal: loan.principal ?? loan.summary?.principalDisbursed ?? 0,
+    status: loan.status,
+    timeline: loan.timeline
+  };
+}
+
+/**
+ * Create a loan in "Submitted and pending approval" state and queue
+ * its deletion on the supplied {@link CleanupGuard}.
+ *
+ * Every numeric term field (principal, repayment schedule, interest
+ * rate, …) is derived from the loan product's template rather than
+ * hard-coded here — mirrors `createActiveLoanForClient` on
+ * `FineractApiClient`, which this factory delegates the create call to.
+ *
+ * @param setup    The per-test {@link ApiSetupManager}.
+ * @param guard    The per-test {@link CleanupGuard}.
+ * @param clientId - resourceId of an ACTIVE client (see module docstring).
+ * @param overrides See {@link CreateTestLoanOverrides}.
+ */
+export async function createTestLoan(
+  setup: ApiSetupManager,
+  guard: CleanupGuard,
+  clientId: number,
+  overrides: CreateTestLoanOverrides = {}
+): Promise<TestLoan> {
+  const loanProductId = await resolveLoanProductId(setup, overrides);
+  const submittedOnDate = overrides.submittedOnDate ?? DEFAULT_ACCOUNT_OPENING_DATE;
+  const template = await setup.api.getLoanTemplate(clientId, loanProductId);
+  const principal = template.principal ?? 1000;
+
+  const response = await setup.api.createLoan({
+    clientId,
+    productId: loanProductId,
+    submittedOnDate,
+    expectedDisbursementDate: overrides.disbursementDate ?? submittedOnDate,
+    principal,
+    loanType: 'individual',
+    loanTermFrequency: template.termFrequency ?? 1,
+    loanTermFrequencyType: template.termPeriodFrequencyType?.id ?? 2,
+    numberOfRepayments: template.numberOfRepayments ?? 1,
+    repaymentEvery: template.repaymentEvery ?? 1,
+    repaymentFrequencyType: template.repaymentFrequencyType?.id ?? 2,
+    interestRatePerPeriod: template.interestRatePerPeriod ?? 0,
+    interestRateFrequencyType: template.interestRateFrequencyType?.id ?? 2,
+    amortizationType: template.amortizationType?.id ?? 1,
+    interestType: template.interestType?.id ?? 0,
+    interestCalculationPeriodType: template.interestCalculationPeriodType?.id ?? 1,
+    transactionProcessingStrategyCode: template.transactionProcessingStrategyCode ?? 'mifos-standard-strategy',
+    dateFormat: 'dd MMMM yyyy',
+    locale: 'en'
+  });
+
+  const loanId: number = response.loanId ?? response.resourceId;
+  if (typeof loanId !== 'number') {
+    throw new Error(
+      `createTestLoan: Fineract create-loan response missing numeric loanId/resourceId, got ${JSON.stringify(response)}`
+    );
+  }
+
+  guard.register(`loan:${loanId}`, async () => {
+    await setup.api.deleteLoan(loanId);
+  });
+
+  return {
+    resourceId: loanId,
+    displayName: `Loan #${loanId}`,
+    clientId,
+    loanProductId,
+    principal
+  };
+}
+
+/**
+ * Create a loan and approve it. Builds on {@link createTestLoan} — the
+ * same deleter is reused, so cleanup still targets the one loan id.
+ */
+export async function createApprovedLoan(
+  setup: ApiSetupManager,
+  guard: CleanupGuard,
+  clientId: number,
+  overrides: CreateTestLoanOverrides = {}
+): Promise<TestLoan> {
+  const submittedOnDate = overrides.submittedOnDate ?? DEFAULT_ACCOUNT_OPENING_DATE;
+  const loan = await createTestLoan(setup, guard, clientId, { ...overrides, submittedOnDate });
+  await setup.api.approveLoan(loan.resourceId, submittedOnDate);
+  return refetchLoan(setup, loan.resourceId, clientId, loan.loanProductId);
+}
+
+/**
+ * Create, approve, AND disburse a loan (Active state).
+ *
+ * Cleanup for this variant is expected to fail — Fineract will not
+ * hard-delete a disbursed loan. Registered anyway so a test that
+ * later undoes the disbursal still gets torn down.
+ */
+export async function createActiveLoan(
+  setup: ApiSetupManager,
+  guard: CleanupGuard,
+  clientId: number,
+  overrides: CreateTestLoanOverrides = {}
+): Promise<TestLoan> {
+  const submittedOnDate = overrides.submittedOnDate ?? DEFAULT_ACCOUNT_OPENING_DATE;
+  const disbursementDate = overrides.disbursementDate ?? submittedOnDate;
+  const loan = await createApprovedLoan(setup, guard, clientId, { ...overrides, submittedOnDate });
+
+  // `loan.principal` comes from the re-fetched loan, so it reflects the
+  // approved amount rather than a create-response fallback. Disbursing
+  // a zero amount is silently accepted by Fineract and leaves the loan
+  // in a state no assertion would expect.
+  if (!loan.principal) {
+    throw new Error(
+      `createActiveLoan: refusing to disburse loan ${loan.resourceId} with principal ${loan.principal} — ` +
+        `the loan template did not yield a usable principal.`
+    );
+  }
+
+  await setup.api.disburseLoan(loan.resourceId, disbursementDate, loan.principal);
+  return refetchLoan(setup, loan.resourceId, clientId, loan.loanProductId);
+}

--- a/playwright/factories/savings.factory.spec.ts
+++ b/playwright/factories/savings.factory.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '../fixtures/test-fixtures';
+import { createActiveTestClient } from './client.factory';
+import { createTestSavingsAccount, createApprovedSavingsAccount, createActiveSavingsAccount } from './savings.factory';
+
+// Live-backend specs — `integration` Playwright project. No browser.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('createTestSavingsAccount() against live Fineract', () => {
+  test('creates an account in Submitted and pending approval', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const account = await createTestSavingsAccount(apiSetup, cleanupGuard, client.resourceId);
+
+    expect(typeof account.resourceId).toBe('number');
+    expect(account.resourceId).toBeGreaterThan(0);
+    expect(account.clientId).toBe(client.resourceId);
+    // Same regression guard as the loan factory: `ensureMinimalSavingsProduct`
+    // spells the key `id`, and reading `resourceId` yielded `undefined`.
+    expect(account.savingsProductId).toBeGreaterThan(0);
+
+    const fetched = await apiSetup.api.getSavingsAccount(account.resourceId);
+    expect(fetched.id).toBe(account.resourceId);
+    expect(fetched.status?.value).toBe('Submitted and pending approval');
+    expect(fetched.savingsProductId).toBe(account.savingsProductId);
+  });
+
+  test('hard-deletes a pending account on flush', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const account = await createTestSavingsAccount(apiSetup, cleanupGuard, client.resourceId);
+    expect(cleanupGuard.size()).toBe(2);
+
+    const summary = await cleanupGuard.flush();
+    // Scoped to the savings deleter on purpose. The owning client is
+    // ACTIVE, and Fineract only hard-deletes clients in Pending state,
+    // so that entry is an expected failure and asserting an empty
+    // `failed` array would be asserting the wrong thing.
+    expect(summary.failed.some((entry) => entry.label === `savings:${account.resourceId}`)).toBe(false);
+    await expect(apiSetup.api.getSavingsAccount(account.resourceId)).rejects.toThrow(/404|not found/i);
+  });
+});
+
+test.describe('createApprovedSavingsAccount() against live Fineract', () => {
+  test('returns server state rather than the command envelope', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const account = await createApprovedSavingsAccount(apiSetup, cleanupGuard, client.resourceId);
+
+    // Fineract's approve response carries no status/timeline; these
+    // only pass because the factory re-reads the account afterwards.
+    expect(account.status?.value).toBe('Approved');
+    expect(account.timeline?.approvedOnDate).toBeTruthy();
+  });
+});
+
+test.describe('createActiveSavingsAccount() against live Fineract', () => {
+  test('activates the account and reports Active status', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const account = await createActiveSavingsAccount(apiSetup, cleanupGuard, client.resourceId);
+
+    expect(account.status?.value).toBe('Active');
+    expect(account.timeline?.activatedOnDate).toBeTruthy();
+
+    const fetched = await apiSetup.api.getSavingsAccount(account.resourceId);
+    expect(fetched.status?.value).toBe('Active');
+  });
+
+  test('records the expected-to-fail deleter without throwing', async ({ apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const account = await createActiveSavingsAccount(apiSetup, cleanupGuard, client.resourceId);
+
+    // Fineract will not hard-delete an activated savings account. The
+    // guard must record that as a failure, not throw and mask the test.
+    // Scope the assertion to the account's own deleter — the active
+    // client also fails to delete, so a bare `failed.length > 0` would
+    // still pass if this deleter were missing or had succeeded.
+    const summary = await cleanupGuard.flush();
+    expect(summary.failed.some((entry) => entry.label === `savings:${account.resourceId}`)).toBe(true);
+  });
+});

--- a/playwright/factories/savings.factory.ts
+++ b/playwright/factories/savings.factory.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Factory for a Fineract savings account owned by the current
+ * Playwright test.
+ *
+ * Mirrors `loan.factory.ts` exactly — three state variants building on
+ * each other:
+ *
+ *  - {@link createTestSavingsAccount} — "Submitted and pending approval".
+ *  - {@link createApprovedSavingsAccount} — approved, not yet activated.
+ *  - {@link createActiveSavingsAccount} — approved AND activated (Active).
+ *
+ * Requires an ACTIVE client for the same reason as the loan factory:
+ * Fineract rejects a savings application against a pending client.
+ *
+ * Cleanup caveat: identical to the loan factory. Fineract only
+ * hard-deletes a savings account while "Submitted and pending
+ * approval"; the deleter registered for the approved/active variants
+ * is expected to fail and is recorded by the `CleanupGuard` without
+ * throwing.
+ *
+ * Portability note: zero Angular/Playwright-page imports. The React
+ * port can adopt this file verbatim.
+ */
+
+import type { ApiSetupManager } from '../utils/api-setup-manager';
+import type { CleanupGuard } from '../utils/cleanup-guard';
+import type { TestSavingsAccount } from '../types/test-data.types';
+import { DEFAULT_ACCOUNT_OPENING_DATE } from './client.factory';
+import { resolveProductId } from './_shared';
+
+/** Caller-supplied tweaks accepted by every savings factory in this module. */
+export interface CreateTestSavingsAccountOverrides {
+  /** Fineract savings product id. Defaults to the shared minimal E2E product. */
+  savingsProductId?: number;
+  /**
+   * Submitted-on date. Defaults to {@link DEFAULT_ACCOUNT_OPENING_DATE},
+   * matching the loan factory's default so specs combining both
+   * account types don't need to reconcile two separate date constants.
+   */
+  submittedOnDate?: string;
+  /** Approval date. Defaults to `submittedOnDate`. */
+  approvedOnDate?: string;
+  /** Activation date. Defaults to `approvedOnDate`. */
+  activatedOnDate?: string;
+}
+
+/**
+ * Re-read a savings account after a state transition and project it.
+ *
+ * Fineract's `approve` / `activate` command responses carry only a thin
+ * `{ officeId, clientId, savingsId, resourceId, changes }` envelope —
+ * no `status` and no `timeline`. Projecting off that envelope produced
+ * a `TestSavingsAccount` whose `status` and `timeline` were always
+ * `undefined`, so any spec asserting on them would read a hole rather
+ * than server state. One extra GET keeps the projection honest.
+ */
+async function refetchSavingsAccount(
+  setup: ApiSetupManager,
+  savingsId: number,
+  clientId: number,
+  savingsProductId: number
+): Promise<TestSavingsAccount> {
+  const account = await setup.api.getSavingsAccount(savingsId);
+  return {
+    resourceId: savingsId,
+    displayName: `Savings #${savingsId}`,
+    clientId,
+    savingsProductId,
+    status: account.status,
+    timeline: account.timeline
+  };
+}
+
+/**
+ * Create a savings account in "Submitted and pending approval" state
+ * and queue its deletion on the supplied {@link CleanupGuard}.
+ *
+ * Delegates the actual create call to
+ * `FineractApiClient#createSavingsAccountForClient`, which derives the
+ * five required interest fields from the product template — see that
+ * method's docstring for why hand-writing them per call site is the
+ * most common source of create-account 400s.
+ *
+ * @param setup    The per-test {@link ApiSetupManager}.
+ * @param guard    The per-test {@link CleanupGuard}.
+ * @param clientId - resourceId of an ACTIVE client (see module docstring).
+ * @param overrides See {@link CreateTestSavingsAccountOverrides}.
+ */
+export async function createTestSavingsAccount(
+  setup: ApiSetupManager,
+  guard: CleanupGuard,
+  clientId: number,
+  overrides: CreateTestSavingsAccountOverrides = {}
+): Promise<TestSavingsAccount> {
+  const submittedOnDate = overrides.submittedOnDate ?? DEFAULT_ACCOUNT_OPENING_DATE;
+
+  let savingsProductId = overrides.savingsProductId;
+  if (savingsProductId === undefined) {
+    savingsProductId = resolveProductId(await setup.ensureMinimalSavingsProduct(), 'savings.factory');
+  }
+
+  const response = await setup.api.createSavingsAccountForClient(clientId, submittedOnDate, savingsProductId);
+  const savingsId: number = response.savingsId ?? response.resourceId;
+  if (typeof savingsId !== 'number') {
+    throw new Error(
+      `createTestSavingsAccount: Fineract create-savings-account response missing numeric savingsId/resourceId, got ${JSON.stringify(
+        response
+      )}`
+    );
+  }
+
+  guard.register(`savings:${savingsId}`, async () => {
+    await setup.api.deleteSavingsAccount(savingsId);
+  });
+
+  return {
+    resourceId: savingsId,
+    displayName: `Savings #${savingsId}`,
+    clientId,
+    savingsProductId
+  };
+}
+
+/**
+ * Create a savings account and approve it. Builds on
+ * {@link createTestSavingsAccount} — the same deleter is reused.
+ */
+export async function createApprovedSavingsAccount(
+  setup: ApiSetupManager,
+  guard: CleanupGuard,
+  clientId: number,
+  overrides: CreateTestSavingsAccountOverrides = {}
+): Promise<TestSavingsAccount> {
+  const submittedOnDate = overrides.submittedOnDate ?? DEFAULT_ACCOUNT_OPENING_DATE;
+  const approvedOnDate = overrides.approvedOnDate ?? submittedOnDate;
+
+  const account = await createTestSavingsAccount(setup, guard, clientId, { ...overrides, submittedOnDate });
+  await setup.api.approveSavingsAccount(account.resourceId, approvedOnDate);
+  return refetchSavingsAccount(setup, account.resourceId, clientId, account.savingsProductId);
+}
+
+/**
+ * Create, approve, AND activate a savings account (Active state).
+ *
+ * Cleanup for this variant is expected to fail — Fineract will not
+ * hard-delete an activated savings account.
+ */
+export async function createActiveSavingsAccount(
+  setup: ApiSetupManager,
+  guard: CleanupGuard,
+  clientId: number,
+  overrides: CreateTestSavingsAccountOverrides = {}
+): Promise<TestSavingsAccount> {
+  const submittedOnDate = overrides.submittedOnDate ?? DEFAULT_ACCOUNT_OPENING_DATE;
+  const approvedOnDate = overrides.approvedOnDate ?? submittedOnDate;
+  const activatedOnDate = overrides.activatedOnDate ?? approvedOnDate;
+
+  const account = await createApprovedSavingsAccount(setup, guard, clientId, {
+    ...overrides,
+    submittedOnDate,
+    approvedOnDate
+  });
+  await setup.api.activateSavingsAccount(account.resourceId, activatedOnDate);
+  return refetchSavingsAccount(setup, account.resourceId, clientId, account.savingsProductId);
+}

--- a/playwright/fixtures/fineract-api.spec.ts
+++ b/playwright/fixtures/fineract-api.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '@playwright/test';
+
+import { FineractApiClient } from './fineract-api';
+
+/**
+ * Pure-logic unit spec for {@link FineractApiClient} URL construction —
+ * no live backend, no browser. The request context is replaced with a
+ * recorder so the assertion is on the URL the client *would* send.
+ *
+ * Regression target: `productId: 0` is a valid product scope. A
+ * truthiness guard (`if (productId)`) drops it, silently downgrading the
+ * template request to an unscoped one. These tests pin the explicit
+ * `!== undefined` guard in `getLoanTemplate` / `getSavingsAccountTemplate`.
+ */
+
+/**
+ * Build a client whose request context records the URL of the next GET
+ * and returns a minimal OK/JSON response, so template methods resolve
+ * without touching the network.
+ *
+ * @param record - Receives the URL passed to `ctx.get`.
+ * @returns A `FineractApiClient` with its private context stubbed.
+ */
+function clientRecordingGetUrl(record: (url: string) => void): FineractApiClient {
+  const client = new FineractApiClient('http://localhost', 'default', 'user', 'pass');
+  // The request context is a private field created in `init()`; the unit
+  // under test is URL construction, so a recording stub stands in for it.
+  (client as unknown as { ctx: unknown }).ctx = {
+    get: async (url: string) => {
+      record(url);
+      return { ok: () => true, json: async () => ({}) };
+    }
+  };
+  return client;
+}
+
+test.describe('FineractApiClient · template product scoping', () => {
+  test('getSavingsAccountTemplate sends productId=0 rather than dropping it', async () => {
+    let requestedUrl = '';
+    const client = clientRecordingGetUrl((url) => (requestedUrl = url));
+
+    await client.getSavingsAccountTemplate(1, 0);
+
+    expect(requestedUrl).toContain('productId=0');
+  });
+
+  test('getLoanTemplate sends productId=0 rather than dropping it', async () => {
+    let requestedUrl = '';
+    const client = clientRecordingGetUrl((url) => (requestedUrl = url));
+
+    await client.getLoanTemplate(1, 0);
+
+    expect(requestedUrl).toContain('productId=0');
+  });
+
+  test('getSavingsAccountTemplate omits productId when it is undefined', async () => {
+    let requestedUrl = '';
+    const client = clientRecordingGetUrl((url) => (requestedUrl = url));
+
+    await client.getSavingsAccountTemplate(1);
+
+    expect(requestedUrl).not.toContain('productId');
+  });
+});

--- a/playwright/fixtures/fineract-api.ts
+++ b/playwright/fixtures/fineract-api.ts
@@ -265,7 +265,10 @@ export class FineractApiClient {
       staffInSelectedOfficeOnly: 'true'
     });
 
-    if (productId) {
+    // Explicit undefined check, not a truthiness test: a product id of 0
+    // is a valid scope and must still be sent, or the template silently
+    // falls back to an unscoped (product-agnostic) response.
+    if (productId !== undefined) {
       query.set('productId', productId.toString());
     }
 
@@ -844,7 +847,13 @@ export class FineractApiClient {
           interestCalculationDaysInYearType: FineractApiClient.SAVINGS_DAYS_IN_YEAR_365,
           accountingRule: 1,
           withdrawalFeeForTransfers: false,
-          dateFormat: FineractApiClient.DEFAULT_DATE_FORMAT,
+          // NOTE: no `dateFormat` here, deliberately. Unlike almost
+          // every other Fineract create endpoint, /savingsproducts
+          // carries no date field at all, and its parameter allow-list
+          // rejects `dateFormat` outright with
+          // "The parameter dateFormat is not supported." `locale` is
+          // still required — it drives decimal parsing on the interest
+          // rate.
           locale: FineractApiClient.DEFAULT_LOCALE,
           charges: []
         });
@@ -888,7 +897,10 @@ export class FineractApiClient {
   async getSavingsAccountTemplate(clientId: number, productId?: number): Promise<any> {
     const query = new URLSearchParams({ clientId: clientId.toString() });
 
-    if (productId) {
+    // Explicit undefined check, not a truthiness test: a product id of 0
+    // is a valid scope and must still be sent, or the template silently
+    // falls back to an unscoped (product-agnostic) response.
+    if (productId !== undefined) {
       query.set('productId', productId.toString());
     }
 

--- a/playwright/types/test-data.types.ts
+++ b/playwright/types/test-data.types.ts
@@ -59,11 +59,27 @@ export interface TestClientTimeline {
   closedOnDate?: readonly number[];
 }
 
-/** Narrow loan-timeline projection — every field optional. */
+/**
+ * Narrow loan-timeline projection — every field optional.
+ *
+ * `expectedDisbursementDate` / `actualDisbursementDate` are the names
+ * Fineract actually returns on `GET /loans/{id}`; `disbursedOnDate` is
+ * kept for callers written against the older projection.
+ */
 export interface TestLoanTimeline {
   submittedOnDate?: readonly number[];
   approvedOnDate?: readonly number[];
+  expectedDisbursementDate?: readonly number[];
+  actualDisbursementDate?: readonly number[];
   disbursedOnDate?: readonly number[];
+  closedOnDate?: readonly number[];
+}
+
+/** Narrow savings-account-timeline projection — every field optional. */
+export interface TestSavingsTimeline {
+  submittedOnDate?: readonly number[];
+  approvedOnDate?: readonly number[];
+  activatedOnDate?: readonly number[];
   closedOnDate?: readonly number[];
 }
 
@@ -101,4 +117,34 @@ export interface TestLoan extends TestEntityIdentity {
   principal: number;
   status?: TestStatus;
   timeline?: TestLoanTimeline;
+}
+
+/** Created Fineract savings account as seen by E2E specs. */
+export interface TestSavingsAccount extends TestEntityIdentity {
+  clientId: number;
+  savingsProductId: number;
+  status?: TestStatus;
+  timeline?: TestSavingsTimeline;
+}
+
+/**
+ * Created Fineract loan product as seen by E2E specs.
+ *
+ * Products are shared, tenant-level infrastructure rather than
+ * per-test data — see `ensureMinimalLoanProduct` in
+ * `fixtures/fineract-api.ts` — so this shape omits a `displayName`
+ * projection and instead carries the two fields specs actually match
+ * against (`name`, `shortName`).
+ */
+export interface TestLoanProduct {
+  resourceId: number;
+  name: string;
+  shortName: string;
+}
+
+/** Created Fineract savings product as seen by E2E specs. */
+export interface TestSavingsProduct {
+  resourceId: number;
+  name: string;
+  shortName: string;
 }


### PR DESCRIPTION
## Description

Adds Layer 4 Playwright test-data factories for loan and savings accounts. Both account types need a way to arrange an account in a known state before a spec touches the UI; these
factories are the foundation the rest of the account E2E work builds on.

Each factory ships three state variants that compose:
- **Submitted** (`createTestLoan` / `createTestSavingsAccount`) — pending approval, hard-deleteable on teardown.
- **Approved** (`createApprovedLoan` / `createApprovedSavingsAccount`) — approved, not yet disbursed/activated.
- **Active** (`createActiveLoan` / `createActiveSavingsAccount`) — fully disbursed or activated.

Two real bugs fixed in the process:

1. **Product id never resolved** — `ensureMinimalLoanProduct` / `ensureMinimalSavingsProduct`
   return the id under `id`, but the factories were reading `product.resourceId` → `undefined`
   → accounts POSTed with no product attached. `resolveProductId()` in `_shared.ts` now reads
   both spellings in one place and throws a caller-tagged error otherwise (unit-tested,
   including the `id: 0` falsy trap).

2. **Projection off thin command envelopes** — Fineract's approve/activate/disburse responses
   carry no `status`, `timeline`, or `principal`. Factories were projecting off them, so
   `principal` fell back to `0` and `createActiveLoan` then disbursed at zero amount.
   Both factories now re-fetch after each transition via `refetchLoan()` / `refetchSavingsAccount()`.

**Dependencies:** Requires WEB-1065 (#3755), WEB-1066 (#3756), WEB-1067 (#3757) to be merged
before this can be rebased onto `dev` as a clean single-commit PR.

## Related issues and discussion
https://mifosforge.jira.com/browse/WEB-1078

## Screenshots, if any

N/A — factory / type layer only, no UI changes.

## Checklist

- [X] If you have multiple commits please combine them into one commit by squashing them.
      _(Will be squashed to 1 commit after WEB-1065/1066/1067 merge and this branch is rebased onto `dev`)_
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reusable test flows for creating, approving, activating, and disbursing loans and savings accounts.
  - Added support for configurable products and lifecycle dates.
  - Added test-data models for loan and savings products, accounts, and timelines.

- **Bug Fixes**
  - Preserved valid zero product IDs when building API requests.
  - Prevented client settings from overriding required date and locale formats.
  - Improved validation and error handling for missing product identifiers.

- **Tests**
  - Expanded Playwright coverage for factory lifecycles, cleanup, API templates, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->