### PR TITLE
WEB-1080 - Fix Inconsistent "Sign Out"/"Logout" labeling across UI

### DIFF
--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3397,7 +3397,7 @@
       "Self Service": "Self Service",
       "Sell Loan": "Sell Loan",
       "Settings": "Settings",
-      "Sign Out": "Sign Out",
+      "Sign Out": "Logout",
       "System": "System",
       "Task Management": "Task Management",
       "Tasks": "Tasks",


### PR DESCRIPTION
Taking Latest Changes

## Description

The toolbar/sidenav menu labels the action "Sign Out" (labels.menus.Sign Out / tooltips.Sign Out translation keys), while the keyboard shortcuts panel labels the identical action "Logout" — inconsistent terminology for the same user-facing action.

Fix: Standardize on "Logout" — update the en-US.json translation value for the Sign Out key to Logout so all surfaces match. Other locale files retain their own translated text and are unaffected by this key-value change.

## Related issues and discussion

[WEB-1080](https://mifosforge.jira.com/browse/WEB-1080)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1080]: https://mifosforge.jira.com/browse/WEB-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Updated the English menu label from “Sign Out” to “Logout.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->