### PR TITLE
WEB-1098: Fix Home search missing modules and blank 404 entry

### DIFF
--- a/src/app/home/activities.ts
+++ b/src/app/home/activities.ts
@@ -59,7 +59,12 @@ const activities: any[] = [
   { activity: 'create accounting closure', path: '' },
   { activity: 'navigation', path: '/navigation' },
   { activity: 'remittances', path: '/remittances/process' },
-  { activity: '', path: 'home' }
+  { activity: 'loans', path: '/loans' },
+  { activity: 'collections', path: '/collections' },
+  { activity: 'notifications', path: '/notifications' },
+  { activity: 'profile', path: '/profile' },
+  { activity: 'settings', path: '/settings' },
+  { activity: 'checker inbox and tasks', path: '/checker-inbox-and-tasks' }
 ];
 
 export { activities };


### PR DESCRIPTION
## Description

The Home screen's "Search Activity" box was missing several modules from its results (Loans, Collections, Notifications, Profile, Settings, Checker Inbox & Tasks were never indexed), and the last entry in the dropdown had a blank label and pointed to an unqualified relative path (`home`), which resolved to `/home/home` and hit the 404 page when clicked.

This change removes the blank/broken entry and adds the missing modules to the search index so global search covers every module in the portal.

## Related issues and discussion

[WEB-1098](https://mifosforge.jira.com/browse/WEB-1098)

## Screenshots, if any

**Before:** blank row in the search dropdown, clicking it → 404 page.

**After:** no blank row; searching "loans", "collections", "notifications", "profile", "settings", or "checker inbox" now returns a matching result.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1098]: https://mifosforge.jira.com/browse/WEB-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added activity entries for loans, collections, notifications, profile, settings, and checker tasks.

* **Bug Fixes**
  * Removed the empty activity entry that linked to the home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->