### PR TITLE
fix(WEB-1070): render single latest exchange rate response

### DIFF
--- a/src/app/organization/exchange-rates/exchange-rates.service.spec.ts
+++ b/src/app/organization/exchange-rates/exchange-rates.service.spec.ts
@@ -106,6 +106,63 @@ describe('ExchangeRatesService', () => {
     expect(await resultPromise).toEqual([]);
   });
 
+  it('should fetch exchange rates from pageItems response', async () => {
+    const resultPromise = firstValueFrom(service.getExchangeRates());
+
+    const req = httpMock.expectOne(
+      (request) => request.url === `${exchangeRatesResource}/latest` && request.method === 'GET'
+    );
+    req.flush({ pageItems: [{ id: 2, sourceCurrency: 'EUR', targetCurrency: 'USD' }] });
+
+    expect(await resultPromise).toEqual([
+      { id: 2, sourceCurrency: 'EUR', sourceCurrencyCode: 'EUR', targetCurrency: 'USD', targetCurrencyCode: 'USD' }
+    ]);
+  });
+
+  it('should fetch exchange rates from a single exchange rate response', async () => {
+    const resultPromise = firstValueFrom(service.getExchangeRates());
+
+    const req = httpMock.expectOne(
+      (request) => request.url === `${exchangeRatesResource}/latest` && request.method === 'GET'
+    );
+    req.flush({
+      id: 3,
+      sourceCurrency: 'USD',
+      targetCurrency: 'CRC',
+      buyRate: 510.5,
+      sellRate: 455.48,
+      referenceRate: 513.12,
+      rateDate: '2026-07-12',
+      latest: true
+    });
+
+    expect(await resultPromise).toEqual([
+      {
+        id: 3,
+        sourceCurrency: 'USD',
+        sourceCurrencyCode: 'USD',
+        targetCurrency: 'CRC',
+        targetCurrencyCode: 'CRC',
+        buyRate: 510.5,
+        sellRate: 455.48,
+        referenceRate: 513.12,
+        rateDate: '2026-07-12',
+        latest: true
+      }
+    ]);
+  });
+
+  it('should return an empty exchange rate list for an empty response object', async () => {
+    const resultPromise = firstValueFrom(service.getExchangeRates());
+
+    const req = httpMock.expectOne(
+      (request) => request.url === `${exchangeRatesResource}/latest` && request.method === 'GET'
+    );
+    req.flush({});
+
+    expect(await resultPromise).toEqual([]);
+  });
+
   it('should create an exchange rate', async () => {
     const resultPromise = firstValueFrom(service.createExchangeRate(exchangeRatePayload));
 

--- a/src/app/organization/exchange-rates/exchange-rates.service.ts
+++ b/src/app/organization/exchange-rates/exchange-rates.service.ts
@@ -20,6 +20,9 @@ import {
 } from './exchange-rate.model';
 import { getCurrencyCode } from './exchange-rate-form.util';
 
+type ExchangeRateResponse = ExchangeRate[] | ExchangeRate | { pageItems?: ExchangeRate[]; error?: string };
+type ExchangeRateResponseObject = ExchangeRate & { pageItems?: ExchangeRate[]; error?: string };
+
 @Injectable({
   providedIn: 'root'
 })
@@ -36,9 +39,7 @@ export class ExchangeRatesService {
     httpParams = this.addParam(httpParams, 'rateDate', filters.rateDate);
 
     return this.httpWithoutDefaultErrorHandler()
-      .get<ExchangeRate[] | { pageItems?: ExchangeRate[]; error?: string }>(`${this.exchangeRatesResource}/latest`, {
-        params: httpParams
-      })
+      .get<ExchangeRateResponse>(`${this.exchangeRatesResource}/latest`, { params: httpParams })
       .pipe(
         catchError((error: HttpErrorResponse) => {
           if (error.status === 404) {
@@ -102,13 +103,32 @@ export class ExchangeRatesService {
     return configurableHttp.skipErrorHandler ? configurableHttp.skipErrorHandler() : this.http;
   }
 
-  private normalizeExchangeRateResponse(
-    response: ExchangeRate[] | { pageItems?: ExchangeRate[]; error?: string }
-  ): ExchangeRate[] {
+  private normalizeExchangeRateResponse(response: ExchangeRateResponse): ExchangeRate[] {
     if (Array.isArray(response)) {
       return response;
     }
-    return response?.pageItems || [];
+    const responseObject = response as ExchangeRateResponseObject;
+    if (Array.isArray(responseObject?.pageItems)) {
+      return responseObject.pageItems;
+    }
+    if (this.isExchangeRate(responseObject)) {
+      return [
+        responseObject
+      ];
+    }
+    return [];
+  }
+
+  private isExchangeRate(response: ExchangeRateResponseObject | null | undefined): response is ExchangeRate {
+    return !!(
+      response &&
+      !response.error &&
+      (response.id ||
+        response.sourceCurrency ||
+        response.targetCurrency ||
+        response.sourceCurrencyCode ||
+        response.targetCurrencyCode)
+    );
   }
 
   private toExchangeRateRequest(exchangeRate: ExchangeRatePayload) {


### PR DESCRIPTION
## Description

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

<img width="1454" height="795" alt="Screenshot 2026-07-29 at 10 47 50 AM" src="https://github.com/user-attachments/assets/61fa6bc6-f288-49b6-9553-9932458ce624" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exchange-rate response handling across paginated, single-rate, and empty responses.
  * Exchange rates are now consistently presented as a list, preserving available currency and rate details.

* **Tests**
  * Added coverage for paginated responses, single exchange-rate objects, and empty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->