### PR TITLE
fix(WEB-1085): prevent invalid client profile image requests

### DIFF
--- a/src/app/clients/clients.service.spec.ts
+++ b/src/app/clients/clients.service.spec.ts
@@ -243,6 +243,42 @@ describe('ClientsService', () => {
     });
   });
 
+  describe('Client Document Requests', () => {
+    it('should download client document attachment for a valid document id', async () => {
+      const mockDocument = new Blob(['profile-image'], { type: 'image/png' });
+      const resultPromise = firstValueFrom(service.downloadClientDocument('123', '45'));
+
+      const req = httpMock.expectOne((r) => r.url === '/clients/123/documents/45/attachment' && r.method === 'GET');
+      expect(req.request.responseType).toBe('blob');
+
+      req.flush(mockDocument);
+      const result = await resultPromise;
+      expect(result).toBe(mockDocument);
+    });
+
+    it('should not request client document attachment for invalid document ids', async () => {
+      const invalidDocumentIds = [
+        '-1',
+        null,
+        undefined,
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        'Infinity',
+        '0',
+        0,
+        '-5'
+      ];
+
+      for (const documentId of invalidDocumentIds) {
+        await expect(firstValueFrom(service.downloadClientDocument('123', documentId))).rejects.toThrow(
+          'Invalid client document id.'
+        );
+      }
+
+      httpMock.expectNone((r) => r.url.includes('/clients/123/documents/'));
+    });
+  });
+
   describe('Client Family Members', () => {
     it('should fetch family members (GET /clients/:id/familymembers)', async () => {
       const mockMembers = [

--- a/src/app/clients/clients.service.ts
+++ b/src/app/clients/clients.service.ts
@@ -29,6 +29,15 @@ export class ClientsService {
   /** Separate HttpClient that bypasses interceptors (for external API calls) */
   private externalHttp = new HttpClient(this.httpBackend);
 
+  private isValidDocumentId(documentId: string | number | null | undefined): boolean {
+    const parsedDocumentId = Number(documentId);
+    return Number.isFinite(parsedDocumentId) && parsedDocumentId > 0;
+  }
+
+  private invalidDocumentIdError(): Observable<never> {
+    return throwError(() => new Error('Invalid client document id.'));
+  }
+
   getFilteredClients(
     orderBy: string,
     sortOrder: string,
@@ -227,7 +236,10 @@ export class ClientsService {
     return this.http.post(`/clients/${clientId}/documents`, formData);
   }
 
-  getClientSignatureImage(clientId: string, documentId: string) {
+  getClientSignatureImage(clientId: string, documentId: string | number | null | undefined) {
+    if (!this.isValidDocumentId(documentId)) {
+      return this.invalidDocumentIdError();
+    }
     return this.http.get(`/clients/${clientId}/documents/${documentId}/attachment`, { responseType: 'blob' });
   }
 
@@ -285,7 +297,10 @@ export class ClientsService {
     return this.http.get(`/clients/${clientId}/documents`);
   }
 
-  downloadClientDocument(parentEntityId: string, documentId: string) {
+  downloadClientDocument(parentEntityId: string, documentId: string | number | null | undefined) {
+    if (!this.isValidDocumentId(documentId)) {
+      return this.invalidDocumentIdError();
+    }
     return this.http.get(`/clients/${parentEntityId}/documents/${documentId}/attachment`, { responseType: 'blob' });
   }
 
@@ -293,7 +308,10 @@ export class ClientsService {
     return this.http.post(`/clients/${clientId}/documents`, documentData);
   }
 
-  deleteClientDocument(parentEntityId: string, documentId: string) {
+  deleteClientDocument(parentEntityId: string, documentId: string | number | null | undefined) {
+    if (!this.isValidDocumentId(documentId)) {
+      return this.invalidDocumentIdError();
+    }
     return this.http.delete(`/clients/${parentEntityId}/documents/${documentId}`);
   }
 

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.spec.ts
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faEye, faFile, faPlus, faTimes } from '@fortawesome/free-solid-svg-icons';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+import { ClientsService } from 'app/clients/clients.service';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { LoansService } from 'app/loans/loans.service';
+import { SavingsService } from 'app/savings/savings.service';
+import { DocumentPreviewService } from 'app/shared/services/document-preview.service';
+import { EntityDocumentsTabComponent } from './entity-documents-tab.component';
+
+describe('EntityDocumentsTabComponent', () => {
+  let fixture: ComponentFixture<EntityDocumentsTabComponent>;
+  let component: EntityDocumentsTabComponent;
+  let clientsService: jest.Mocked<ClientsService>;
+  let documentPreviewService: jest.Mocked<DocumentPreviewService>;
+
+  beforeEach(async () => {
+    clientsService = {
+      downloadClientDocument: jest.fn()
+    } as any;
+    documentPreviewService = {
+      isPreviewable: jest.fn(() => true),
+      resolvePreviewUrl: jest.fn((document: any, downloadFn: any) => {
+        downloadFn(document);
+        return Promise.resolve({ url: 'blob:document', type: 'image' });
+      }),
+      release: jest.fn()
+    } as any;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        EntityDocumentsTabComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: ClientsService, useValue: clientsService },
+        { provide: LoansService, useValue: {} },
+        { provide: SavingsService, useValue: {} },
+        { provide: DocumentPreviewService, useValue: documentPreviewService },
+        { provide: AuthenticationService, useValue: { getCredentials: () => ({ permissions: ['ALL_FUNCTIONS'] }) } },
+        { provide: MatDialog, useValue: { open: jest.fn(() => ({ afterClosed: () => of(null) })) } }
+      ]
+    }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIcons(faEye, faFile, faPlus, faTimes);
+
+    fixture = TestBed.createComponent(EntityDocumentsTabComponent);
+    component = fixture.componentInstance;
+    component.entityId = '3616';
+    component.entityType = 'clients';
+    component.callbackUpload = jest.fn(() => of({}));
+    component.callbackDelete = jest.fn();
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    -1,
+    Number.POSITIVE_INFINITY,
+    'Infinity'
+  ])('does not prefetch a thumbnail for an invalid client document id: %s', (documentId) => {
+    component.entityDocuments = [{ id: documentId, name: 'profile-image.png', fileName: 'profile-image.png' }];
+
+    fixture.detectChanges();
+
+    expect(component.isPreviewable(component.entityDocuments[0])).toBe(false);
+    expect(documentPreviewService.resolvePreviewUrl).not.toHaveBeenCalled();
+    expect(clientsService.downloadClientDocument).not.toHaveBeenCalled();
+  });
+
+  it('prefetches a thumbnail for a valid client document id', async () => {
+    component.entityDocuments = [{ id: 45, name: 'profile-image.png', fileName: 'profile-image.png' }];
+    clientsService.downloadClientDocument.mockReturnValue(of(new Blob(['image'], { type: 'image/png' })) as any);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.isPreviewable(component.entityDocuments[0])).toBe(true);
+    expect(documentPreviewService.resolvePreviewUrl).toHaveBeenCalled();
+    expect(clientsService.downloadClientDocument).toHaveBeenCalledWith('3616', 45);
+  });
+});

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.ts
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.ts
@@ -29,7 +29,7 @@ import { LoansService } from 'app/loans/loans.service';
 import { SavingsService } from 'app/savings/savings.service';
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
 import { DocumentPreviewService } from 'app/shared/services/document-preview.service';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
@@ -112,6 +112,9 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
   }
 
   deleteDocument(documentId: string, name: string): void {
+    if (!this.isValidDocumentId(documentId)) {
+      return;
+    }
     const deleteDocumentDialogRef = this.dialog.open(DeleteDialogComponent, {
       data: { deleteContext: `Document: ${name}` }
     });
@@ -129,7 +132,7 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
   }
 
   isPreviewable(document: any): boolean {
-    return this.documentPreviewService.isPreviewable(document);
+    return this.isValidDocumentId(document?.id) && this.documentPreviewService.isPreviewable(document);
   }
 
   async openPreview(document: any): Promise<void> {
@@ -192,6 +195,9 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
   }
 
   private getDownloadObservable(documentId: string): Observable<Blob> {
+    if (!this.isValidDocumentId(documentId)) {
+      return throwError(() => new Error('Invalid document id.'));
+    }
     if (this.entityType === 'savings') {
       return this.savingsService.downloadSavingsDocument(this.entityId, documentId);
     }
@@ -216,7 +222,7 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
   }
 
   private setThumbnail(document: any): void {
-    if (!this.documentPreviewService.isPreviewable(document)) {
+    if (!this.isPreviewable(document)) {
       return;
     }
     this.documentPreviewService
@@ -234,5 +240,10 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
       return;
     }
     this.entityDocuments.forEach((doc: any) => this.setThumbnail(doc));
+  }
+
+  private isValidDocumentId(documentId: string | number | null | undefined): boolean {
+    const parsedDocumentId = Number(documentId);
+    return Number.isFinite(parsedDocumentId) && parsedDocumentId > 0;
   }
 }


### PR DESCRIPTION
## Description

Fixes the client profile display by preventing invalid document requests when a client does not have a profile image.

Previously, the frontend attempted to load a document using an invalid identifier (`-1`), resulting in unnecessary `404` responses from the backend and affecting the client profile display.

This change ensures that document requests are only made when a valid document ID is available. When no profile image exists, the existing fallback behavior is used instead of issuing an invalid request.

## Related issues and discussion

WEB-1085

## Screenshots, if any



https://github.com/user-attachments/assets/176324b8-8143-4fe7-a467-f1ff3c76ada1




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid document IDs from triggering download, preview, signature retrieval, or deletion requests.
  * Improved document thumbnail handling by skipping previews for invalid documents.
  * Valid document downloads continue to work as expected.

* **Tests**
  * Added coverage for valid document downloads and invalid ID handling across client document workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->