### PR TITLE
fix(WEB-1077): redirect to originally requested URL after login

### DIFF
--- a/src/app/core/authentication/authentication.guard.ts
+++ b/src/app/core/authentication/authentication.guard.ts
@@ -8,7 +8,7 @@
 
 /** Angular Imports */
 import { Injectable, inject } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
 
 /** Custom Services */
 import { Logger } from '../logger/logger.service';
@@ -28,16 +28,31 @@ export class AuthenticationGuard {
   /**
    * Ensures route access is authorized only when user is authenticated, otherwise redirects to login.
    *
+   * When the session is missing, the originally requested URL is preserved as a
+   * `returnUrl` query param so the user lands on that page after logging in.
+   *
    * @returns {boolean} True if user is authenticated.
    */
-  canActivate(): boolean {
+  canActivate(_route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
     if (this.authenticationService.isAuthenticated()) {
       return true;
     }
 
     log.debug('User not authenticated, redirecting to login...');
     this.authenticationService.logout();
-    this.router.navigate(['/login'], { replaceUrl: true });
+    this.redirectToLogin(state.url);
     return false;
+  }
+
+  /**
+   * Redirects to the login page, preserving the attempted URL as `returnUrl`.
+   * The root path and the login page itself are not preserved.
+   */
+  private redirectToLogin(attemptedUrl: string): void {
+    const shouldPreserve = attemptedUrl && attemptedUrl !== '/' && !attemptedUrl.startsWith('/login');
+    this.router.navigate(['/login'], {
+      replaceUrl: true,
+      queryParams: shouldPreserve ? { returnUrl: attemptedUrl } : {}
+    });
   }
 }

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -9,7 +9,7 @@
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { take } from 'rxjs/operators';
 /**
  * Interface for version information.
@@ -83,6 +83,7 @@ export class LoginComponent implements OnInit {
   private settingsService = inject(SettingsService);
   private themingService = inject(ThemingService);
   private router = inject(Router);
+  private route = inject(ActivatedRoute);
   private versionService = inject(VersionService);
   private translateService = inject(TranslateService);
   private destroyRef = inject(DestroyRef);
@@ -136,7 +137,18 @@ export class LoginComponent implements OnInit {
       } else if (alertType === this.translateService.instant('errors.auth.success.type')) {
         this.resetPassword = false;
         this.twoFactorAuthenticationRequired = false;
-        this.router.navigate(['/'], { replaceUrl: true });
+        // Fall back to the dashboard if navigating to the returnUrl fails or is rejected
+        // (e.g. the target route is guarded), so the user is never stranded on the login page.
+        void this.router
+          .navigateByUrl(this.getReturnUrl(), { replaceUrl: true })
+          .then((navigated) => {
+            if (!navigated) {
+              void this.router.navigateByUrl('/', { replaceUrl: true });
+            }
+          })
+          .catch(() => {
+            void this.router.navigateByUrl('/', { replaceUrl: true });
+          });
       } else if (alertType === this.translateService.instant('errors.tenant.changed.type')) {
         this.updateLogo();
       }
@@ -226,5 +238,25 @@ export class LoginComponent implements OnInit {
 
   onLogoErrorDark(): void {
     this.logoPathDark = 'assets/images/white-mifos.png';
+  }
+
+  /**
+   * Returns the originally requested page captured by the authentication guard,
+   * falling back to the dashboard. Ignores anything that is not a safe in-app
+   * path, that would loop back to the login flow, or that is a protocol-relative
+   * URL (e.g. `//evil.com` or `/\evil.com`) which could redirect off-site.
+   */
+  private getReturnUrl(): string {
+    const returnUrl = this.route.snapshot.queryParams['returnUrl'];
+    if (
+      typeof returnUrl !== 'string' ||
+      !returnUrl.startsWith('/') ||
+      returnUrl.startsWith('//') ||
+      returnUrl.startsWith('/\\') ||
+      returnUrl.startsWith('/login')
+    ) {
+      return '/';
+    }
+    return returnUrl;
   }
 }


### PR DESCRIPTION
Preserve the attempted URL as a `returnUrl` query param when the authentication guard redirects an unauthenticated user to the login page, and navigate back to it after a successful login (falling back to the dashboard for missing/unsafe values).

## Description

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the originally requested page when redirecting unauthenticated visitors to the login screen.
  * After successful login, redirected users back to their intended destination instead of always sending them to the home page.
  * Improved redirect safety by validating the stored return destination, preventing login-loop scenarios, and falling back to the home page when the return URL is invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->