### PR TITLE
WEB-1101: Add missing translation keys for Disable/Enable Withhold Ta…

### DIFF
--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3352,6 +3352,8 @@
       "Disburse": "Disburse",
       "Disburse to Savings": "Disburse to Savings",
       "Discount Fee": "Discount Fee",
+      "Disable Withhold Tax": "Disable Withhold Tax",
+      "Enable Withhold Tax": "Enable Withhold Tax",
       "Edit Repayment Schedule": "Edit Repayment Schedule",
       "Foreclosure": "Foreclosure",
       "Frequent Postings": "Frequent Postings",


### PR DESCRIPTION
## Description

The "More" submenu on the savings account hamburger menu displayed the raw i18n key `labels.menus.Disable Withhold Tax` (and `Enable Withhold Tax`) instead of a readable label, because the `menus` translation namespace never had entries for these two menu actions. Added the missing `Disable Withhold Tax` and `Enable Withhold Tax` keys to `src/assets/translations/en-US.json` so `ngx-translate` resolves a proper label instead of falling back to the raw key. This also fixes the same menu action on the recurring deposit and fixed deposit account views, since they share the same translation keys. No new dependencies are required.

## Related issues and discussion

[WEB-1101](https://mifosforge.jira.com/browse/WEB-1101)

<img width="553" height="934" alt="image" src="https://github.com/user-attachments/assets/a2d6a8c5-02e7-407f-b743-a92bcb3ffea8" />

_Before:_ menu item shows `labels.menus.Disable Withhold Tax`
_After:_ menu item shows `Disable Withhold Tax`

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1101]: https://mifosforge.jira.com/browse/WEB-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added English menu labels for enabling and disabling withholding tax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->