### PR TITLE
WEB-1103: Allow future dates for Incorporation Validity Till Date

### DIFF
--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
@@ -171,8 +171,7 @@
           <mat-label>{{ 'labels.inputs.Incorporation Validity Till Date' | translate }}</mat-label>
           <input
             matInput
-            [min]="minDate"
-            [max]="maxDate"
+            [min]="createClientForm.get('dateOfBirth')?.value || minDate"
             [matDatepicker]="incorpValidityTillDateDatePicker"
             formControlName="incorpValidityTillDate"
           />

--- a/src/app/clients/edit-client/edit-client.component.html
+++ b/src/app/clients/edit-client/edit-client.component.html
@@ -234,8 +234,7 @@
                 [placeholder]="'labels.inputs.Incorporation Validity Till Date' | translate"
                 [title]="'labels.inputs.Incorporation Validity Till Date' | translate"
                 matInput
-                [min]="minDate"
-                [max]="maxDate"
+                [min]="editClientForm.get('dateOfBirth')?.value || minDate"
                 [matDatepicker]="incorpValidityTillDateDatePicker"
                 formControlName="incorpValidityTillDate"
               />


### PR DESCRIPTION
## Description

The `Incorporation Validity Till Date` field for Entity clients had a `[max]="maxDate"` binding on its datepicker that capped selectable dates at today's business date, blocking any future expiry date. Since this field represents the validity/expiry date of a company's incorporation documents, future dates are valid and expected.

Removed the `max` cap and changed `[min]` from the generic `minDate` to the entity's Incorporation Date value — which Fineract stores in the `dateOfBirth` form control for Entity legal form clients — falling back to `minDate` when it isn't set yet. This ensures the validity date can't be set before the incorporation date, while still allowing future expiry dates.

Applied to both the client creation stepper (`client-general-step.component.html`) and the edit-client form (`edit-client.component.html`), matching the equivalent fix already merged in mifosx-community-app. No new dependencies required.

## Related issues and discussion

[WEB-1103](https://mifosforge.jira.com/browse/WEB-1103)

## Screenshots, if any

<img width="1613" height="1179" alt="image" src="https://github.com/user-attachments/assets/e581e267-4829-47e2-b82d-130f17dd904a" />

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1103]: https://mifosforge.jira.com/browse/WEB-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated incorporation validity date selection to prevent dates earlier than the client’s date of birth.
  * Removed the previous maximum-date restriction, allowing valid future dates to be selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->