### PR TITLE
WEB-1081 - Date picker disables future dates for "Specified Due Date" charges

### DIFF
--- a/src/app/savings/saving-account-actions/add-charge-savings-account/add-charge-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/add-charge-savings-account/add-charge-savings-account.component.ts
@@ -11,6 +11,7 @@ import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormGroup, FormBuilder, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { Router, ActivatedRoute, RouterLink } from '@angular/router';
+import { switchMap } from 'rxjs';
 
 /** Custom Services */
 import { SavingsService } from '../../savings.service';
@@ -79,40 +80,49 @@ export class AddChargeSavingsAccountComponent implements OnInit {
 
   buildDependencies() {
     this.savingsChargeForm.controls.chargeId.valueChanges
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((chargeId) => {
-        this.savingsService.getChargeTemplate(chargeId).subscribe((data: any) => {
-          this.chargeDetails = data;
-          const chargeTimeType = data.chargeTimeType.id;
-          if (
-            data.chargeTimeType.value === 'Withdrawal Fee' ||
-            data.chargeTimeType.value === 'Saving No Activity Fee'
-          ) {
-            this.chargeDetails.dueDateNotRequired = true;
-          }
-          if (data.chargeTimeType.value === 'Annual Fee' || data.chargeTimeType.value === 'Monthly Fee') {
-            this.chargeDetails.chargeTimeTypeAnnualOrMonth = true;
-          }
-          if (!this.chargeDetails.dueDateNotRequired && !this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
-            this.savingsChargeForm.addControl('dueDate', new FormControl('', Validators.required));
-          } else {
-            this.savingsChargeForm.removeControl('dueDate');
-          }
-          if (!this.chargeDetails.dueDateNotRequired && this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
-            this.savingsChargeForm.addControl('feeOnMonthDay', new FormControl('', Validators.required));
-          } else {
-            this.savingsChargeForm.removeControl('feeOnMonthDay');
-          }
-          if (chargeTimeType.value === 'Monthly Fee') {
-            this.savingsChargeForm.addControl('feeInterval', new FormControl(data.feeInterval, Validators.required));
-          } else {
-            this.savingsChargeForm.removeControl('feeInterval');
-          }
-          this.savingsChargeForm.patchValue({
-            amount: data.amount,
-            chargeCalculationType: data.chargeCalculationType.id,
-            chargeTimeType: data.chargeTimeType.id
-          });
+      .pipe(
+        switchMap((chargeId) => this.savingsService.getChargeTemplate(chargeId)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((data: any) => {
+        this.chargeDetails = data;
+        const chargeTimeType = data.chargeTimeType.id;
+        if (data.chargeTimeType.value === 'Withdrawal Fee' || data.chargeTimeType.value === 'Saving No Activity Fee') {
+          this.chargeDetails.dueDateNotRequired = true;
+        }
+        if (data.chargeTimeType.value === 'Annual Fee' || data.chargeTimeType.value === 'Monthly Fee') {
+          this.chargeDetails.chargeTimeTypeAnnualOrMonth = true;
+        }
+        // Allow future dates for charge types that require a future due date
+        if (
+          data.chargeTimeType.value === 'Specified due date' ||
+          data.chargeTimeType.value === 'Weekly Fee' ||
+          data.chargeTimeType.value === 'Annual Fee' ||
+          data.chargeTimeType.value === 'Monthly Fee'
+        ) {
+          this.maxDate = new Date(2100, 11, 31);
+        } else {
+          this.maxDate = this.settingsService.businessDate;
+        }
+        if (!this.chargeDetails.dueDateNotRequired && !this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
+          this.savingsChargeForm.addControl('dueDate', new FormControl('', Validators.required));
+        } else {
+          this.savingsChargeForm.removeControl('dueDate');
+        }
+        if (!this.chargeDetails.dueDateNotRequired && this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
+          this.savingsChargeForm.addControl('feeOnMonthDay', new FormControl('', Validators.required));
+        } else {
+          this.savingsChargeForm.removeControl('feeOnMonthDay');
+        }
+        if (chargeTimeType.value === 'Monthly Fee') {
+          this.savingsChargeForm.addControl('feeInterval', new FormControl(data.feeInterval, Validators.required));
+        } else {
+          this.savingsChargeForm.removeControl('feeInterval');
+        }
+        this.savingsChargeForm.patchValue({
+          amount: data.amount,
+          chargeCalculationType: data.chargeCalculationType.id,
+          chargeTimeType: data.chargeTimeType.id
         });
       });
   }

--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
@@ -19,6 +19,7 @@ import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-
 import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
 import { DatepickerBase } from 'app/shared/form-dialog/formfield/model/datepicker-base';
 import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
 import {
   MatTableDataSource,
   MatTable,
@@ -74,6 +75,7 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
   private dialog = inject(MatDialog);
   private dateUtils = inject(Dates);
   private translateService = inject(TranslateService);
+  private settingsService = inject(SettingsService);
 
   /** Savings Account Product Template */
   @Input() savingsAccountProductTemplate: any;
@@ -180,13 +182,20 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
    * @param {any} charge Charge
    */
   editChargeDate(charge: any) {
+    const chargeTimeType = charge.chargeTimeType.value;
+    const isFutureDateAllowed =
+      chargeTimeType === 'Specified due date' ||
+      chargeTimeType === 'Weekly Fee' ||
+      chargeTimeType === 'Monthly Fee' ||
+      chargeTimeType === 'Annual Fee';
     const formfields: FormfieldBase[] = [
       new DatepickerBase({
         controlName: 'date',
         label: this.translateService.instant('labels.inputs.Date'),
         value: charge.dueDate || charge.feeOnMonthDay || '',
         type: 'datetime-local',
-        required: false
+        required: false,
+        maxDate: isFutureDateAllowed ? new Date(2100, 11, 31) : this.settingsService.businessDate
       })
     ];
     const data = {


### PR DESCRIPTION
Taking Latest Changes

## Description

When creating a charge with charge time type Specified Due Date and adding it to a savings account, the date picker does not allow the user to select future dates.

For this charge type, future dates should be available because the charge is intended to be assigned with a specific due date. This should behave similarly to charges such as Annual Fee and Monthly Fee, where future dates can be selected when creating the charge.

## Related issues and discussion

[WEB-1081](https://mifosforge.jira.com/browse/WEB-1081)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1081]: https://mifosforge.jira.com/browse/WEB-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the allowed due-date range for specified, weekly, monthly, and annual savings account charges.
  * Date pickers now correctly allow future dates for applicable charge types, while retaining the current date limit for others.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->