### PR TITLE
fix(WEB-1079): resolve exchange rate edit failure

### DIFF
--- a/src/app/organization/exchange-rates/exchange-rates.service.spec.ts
+++ b/src/app/organization/exchange-rates/exchange-rates.service.spec.ts
@@ -163,6 +163,61 @@ describe('ExchangeRatesService', () => {
     expect(await resultPromise).toEqual([]);
   });
 
+  it('should resolve one exchange rate for edit from the latest response', async () => {
+    const resultPromise = firstValueFrom(service.getExchangeRate('3'));
+
+    const req = httpMock.expectOne(
+      (request) => request.url === `${exchangeRatesResource}/latest` && request.method === 'GET'
+    );
+    expect(req.request.url).not.toBe(`${exchangeRatesResource}/3`);
+    req.flush([
+      {
+        id: 2,
+        sourceCurrency: 'EUR',
+        targetCurrency: 'USD',
+        buyRate: 1.1,
+        sellRate: 1.2,
+        referenceRate: 1.15,
+        rateDate: '2026-07-11',
+        latest: false
+      },
+      {
+        id: 3,
+        sourceCurrency: 'USD',
+        targetCurrency: 'CRC',
+        buyRate: 510.5,
+        sellRate: 455.48,
+        referenceRate: 513.12,
+        rateDate: '2026-07-12',
+        latest: true
+      }
+    ]);
+
+    expect(await resultPromise).toEqual({
+      id: 3,
+      sourceCurrency: 'USD',
+      sourceCurrencyCode: 'USD',
+      targetCurrency: 'CRC',
+      targetCurrencyCode: 'CRC',
+      buyRate: 510.5,
+      sellRate: 455.48,
+      referenceRate: 513.12,
+      rateDate: '2026-07-12',
+      latest: true
+    });
+  });
+
+  it('should error when an exchange rate cannot be resolved for edit', async () => {
+    const resultPromise = firstValueFrom(service.getExchangeRate('9'));
+
+    const req = httpMock.expectOne(
+      (request) => request.url === `${exchangeRatesResource}/latest` && request.method === 'GET'
+    );
+    req.flush([{ id: 3, sourceCurrency: 'USD', targetCurrency: 'CRC' }]);
+
+    await expect(resultPromise).rejects.toThrow('Exchange rate not found with id: 9');
+  });
+
   it('should create an exchange rate', async () => {
     const resultPromise = firstValueFrom(service.createExchangeRate(exchangeRatePayload));
 

--- a/src/app/organization/exchange-rates/exchange-rates.service.ts
+++ b/src/app/organization/exchange-rates/exchange-rates.service.ts
@@ -52,9 +52,17 @@ export class ExchangeRatesService {
   }
 
   getExchangeRate(exchangeRateId: string): Observable<ExchangeRate> {
-    return this.http
-      .get<ExchangeRate>(`${this.exchangeRatesResource}/${exchangeRateId}`)
-      .pipe(map((rate) => this.normalizeExchangeRate(rate)));
+    return this.getExchangeRates().pipe(
+      map((rates) => {
+        const exchangeRate = this.normalizeExchangeRateResponse(rates).find(
+          (rate) => rate.id?.toString() === exchangeRateId.toString()
+        );
+        if (!exchangeRate) {
+          throw new Error(`Exchange rate not found with id: ${exchangeRateId}`);
+        }
+        return exchangeRate;
+      })
+    );
   }
 
   createExchangeRate(exchangeRate: ExchangeRatePayload): Observable<{ resourceId: number }> {


### PR DESCRIPTION
## Description

Fixes the issue where editing an existing exchange rate resulted in a server error due to an incorrect request generated by the Web-App. The edit flow now sends the expected request, allowing exchange rates to be updated successfully without affecting the existing create or list functionality.

## Related issues and discussion

WEB-1079

## Screenshots, if any

https://github.com/user-attachments/assets/7efcd6dc-aa67-4a43-8715-8ad1690af4ad




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exchange-rate lookups now resolve the requested rate from the latest exchange-rate data instead of using a per-id fetch.
  * Added explicit handling to reject when the requested exchange rate id cannot be found.
  * Verified the returned currency code and latest/rate fields are mapped correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->