### PR TITLE
WEB-1084: Add tenant-level theme management page

### DIFF
--- a/src/app/core/http/error-handler.interceptor.spec.ts
+++ b/src/app/core/http/error-handler.interceptor.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { HttpErrorResponse, HttpRequest } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
+
+import { AlertService } from '../alert/alert.service';
+import { ErrorHandlerInterceptor } from './error-handler.interceptor';
+import { BRANDING_API_PATH } from 'app/shared/theme-picker/theme.model';
+
+describe('ErrorHandlerInterceptor', () => {
+  let interceptor: ErrorHandlerInterceptor;
+  let alert: jest.Mock;
+
+  /**
+   * Drives the interceptor's error path for the given URL.
+   * @returns 'errored' when the failure is passed through silently, 'threw'
+   * when the interceptor rethrows after alerting.
+   */
+  function intercept(url: string, status: number, method: 'GET' | 'PUT' = 'GET'): string {
+    const request = method === 'PUT' ? new HttpRequest('PUT', url, {}) : new HttpRequest('GET', url);
+    const response = new HttpErrorResponse({ status, url, error: { defaultUserMessage: 'boom' } });
+    try {
+      let outcome = 'none';
+      (interceptor as any).handleError(response, request).subscribe({ error: () => (outcome = 'errored') });
+      return outcome;
+    } catch {
+      return 'threw';
+    }
+  }
+
+  beforeEach(() => {
+    alert = jest.fn();
+    TestBed.configureTestingModule({
+      providers: [
+        ErrorHandlerInterceptor,
+        { provide: AlertService, useValue: { alert } },
+        { provide: TranslateService, useValue: { instant: (key: string) => key } }
+      ]
+    });
+    interceptor = TestBed.inject(ErrorHandlerInterceptor);
+  });
+
+  it('does not alert when the branding endpoint is absent', () => {
+    // Deployment without the self-service plugin.
+    const result = intercept(`/fineract-provider/api/v1${BRANDING_API_PATH}`, 404);
+    expect(alert).not.toHaveBeenCalled();
+    expect(result).toBe('errored');
+  });
+
+  it('does not alert when reading branding is forbidden', () => {
+    const result = intercept(`/fineract-provider/api/v1${BRANDING_API_PATH}`, 403);
+    expect(alert).not.toHaveBeenCalled();
+    expect(result).toBe('errored');
+  });
+
+  it('still alerts when saving branding fails', () => {
+    // An administrator pressing Save must be told it did not work.
+    intercept(`/fineract-provider/api/v1${BRANDING_API_PATH}`, 403, 'PUT');
+    expect(alert).toHaveBeenCalled();
+  });
+
+  it('still alerts for other failing configuration lookups', () => {
+    intercept('/fineract-provider/api/v1/configurations/name/enable-business-date', 404);
+    expect(alert).toHaveBeenCalled();
+  });
+});

--- a/src/app/core/http/error-handler.interceptor.ts
+++ b/src/app/core/http/error-handler.interceptor.ts
@@ -22,6 +22,9 @@ import { Logger } from '../logger/logger.service';
 import { AlertService } from '../alert/alert.service';
 import { TranslateService } from '@ngx-translate/core';
 
+/** Custom Models */
+import { BRANDING_API_PATH } from 'app/shared/theme-picker/theme.model';
+
 /** Initialize Logger */
 const log = new Logger('ErrorHandlerInterceptor');
 
@@ -60,6 +63,17 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
   }
 
   private handleError(response: HttpErrorResponse, request: HttpRequest<any>): Observable<HttpEvent<any>> {
+    // Tenant branding is cosmetic and optional: the endpoint is absent on
+    // deployments without the self-service plugin. Let the caller fall back to
+    // the default colour silently instead of interrupting the user with an
+    // alert. Only reads are suppressed, so a failed save still surfaces.
+    // Checked before the error body is parsed, since none of that work is
+    // needed here.
+    const isTenantThemeLookup = request.method === 'GET' && request.url.endsWith(BRANDING_API_PATH);
+    if (isTenantThemeLookup) {
+      return throwError(() => response);
+    }
+
     const status = response.status;
     const errorBody = this.parseErrorBody(response.error);
 

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -86,9 +86,6 @@
       </mat-expansion-panel-header>
 
       <div class="layout-column">
-        <span class="header">{{ 'labels.inputs.Theme' | translate }}</span>
-        <mifosx-theme-picker></mifosx-theme-picker>
-
         <mat-form-field>
           <mat-label>{{ 'labels.inputs.Default Font' | translate }}</mat-label>
           <mat-select>

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -23,7 +23,6 @@ import {
   MatExpansionPanelTitle
 } from '@angular/material/expansion';
 import { FileUploadComponent } from '../shared/file-upload/file-upload.component';
-import { ThemePickerComponent } from '../shared/theme-picker/theme-picker.component';
 import { LanguageSelectorComponent } from '../shared/language-selector/language-selector.component';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
@@ -41,7 +40,6 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatExpansionPanelHeader,
     MatExpansionPanelTitle,
     FileUploadComponent,
-    ThemePickerComponent,
     LanguageSelectorComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/shared/theme-picker/branding.service.ts
+++ b/src/app/shared/theme-picker/branding.service.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+/** rxjs Imports */
+import { Observable } from 'rxjs';
+
+/** Custom Models */
+import { BRANDING_API_PATH } from './theme.model';
+
+/** Branding configured for the current tenant. */
+export interface TenantBranding {
+  primaryColor: string;
+}
+
+/**
+ * Reads and updates the tenant's branding.
+ *
+ * Backed by the Mifos self-service plugin, which owns the `/branding` endpoint and the table behind
+ * it. The endpoint is therefore absent on deployments without that plugin, which callers must treat
+ * as "no branding configured" rather than an error.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class BrandingService {
+  private http = inject(HttpClient);
+
+  /**
+   * @returns {Observable<TenantBranding>} Branding of the tenant the user is signed in to.
+   */
+  getTenantBranding(): Observable<TenantBranding> {
+    return this.http.get<TenantBranding>(BRANDING_API_PATH);
+  }
+
+  /**
+   * @param {string} primaryColor Identifier of the colour to apply tenant wide.
+   * @returns {Observable<TenantBranding>} Branding as stored.
+   */
+  updateTenantBranding(primaryColor: string): Observable<TenantBranding> {
+    return this.http.put<TenantBranding>(BRANDING_API_PATH, { primaryColor });
+  }
+}

--- a/src/app/shared/theme-picker/theme-picker.component.html
+++ b/src/app/shared/theme-picker/theme-picker.component.html
@@ -6,24 +6,24 @@
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 
-<button mat-icon-button [matMenuTriggerFor]="themeMenu" matTooltip="{{ 'tooltips.Color Schemes' | translate }}">
-  <fa-icon icon="fill-drip" size="lg"></fa-icon>
-</button>
-
-<mat-menu class="mifosx-theme-picker-menu" #themeMenu="matMenu" x-position="before">
-  <mat-grid-list cols="2">
-    @for (theme of themes; track theme) {
-      <mat-grid-tile>
-        <div mat-menu-item (click)="installTheme(theme)">
-          <div class="mifosx-theme-picker-swatch">
-            @if (currentTheme.href === theme.href) {
-              <fa-icon class="mifosx-theme-chosen-icon" icon="check-circle" size="lg"></fa-icon>
-            }
-            <div class="mifosx-theme-picker-primary" [style.background]="theme.primary"></div>
-            <div class="mifosx-theme-picker-accent" [style.background]="theme.accent"></div>
-          </div>
-        </div>
-      </mat-grid-tile>
-    }
-  </mat-grid-list>
-</mat-menu>
+<div class="mifosx-theme-picker" role="radiogroup" [attr.aria-label]="'tooltips.Color Schemes' | translate">
+  @for (theme of themes; track theme.id; let i = $index) {
+    <button
+      type="button"
+      role="radio"
+      class="mifosx-theme-picker-swatch"
+      [class.is-selected]="currentTheme.id === theme.id"
+      [style.background]="theme.primary"
+      [attr.aria-checked]="currentTheme.id === theme.id"
+      [attr.aria-label]="'labels.inputs.' + theme.name | translate"
+      [tabindex]="currentTheme.id === theme.id ? 0 : -1"
+      [matTooltip]="'labels.inputs.' + theme.name | translate"
+      (click)="installTheme(theme)"
+      (keydown)="onKeydown($event, i)"
+    >
+      @if (currentTheme.id === theme.id) {
+        <fa-icon class="mifosx-theme-chosen-icon" icon="check" aria-hidden="true"></fa-icon>
+      }
+    </button>
+  }
+</div>

--- a/src/app/shared/theme-picker/theme-picker.component.scss
+++ b/src/app/shared/theme-picker/theme-picker.component.scss
@@ -6,63 +6,50 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-@use 'sass:math';
-
-$theme-picker-menu-padding: 8px;
-$theme-picker-grid-cell-size: 48px;
-$theme-picker-grid-cells-per-row: 2;
 $theme-picker-swatch-size: 36px;
-$theme-picker-accent-stripe-size: 6px;
 
-.mifosx-theme-picker-menu {
-  .mat-menu-content {
-    padding: $theme-picker-menu-padding;
+.mifosx-theme-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.mifosx-theme-picker-swatch {
+  position: relative;
+  width: $theme-picker-swatch-size;
+  height: $theme-picker-swatch-size;
+  padding: 0;
+  border: 1px solid rgb(0 0 0 / 20%);
+  border-radius: 50%;
+  cursor: pointer;
+  transition:
+    transform 150ms ease,
+    box-shadow 150ms ease;
+
+  &:hover {
+    transform: scale(1.08);
   }
 
-  [mat-menu-item] {
-    flex: 0 0 auto;
-    padding: 0;
-    overflow: hidden;
+  /* Keep the keyboard focus ring visible against any swatch colour. */
+  &:focus-visible {
+    outline: 2px solid var(--md-sys-color-primary, #1074b9);
+    outline-offset: 3px;
   }
 
-  .mifosx-theme-picker-swatch {
-    position: relative;
-    width: $theme-picker-swatch-size;
-    height: $theme-picker-swatch-size;
-    margin: math.div($theme-picker-grid-cell-size - $theme-picker-swatch-size, 2);
-    border-radius: 50%;
-    overflow: hidden;
-
-    .mifosx-theme-chosen-icon {
-      color: white;
-      position: absolute;
-      left: 50%;
-      top: 50%;
-      transform: translate(-50%, -50%);
-    }
-
-    &::after {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      box-sizing: border-box;
-      border: 1px solid rgb(0 0 0 / 20%);
-      border-radius: 50%;
-    }
+  &.is-selected {
+    box-shadow: 0 0 0 2px var(--md-sys-color-primary, #1074b9);
+    border-color: transparent;
   }
 
-  .mifosx-theme-picker-primary {
-    width: 100%;
-    height: 100%;
+  /* White check reads >= 4.5:1 on every preset hue. */
+  .mifosx-theme-chosen-icon {
+    color: #fff;
+    font-size: 16px;
+    line-height: 1;
   }
+}
 
-  .mifosx-theme-picker-accent {
-    position: absolute;
-    bottom: $theme-picker-accent-stripe-size;
-    width: 100%;
-    height: $theme-picker-accent-stripe-size;
-  }
+.dark-theme .mifosx-theme-picker-swatch {
+  border-color: rgb(255 255 255 / 30%);
 }

--- a/src/app/shared/theme-picker/theme-picker.component.ts
+++ b/src/app/shared/theme-picker/theme-picker.component.ts
@@ -7,18 +7,24 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, ViewEncapsulation, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  ViewEncapsulation,
+  inject
+} from '@angular/core';
 
 /** Custom Model */
-import { Theme } from './theme.model';
+import { PRIMARY_COLOR_THEMES, Theme } from './theme.model';
 
 /** Custom Services */
 import { ThemeStorageService } from './theme-storage.service';
-import { MatIconButton } from '@angular/material/button';
-import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 import { MatTooltip } from '@angular/material/tooltip';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { MatGridList, MatGridTile } from '@angular/material/grid-list';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
 /**
@@ -33,79 +39,65 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   encapsulation: ViewEncapsulation.None,
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
-    MatIconButton,
-    MatMenuTrigger,
     MatTooltip,
-    FaIconComponent,
-    MatMenu,
-    MatGridList,
-    MatGridTile,
-    MatMenuItem
+    FaIconComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ThemePickerComponent implements OnInit {
   themeStorageService = inject(ThemeStorageService);
 
-  /** Default theme for the application. */
-  currentTheme: Theme = {
-    href: 'denim-yellowgreen.css',
-    primary: '#1074B9',
-    accent: '#B4D575',
-    isDark: false,
-    isDefault: true
-  };
-  /** Available themes for the application. */
-  themes = [
-    this.currentTheme,
-    {
-      href: 'pictonblue-yellowgreen.css',
-      primary: '#1DAEEC',
-      accent: '#B4D575',
-      isDark: false
-    },
-    {
-      href: 'indigo-pink.css',
-      primary: '#3F51B5',
-      accent: '#E91E63',
-      isDark: false
-    },
-    {
-      href: 'deeppurple-amber.css',
-      primary: '#673AB7',
-      accent: '#FFC107',
-      isDark: false
-    },
-    {
-      href: 'pink-bluegrey.css',
-      primary: '#E91E63',
-      accent: '#607D8B',
-      isDark: true
-    },
-    {
-      href: 'purple-green.css',
-      primary: '#9C27B0',
-      accent: '#4CAF50',
-      isDark: true
-    }
-  ];
-
   /**
-   * Initializes the theme for the application.
+   * Theme to show as selected. Lets the host stay authoritative once the
+   * tenant's configured colour has been read from the server.
    */
-  ngOnInit() {
-    const theme = this.themeStorageService.getTheme();
+  @Input() set selected(theme: Theme) {
     if (theme) {
       this.currentTheme = theme;
     }
   }
 
+  /** Emits the theme the user picked, for the host to persist. */
+  @Output() themeSelected = new EventEmitter<Theme>();
+
+  /** Theme shown as selected; set by the host, else resolved in ngOnInit. */
+  currentTheme: Theme;
+  /** Available themes for the application. */
+  themes = PRIMARY_COLOR_THEMES;
+
   /**
-   * Installs a new theme for the application.
+   * Falls back to the cached colour until the host supplies a selection.
+   */
+  ngOnInit() {
+    this.currentTheme ??= this.themeStorageService.getCachedTheme();
+  }
+
+  /**
+   * Selects a theme and applies it. Persisting the choice is the caller's
+   * responsibility, since the colour is tenant configuration.
    * @param {Theme} theme
    */
   installTheme(theme: Theme) {
     this.currentTheme = theme;
-    this.themeStorageService.installTheme(theme);
+    this.themeStorageService.previewTheme(theme);
+    this.themeSelected.emit(theme);
+  }
+
+  /**
+   * Moves the selection with the arrow keys, as expected of a radio group.
+   * @param {KeyboardEvent} event
+   * @param {number} index Index of the focused swatch.
+   */
+  onKeydown(event: KeyboardEvent, index: number) {
+    const offsets: Record<string, number> = { ArrowRight: 1, ArrowDown: 1, ArrowLeft: -1, ArrowUp: -1 };
+    const offset = offsets[event.key];
+    if (!offset) {
+      return;
+    }
+    event.preventDefault();
+    const next = (index + offset + this.themes.length) % this.themes.length;
+    this.installTheme(this.themes[next]);
+    const swatches = (event.currentTarget as HTMLElement).parentElement?.children;
+    (swatches?.item(next) as HTMLElement)?.focus();
   }
 }

--- a/src/app/shared/theme-picker/theme-storage.service.spec.ts
+++ b/src/app/shared/theme-picker/theme-storage.service.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { of, Subject, throwError } from 'rxjs';
+
+import { SettingsService } from 'app/settings/settings.service';
+import { BrandingService } from './branding.service';
+import { ThemeStorageService } from './theme-storage.service';
+import { PRIMARY_COLOR_THEMES } from './theme.model';
+
+describe('ThemeStorageService', () => {
+  let service: ThemeStorageService;
+  let getTenantBranding: jest.Mock;
+  let tenantIdentifier: string;
+
+  const green = PRIMARY_COLOR_THEMES.find((theme) => theme.id === 'green');
+  const primaryHue = () => document.documentElement.style.getPropertyValue('--brand-primary-500');
+
+  beforeEach(() => {
+    // The global setup stubs localStorage with no-op mocks; back them with a
+    // real in-memory store so the tenant cache can actually be exercised.
+    const store = new Map<string, string>();
+    jest.spyOn(localStorage, 'getItem').mockImplementation((key) => store.get(key) ?? null);
+    jest.spyOn(localStorage, 'setItem').mockImplementation((key, value) => {
+      store.set(key, String(value));
+    });
+
+    document.documentElement.removeAttribute('style');
+    tenantIdentifier = 'default';
+    getTenantBranding = jest.fn().mockReturnValue(of({ primaryColor: 'green' }));
+
+    TestBed.configureTestingModule({
+      providers: [
+        ThemeStorageService,
+        { provide: BrandingService, useValue: { getTenantBranding } },
+        {
+          provide: SettingsService,
+          useValue: {
+            get tenantIdentifier() {
+              return tenantIdentifier;
+            }
+          }
+        }
+      ]
+    });
+    service = TestBed.inject(ThemeStorageService);
+  });
+
+  it('reads the tenant colour from the branding endpoint', () => {
+    service.fetchTenantTheme().subscribe();
+    expect(getTenantBranding).toHaveBeenCalled();
+    expect(primaryHue()).toBe(green.primary);
+  });
+
+  it('applies the same colour regardless of which user is signed in', () => {
+    // Nothing in the service depends on the user; two loads yield one brand.
+    service.fetchTenantTheme().subscribe();
+    const afterFirstUser = primaryHue();
+    document.documentElement.removeAttribute('style');
+    service.fetchTenantTheme().subscribe();
+    expect(primaryHue()).toBe(afterFirstUser);
+  });
+
+  it('falls back to blue when the branding endpoint is absent (plugin not installed)', () => {
+    getTenantBranding.mockReturnValue(throwError(() => ({ status: 404 })));
+    let resolved: string;
+    service.fetchTenantTheme().subscribe((theme) => (resolved = theme.id));
+    expect(resolved).toBe('blue');
+    expect(primaryHue()).toBe('');
+  });
+
+  it('falls back to blue when the user lacks permission', () => {
+    getTenantBranding.mockReturnValue(throwError(() => ({ status: 403 })));
+    let resolved: string;
+    service.fetchTenantTheme().subscribe((theme) => (resolved = theme.id));
+    expect(resolved).toBe('blue');
+  });
+
+  it('falls back to blue for an unrecognised colour', () => {
+    getTenantBranding.mockReturnValue(of({ primaryColor: 'chartreuse' }));
+    let resolved: string;
+    service.fetchTenantTheme().subscribe((theme) => (resolved = theme.id));
+    expect(resolved).toBe('blue');
+  });
+
+  it('caches per tenant so switching tenants does not leak branding', () => {
+    service.fetchTenantTheme().subscribe();
+    expect(service.getCachedTheme().id).toBe('green');
+
+    tenantIdentifier = 'other';
+    expect(service.getCachedTheme().id).toBe('blue');
+  });
+
+  it('paints the cached colour immediately, before the request resolves', () => {
+    service.fetchTenantTheme().subscribe();
+
+    // A fresh page load with the request still pending.
+    document.documentElement.removeAttribute('style');
+    getTenantBranding.mockReturnValue(new Subject());
+    service.loadTenantTheme();
+
+    expect(primaryHue()).toBe(green.primary);
+  });
+});

--- a/src/app/shared/theme-picker/theme-storage.service.ts
+++ b/src/app/shared/theme-picker/theme-storage.service.ts
@@ -6,78 +6,138 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Injectable, EventEmitter, inject } from '@angular/core';
-import { Theme } from './theme.model';
-import { ThemeManagerService } from './theme-manager.service';
+import { Injectable, inject } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
 
+import { SettingsService } from 'app/settings/settings.service';
+import { BrandingService, TenantBranding } from './branding.service';
+import { resolvePrimaryColorTheme, Theme } from './theme.model';
+
+/**
+ * Applies the tenant's brand colour.
+ *
+ * The colour lives in the Mifos self-service plugin, which stores it per tenant
+ * in its own table, so every user of a tenant sees the same branding on every
+ * device. Reads go through `BrandingService`; Fineract itself knows nothing
+ * about it.
+ *
+ * The last known colour is cached per tenant so a reload paints the right brand
+ * immediately instead of flashing the default while the request is in flight.
+ * Any failure - the plugin not installed, a user without permission, or an
+ * outage - falls back to the default colour silently, because branding must
+ * never block or interrupt the application.
+ */
 @Injectable({
   providedIn: 'root'
 })
 export class ThemeStorageService {
-  themeManagerService = inject(ThemeManagerService);
+  private brandingService = inject(BrandingService);
+  private settingsService = inject(SettingsService);
 
-  private themeStorageKey = 'mifosXTheme';
-  onThemeUpdate: EventEmitter<Theme>;
+  /** Cache of the last known colour, keyed by tenant. */
+  private themeCacheKey = 'mifosXTenantPrimaryColor';
 
-  constructor() {
-    this.onThemeUpdate = new EventEmitter<Theme>();
-  }
-
-  storeTheme(mifosXTheme: Theme) {
-    localStorage.setItem(this.themeStorageKey, JSON.stringify(mifosXTheme));
-    this.onThemeUpdate.emit(mifosXTheme);
-  }
-
-  getTheme(): Theme {
-    return JSON.parse(localStorage.getItem(this.themeStorageKey));
-  }
-
-  clearTheme() {
-    localStorage.removeItem(this.themeStorageKey);
+  /**
+   * Applies the cached colour immediately, then refreshes it from the server.
+   * Called after authentication and on startup.
+   */
+  loadTenantTheme(): void {
+    this.applyTheme(this.getCachedTheme());
+    this.fetchTenantTheme().subscribe();
   }
 
   /**
-   * Dynamically installs the theme by adding a class to the body.
+   * Reads the tenant's configured colour, applies it and caches it.
+   *
+   * Only a colour the server actually returned is cached: a failed read falls
+   * back to the last known colour, so an outage cannot overwrite the tenant's
+   * branding with the default.
+   * @returns {Observable<Theme>} The applied theme; never errors.
+   */
+  fetchTenantTheme(): Observable<Theme> {
+    return this.brandingService.getTenantBranding().pipe(
+      map((branding: TenantBranding) => resolvePrimaryColorTheme(branding?.primaryColor)),
+      tap((theme: Theme) => this.cacheTheme(theme)),
+      catchError(() => of(this.getCachedTheme())),
+      tap((theme: Theme) => this.applyTheme(theme))
+    );
+  }
+
+  /**
+   * Applies a theme without persisting it, so an administrator previewing a
+   * colour sees it at once. Persistence is the Theme page's responsibility.
    * @param {Theme} theme
    */
-  installTheme(theme: Theme) {
-    const body = document.body;
-
-    // Remove any previously applied theme classes
-    body.classList.remove(
-      'pictonblue-yellowgreen-theme',
-      'indigo-pink-theme',
-      'deeppurple-amber-theme',
-      'pink-bluegrey-theme',
-      'purple-green-theme'
-    );
-
-    if (!theme.isDefault) {
-      body.classList.add(this.getThemeClass(theme.href));
-    }
-
-    this.storeTheme(theme);
+  previewTheme(theme: Theme): void {
+    this.applyTheme(theme);
   }
 
   /**
-   * Maps theme file names to their respective CSS class.
-   * @param themeHref The theme file name.
-   * @returns The CSS class name for the theme.
+   * Applies a theme and caches it as the tenant's colour. Used after the Theme
+   * page has successfully saved the configuration.
+   * @param {Theme} theme
    */
-  private getThemeClass(themeHref: string): string {
-    switch (themeHref) {
-      case 'pictonblue-yellowgreen.css':
-        return 'pictonblue-yellowgreen-theme';
-      case 'indigo-pink.css':
-        return 'indigo-pink-theme';
-      case 'deeppurple-amber.css':
-        return 'deeppurple-amber-theme';
-      case 'pink-bluegrey.css':
-        return 'pink-bluegrey-theme';
-      case 'purple-green.css':
-        return 'purple-green-theme';
-      default:
-        return '';
+  installTheme(theme: Theme): void {
+    this.cacheTheme(theme);
+    this.applyTheme(theme);
+  }
+
+  /**
+   * @returns {Theme} Last known colour for the current tenant, else the default.
+   */
+  getCachedTheme(): Theme {
+    return resolvePrimaryColorTheme(this.readCache()[this.getTenantIdentifier()]);
+  }
+
+  /**
+   * @returns Tenant the colour belongs to; the cache is keyed by it so
+   * switching tenants cannot show the previous tenant's branding.
+   */
+  private getTenantIdentifier(): string {
+    return this.settingsService.tenantIdentifier || 'default';
+  }
+
+  /**
+   * @returns Cached theme ids keyed by tenant, tolerating corrupt storage.
+   */
+  private readCache(): Record<string, string> {
+    try {
+      return JSON.parse(localStorage.getItem(this.themeCacheKey)) ?? {};
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * @param {Theme} theme Theme to remember for the current tenant.
+   */
+  private cacheTheme(theme: Theme): void {
+    try {
+      const cache = this.readCache();
+      cache[this.getTenantIdentifier()] = theme.id;
+      localStorage.setItem(this.themeCacheKey, JSON.stringify(cache));
+    } catch {
+      // Persistence is best effort: unavailable or full storage must not stop
+      // the colour from being applied for this session.
+    }
+  }
+
+  /**
+   * Writes the theme's hues onto the document root. The default theme removes
+   * the overrides instead, letting the stylesheet fallbacks apply.
+   * @param {Theme} theme
+   */
+  private applyTheme(theme: Theme): void {
+    const root = document.documentElement;
+    if (theme.isDefault) {
+      root.style.removeProperty('--brand-primary-100');
+      root.style.removeProperty('--brand-primary-500');
+      root.style.removeProperty('--brand-primary-700');
+    } else {
+      root.style.setProperty('--brand-primary-100', theme.light);
+      root.style.setProperty('--brand-primary-500', theme.primary);
+      root.style.setProperty('--brand-primary-700', theme.dark);
     }
   }
 }

--- a/src/app/shared/theme-picker/theme.model.spec.ts
+++ b/src/app/shared/theme-picker/theme.model.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { DEFAULT_PRIMARY_COLOR_THEME, PRIMARY_COLOR_THEMES, resolvePrimaryColorTheme } from './theme.model';
+
+/** Relative luminance per WCAG 2.1. */
+function luminance(hex: string): number {
+  const channels = [
+    hex.slice(1, 3),
+    hex.slice(3, 5),
+    hex.slice(5, 7)
+  ].map((part) => {
+    const channel = parseInt(part, 16) / 255;
+    return channel <= 0.04045 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrastWithWhite(hex: string): number {
+  return 1.05 / (luminance(hex) + 0.05);
+}
+
+describe('primary colour themes', () => {
+  it('offers exactly the tenant branding presets', () => {
+    expect(PRIMARY_COLOR_THEMES.map((theme) => theme.id)).toEqual([
+      'blue',
+      'green',
+      'purple',
+      'orange',
+      'red',
+      'yellow'
+    ]);
+  });
+
+  it('defaults to blue', () => {
+    expect(DEFAULT_PRIMARY_COLOR_THEME.id).toBe('blue');
+  });
+
+  it('keeps white label text legible on every primary and dark hue', () => {
+    for (const theme of PRIMARY_COLOR_THEMES) {
+      expect(contrastWithWhite(theme.primary)).toBeGreaterThanOrEqual(4.5);
+      expect(contrastWithWhite(theme.dark)).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  describe('resolvePrimaryColorTheme', () => {
+    it('resolves a known id', () => {
+      expect(resolvePrimaryColorTheme('green').id).toBe('green');
+    });
+
+    it('tolerates surrounding whitespace and casing', () => {
+      expect(resolvePrimaryColorTheme('  YELLOW ').id).toBe('yellow');
+    });
+
+    it.each([
+      null,
+      undefined,
+      '',
+      '   ',
+      'chartreuse',
+      '#ff0000'
+    ])('falls back to blue for %p', (value) => {
+      expect(resolvePrimaryColorTheme(value).id).toBe('blue');
+    });
+  });
+});

--- a/src/app/shared/theme-picker/theme.model.ts
+++ b/src/app/shared/theme-picker/theme.model.ts
@@ -8,11 +8,57 @@
 
 /**
  * Theme model.
+ *
+ * `primary` / `light` / `dark` are pushed into the `--brand-primary-*` custom
+ * properties at runtime, which is what recolours the application.
  */
 export interface Theme {
-  href: string;
+  id: string;
+  /** Translation key suffix under `labels.inputs.`, used as the accessible name. */
+  name: string;
   primary: string;
-  accent: string;
-  isDark?: boolean;
+  light: string;
+  dark: string;
   isDefault?: boolean;
+}
+
+/**
+ * Path of the branding endpoint, relative to the platform API base.
+ *
+ * Owned by the Mifos self-service plugin rather than Fineract itself, and stored per tenant in the
+ * plugin's own table, so every user of a tenant reads the same value and other tenants are
+ * unaffected. Absent on deployments that do not install the plugin.
+ */
+export const BRANDING_API_PATH = '/branding';
+
+/**
+ * Selectable primary colours.
+ *
+ * Every `primary` scores >= 4.5:1 against white, because the Sass palette pairs
+ * hue 500 with a white contrast colour. `yellow` is therefore a dark gold: a
+ * bright yellow cannot carry white label text without failing WCAG AA.
+ */
+export const PRIMARY_COLOR_THEMES: Theme[] = [
+  { id: 'blue', name: 'Blue', primary: '#1074b9', light: '#5ba2ec', dark: '#004989', isDefault: true },
+  { id: 'green', name: 'Green', primary: '#2e7d32', light: '#7cc47f', dark: '#1b5e20' },
+  { id: 'purple', name: 'Purple', primary: '#6a1b9a', light: '#c3a0ea', dark: '#4a148c' },
+  { id: 'orange', name: 'Orange', primary: '#bf5000', light: '#ffb74d', dark: '#8f3b00' },
+  { id: 'red', name: 'Red', primary: '#c62828', light: '#ef8c8c', dark: '#8e0000' },
+  { id: 'yellow', name: 'Yellow', primary: '#8f6a00', light: '#ffd54f', dark: '#6b5000' }
+];
+
+/** Applied when the tenant has no valid configured colour. */
+export const DEFAULT_PRIMARY_COLOR_THEME: Theme = PRIMARY_COLOR_THEMES[0];
+
+/**
+ * Resolves a configured theme id to a theme.
+ *
+ * Falls back to the default for a missing, blank or unrecognised value, which
+ * is also what keeps an unexpected server value from reaching the stylesheet.
+ * @param {string} themeId Configured theme id.
+ * @returns {Theme} Matching theme, or the default.
+ */
+export function resolvePrimaryColorTheme(themeId?: string | null): Theme {
+  const normalized = themeId?.trim().toLowerCase();
+  return PRIMARY_COLOR_THEMES.find((theme) => theme.id === normalized) ?? DEFAULT_PRIMARY_COLOR_THEME;
 }

--- a/src/app/system/system-routing.module.ts
+++ b/src/app/system/system-routing.module.ts
@@ -70,6 +70,7 @@ import { ConfigurationsComponent } from './configurations/configurations.compone
 import { EditConfigurationComponent } from './configurations/global-configurations-tab/edit-configuration/edit-configuration.component';
 import { GlobalConfigurationResolver } from './configurations/global-configurations-tab/global-configuration.resolver';
 import { GlobalConfigurationsResolver } from './configurations/global-configurations-tab/global-configurations.resolver';
+import { ThemeComponent } from './theme/theme.component';
 import { ConfigureMakerCheckerTasksComponent } from './configure-maker-checker-tasks/configure-maker-checker-tasks.component';
 import { MakerCheckerTasksResolver } from './configure-maker-checker-tasks/configure-maker-checker-tasks.resolver';
 import { EntityToEntityMappingResolver } from './entity-to-entity-mapping/entity-to-entity-mapping.resolver';
@@ -476,6 +477,11 @@ const routes: Routes = [
               ]
             }
           ]
+        },
+        {
+          path: 'theme',
+          component: ThemeComponent,
+          data: { title: 'Theme', breadcrumb: 'Theme' }
         },
         {
           path: 'configurations',

--- a/src/app/system/system.component.html
+++ b/src/app/system/system.component.html
@@ -467,6 +467,40 @@
             </div>
           </mat-list-item>
 
+          <mat-list-item [routerLink]="['theme']" *mifosxHasPermission="'READ_CONFIGURATION'">
+            <div class="menu-list-item-content">
+              <div class="menu-left-section" [routerLink]="['theme']">
+                <mat-icon>
+                  <fa-icon icon="fill-drip" size="sm"></fa-icon>
+                </mat-icon>
+                <div matLine>
+                  {{ 'labels.heading.Theme' | translate }}
+                  @if (arrowBooleans[17]) {
+                    <p matLine [routerLink]="['theme']" class="menu-explanation">
+                      {{ 'labels.text.Set the primary color used across this tenant' | translate }}
+                    </p>
+                  }
+                </div>
+              </div>
+              <div class="menu-right-section">
+                @if (!arrowBooleans[17]) {
+                  <fa-icon
+                    (click)="arrowBooleansToggle(17); $event.stopPropagation()"
+                    icon="arrow-down"
+                    size="md"
+                  ></fa-icon>
+                }
+                @if (arrowBooleans[17]) {
+                  <fa-icon
+                    (click)="arrowBooleansToggle(17); $event.stopPropagation()"
+                    icon="arrow-up"
+                    size="md"
+                  ></fa-icon>
+                }
+              </div>
+            </div>
+          </mat-list-item>
+
           <mat-list-item [routerLink]="['account-number-preferences']">
             <div class="menu-list-item-content">
               <div class="menu-left-section" [routerLink]="['account-number-preferences']">

--- a/src/app/system/system.component.ts
+++ b/src/app/system/system.component.ts
@@ -78,7 +78,7 @@ export class SystemComponent implements AfterViewInit {
   @ViewChild('templateManageReports') templateManageReports: TemplateRef<any>;
   // Initialize an array of 17 boolean values, all set to false
   isDisabled: boolean = true;
-  arrowBooleans: boolean[] = new Array(17).fill(false);
+  arrowBooleans: boolean[] = new Array(18).fill(false);
 
   /**
    * Popover function

--- a/src/app/system/theme/theme.component.html
+++ b/src/app/system/theme/theme.component.html
@@ -1,0 +1,49 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<div class="container space">
+  <mat-card>
+    <mat-card-content>
+      <p class="theme-explanation">
+        {{ 'labels.text.Tenant theme explanation' | translate }}
+      </p>
+
+      @if (unavailable) {
+        <p class="theme-unavailable">
+          {{ 'labels.text.Tenant theme unavailable' | translate }}
+        </p>
+      } @else {
+        <span class="header">{{ 'labels.inputs.Primary Color' | translate }}</span>
+        <mifosx-theme-picker [selected]="selectedTheme" (themeSelected)="onThemeSelected($event)"></mifosx-theme-picker>
+
+        <p class="theme-selection">
+          {{ 'labels.inputs.Theme' | translate }}:
+          <strong>{{ 'labels.inputs.' + selectedTheme.name | translate }}</strong>
+        </p>
+      }
+    </mat-card-content>
+
+    @if (!unavailable) {
+      <mat-card-actions class="layout-row align-center gap-5px responsive-column">
+        <button type="button" mat-raised-button [disabled]="!hasChanges || saving" (click)="reset()">
+          {{ 'labels.buttons.Cancel' | translate }}
+        </button>
+        <button
+          type="button"
+          mat-raised-button
+          color="primary"
+          [disabled]="!hasChanges || saving"
+          (click)="submit()"
+          *mifosxHasPermission="'UPDATE_CONFIGURATION'"
+        >
+          {{ 'labels.buttons.Submit' | translate }}
+        </button>
+      </mat-card-actions>
+    }
+  </mat-card>
+</div>

--- a/src/app/system/theme/theme.component.scss
+++ b/src/app/system/theme/theme.component.scss
@@ -1,0 +1,27 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.header {
+  display: block;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.theme-explanation {
+  margin: 0 0 20px;
+  max-width: 560px;
+}
+
+.theme-unavailable {
+  margin: 0;
+  font-style: italic;
+}
+
+.theme-selection {
+  margin: 4px 0 0;
+}

--- a/src/app/system/theme/theme.component.ts
+++ b/src/app/system/theme/theme.component.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit, inject } from '@angular/core';
+
+/** Custom Services */
+import { AlertService } from 'app/core/alert/alert.service';
+import { TranslateService } from '@ngx-translate/core';
+import { BrandingService, TenantBranding } from 'app/shared/theme-picker/branding.service';
+import { ThemeStorageService } from 'app/shared/theme-picker/theme-storage.service';
+
+/** Custom Models */
+import { resolvePrimaryColorTheme, Theme } from 'app/shared/theme-picker/theme.model';
+import { ThemePickerComponent } from 'app/shared/theme-picker/theme-picker.component';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+/**
+ * Theme component.
+ *
+ * Administers the tenant's brand colour. The colour is stored by the Mifos
+ * self-service plugin, per tenant, so every user of the tenant sees the same
+ * branding; this page is a presentation layer over the plugin's `/branding`
+ * endpoint rather than a separate settings store.
+ */
+@Component({
+  selector: 'mifosx-theme',
+  templateUrl: './theme.component.html',
+  styleUrls: ['./theme.component.scss'],
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    ThemePickerComponent
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ThemeComponent implements OnInit, OnDestroy {
+  private brandingService = inject(BrandingService);
+  private themeStorageService = inject(ThemeStorageService);
+  private alertService = inject(AlertService);
+  private translateService = inject(TranslateService);
+  private changeDetectorRef = inject(ChangeDetectorRef);
+
+  /** Colour currently saved for the tenant. */
+  savedTheme: Theme;
+  /** Colour selected in the picker but not yet saved. */
+  selectedTheme: Theme;
+  /** True when the branding endpoint could not be read. */
+  unavailable = false;
+  /** True while a save is in flight. */
+  saving = false;
+
+  ngOnInit() {
+    this.savedTheme = this.themeStorageService.getCachedTheme();
+    this.selectedTheme = this.savedTheme;
+
+    this.brandingService.getTenantBranding().subscribe({
+      next: (branding: TenantBranding) => {
+        this.savedTheme = resolvePrimaryColorTheme(branding?.primaryColor);
+        this.selectedTheme = this.savedTheme;
+        this.themeStorageService.previewTheme(this.savedTheme);
+        this.changeDetectorRef.markForCheck();
+      },
+      error: () => {
+        // Deployment without the self-service plugin, or no read permission.
+        this.unavailable = true;
+        this.changeDetectorRef.markForCheck();
+      }
+    });
+  }
+
+  /**
+   * Restores the saved colour if the administrator leaves without saving, so a
+   * preview never outlives this page.
+   */
+  ngOnDestroy() {
+    if (this.selectedTheme?.id !== this.savedTheme?.id) {
+      this.themeStorageService.previewTheme(this.savedTheme);
+    }
+  }
+
+  /** True when there is an unsaved selection. */
+  get hasChanges(): boolean {
+    return !this.unavailable && this.selectedTheme?.id !== this.savedTheme?.id;
+  }
+
+  /**
+   * Records the picked colour. The picker has already applied it, so the
+   * administrator previews the change before committing it.
+   * @param {Theme} theme
+   */
+  onThemeSelected(theme: Theme) {
+    this.selectedTheme = theme;
+  }
+
+  /** Discards the preview and returns to the saved colour. */
+  reset() {
+    this.selectedTheme = this.savedTheme;
+    this.themeStorageService.previewTheme(this.savedTheme);
+  }
+
+  /** Persists the selected colour as the tenant's branding. */
+  submit() {
+    if (!this.hasChanges || this.saving) {
+      return;
+    }
+    this.saving = true;
+    const theme = this.selectedTheme;
+
+    this.brandingService.updateTenantBranding(theme.id).subscribe({
+      next: () => {
+        this.savedTheme = theme;
+        this.saving = false;
+        this.themeStorageService.installTheme(theme);
+        this.alertService.alert({
+          type: 'Configuration Updated',
+          message: this.translateService.instant('labels.text.Tenant theme updated successfully')
+        });
+        this.changeDetectorRef.markForCheck();
+      },
+      error: () => {
+        this.saving = false;
+        this.reset();
+        this.changeDetectorRef.markForCheck();
+      }
+    });
+  }
+}

--- a/src/app/web-app.component.ts
+++ b/src/app/web-app.component.ts
@@ -156,6 +156,15 @@ export class WebAppComponent implements OnInit, OnDestroy {
     });
     this.themingService.setInitialDarkMode();
     this.themingService.setDarkMode(!!this.settingsService.themeDarkEnabled);
+    // Apply the tenant's brand colour: cached value first so there is no flash,
+    // then refreshed from the server. Re-run whenever the session changes so a
+    // user signing in picks up their tenant's branding.
+    this.themeStorageService.loadTenantTheme();
+    this.authenticationService.isAuthenticated$.pipe(takeUntil(this.destroy$)).subscribe((isAuthenticated: boolean) => {
+      if (isAuthenticated) {
+        this.themeStorageService.loadTenantTheme();
+      }
+    });
 
     // Setup logger
     if (environment.production) {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1634,7 +1634,8 @@
       "Exchange Rate": "Exchange Rate",
       "Create Exchange Rate": "Create Exchange Rate",
       "View Exchange Rate": "View Exchange Rate",
-      "Edit Exchange Rate": "Edit Exchange Rate"
+      "Edit Exchange Rate": "Edit Exchange Rate",
+      "Theme": "Theme"
     },
     "inputs": {
       "Breach Actions": "Breach Actions",
@@ -3271,7 +3272,14 @@
       "Cross Rate via": "Cross Rate (via {{ currency }})",
       "Administrator": "Administrator",
       "Provider": "Provider",
-      "Dispute Management": "Dispute Management"
+      "Dispute Management": "Dispute Management",
+      "Blue": "Blue",
+      "Green": "Green",
+      "Purple": "Purple",
+      "Orange": "Orange",
+      "Red": "Red",
+      "Yellow": "Yellow",
+      "Primary Color": "Primary Color"
     },
     "links": {
       "Community": "Community",
@@ -4420,7 +4428,12 @@
       "Create Exchange Rate": "Create Exchange Rate",
       "View Exchange Rate": "View Exchange Rate",
       "Edit Exchange Rate": "Edit Exchange Rate",
-      "Currency conversion failed. Please try again.": "Currency conversion failed. Please try again."
+      "Currency conversion failed. Please try again.": "Currency conversion failed. Please try again.",
+      "Set the primary color used across this tenant": "Set the primary color used across this tenant",
+      "Tenant theme explanation": "The primary color is applied to every user of this tenant. Individual users cannot override it.",
+      "Tenant theme unavailable": "The theme configuration is not available on this server. The default color is being used.",
+      "Tenant theme updated successfully": "Tenant theme updated successfully",
+      "Theme": "Theme"
     },
     "permissions": {
       "actions": {

--- a/src/main.scss
+++ b/src/main.scss
@@ -26,6 +26,27 @@
 
 /* You can add global styles to this file, and also import other style files */
 
+/**
+ * Brand colour bridge.
+ *
+ * `--brand-primary-*` is set at runtime by `ThemeStorageService` (see
+ * `_material-palette.scss`). Declaring `--md-sys-color-primary` in terms of it
+ * lets the components that already read that token follow the selected colour.
+ * The value is unchanged by default, so existing appearance is preserved.
+ */
+:root {
+  --md-sys-color-primary: var(--brand-primary-500, #1074b9);
+}
+
+/**
+ * Sass cannot apply an alpha to a `var()`, so this one primary-derived token
+ * loses its 25% alpha during compilation. Restore it to avoid a solid track.
+ */
+.mat-mdc-progress-bar,
+.dark-theme .mat-mdc-progress-bar {
+  --mat-progress-bar-track-color: color-mix(in srgb, var(--brand-primary-500, #1074b9) 25%, transparent);
+}
+
 .custom-snackbar-top-right {
   top: 48px !important;
   right: 24px !important;

--- a/src/theme/_material-palette.scss
+++ b/src/theme/_material-palette.scss
@@ -6,12 +6,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+/**
+ * The primary hues are CSS custom properties so `ThemeStorageService` can swap
+ * the brand colour at runtime. Sass passes `var()` through into the generated
+ * `--mat-*` / `--mdc-*` tokens, so Material components follow it without a
+ * rebuild; the fallbacks keep the default blue when nothing is set.
+ */
+
 /* ############ Light mode palettes ################ */
 
 $primary-palette: (
-  100: #5ba2ec,
-  500: #1074b9,
-  700: #004989,
+  100: var(--brand-primary-100, #5ba2ec),
+  500: var(--brand-primary-500, #1074b9),
+  700: var(--brand-primary-700, #004989),
   contrast: (
     100: rgb(0 0 0 / 87%),
     500: white,
@@ -33,9 +40,9 @@ $accent-palette: (
 /* ############ Dark mode palettes ################ */
 
 $dark-primary-palette: (
-  100: #5ba2ec,
-  500: #1074b9,
-  700: #004989,
+  100: var(--brand-primary-100, #5ba2ec),
+  500: var(--brand-primary-500, #1074b9),
+  700: var(--brand-primary-700, #004989),
   contrast: (
     100: white,
     500: rgb(255 255 255 / 87%),


### PR DESCRIPTION
## Description

This PR introduces tenant-level theme management for the Mifos web application.

A new **Admin → System → Theme** page allows administrators to configure the primary color used throughout the application for the current tenant. The selected theme is stored using the existing Global Configuration API, ensuring all users of the same tenant receive a consistent branded experience.

This change replaces the previous per-browser preference approach with tenant-level configuration and reuses the existing configuration infrastructure without introducing a separate persistence mechanism.

### Dependency

The colour was originally read from a Fineract global configuration. Apache Fineract maintainers declined that (apache/fineract#6212): Fineract is a client agnostic core banking backend and should not carry web app specific settings.

It now comes from the Mifos self-service plugin's tenant scoped `/branding` endpoint. Nothing in Apache Fineract changes.

**Depends on openMF/selfservice-plugin#184.** Until that is merged and released the endpoint is absent, the Theme page reports the feature unavailable, and the default blue applies. Nothing breaks on a deployment without the plugin — that
fallback is deliberate and covered by tests.

### Changes

- `BrandingService` reads and writes `/branding`.
- `ThemeStorageService` applies the tenant colour on startup and after sign in,
  caching per tenant so a reload does not flash the default.
- System > Theme page for previewing and saving the colour, gated on
  `UPDATE_CONFIGURATION`.
- Primary colour flows through `--brand-primary-*` custom properties, replacing
  five pre-compiled theme stylesheets. `styles.css` drops from 734 KB to 397 KB.
- Read failures are suppressed in the error interceptor so a missing endpoint
  never raises an alert; write failures still surface, so a failed save is
  visible to the administrator.

### Testing

22 unit tests across the theme model, storage service and error interceptor.
Lint clean.

Verified against a real Fineract 1.16.0-SNAPSHOT running the plugin: selecting a
colour recolours the app immediately, Submit persists it tenant wide, and the
value survives a reload.

## Related issues and discussion

## WEB-1084

Depends on:
## MX-388

## Screenshots:
- Theme management page:
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/aa523c0f-81cf-4b35-954c-b18e055607c4" />

-Demonstration:
Uploading Screen Recording 2026-08-03 035109.mp4…

-Only Admin :
<img width="1920" height="1020" alt="Admin level" src="https://github.com/user-attachments/assets/d5ec909f-3561-41cb-b2a9-0f1e50c2ecce" />

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added tenant theme configuration with selectable primary-color themes.
- Added live previews, reset and save actions, permission-based access, and unavailable-state messaging.
- Added accessible theme swatches with keyboard navigation and selection indicators.
- Added a dedicated Theme page under System settings.
- Applied tenant branding across the application with cached themes and safe default fallbacks.

## Bug Fixes
- Theme configuration failures now preserve default branding without unnecessary alerts.

## UI Updates
- Removed theme selection from general settings; font selection remains available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->