### PR TITLE
fix(WEB-1088): correct checker inbox date display and advanced-search…

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.html
@@ -60,7 +60,7 @@
             [min]="minDate"
             [max]="maxDate"
             [matDatepicker]="makerDateTimetoPicker"
-            formControlName="makerDateTimeto"
+            formControlName="makerDateTimeTo"
           />
           <mat-datepicker-toggle matSuffix [for]="makerDateTimetoPicker"></mat-datepicker-toggle>
           <mat-datepicker #makerDateTimetoPicker></mat-datepicker>
@@ -91,6 +91,9 @@
         </mat-form-field>
         <button mat-raised-button color="primary" id="search-button" type="button" (click)="search()">
           <fa-icon icon="search" class="m-r-10"></fa-icon>{{ 'labels.buttons.Advanced Search' | translate }}
+        </button>
+        <button mat-raised-button id="reset-button" type="button" (click)="resetFilters()">
+          {{ 'labels.buttons.Reset' | translate }}
         </button>
       </div>
     </form>
@@ -140,6 +143,10 @@
       <ng-container matColumnDef="entity">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Entity' | translate }}</th>
         <td mat-cell *matCellDef="let makerChecker">{{ makerChecker.entityName }}</td>
+      </ng-container>
+      <ng-container matColumnDef="resourceId">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Resource ID' | translate }}</th>
+        <td mat-cell *matCellDef="let makerChecker">{{ makerChecker.resourceId }}</td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { SelectionModel } from '@angular/cdk/collections';
@@ -74,6 +74,7 @@ export class CheckerInboxComponent implements OnInit {
   private settingsService = inject(SettingsService);
   private formBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
+  private cdr = inject(ChangeDetectorRef);
 
   /** Data to be displayed */
   searchData: any;
@@ -103,7 +104,8 @@ export class CheckerInboxComponent implements OnInit {
     'status',
     'user',
     'action',
-    'entity'
+    'entity',
+    'resourceId'
   ];
 
   /**
@@ -120,7 +122,7 @@ export class CheckerInboxComponent implements OnInit {
     this.route.data
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((data: { makerCheckerResource: any; makerCheckerTemplate: any }) => {
-        this.searchData = data.makerCheckerResource;
+        this.searchData = this.transformDates(data.makerCheckerResource);
         if (this.searchData.length > 0) {
           this.checkerData = true;
         }
@@ -140,7 +142,7 @@ export class CheckerInboxComponent implements OnInit {
   createMakerCheckerSearchForm() {
     this.makerCheckerSearchForm = this.formBuilder.group({
       makerDateTimeFrom: [''],
-      makerDateTimeto: [''],
+      makerDateTimeTo: [''],
       actionName: [''],
       entityName: [''],
       resourceId: ['']
@@ -159,17 +161,43 @@ export class CheckerInboxComponent implements OnInit {
     const makerCheckerSearchParams = {
       ...this.makerCheckerSearchForm.value,
       makerDateTimeFrom: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.makerDateTimeFrom, dateFormat),
-      makerDateTimeto: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.makerDateTimeto, dateFormat)
+      makerDateTimeTo: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.makerDateTimeTo, dateFormat)
     };
     this.tasksService.getMakerCheckerData(makerCheckerSearchParams).subscribe((response: any) => {
-      this.searchData = response;
+      this.searchData = this.transformDates(response);
       if (this.searchData.length === 0) {
         this.noSearchedData = true;
       } else {
         this.noSearchedData = false;
+        this.checkerData = true;
       }
       this.dataSource = new MatTableDataSource(this.searchData);
       this.selection = new SelectionModel(true, []);
+      // OnPush: the response arrives asynchronously, so mark the view for re-check
+      // to reflect the updated results without requiring a second click.
+      this.cdr.markForCheck();
+    });
+  }
+
+  /**
+   * Clears all filters and reloads the unfiltered checker inbox.
+   */
+  resetFilters() {
+    this.makerCheckerSearchForm.reset();
+    this.search();
+  }
+
+  /**
+   * The backend returns `madeOnDate` as an epoch value in seconds, whereas the date pipe
+   * expects milliseconds. Multiply by 1000 so the date renders correctly (e.g. avoids
+   * showing dates like "21 January 1970").
+   */
+  private transformDates(data: any[]): any[] {
+    return (data || []).map((item: any) => {
+      if (item.madeOnDate && typeof item.madeOnDate === 'number' && item.madeOnDate < 1e12) {
+        item.madeOnDate = item.madeOnDate * 1000;
+      }
+      return item;
     });
   }
 


### PR DESCRIPTION
… filters

The Checker Inbox showed madeOnDate incorrectly (e.g. "21 January 1970") because the backend returns it as epoch seconds while the UI treated it as milliseconds, and the "To date" filter was ignored because the form control / query param was named "makerDateTimeto" instead of "makerDateTimeTo".

- Convert madeOnDate from epoch seconds to milliseconds before formatting.
- Rename the "To date" control/param to makerDateTimeTo so the upper bound applies.
- Add a Reset button that clears the filters and reloads the list.
- Add a Resource ID column to the results table.
- Mark the view for check after the async search so results render on the first click (the component uses OnPush change detection).

## Description

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Reset** button for advanced search filters.
  - Added a **Resource ID** column to checker inbox results.

- **Bug Fixes**
  - Corrected the advanced search “To date” filter.
  - Improved timestamp display in search results.
  - Ensured refreshed results appear reliably after searches and filter resets.
  - Improved consistency when displaying checker inbox data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
### Backend dependency
The date-range filter (From/To date) depends on a Fineract backend fix:
- Jira: https://issues.apache.org/jira/browse/FINERACT-2683
- PR:   apache/fineract#6120

That backend change fixes `makerDateTimeFrom` / `makerDateTimeTo` filtering
(records migrated to `made_on_date_utc` were not matched) and adds `dd MMMM yyyy`
fallback date parsing. Until it is merged, the date-range filter will not return
correct results on stock Fineract (and may error if `dateFormat`/`locale` are
omitted). The rest of this PR — the `madeOnDate` display fix, Reset button,
Resource ID column, and Action/Entity filters — is independent and works without it.
