### PR TITLE
MX-279: Add Dispute Management tab to Mifos client profile

### DIFF
--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -23,6 +23,7 @@ import { IdentitiesTabComponent } from './clients-view/identities-tab/identities
 import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component';
 import { BureauReadinessComponent } from './clients-view/bureau-readiness/bureau-readiness.component';
 import { CreditProfileComponent } from './clients-view/credit-profile/credit-profile.component';
+import { DisputeManagementComponent } from './clients-view/dispute-management/dispute-management.component';
 import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
 import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
 import { AddressTabComponent } from './clients-view/address-tab/address-tab.component';
@@ -186,6 +187,11 @@ const routes: Routes = [
               path: 'credit-profile',
               component: CreditProfileComponent,
               data: { title: 'Credit Profile', breadcrumb: 'Credit Profile', routeParamBreadcrumb: false }
+            },
+            {
+              path: 'dispute-management',
+              component: DisputeManagementComponent,
+              data: { title: 'Dispute Management', breadcrumb: 'Dispute Management', routeParamBreadcrumb: false }
             },
             {
               path: 'datatables',

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -508,6 +508,15 @@
         >
           {{ 'labels.inputs.Credit Profile' | translate }}
         </a>
+        <a
+          mat-tab-link
+          [routerLink]="['./dispute-management']"
+          routerLinkActive
+          #disputeManagement="routerLinkActive"
+          [active]="disputeManagement.isActive"
+        >
+          {{ 'labels.inputs.Dispute Management' | translate }}
+        </a>
       }
       @for (clientDatatable of clientDatatables; track clientDatatable) {
         <a

--- a/src/app/clients/clients-view/dispute-management/dispute-management.component.html
+++ b/src/app/clients/clients-view/dispute-management/dispute-management.component.html
@@ -1,0 +1,180 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<div class="cbild-dispute-management">
+  <!-- Role selector -->
+  <mat-card class="cbild-role-card">
+    <mat-card-content>
+      <mat-form-field appearance="outline">
+        <mat-label>{{ 'labels.cbild.dashboard.role' | translate }}</mat-label>
+        <mat-select [(ngModel)]="selectedRole" (ngModelChange)="onRoleChange($event)">
+          @for (role of roles; track role.value) {
+            <mat-option [value]="role.value">{{ role.label }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- Raise Dispute Form -->
+  <mat-card class="cbild-section-card">
+    <mat-card-content>
+      <h3 class="cbild-section-title">
+        <mat-icon>report_problem</mat-icon>
+        {{ 'labels.cbild.dispute.raiseTitle' | translate }}
+      </h3>
+      <mat-divider></mat-divider>
+      <form [formGroup]="raiseForm" class="cbild-form">
+        <mat-form-field appearance="outline" class="cbild-full-width">
+          <mat-label>{{ 'labels.cbild.dispute.submissionRecordId' | translate }}</mat-label>
+          <input matInput type="number" formControlName="submissionRecordId" />
+          @if (raiseForm.get('submissionRecordId')?.invalid && raiseForm.get('submissionRecordId')?.touched) {
+            <mat-error>{{ 'labels.cbild.dispute.submissionIdRequired' | translate }}</mat-error>
+          }
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="cbild-full-width">
+          <mat-label>{{ 'labels.cbild.dispute.disputeDetails' | translate }}</mat-label>
+          <textarea matInput formControlName="disputeDetails" rows="3"></textarea>
+          @if (raiseForm.get('disputeDetails')?.invalid && raiseForm.get('disputeDetails')?.touched) {
+            <mat-error>{{ 'labels.cbild.dispute.detailsRequired' | translate }}</mat-error>
+          }
+        </mat-form-field>
+
+        <button mat-raised-button color="primary" [disabled]="raiseForm.invalid || isRaising" (click)="raiseDispute()">
+          @if (isRaising) {
+            <mat-icon>hourglass_empty</mat-icon>
+          } @else {
+            <mat-icon>add_circle</mat-icon>
+          }
+          {{ 'labels.cbild.dispute.raise' | translate }}
+        </button>
+      </form>
+
+      <!-- Raised dispute result -->
+      @if (raisedDispute) {
+        <div class="cbild-dispute-result">
+          <ng-container *ngTemplateOutlet="disputeCard; context: { dispute: raisedDispute }"></ng-container>
+        </div>
+      }
+    </mat-card-content>
+  </mat-card>
+
+  <!-- Look Up Dispute -->
+  <mat-card class="cbild-section-card">
+    <mat-card-content>
+      <h3 class="cbild-section-title">
+        <mat-icon>search</mat-icon>
+        {{ 'labels.cbild.dispute.lookupTitle' | translate }}
+      </h3>
+      <mat-divider></mat-divider>
+      <div class="cbild-lookup-row">
+        <mat-form-field appearance="outline">
+          <mat-label>{{ 'labels.cbild.dispute.disputeId' | translate }}</mat-label>
+          <input matInput type="number" [(ngModel)]="lookupDisputeId" />
+        </mat-form-field>
+        <button mat-raised-button color="accent" [disabled]="!lookupDisputeId || isLooking" (click)="lookupDispute()">
+          @if (isLooking) {
+            <mat-icon>hourglass_empty</mat-icon>
+          } @else {
+            <mat-icon>search</mat-icon>
+          }
+          {{ 'labels.cbild.dispute.lookup' | translate }}
+        </button>
+      </div>
+
+      @if (lookedUpDispute) {
+        <ng-container *ngTemplateOutlet="disputeCard; context: { dispute: lookedUpDispute }"></ng-container>
+      }
+    </mat-card-content>
+  </mat-card>
+</div>
+
+<!-- Dispute Card Template -->
+<ng-template #disputeCard let-dispute="dispute">
+  <div class="cbild-dispute-card">
+    <div class="cbild-dispute-header">
+      <span class="cbild-dispute-id">{{ 'labels.cbild.dispute.id' | translate }} #{{ dispute.id }}</span>
+      <span [class]="'cbild-status-badge ' + getStatusClass(dispute.status)">{{ dispute.status }}</span>
+    </div>
+
+    <mat-divider class="cbild-divider"></mat-divider>
+
+    <div class="cbild-dispute-details">
+      <div class="cbild-detail-row">
+        <span class="cbild-label">{{ 'labels.cbild.dispute.submissionRef' | translate }}</span>
+        <span class="cbild-value">{{ dispute.submissionRecordId }}</span>
+      </div>
+      <div class="cbild-detail-row">
+        <span class="cbild-label">{{ 'labels.cbild.dispute.raisedBy' | translate }}</span>
+        <span class="cbild-value">{{ dispute.raisedBy }}</span>
+      </div>
+      <div class="cbild-detail-row">
+        <span class="cbild-label">{{ 'labels.cbild.dispute.openedAt' | translate }}</span>
+        <span class="cbild-value">{{ dispute.openedAt | dateFormat }}</span>
+      </div>
+      <div class="cbild-detail-row">
+        <span class="cbild-label">{{ 'labels.cbild.dispute.details' | translate }}</span>
+        <span class="cbild-value">{{ dispute.disputeDetails }}</span>
+      </div>
+      @if (dispute.resolvedAt) {
+        <div class="cbild-detail-row">
+          <span class="cbild-label">{{ 'labels.cbild.dispute.resolvedAt' | translate }}</span>
+          <span class="cbild-value">{{ dispute.resolvedAt | dateFormat }}</span>
+        </div>
+      }
+      @if (dispute.resolutionNotes) {
+        <div class="cbild-detail-row">
+          <span class="cbild-label">{{ 'labels.cbild.dispute.resolutionNotes' | translate }}</span>
+          <span class="cbild-value">{{ dispute.resolutionNotes }}</span>
+        </div>
+      }
+      <div class="cbild-detail-row">
+        <span class="cbild-label">{{ 'labels.cbild.dispute.expiry' | translate }}</span>
+        <span class="cbild-value">{{ dispute.expiryDate }}</span>
+      </div>
+    </div>
+
+    <!-- Actions -->
+    @if (dispute.status !== 'RESOLVED') {
+      <div class="cbild-actions">
+        @if (canMoveToUnderReview(dispute)) {
+          <button
+            mat-stroked-button
+            color="primary"
+            [disabled]="isUpdating"
+            (click)="updateStatus(dispute, 'UNDER_REVIEW')"
+          >
+            <mat-icon>rate_review</mat-icon>
+            {{ 'labels.cbild.dispute.markUnderReview' | translate }}
+          </button>
+        }
+
+        @if (canResolve(dispute)) {
+          <mat-form-field appearance="outline" class="cbild-full-width">
+            <mat-label>{{ 'labels.cbild.dispute.resolutionNotes' | translate }}</mat-label>
+            <textarea
+              matInput
+              [ngModel]="resolutionNotesMap.get(dispute.id) || ''"
+              (ngModelChange)="resolutionNotesMap.set(dispute.id, $event)"
+              rows="2"
+            ></textarea>
+          </mat-form-field>
+          <button
+            mat-raised-button
+            color="warn"
+            [disabled]="isUpdating || !resolutionNotesMap.get(dispute.id)"
+            (click)="updateStatus(dispute, 'RESOLVED')"
+          >
+            <mat-icon>check_circle</mat-icon>
+            {{ 'labels.cbild.dispute.resolve' | translate }}
+          </button>
+        }
+      </div>
+    }
+  </div>
+</ng-template>

--- a/src/app/clients/clients-view/dispute-management/dispute-management.component.scss
+++ b/src/app/clients/clients-view/dispute-management/dispute-management.component.scss
@@ -1,0 +1,138 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.cbild-dispute-management {
+  padding: 16px;
+}
+
+.cbild-role-card {
+  margin-bottom: 16px;
+
+  mat-card-content {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  mat-form-field {
+    width: 240px;
+  }
+}
+
+.cbild-section-card {
+  margin-bottom: 16px;
+}
+
+.cbild-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.cbild-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.cbild-full-width {
+  width: 100%;
+}
+
+.cbild-lookup-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
+.cbild-dispute-result {
+  margin-top: 16px;
+}
+
+.cbild-dispute-card {
+  border: 1px solid var(--cbild-card-border, #e2e8f0);
+  border-radius: 8px;
+  padding: 16px;
+  margin-top: 16px;
+  background: var(--cbild-card-bg, #f8fafc);
+}
+
+.cbild-dispute-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.cbild-dispute-id {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.cbild-divider {
+  margin: 12px 0;
+}
+
+.cbild-dispute-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cbild-detail-row {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.cbild-label {
+  font-size: 12px;
+  color: var(--mdc-theme-text-secondary-on-background, rgb(0 0 0 / 54%));
+  min-width: 140px;
+}
+
+.cbild-value {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.cbild-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.cbild-status-badge {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.cbild-status-open {
+  background: var(--cbild-status-open-bg, #dbeafe);
+  color: var(--cbild-status-open-fg, #1d4ed8);
+}
+
+.cbild-status-pending {
+  background: var(--cbild-status-pending-bg, #fef9c3);
+  color: var(--cbild-status-pending-fg, #d97706);
+}
+
+.cbild-status-accepted {
+  background: var(--cbild-status-accepted-bg, #dcfce7);
+  color: var(--cbild-status-accepted-fg, #16a34a);
+}

--- a/src/app/clients/clients-view/dispute-management/dispute-management.component.ts
+++ b/src/app/clients/clients-view/dispute-management/dispute-management.component.ts
@@ -1,0 +1,244 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Component, OnInit, OnDestroy, inject, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { HttpErrorResponse } from '@angular/common/http';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatIcon } from '@angular/material/icon';
+import { MatDivider } from '@angular/material/divider';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { FormsModule } from '@angular/forms';
+import { TranslateService } from '@ngx-translate/core';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { AlertService } from 'app/core/alert/alert.service';
+import { CreditBureauService } from 'app/credit-bureau/credit-bureau.service';
+import { DisputeCase, CbildRole, CBILD_ROLE_LABELS } from 'app/credit-bureau/credit-bureau.models';
+
+/**
+ * CB-ILD Dispute Management — MX-279 Tab 4.
+ * Raise disputes and manage OPEN→UNDER_REVIEW→RESOLVED workflow.
+ * Route: /clients/{id}/dispute-management
+ * Roles: All roles can raise + move to UNDER_REVIEW. COMPLIANCE only can RESOLVE.
+ * @author Satyam Mishra — MSOC 2026
+ */
+@Component({
+  selector: 'mifosx-dispute-management',
+  templateUrl: './dispute-management.component.html',
+  styleUrls: ['./dispute-management.component.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    MatIcon,
+    MatDivider,
+    MatProgressBar,
+    FormsModule
+  ]
+})
+export class DisputeManagementComponent implements OnInit, OnDestroy {
+  private route = inject(ActivatedRoute);
+  private creditBureauService = inject(CreditBureauService);
+  private alertService = inject(AlertService);
+  private cdr = inject(ChangeDetectorRef);
+  private translateService = inject(TranslateService);
+  private fb = inject(FormBuilder);
+
+  clientId: number;
+  selectedRole: CbildRole = 'CREDIT_ANALYST';
+
+  roles: { value: CbildRole; label: string }[] = [
+    { value: 'KYC_OFFICER', label: CBILD_ROLE_LABELS.KYC_OFFICER },
+    { value: 'CREDIT_ANALYST', label: CBILD_ROLE_LABELS.CREDIT_ANALYST },
+    { value: 'COMPLIANCE', label: CBILD_ROLE_LABELS.COMPLIANCE }
+  ];
+
+  // Raise dispute form
+  raiseForm: FormGroup;
+  isRaising = false;
+  raisedDispute: DisputeCase | null = null;
+
+  // Look up dispute
+  lookupDisputeId: number | null = null;
+  isLooking = false;
+  lookedUpDispute: DisputeCase | null = null;
+
+  // Update status
+  isUpdating = false;
+  resolutionNotesMap = new Map<number, string>();
+
+  get isCompliance(): boolean {
+    return this.selectedRole === 'COMPLIANCE';
+  }
+
+  private destroy$ = new Subject<void>();
+
+  constructor() {
+    const rawId = this.route.parent?.snapshot.params['clientId'];
+    this.clientId = rawId ? +rawId : 0;
+  }
+
+  ngOnInit(): void {
+    const saved = this.creditBureauService.getRole();
+    this.selectedRole = saved;
+    this.creditBureauService.setRole(this.selectedRole);
+
+    this.raiseForm = this.fb.group({
+      submissionRecordId: [
+        null,
+        [
+          Validators.required,
+          Validators.min(1)
+        ]
+      ],
+      disputeDetails: [
+        '',
+        [
+          Validators.required,
+          Validators.minLength(10)
+        ]
+      ]
+    });
+  }
+
+  onRoleChange(role: CbildRole): void {
+    this.selectedRole = role;
+    this.creditBureauService.setRole(role);
+    this.raisedDispute = null;
+    this.lookedUpDispute = null;
+    this.cdr.markForCheck();
+  }
+
+  raiseDispute(): void {
+    if (this.raiseForm.invalid) {
+      this.raiseForm.markAllAsTouched();
+      return;
+    }
+    this.isRaising = true;
+    this.cdr.markForCheck();
+
+    const { submissionRecordId, disputeDetails } = this.raiseForm.value;
+
+    this.creditBureauService
+      .createDispute(+submissionRecordId, disputeDetails)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (dispute: DisputeCase) => {
+          this.raisedDispute = dispute;
+          this.isRaising = false;
+          this.raiseForm.reset();
+          this.alertService.alert({
+            type: 'success',
+            message: this.translateService.instant('labels.cbild.dispute.raised', { id: dispute.id })
+          });
+          this.cdr.markForCheck();
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isRaising = false;
+          this.alertService.alert({ type: 'error', message: this.getErrorMessage(err) });
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  lookupDispute(): void {
+    if (!this.lookupDisputeId) return;
+    this.isLooking = true;
+    this.lookedUpDispute = null;
+    this.cdr.markForCheck();
+
+    this.creditBureauService
+      .getDispute(this.lookupDisputeId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (dispute: DisputeCase) => {
+          this.lookedUpDispute = dispute;
+          this.isLooking = false;
+          this.cdr.markForCheck();
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isLooking = false;
+          this.alertService.alert({ type: 'error', message: this.getErrorMessage(err) });
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  updateStatus(dispute: DisputeCase, newStatus: string): void {
+    this.isUpdating = true;
+    this.cdr.markForCheck();
+
+    const notes = newStatus === 'RESOLVED' ? this.resolutionNotesMap.get(dispute.id) || '' : undefined;
+
+    this.creditBureauService
+      .updateDisputeStatus(dispute.id, newStatus, notes)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (updated: DisputeCase) => {
+          if (this.raisedDispute?.id === dispute.id) this.raisedDispute = updated;
+          if (this.lookedUpDispute?.id === dispute.id) this.lookedUpDispute = updated;
+          this.isUpdating = false;
+          this.resolutionNotesMap.delete(dispute.id);
+          this.alertService.alert({
+            type: 'success',
+            message: this.translateService.instant('labels.cbild.dispute.statusUpdated', { status: newStatus })
+          });
+          this.cdr.markForCheck();
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isUpdating = false;
+          this.alertService.alert({ type: 'error', message: this.getErrorMessage(err) });
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  getStatusClass(status: string): string {
+    switch (status) {
+      case 'OPEN':
+        return 'cbild-status-open';
+      case 'UNDER_REVIEW':
+        return 'cbild-status-pending';
+      case 'RESOLVED':
+        return 'cbild-status-accepted';
+      default:
+        return '';
+    }
+  }
+
+  canMoveToUnderReview(dispute: DisputeCase): boolean {
+    return dispute.status === 'OPEN';
+  }
+
+  canResolve(dispute: DisputeCase): boolean {
+    return this.isCompliance && dispute.status === 'UNDER_REVIEW';
+  }
+
+  private getErrorMessage(err: HttpErrorResponse): string {
+    const t = (key: string) => this.translateService.instant(key);
+    switch (err?.status) {
+      case 400:
+        return err?.error?.message || t('labels.cbild.errors.badRequest');
+      case 401:
+        return t('labels.cbild.errors.unauthorized');
+      case 403:
+        return t('labels.cbild.errors.forbidden');
+      case 503:
+        return t('labels.cbild.errors.serviceUnavailable');
+      default:
+        return err?.error?.message || t('labels.cbild.errors.unexpected');
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/src/app/clients/clients.module.ts
+++ b/src/app/clients/clients.module.ts
@@ -27,6 +27,7 @@ import { UploadDocumentDialogComponent } from './clients-view/custom-dialogs/upl
 import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component';
 import { BureauReadinessComponent } from './clients-view/bureau-readiness/bureau-readiness.component';
 import { CreditProfileComponent } from './clients-view/credit-profile/credit-profile.component';
+import { DisputeManagementComponent } from './clients-view/dispute-management/dispute-management.component';
 import { EditNotesDialogComponent } from './clients-view/custom-dialogs/edit-notes-dialog/edit-notes-dialog.component';
 import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
 import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
@@ -91,6 +92,7 @@ import { ClientDatatableStepComponent } from './client-stepper/client-datatable-
     NotesTabComponent,
     BureauReadinessComponent,
     CreditProfileComponent,
+    DisputeManagementComponent,
     EditNotesDialogComponent,
     DocumentsTabComponent,
     DatatableTabComponent,

--- a/src/app/credit-bureau/credit-bureau.service.ts
+++ b/src/app/credit-bureau/credit-bureau.service.ts
@@ -143,10 +143,10 @@ export class CreditBureauService {
     );
   }
 
-  updateDisputeStatus(disputeId: number, newStatus: string): Observable<DisputeCase> {
+  updateDisputeStatus(disputeId: number, newStatus: string, resolutionNotes?: string): Observable<DisputeCase> {
     return this.externalHttp.put<DisputeCase>(
       `${this.baseUrl}/api/disputes/${disputeId}/status`,
-      { newStatus },
+      { newStatus, ...(resolutionNotes ? { resolutionNotes } : {}) },
       { headers: this.getHeaders() }
     );
   }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3242,7 +3242,8 @@
       "Cross Rate": "Křížový kurz",
       "Cross Rate via": "Křížový kurz (přes {{ currency }})",
       "Administrator": "Administrátor",
-      "Provider": "Poskytovatel"
+      "Provider": "Poskytovatel",
+      "Dispute Management": "Správa sporů"
     },
     "links": {
       "Community": "Společenství",
@@ -4629,6 +4630,32 @@
         "latePayments": "Opožděné platby",
         "noData": "Kreditní profil není k dispozici",
         "noDataHint": "Spusťte kontrolu bureau"
+      },
+      "dispute": {
+        "raiseTitle": "Podat nový spor",
+        "lookupTitle": "Vyhledat existující spor",
+        "submissionRecordId": "ID záznamu podání",
+        "disputeDetails": "Podrobnosti sporu",
+        "submissionIdRequired": "ID záznamu je povinné",
+        "detailsRequired": "Podrobnosti musí mít alespoň 10 znaků",
+        "raise": "Podat spor",
+        "lookup": "Vyhledat",
+        "disputeId": "ID sporu",
+        "id": "Spor",
+        "submissionRef": "Ref. podání",
+        "raisedBy": "Podal",
+        "openedAt": "Otevřeno",
+        "details": "Podrobnosti",
+        "resolvedAt": "Vyřešeno",
+        "resolutionNotes": "Poznámky k řešení",
+        "expiry": "Datum vypršení",
+        "markUnderReview": "Označit jako v přezkumu",
+        "resolve": "Vyřešit spor",
+        "raised": "Spor #{{ id }} úspěšně podán",
+        "statusUpdated": "Stav sporu aktualizován na {{ status }}"
+      },
+      "errors": {
+        "badRequest": "Neplatný požadavek. Zkontrolujte ID záznamu podání."
       }
     }
   },

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3244,7 +3244,8 @@
       "Cross Rate": "Kreuzkurs",
       "Cross Rate via": "Kreuzkurs (über {{ currency }})",
       "Administrator": "Administrator",
-      "Provider": "Anbieter"
+      "Provider": "Anbieter",
+      "Dispute Management": "Streitverwaltung"
     },
     "links": {
       "Community": "Gemeinschaft",
@@ -4629,6 +4630,32 @@
         "latePayments": "Verspätete Zahlungen",
         "noData": "Kein Kreditprofil verfügbar",
         "noDataHint": "Zuerst Bürobereitschaftsprüfung durchführen"
+      },
+      "dispute": {
+        "raiseTitle": "Neuen Streitfall einreichen",
+        "lookupTitle": "Bestehenden Streitfall suchen",
+        "submissionRecordId": "Einreichungs-ID",
+        "disputeDetails": "Streitdetails",
+        "submissionIdRequired": "Einreichungs-ID ist erforderlich",
+        "detailsRequired": "Details müssen mindestens 10 Zeichen haben",
+        "raise": "Streit einreichen",
+        "lookup": "Suchen",
+        "disputeId": "Streit-ID",
+        "id": "Streitfall",
+        "submissionRef": "Einreichungsref.",
+        "raisedBy": "Eingereicht von",
+        "openedAt": "Geöffnet am",
+        "details": "Details",
+        "resolvedAt": "Gelöst am",
+        "resolutionNotes": "Lösungsnotizen",
+        "expiry": "Ablaufdatum",
+        "markUnderReview": "Als in Prüfung markieren",
+        "resolve": "Streit lösen",
+        "raised": "Streitfall #{{ id }} erfolgreich eingereicht",
+        "statusUpdated": "Streitstatus auf {{ status }} aktualisiert"
+      },
+      "errors": {
+        "badRequest": "Ungültige Anfrage. Bitte überprüfen Sie die Einreichungs-ID."
       }
     }
   },

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3270,7 +3270,8 @@
       "Cross Rate": "Cross Rate",
       "Cross Rate via": "Cross Rate (via {{ currency }})",
       "Administrator": "Administrator",
-      "Provider": "Provider"
+      "Provider": "Provider",
+      "Dispute Management": "Dispute Management"
     },
     "links": {
       "Community": "Community",
@@ -4734,7 +4735,8 @@
         "forbidden": "You do not have permission to check bureau readiness.",
         "clientNotFound": "Client {{ clientId }} not found in Fineract.",
         "serviceUnavailable": "CDC or Fineract is unreachable. Please try again later.",
-        "unexpected": "An unexpected error occurred. Please try again."
+        "unexpected": "An unexpected error occurred. Please try again.",
+        "badRequest": "Invalid request. Please check the submission record ID."
       },
       "dashboard": {
         "role": "Your CB-ILD Role",
@@ -4770,6 +4772,29 @@
         "latePayments": "Late Payments",
         "noData": "No credit profile available yet",
         "noDataHint": "Run Bureau Readiness check first to pull data from CDC"
+      },
+      "dispute": {
+        "raiseTitle": "Raise a New Dispute",
+        "lookupTitle": "Look Up Existing Dispute",
+        "submissionRecordId": "Submission Record ID",
+        "disputeDetails": "Dispute Details",
+        "submissionIdRequired": "Submission Record ID is required",
+        "detailsRequired": "Dispute details must be at least 10 characters",
+        "raise": "Raise Dispute",
+        "lookup": "Look Up",
+        "disputeId": "Dispute ID",
+        "id": "Dispute",
+        "submissionRef": "Submission Ref",
+        "raisedBy": "Raised By",
+        "openedAt": "Opened At",
+        "details": "Details",
+        "resolvedAt": "Resolved At",
+        "resolutionNotes": "Resolution Notes",
+        "expiry": "Expiry Date",
+        "markUnderReview": "Mark Under Review",
+        "resolve": "Resolve Dispute",
+        "raised": "Dispute #{{ id }} raised successfully",
+        "statusUpdated": "Dispute status updated to {{ status }}"
       }
     },
     "selections": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3243,7 +3243,8 @@
       "Cross Rate": "Tipo cruzado",
       "Cross Rate via": "Tipo cruzado (vía {{ currency }})",
       "Administrator": "Administrador",
-      "Provider": "Proveedor"
+      "Provider": "Proveedor",
+      "Dispute Management": "Gestión de disputas"
     },
     "links": {
       "Community": "Comunidad",
@@ -4634,6 +4635,32 @@
         "latePayments": "Pagos tardíos",
         "noData": "Sin perfil de crédito aún",
         "noDataHint": "Ejecute primero la verificación del buró"
+      },
+      "dispute": {
+        "raiseTitle": "Presentar una nueva disputa",
+        "lookupTitle": "Buscar disputa existente",
+        "submissionRecordId": "ID de registro de envío",
+        "disputeDetails": "Detalles de la disputa",
+        "submissionIdRequired": "El ID de registro es obligatorio",
+        "detailsRequired": "Los detalles deben tener al menos 10 caracteres",
+        "raise": "Presentar disputa",
+        "lookup": "Buscar",
+        "disputeId": "ID de disputa",
+        "id": "Disputa",
+        "submissionRef": "Ref. de envio",
+        "raisedBy": "Presentado por",
+        "openedAt": "Abierto el",
+        "details": "Detalles",
+        "resolvedAt": "Resuelto el",
+        "resolutionNotes": "Notas de resolución",
+        "expiry": "Fecha de vencimiento",
+        "markUnderReview": "Marcar en revisión",
+        "resolve": "Resolver disputa",
+        "raised": "Disputa #{{ id }} presentada exitosamente",
+        "statusUpdated": "Estado actualizado a {{ status }}"
+      },
+      "errors": {
+        "badRequest": "Solicitud inválida. Verifique el ID de registro."
       }
     }
   },

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3248,7 +3248,8 @@
       "Cross Rate": "Tipo cruzado",
       "Cross Rate via": "Tipo cruzado (vía {{ currency }})",
       "Administrator": "Administrador",
-      "Provider": "Proveedor"
+      "Provider": "Proveedor",
+      "Dispute Management": "Gestión de disputas"
     },
     "links": {
       "Community": "Comunidad",
@@ -4658,6 +4659,32 @@
         "latePayments": "Pagos tardíos",
         "noData": "Sin perfil de crédito aún",
         "noDataHint": "Ejecute primero la verificación del buró"
+      },
+      "dispute": {
+        "raiseTitle": "Presentar una nueva disputa",
+        "lookupTitle": "Buscar disputa existente",
+        "submissionRecordId": "ID de registro de envío",
+        "disputeDetails": "Detalles de la disputa",
+        "submissionIdRequired": "El ID de registro es obligatorio",
+        "detailsRequired": "Los detalles deben tener al menos 10 caracteres",
+        "raise": "Presentar disputa",
+        "lookup": "Buscar",
+        "disputeId": "ID de disputa",
+        "id": "Disputa",
+        "submissionRef": "Ref. de envío",
+        "raisedBy": "Presentado por",
+        "openedAt": "Abierto el",
+        "details": "Detalles",
+        "resolvedAt": "Resuelto el",
+        "resolutionNotes": "Notas de resolución",
+        "expiry": "Fecha de vencimiento",
+        "markUnderReview": "Marcar en revisión",
+        "resolve": "Resolver disputa",
+        "raised": "Disputa #{{ id }} presentada exitosamente",
+        "statusUpdated": "Estado actualizado a {{ status }}"
+      },
+      "errors": {
+        "badRequest": "Solicitud inválida. Verifique el ID de registro de envío."
       }
     }
   },

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3245,7 +3245,8 @@
       "Cross Rate": "Taux croisé",
       "Cross Rate via": "Taux croisé (via {{ currency }})",
       "Administrator": "Administrateur",
-      "Provider": "Fournisseur"
+      "Provider": "Fournisseur",
+      "Dispute Management": "Gestion des litiges"
     },
     "links": {
       "Community": "Communauté",
@@ -4635,6 +4636,32 @@
         "latePayments": "Paiements en retard",
         "noData": "Aucun profil de crédit",
         "noDataHint": "Exécutez la vérification du bureau"
+      },
+      "dispute": {
+        "raiseTitle": "Soumettre un nouveau litige",
+        "lookupTitle": "Rechercher un litige existant",
+        "submissionRecordId": "ID d'enregistrement",
+        "disputeDetails": "Détails du litige",
+        "submissionIdRequired": "L'ID d'enregistrement est requis",
+        "detailsRequired": "Les détails doivent comporter au moins 10 caractères",
+        "raise": "Soumettre un litige",
+        "lookup": "Rechercher",
+        "disputeId": "ID du litige",
+        "id": "Litige",
+        "submissionRef": "Ref. soumission",
+        "raisedBy": "Soumis par",
+        "openedAt": "Ouvert le",
+        "details": "Détails",
+        "resolvedAt": "Résolu le",
+        "resolutionNotes": "Notes de résolution",
+        "expiry": "Date d'expiration",
+        "markUnderReview": "Marquer en cours d'examen",
+        "resolve": "Résoudre le litige",
+        "raised": "Litige #{{ id }} soumis avec succès",
+        "statusUpdated": "Statut mis à jour à {{ status }}"
+      },
+      "errors": {
+        "badRequest": "Requête invalide. Vérifiez l'ID d'enregistrement."
       }
     }
   },

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3242,7 +3242,8 @@
       "Cross Rate": "Tasso incrociato",
       "Cross Rate via": "Tasso incrociato (tramite {{ currency }})",
       "Administrator": "Amministratore",
-      "Provider": "Provider"
+      "Provider": "Provider",
+      "Dispute Management": "Gestione delle controversie"
     },
     "links": {
       "Community": "Comunità",
@@ -4633,6 +4634,32 @@
         "latePayments": "Pagamenti in ritardo",
         "noData": "Nessun profilo di credito",
         "noDataHint": "Eseguire prima il controllo del bureau"
+      },
+      "dispute": {
+        "raiseTitle": "Presenta una nuova controversia",
+        "lookupTitle": "Cerca controversia esistente",
+        "submissionRecordId": "ID registrazione invio",
+        "disputeDetails": "Dettagli controversia",
+        "submissionIdRequired": "ID registrazione obbligatorio",
+        "detailsRequired": "I dettagli devono avere almeno 10 caratteri",
+        "raise": "Presenta controversia",
+        "lookup": "Cerca",
+        "disputeId": "ID controversia",
+        "id": "Controversia",
+        "submissionRef": "Rif. invio",
+        "raisedBy": "Presentata da",
+        "openedAt": "Aperta il",
+        "details": "Dettagli",
+        "resolvedAt": "Risolta il",
+        "resolutionNotes": "Note di risoluzione",
+        "expiry": "Data di scadenza",
+        "markUnderReview": "Segna in revisione",
+        "resolve": "Risolvi controversia",
+        "raised": "Controversia #{{ id }} presentata con successo",
+        "statusUpdated": "Stato aggiornato a {{ status }}"
+      },
+      "errors": {
+        "badRequest": "Richiesta non valida. Verificare l'ID di registrazione."
       }
     }
   },

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3242,7 +3242,8 @@
       "Cross Rate": "교차 환율",
       "Cross Rate via": "교차 환율 ({{ currency }} 경유)",
       "Administrator": "관리자",
-      "Provider": "제공자"
+      "Provider": "제공자",
+      "Dispute Management": "분쟁 관리"
     },
     "links": {
       "Community": "지역 사회",
@@ -4632,6 +4633,32 @@
         "latePayments": "연체 횟수",
         "noData": "신용 프로필 없음",
         "noDataHint": "신용조회 준비 확인 실행"
+      },
+      "dispute": {
+        "raiseTitle": "새 분쟁 제기",
+        "lookupTitle": "기존 분쟁 조회",
+        "submissionRecordId": "제출 기록 ID",
+        "disputeDetails": "분쟁 세부 사항",
+        "submissionIdRequired": "제출 기록 ID가 필요합니다",
+        "detailsRequired": "세부 사항은 최소 10자 이상이어야 합니다",
+        "raise": "분쟁 제기",
+        "lookup": "조회",
+        "disputeId": "분쟁 ID",
+        "id": "분쟁",
+        "submissionRef": "제출 참조",
+        "raisedBy": "제기자",
+        "openedAt": "개시일",
+        "details": "세부 사항",
+        "resolvedAt": "해결일",
+        "resolutionNotes": "해결 메모",
+        "expiry": "만료일",
+        "markUnderReview": "검토 중으로 표시",
+        "resolve": "분쟁 해결",
+        "raised": "분쟁 #{{ id }} 성공적으로 제기됨",
+        "statusUpdated": "분쟁 상태가 {{ status }}로 업데이트됨"
+      },
+      "errors": {
+        "badRequest": "잘못된 요청입니다. 제출 기록 ID를 확인하세요."
       }
     }
   },

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3241,7 +3241,8 @@
       "Cross Rate": "Kryžminis kursas",
       "Cross Rate via": "Kryžminis kursas (per {{ currency }})",
       "Administrator": "Administratorius",
-      "Provider": "Teikėjas"
+      "Provider": "Teikėjas",
+      "Dispute Management": "Gincu valdymas"
     },
     "links": {
       "Community": "bendruomenė",
@@ -4633,6 +4634,32 @@
         "latePayments": "Pavėluoti mokėjimai",
         "noData": "Kredito profilis nepasiekiamas",
         "noDataHint": "Atlikite biuro patikrinimą"
+      },
+      "dispute": {
+        "raiseTitle": "Pateikti nauja gincu",
+        "lookupTitle": "Ieskoti esamo ginco",
+        "submissionRecordId": "Pateikimo iraso ID",
+        "disputeDetails": "Ginco detales",
+        "submissionIdRequired": "Pateikimo iraso ID yra privalomas",
+        "detailsRequired": "Detales turi buti bent 10 simboliu",
+        "raise": "Pateikti gincu",
+        "lookup": "Ieskoti",
+        "disputeId": "Ginco ID",
+        "id": "Gincas",
+        "submissionRef": "Pateikimo ref.",
+        "raisedBy": "Pateike",
+        "openedAt": "Atidarytas",
+        "details": "Detales",
+        "resolvedAt": "Issprendyta",
+        "resolutionNotes": "Sprendimo pastabos",
+        "expiry": "Galiojimo pabaiga",
+        "markUnderReview": "Pazymeti kaip perziurima",
+        "resolve": "Issprusti gincu",
+        "raised": "Gincas #{{ id }} sekmin gai pateiktas",
+        "statusUpdated": "Ginco busena atnaujinta i {{ status }}"
+      },
+      "errors": {
+        "badRequest": "Neteisinga užklausa. Patikrinkite pateikimo įrašo ID."
       }
     }
   },

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3242,7 +3242,8 @@
       "Cross Rate": "Krusta kurss",
       "Cross Rate via": "Krusta kurss (caur {{ currency }})",
       "Administrator": "Administrators",
-      "Provider": "Nodrošinātājs"
+      "Provider": "Nodrošinātājs",
+      "Dispute Management": "Stridu parvaldiba"
     },
     "links": {
       "Community": "kopiena",
@@ -4632,6 +4633,32 @@
         "latePayments": "Nokavēti maksājumi",
         "noData": "Kredīta profils nav pieejams",
         "noDataHint": "Veiciet biroja pārbaudi"
+      },
+      "dispute": {
+        "raiseTitle": "Iesniegt jaunu stridu",
+        "lookupTitle": "Meklet esosu stridu",
+        "submissionRecordId": "Iesnieguma ieraksta ID",
+        "disputeDetails": "Strida detajas",
+        "submissionIdRequired": "Iesnieguma ieraksta ID ir obligats",
+        "detailsRequired": "Detalam jabut vismaz 10 rakstzimem",
+        "raise": "Iesniegt stridu",
+        "lookup": "Meklet",
+        "disputeId": "Strida ID",
+        "id": "Strids",
+        "submissionRef": "Iesnieguma atsauce",
+        "raisedBy": "Iesniedza",
+        "openedAt": "Atverats",
+        "details": "Detajas",
+        "resolvedAt": "Atrisinats",
+        "resolutionNotes": "Atrisinajuma piezimes",
+        "expiry": "Derigiuma termins",
+        "markUnderReview": "Atzimei ka parskatamu",
+        "resolve": "Atrisinati stridu",
+        "raised": "Strid s #{{ id }} veiksmigi iesniegts",
+        "statusUpdated": "Strida statuss atjauninats uz {{ status }}"
+      },
+      "errors": {
+        "badRequest": "Nederīgs pieprasījums. Pārbaudiet iesnieguma ieraksta ID."
       }
     }
   },

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3241,7 +3241,8 @@
       "Cross Rate": "क्रस दर",
       "Cross Rate via": "क्रस दर ({{ currency }} मार्फत)",
       "Administrator": "प्रशासक",
-      "Provider": "प्रदायक"
+      "Provider": "प्रदायक",
+      "Dispute Management": "Vivad Vyavasthapan"
     },
     "links": {
       "Community": "समुदाय",
@@ -4632,6 +4633,32 @@
         "latePayments": "ढिलो भुक्तानी",
         "noData": "प्रोफाइल उपलब्ध छैन",
         "noDataHint": "ब्यूरो जाँच चलाउनुहोस्"
+      },
+      "dispute": {
+        "raiseTitle": "Naya vivad uthaunus",
+        "lookupTitle": "Avasthit vivad khojnus",
+        "submissionRecordId": "Submission Record ID",
+        "disputeDetails": "Vivadko vivaran",
+        "submissionIdRequired": "Submission ID aavasyak cha",
+        "detailsRequired": "Vivaran kamtima 10 akshar hunuparcha",
+        "raise": "Vivad uthaunus",
+        "lookup": "Khojnus",
+        "disputeId": "Vivad ID",
+        "id": "Vivad",
+        "submissionRef": "Submission sandarbha",
+        "raisedBy": "Uthaaune vyakti",
+        "openedAt": "Kholiyako miti",
+        "details": "Vivaran",
+        "resolvedAt": "Samadhan miti",
+        "resolutionNotes": "Samadhan notaharu",
+        "expiry": "Myad samapti",
+        "markUnderReview": "Sameekshama chinh lagaunus",
+        "resolve": "Vivad samadhan garnus",
+        "raised": "Vivad #{{ id }} safaltapurbak uthaiyo",
+        "statusUpdated": "Vivadko sthiti {{ status }} ma update bhayo"
+      },
+      "errors": {
+        "badRequest": "अमान्य अनुरोध। सबमिशन रेकर्ड ID जाँच गर्नुहोस्।"
       }
     }
   },

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3241,7 +3241,8 @@
       "Cross Rate": "Taxa cruzada",
       "Cross Rate via": "Taxa cruzada (via {{ currency }})",
       "Administrator": "Administrador",
-      "Provider": "Fornecedor"
+      "Provider": "Fornecedor",
+      "Dispute Management": "Gestão de disputas"
     },
     "links": {
       "Community": "Comunidade",
@@ -4632,6 +4633,32 @@
         "latePayments": "Pagamentos atrasados",
         "noData": "Nenhum perfil disponível",
         "noDataHint": "Execute a verificação do bureau"
+      },
+      "dispute": {
+        "raiseTitle": "Levantar nova disputa",
+        "lookupTitle": "Consultar disputa existente",
+        "submissionRecordId": "ID do registo de envio",
+        "disputeDetails": "Detalhes da disputa",
+        "submissionIdRequired": "ID do registo é obrigatório",
+        "detailsRequired": "Os detalhes devem ter pelo menos 10 caracteres",
+        "raise": "Levantar disputa",
+        "lookup": "Consultar",
+        "disputeId": "ID da disputa",
+        "id": "Disputa",
+        "submissionRef": "Ref. envio",
+        "raisedBy": "Levantado por",
+        "openedAt": "Aberto em",
+        "details": "Detalhes",
+        "resolvedAt": "Resolvido em",
+        "resolutionNotes": "Notas de resolução",
+        "expiry": "Data de validade",
+        "markUnderReview": "Marcar em revisão",
+        "resolve": "Resolver disputa",
+        "raised": "Disputa #{{ id }} levantada com sucesso",
+        "statusUpdated": "Estado atualizado para {{ status }}"
+      },
+      "errors": {
+        "badRequest": "Pedido inválido. Verifique o ID do registo de envio."
       }
     }
   },

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3239,7 +3239,8 @@
       "Cross Rate": "Kiwango cha msalaba",
       "Cross Rate via": "Kiwango cha msalaba (kupitia {{ currency }})",
       "Administrator": "Msimamizi",
-      "Provider": "Mtoa huduma"
+      "Provider": "Mtoa huduma",
+      "Dispute Management": "Usimamizi wa Migogoro"
     },
     "links": {
       "Community": "Jumuiya",
@@ -4629,6 +4630,32 @@
         "latePayments": "Malipo ya kuchelewa",
         "noData": "Hakuna wasifu bado",
         "noDataHint": "Endesha ukaguzi wa shirika"
+      },
+      "dispute": {
+        "raiseTitle": "Anza mgogoro mpya",
+        "lookupTitle": "Tafuta mgogoro uliopo",
+        "submissionRecordId": "ID ya rekodi ya uwasilishaji",
+        "disputeDetails": "Maelezo ya mgogoro",
+        "submissionIdRequired": "ID ya rekodi inahitajika",
+        "detailsRequired": "Maelezo lazima yawe na angalau herufi 10",
+        "raise": "Anza mgogoro",
+        "lookup": "Tafuta",
+        "disputeId": "ID ya mgogoro",
+        "id": "Mgogoro",
+        "submissionRef": "Kumbukumbu ya uwasilishaji",
+        "raisedBy": "Ilianzishwa na",
+        "openedAt": "Ilifunguliwa",
+        "details": "Maelezo",
+        "resolvedAt": "Ilitatuliwa",
+        "resolutionNotes": "Maelezo ya utatuzi",
+        "expiry": "Tarehe ya kumalizika",
+        "markUnderReview": "Weka alama ya kukaguliwa",
+        "resolve": "Tatua mgogoro",
+        "raised": "Mgogoro #{{ id }} ulianzishwa kwa mafanikio",
+        "statusUpdated": "Hali ya mgogoro imesasishwa hadi {{ status }}"
+      },
+      "errors": {
+        "badRequest": "Ombi batili. Angalia ID ya rekodi ya uwasilishaji."
       }
     }
   },


### PR DESCRIPTION
## Summary
Adds Dispute Management tab (Tab 4) to the Mifos client profile as part of CB-ILD Phase 3 Angular frontend.

## What Changed
- `src/app/clients/clients-view/dispute-management/` — DisputeManagement component (ts + html + scss)
- `src/app/clients/clients.module.ts` — DisputeManagementComponent registered
- `src/app/clients/clients-routing.module.ts` — dispute-management route added
- `src/app/clients/clients-view/clients-view.component.html` — tab link added after Credit Profile
- `src/assets/translations/en-US.json` + all 11 language files — dispute management translations added
- `src/app/credit-bureau/credit-bureau.service.ts` — updateDisputeStatus accepts optional resolutionNotes

## Test Results
- Raise dispute → status OPEN 
- Mark Under Review → status UNDER_REVIEW 
- Resolve (Compliance only) → status RESOLVED with notes 
- KYC Officer resolve attempt → ACCESS_DENIED 403 
- All 11 language files updated — 21 keys each 

## Related
- Jira: MX-279
- Depends on: MX-277 (PR #3704), MX-278 (PR #3708), MX-378 (PR #3721)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Dispute Management to client views with role-based dispute submission and lookup.
  * Added dispute status tracking, review actions, resolution notes, validation, and expiry details.
  * Added conditional access based on credit bureau integration and permissions.

* **Localization**
  * Added dispute workflow translations across supported languages, including success, error, validation, and status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->