### PR TITLE
WEB-1099: Strip leading hierarchy dots from report select option names

### DIFF
--- a/src/app/reports/common-models/select-option.model.ts
+++ b/src/app/reports/common-models/select-option.model.ts
@@ -13,6 +13,7 @@ export class SelectOption {
 
   constructor(options: any[]) {
     this.id = options[0];
-    this.name = options[1];
+    // Office hierarchy is prefixed with leading dots (e.g. "...Branch Name") by the report SQL to denote nesting depth.
+    this.name = typeof options[1] === 'string' ? options[1].replace(/^\.+/, '') : options[1];
   }
 }


### PR DESCRIPTION
## Description

Office names in report parameter dropdowns (e.g. Reports > Active Loans - Summary > Office) were displayed with leading dots such as `...Foo` or `........Foo - Dubai Branch`. Fineract's report SQL prefixes office names with dots to encode hierarchy depth, and the frontend's `SelectOption` model — which backs every report "select" type parameter, not just Office — was passing that raw string through unchanged.

Stripped the leading dot prefix when the option name is constructed in `SelectOption` (`src/app/reports/common-models/select-option.model.ts`), so all report select dropdowns render clean names (`Foo`, `Foo - Dubai Branch`, etc.) instead of the raw hierarchy-encoded string. No new dependencies required.

## Related issues and discussion

[WEB-1099](https://mifosforge.jira.com/browse/WEB-1099)

## Screenshots, if any

<img width="2102" height="1440" alt="image" src="https://github.com/user-attachments/assets/135600ff-f4bf-47dc-9d37-06d72ec26813" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1099]: https://mifosforge.jira.com/browse/WEB-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Option names now consistently display without leading dots.
  * Non-string option values continue to be handled unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->