### PR TITLE
WEB-1006: feat: move backend info to System Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ MIFOS_PASSWORD_REGEX=^(?=.*[A-Z])(?=.*[a-z])(?=.*\d).{8,50}$
 | Variable                           | Description                                                         | Default Value |
 | ---------------------------------- | ------------------------------------------------------------------- | ------------- |
 | MIFOS_DISPLAY_TENANT_SELECTOR      | Display tenant selector in Login view                               | true          |
-| MIFOS_DISPLAY_BACKEND_INFO         | Display backend info in footer                                      | true          |
+| MIFOS_DISPLAY_BACKEND_INFO         | Display backend info in footer and Login view                       | false         |
 | MIFOS_PRODUCTION_MODE              | Enable production UI mode (see [Production Mode](#production-mode)) | false         |
 | MIFOS_ALLOW_SERVER_SWITCH_SELECTOR | Display DNS server list                                             | true          |
 | MIFOS_COMPLIANCE_HIDE_CLIENT_DATA  | Hide client names in UI (mask with \*)                              | false         |

--- a/src/app/core/shell/toolbar/toolbar.component.html
+++ b/src/app/core/shell/toolbar/toolbar.component.html
@@ -225,6 +225,12 @@
     </mat-icon>
     <span>{{ 'labels.menus.Help' | translate }}</span>
   </button>
+  <button mat-menu-item [routerLink]="['/system', 'system-information']" tabindex="0">
+    <mat-icon>
+      <fa-icon icon="info-circle" size="sm"></fa-icon>
+    </mat-icon>
+    <span>{{ 'labels.heading.System Information' | translate }}</span>
+  </button>
   <button mat-menu-item [routerLink]="['/profile']" tabindex="0">
     <mat-icon>
       <fa-icon icon="user" size="sm"></fa-icon>

--- a/src/app/shared/footer/footer.component.html
+++ b/src/app/shared/footer/footer.component.html
@@ -1,12 +1,12 @@
-﻿<!--
+<!--
   Copyright since 2025 Mifos Initiative
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
-<!-- Business date: independent of variant -->
-@if (displayBackEndInfo && isBusinessDateDefined) {
+<!-- Business date: independent of variant and of the backend info setting -->
+@if (isBusinessDateDefined) {
   <div class="business-date-field">
     <span class="business-date-label">{{ 'labels.text.Current Business Date' | translate }}</span>
     <span class="business-date-chip">
@@ -16,68 +16,67 @@
   </div>
 }
 
-@if (variant === 'compact') {
-  <!-- Compact mode for Login -->
-  <div class="footer-compact">
-    @if (displayBackEndInfo) {
+<!-- Backend info: opt-in, the full set is always available in the System Information view -->
+@if (displayBackEndInfo && (systemInformation$ | async); as systemInformation) {
+  @if (variant === 'compact') {
+    <!-- Compact mode for Login -->
+    <div class="footer-compact">
       <div class="footer-info">
         <span class="info-item">
           <span class="info-label">{{ 'APP_NAME' | translate }}</span>
-          <span class="info-value">{{ versions.mifos }}</span>
+          <span class="info-value">{{ systemInformation.webApp.version }}</span>
         </span>
-        <span class="info-separator">â€¢</span>
+        <span class="info-separator">•</span>
         <span class="info-item">
           <span class="info-label">{{ 'labels.text.Fineract' | translate }}:</span>
-          <span class="info-value">{{ versions.fineract.version }}</span>
+          <span class="info-value">{{ systemInformation.fineract.version }}</span>
         </span>
-        <span class="info-separator">â€¢</span>
+        <span class="info-separator">•</span>
         <span class="info-item">
           <span class="info-label">{{ 'labels.inputs.Server' | translate }}:</span>
-          <span class="info-value">{{ server }}</span>
+          <span class="info-value">{{ systemInformation.server }}</span>
         </span>
       </div>
-    }
-  </div>
-} @else {
-  <!-- Default mode for Shell -->
-  @if (displayBackEndInfo) {
+    </div>
+  } @else {
+    <!-- Default mode for Shell -->
     <div class="layout-column m-b-20 f12" ngClass="{{ styleClass }}" id="footer">
       <div class="layout-column m-t-10 m-b-10 content-wrapper footer-center">
         <table class="versions">
           <tr>
             <td class="footer-content">{{ 'APP_NAME' | translate }}</td>
             <td class="right footer-content">
-              {{ versions.mifos }} - <b>{{ hash }}</b>
+              {{ systemInformation.webApp.version }} - <b>{{ systemInformation.webApp.hash }}</b>
             </td>
           </tr>
           <tr>
             <td class="footer-content">{{ 'labels.text.Fineract' | translate }}</td>
             <td class="right footer-content">
-              {{ versions.fineract.version }} - <b>{{ versions.fineract.hash }}</b>
+              {{ systemInformation.fineract.version }} - <b>{{ systemInformation.fineract.hash }}</b>
             </td>
           </tr>
           <tr>
             <td class="footer-content">{{ 'labels.inputs.Server' | translate }}</td>
             <td class="right footer-content">
-              {{ server }}
+              {{ systemInformation.server }}
             </td>
           </tr>
           <tr>
             <td class="footer-content">{{ 'labels.version.Username' | translate }}</td>
             <td class="right footer-content">
-              {{ username }}
+              {{ systemInformation.username }}
             </td>
           </tr>
           <tr>
             <td class="footer-content">{{ 'labels.version.Name' | translate }}</td>
             <td class="right footer-content">
-              {{ name }}
+              {{ systemInformation.name }}
             </td>
           </tr>
           <tr>
             <td class="footer-content">{{ 'labels.version.Render Time' | translate }}</td>
             <td class="right footer-content">
-              {{ renderTime | date: 'dd MMMM yyyy HH:mm:ss' }}
+              {{ systemInformation.renderTime | date: 'dd MMMM yyyy HH:mm:ss' }}
             </td>
           </tr>
         </table>

--- a/src/app/shared/footer/footer.component.ts
+++ b/src/app/shared/footer/footer.component.ts
@@ -14,11 +14,11 @@ import { AuthenticationService } from 'app/core/authentication/authentication.se
 import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
 import { SystemService } from 'app/system/system.service';
-import { VersionService } from 'app/system/version.service';
+import { SystemInfoService, SystemInformation } from 'app/system/system-info.service';
 
 /** Environment Configuration */
 import { environment } from '../../../environments/environment';
-import { Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import { NgClass, DatePipe } from '@angular/common';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -38,37 +38,29 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FooterComponent implements OnInit, OnDestroy {
+  /** Interval between business date configuration refreshes, in milliseconds. */
+  private static readonly configurationsRefreshInterval = 60000;
+
   private systemService = inject(SystemService);
   private settingsService = inject(SettingsService);
   private authenticationService = inject(AuthenticationService);
   private alertService = inject(AlertService);
   private dateUtils = inject(Dates);
-  private versionService = inject(VersionService);
+  private systemInfoService = inject(SystemInfoService);
   private translateService = inject(TranslateService);
   private cdr = inject(ChangeDetectorRef);
-
-  username: string = '';
-  name: string = '';
-  renderTime: Date = new Date();
 
   @Input() styleClass: string = '';
   @Input() variant: 'default' | 'compact' = 'default';
 
-  /** Mifos X version. */
-  versions: any = {
-    mifos: environment.version,
-    fineract: {
-      version: '',
-      hash: ''
-    }
-  };
-  /** Mifos X hash */
-  hash: string = environment.hash;
-  server = '';
+  /**
+   * Backend information, only resolved when `displayBackEndInfo` is enabled.
+   * The full set is always available in the System Information view.
+   */
+  systemInformation$: Observable<SystemInformation>;
+
   /** Business Date */
   businessDate: Date = null;
-  /** Tenant name */
-  tenant: string;
 
   isBusinessDateEnabled = false;
   isBusinessDateDefined = false;
@@ -80,66 +72,37 @@ export class FooterComponent implements OnInit, OnDestroy {
 
   constructor() {
     this.displayBackEndInfo = environment.displayBackEndInfo === 'true';
-    this.setUserInfo();
-    this.renderTime = new Date();
   }
 
   ngOnInit() {
+    // The business date is kept up to date regardless of `displayBackEndInfo`: it is
+    // displayed on its own and stored in the settings service for the whole application.
+    this.alert$ = this.alertService.alertEvent.subscribe((alertEvent: Alert) => {
+      const alertType = alertEvent.type;
+      if (alertType === SettingsService.businessDateType + ' Set Config') {
+        this.isBusinessDateEnabled = alertEvent.enabled ? true : false;
+        this.isBusinessDateDefined = false;
+        if (this.isBusinessDateEnabled) {
+          this.setBusinessDate();
+        }
+      } else if (alertType === SettingsService.businessDateType + ' Set') {
+        if (this.isBusinessDateEnabled) {
+          this.setBusinessDate();
+        }
+      } else if (alertType === this.translateService.instant('errors.auth.startType')) {
+        this.scheduleConfigurationsRefresh();
+      }
+    });
+    this.getConfigurations();
+
     if (this.displayBackEndInfo) {
-      this.alert$ = this.alertService.alertEvent.subscribe((alertEvent: Alert) => {
-        const alertType = alertEvent.type;
-        if (alertType === SettingsService.businessDateType + ' Set Config') {
-          this.isBusinessDateEnabled = alertEvent.enabled ? true : false;
-          this.isBusinessDateDefined = false;
-          if (this.isBusinessDateEnabled) {
-            this.setBusinessDate();
-          }
-        } else if (alertType === SettingsService.businessDateType + ' Set') {
-          if (this.isBusinessDateEnabled) {
-            this.setBusinessDate();
-          }
-        } else if (alertType === this.translateService.instant('errors.auth.startType')) {
-          this.timer = setTimeout(() => {
-            this.getConfigurations();
-          }, 60000);
-        }
-      });
-      this.getConfigurations();
-      this.server = this.settingsService.server;
-      this.tenant = this.tenantIdentifier();
-      this.versionService.getBackendInfo().subscribe((data: any) => {
-        if (data.git && data.git.build && data.git.build.version) {
-          const buildVersion: string = data.git.build.version.split('-');
-          this.versions.fineract.version = buildVersion[0];
-          this.versions.fineract.hash = buildVersion[1];
-        }
-      });
-      this.setUserInfo();
+      this.systemInformation$ = this.systemInfoService.getSystemInformation();
     }
-  }
-
-  setUserInfo() {
-    const credentials = this.authenticationService.getCredentials();
-    if (credentials) {
-      this.username = credentials.username;
-      this.name = credentials.staffDisplayName || credentials.username;
-    } else {
-      this.username = '';
-      this.name = '';
-    }
-  }
-
-  tenantIdentifier() {
-    if (!this.settingsService.tenantIdentifier || this.settingsService.tenantIdentifier === '') {
-      return 'default';
-    }
-    return this.settingsService.tenantIdentifier;
   }
 
   ngOnDestroy() {
-    if (this.displayBackEndInfo) {
-      clearTimeout(this.timer);
-    }
+    clearTimeout(this.timer);
+    this.alert$?.unsubscribe();
   }
 
   /**
@@ -154,9 +117,7 @@ export class FooterComponent implements OnInit, OnDestroy {
           this.settingsService.setBusinessDateConfig(configurationData.enabled);
           if (this.isBusinessDateEnabled) {
             this.setBusinessDate();
-            this.timer = setTimeout(() => {
-              this.getConfigurations();
-            }, 60000);
+            this.scheduleConfigurationsRefresh();
           } else {
             clearTimeout(this.timer);
           }
@@ -164,6 +125,17 @@ export class FooterComponent implements OnInit, OnDestroy {
     } else {
       clearTimeout(this.timer);
     }
+  }
+
+  /**
+   * Schedules the next configuration refresh, replacing any pending one so that
+   * a single polling chain is active at a time.
+   */
+  private scheduleConfigurationsRefresh(): void {
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.getConfigurations();
+    }, FooterComponent.configurationsRefreshInterval);
   }
 
   /**

--- a/src/app/system/system-info.service.ts
+++ b/src/app/system/system-info.service.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { Injectable, inject } from '@angular/core';
+
+/** rxjs Imports */
+import { Observable, of } from 'rxjs';
+import { catchError, map, shareReplay } from 'rxjs/operators';
+
+/** Custom Services */
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { VersionService } from 'app/system/version.service';
+
+/** Environment Configuration */
+import { environment } from '../../environments/environment';
+
+/** Version and build hash of a deployed component. */
+export interface ComponentVersion {
+  version: string;
+  hash: string;
+}
+
+/** Backend and environment information useful for support and debugging. */
+export interface SystemInformation {
+  webApp: ComponentVersion;
+  fineract: ComponentVersion;
+  server: string;
+  tenant: string;
+  username: string;
+  name: string;
+  renderTime: Date;
+  /** Business date, or null when the business date configuration is disabled. */
+  businessDate: Date | null;
+}
+
+/**
+ * Single source of truth for the backend/environment information shown in the
+ * System Information view and, when enabled, in the footer.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class SystemInfoService {
+  private versionService = inject(VersionService);
+  private settingsService = inject(SettingsService);
+  private authenticationService = inject(AuthenticationService);
+
+  /** The actuator response does not change while the app is loaded, so it is fetched once and replayed. */
+  private fineractVersion$: Observable<ComponentVersion>;
+
+  /**
+   * Returns the backend information. `renderTime` is evaluated per subscription,
+   * so each view reports the moment it was rendered.
+   */
+  getSystemInformation(): Observable<SystemInformation> {
+    return this.getFineractVersion().pipe(
+      map((fineract: ComponentVersion) => {
+        const credentials = this.authenticationService.getCredentials();
+        return {
+          webApp: { version: environment.version, hash: environment.hash },
+          fineract,
+          server: this.settingsService.server,
+          tenant: this.tenantIdentifier(),
+          username: credentials ? credentials.username : '',
+          name: credentials ? credentials.staffDisplayName || credentials.username : '',
+          renderTime: new Date(),
+          businessDate: this.businessDate()
+        };
+      })
+    );
+  }
+
+  /**
+   * Fineract version and build hash, parsed from the actuator info endpoint.
+   * Only successful responses are cached: the footer renders on the Login view,
+   * so the first request can run before authentication and fail. Dropping the
+   * cached observable on error lets the next view retry instead of replaying
+   * empty values for the rest of the session.
+   */
+  getFineractVersion(): Observable<ComponentVersion> {
+    if (!this.fineractVersion$) {
+      this.fineractVersion$ = this.versionService.getBackendInfo().pipe(
+        map((data: any) => {
+          const buildVersion: string = data?.git?.build?.version;
+          if (!buildVersion) {
+            return { version: '', hash: '' };
+          }
+          const versionAndHash: string[] = buildVersion.split('-');
+          return { version: versionAndHash[0], hash: versionAndHash[1] || '' };
+        }),
+        shareReplay({ bufferSize: 1, refCount: false }),
+        catchError(() => {
+          this.fineractVersion$ = null;
+          return of({ version: '', hash: '' });
+        })
+      );
+    }
+    return this.fineractVersion$;
+  }
+
+  private tenantIdentifier(): string {
+    return this.settingsService.tenantIdentifier || 'default';
+  }
+
+  private businessDate(): Date | null {
+    return `${this.settingsService.businessDateConfig}` === 'true' ? this.settingsService.businessDate : null;
+  }
+}

--- a/src/app/system/system-information/system-information.component.html
+++ b/src/app/system/system-information/system-information.component.html
@@ -8,26 +8,56 @@
 
 <div class="container">
   <mat-card>
-    <div class="system-info-section">
-      <table class="system-info-table">
-        <tr>
-          <td class="info-label">{{ 'labels.version.Tenant' | translate }}</td>
-          <td class="info-value">{{ tenant }}</td>
-        </tr>
-        <tr>
-          <td class="info-label">{{ 'labels.version.Mifos WebApp' | translate }}</td>
-          <td class="info-value">{{ mifosVersion }}</td>
-        </tr>
-        <tr>
-          <td class="info-label">{{ 'labels.version.Apache Fineract' | translate }}</td>
-          <td class="info-value">{{ fineractVersion }}</td>
-        </tr>
-        <tr>
-          <td class="info-label">{{ 'labels.version.Server' | translate }}</td>
-          <td class="info-value">{{ server }}</td>
-        </tr>
-      </table>
-    </div>
+    @if (systemInformation$ | async; as systemInformation) {
+      <div class="system-info-section">
+        <table class="system-info-table">
+          <tr>
+            <td class="info-label">{{ 'labels.version.Tenant' | translate }}</td>
+            <td class="info-value">{{ systemInformation.tenant }}</td>
+          </tr>
+          <tr>
+            <td class="info-label">{{ 'labels.version.Mifos WebApp' | translate }}</td>
+            <td class="info-value">
+              {{ systemInformation.webApp.version }}
+              @if (systemInformation.webApp.hash) {
+                <span class="info-hash">{{ systemInformation.webApp.hash }}</span>
+              }
+            </td>
+          </tr>
+          <tr>
+            <td class="info-label">{{ 'labels.version.Apache Fineract' | translate }}</td>
+            <td class="info-value">
+              {{ systemInformation.fineract.version }}
+              @if (systemInformation.fineract.hash) {
+                <span class="info-hash">{{ systemInformation.fineract.hash }}</span>
+              }
+            </td>
+          </tr>
+          <tr>
+            <td class="info-label">{{ 'labels.version.Server' | translate }}</td>
+            <td class="info-value">{{ systemInformation.server }}</td>
+          </tr>
+          <tr>
+            <td class="info-label">{{ 'labels.version.Username' | translate }}</td>
+            <td class="info-value">{{ systemInformation.username }}</td>
+          </tr>
+          <tr>
+            <td class="info-label">{{ 'labels.version.Name' | translate }}</td>
+            <td class="info-value">{{ systemInformation.name }}</td>
+          </tr>
+          @if (systemInformation.businessDate) {
+            <tr>
+              <td class="info-label">{{ 'labels.text.Current Business Date' | translate }}</td>
+              <td class="info-value">{{ systemInformation.businessDate | date: 'dd MMMM yyyy' }}</td>
+            </tr>
+          }
+          <tr>
+            <td class="info-label">{{ 'labels.version.Render Time' | translate }}</td>
+            <td class="info-value">{{ systemInformation.renderTime | date: 'dd MMMM yyyy HH:mm:ss' }}</td>
+          </tr>
+        </table>
+      </div>
+    }
 
     <div class="licensing-section">
       <h2>{{ 'labels.heading.Software Licensing' | translate }}</h2>

--- a/src/app/system/system-information/system-information.component.scss
+++ b/src/app/system/system-information/system-information.component.scss
@@ -32,6 +32,17 @@
   .info-value {
     font-weight: 600;
     color: var(--md-sys-color-on-surface, #333);
+    overflow-wrap: anywhere;
+  }
+
+  .info-hash {
+    font-weight: 500;
+    font-family: monospace;
+    color: var(--md-sys-color-on-surface-variant, #555);
+
+    &::before {
+      content: ' - ';
+    }
   }
 }
 
@@ -87,6 +98,10 @@
 
     .info-value {
       color: rgb(255 255 255 / 87%);
+    }
+
+    .info-hash {
+      color: #bbb;
     }
   }
 

--- a/src/app/system/system-information/system-information.component.ts
+++ b/src/app/system/system-information/system-information.component.ts
@@ -9,9 +9,8 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { MatCard } from '@angular/material/card';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
-import { SettingsService } from 'app/settings/settings.service';
-import { VersionService } from 'app/system/version.service';
-import { environment } from '../../../environments/environment';
+import { SystemInfoService, SystemInformation } from 'app/system/system-info.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'mifosx-system-information',
@@ -24,23 +23,12 @@ import { environment } from '../../../environments/environment';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SystemInformationComponent implements OnInit {
-  private settingsService = inject(SettingsService);
-  private versionService = inject(VersionService);
+  private systemInfoService = inject(SystemInfoService);
 
-  tenant = '';
-  mifosVersion = '';
-  fineractVersion = '';
-  server = '';
+  /** Backend and environment information. */
+  systemInformation$: Observable<SystemInformation>;
 
   ngOnInit(): void {
-    this.tenant = this.settingsService.tenantIdentifier || 'default';
-    this.mifosVersion = environment.version;
-    this.server = this.settingsService.server;
-
-    this.versionService.getBackendInfo().subscribe((data: any) => {
-      if (data.git && data.git.build && data.git.build.version) {
-        this.fineractVersion = data.git.build.version;
-      }
-    });
+    this.systemInformation$ = this.systemInfoService.getSystemInformation();
   }
 }

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -43,7 +43,8 @@
   // Display or not the Server Selector
   window['env']['allowServerSwitch'] = '$MIFOS_ALLOW_SERVER_SWITCH_SELECTOR';
 
-  // Display or not the BackEnd Info
+  // Display or not the BackEnd Info in the footer and the Login view.
+  // Regardless of this setting, it is always available in Admin > System > System Information
   window['env']['displayBackEndInfo'] = '$MIFOS_DISPLAY_BACKEND_INFO';
 
   // Show minimal production hero on login page

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -64,7 +64,8 @@ export const environment = {
 
   defaultCharDelimiter: loadedEnv['defaultCharDelimiter'] || ',',
 
-  displayBackEndInfo: loadedEnv['displayBackEndInfo'] || 'true',
+  // Backend info is available in the System Information view, so it is hidden by default
+  displayBackEndInfo: loadedEnv['displayBackEndInfo'] || 'false',
   displayTenantSelector: loadedEnv['displayTenantSelector'] || 'true',
   /** Production mode - when true, shows minimal hero with only branding at bottom */
   productionMode: loadedEnv['productionMode'] === 'true' || loadedEnv['productionMode'] === true || false,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -66,7 +66,8 @@ export const environment = {
 
   defaultCharDelimiter: loadedEnv.defaultCharDelimiter || ',',
 
-  displayBackEndInfo: loadedEnv.displayBackEndInfo || 'true',
+  // Backend info is available in the System Information view, so it is hidden by default
+  displayBackEndInfo: loadedEnv.displayBackEndInfo || 'false',
   displayTenantSelector: loadedEnv.displayTenantSelector || 'true',
   /** Production mode - when true, shows minimal hero with only branding at bottom */
   productionMode: loadedEnv.productionMode === 'true' || loadedEnv.productionMode === true || false,


### PR DESCRIPTION
## Description

The Home dashboard rendered the backend/release block (WebApp version, Fineract
version, server URL, username, tenant, render time) in the shell footer on every
page, taking up noticeable vertical space for information that is only needed
occasionally, for support and debugging.

Following the maintainer discussion, that information now lives in the existing
**System Information** page instead of the footer:

- `MIFOS_DISPLAY_BACKEND_INFO` now defaults to `false`, so the footer block and
  the login version block are hidden out of the box. Setting it to `true`
  restores the previous rendering exactly — no visual or behavioural change for
  deployments that opt in.
- System Information (Admin → System → System Information) now shows the full
  debugging set: tenant, WebApp version and build hash, Fineract version and
  build hash, server URL, username, staff name, current business date and render
  time. It previously showed only tenant, versions and server.
- The page is also reachable from the top-right application menu, next to Help
  and Profile. Its route was already guarded by authentication only, while the
  sole navigation path to it sat behind `READ_CONFIGURATION`, so support staff
  had no way to reach it once the footer was hidden.
- A new `SystemInfoService` is the single source of truth for this data. The
  `git.build.version` parsing was previously duplicated across the footer, the
  System Information page and the login page, each issuing its own
  `/actuator/info` request; the service parses it once and replays the result.

The **Current Business Date** chip is deliberately kept visible and is no longer
tied to `MIFOS_DISPLAY_BACKEND_INFO`. That flag previously also gated the polling
that writes `SettingsService.businessDate`, which around 80 components read as
`maxDate` / default transaction date. Changing the default without decoupling it
would have silently stopped business-date polling and pinned every date picker to
the browser's local "today" fallback.

Two small fixes were made in the same files: the footer's alert subscription is
now torn down in `ngOnDestroy` (it previously leaked), and a mis-encoded
separator character in the compact footer variant was corrected.

No About page or dialog was added and `about-us` is untouched — the existing
System Information page is reused. No translation files changed: every key used
(`labels.version.*`, `labels.text.Current Business Date`,
`labels.heading.System Information`) already exists in all supported locales.

**Dependencies:** none. No new packages, no API changes, no migrations.

**Upgrade note for existing deployments:** anyone relying on the footer block
must now set `MIFOS_DISPLAY_BACKEND_INFO=true` explicitly. `README.md` and
`env.template.js` have been updated with the new default.

## Related issues and discussion

#WEB-1006

## Screenshots, if any
# After:
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/ce921279-8d79-40e5-85ae-8334f4a96ab3" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/514262cb-4231-4abd-93cc-aadbda2fcd74" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/ea9bfe96-c17d-4b3a-8cdc-8eb5a754ec81" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/486334e8-ecbd-4021-9f54-8a4fda35df07" />

When displayBackEndInfo='' :

<img width="962" height="607" alt="image" src="https://github.com/user-attachments/assets/5f646882-acdb-4bd5-a0e5-124919f40181" />
Footer details are hidden:

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/5fdda671-c998-4699-93e3-0171fb3761de" />

When displayBackEndInfo='true'  :

<img width="912" height="556" alt="image" src="https://github.com/user-attachments/assets/65db5c1e-2858-4dd4-9daf-0453c334da23" />
Footer details are visible:

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/e2ea5069-a25e-4e65-ae4b-0744d1be7368" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a System Information option to the user help menu.
  * System Information now displays application, backend, server, tenant, user, business date, and render-time details.
  * Added improved formatting for version hashes, including dark-theme support.

* **Changes**
  * Backend information is now hidden by default and can be enabled through configuration.
  * Business date remains visible independently of backend information settings.
  * Clarified where backend information is displayed in configuration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->