### PR TITLE
fix(WEB-1100): use business date for client activation date picker an…

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/client-approval/client-approval.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/client-approval/client-approval.component.ts
@@ -164,11 +164,13 @@ export class ClientApprovalComponent implements AfterViewInit {
   }
 
   approveClients() {
+    const businessDate = this.settingsService.businessDate || new Date();
     const formfields: FormfieldBase[] = [
       new DatepickerBase({
         controlName: 'actDate',
         label: 'Date',
-        value: new Date(),
+        value: businessDate,
+        maxDate: businessDate,
         type: 'datetime-local',
         required: true
       })
@@ -176,7 +178,8 @@ export class ClientApprovalComponent implements AfterViewInit {
     const data = {
       title: 'Enter Clients Activation Date',
       layout: { addButtonText: 'Confirm' },
-      formfields: formfields
+      formfields: formfields,
+      pristine: false
     };
     const clientApprovalDialogRef = this.dialog.open(FormDialogComponent, { data });
     clientApprovalDialogRef.afterClosed().subscribe((response: any) => {


### PR DESCRIPTION
…d enable confirm on first selection

In the Client Approval flow, the activation-date picker did not allow selecting today's date on the first attempt (Confirm stayed disabled) and followed the browser date rather than the system business date.

- Default the picker value and max date to the system business date.
- Open the dialog non-pristine so the pre-filled date is immediately valid and Confirm is enabled on the first selection.

## Description

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client approval date selection now defaults to the configured business date.
  * Prevented users from selecting an approval date later than the business date.
  * Improved dialog state handling when approving clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->