### PR TITLE
WEB-1104: Hide Close action for already-closed clients

### DIFF
--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -282,7 +282,11 @@
   </mat-menu>
 
   <mat-menu #Actions="matMenu">
-    <button mat-menu-item (click)="doAction('Close')">{{ 'labels.buttons.Close' | translate }}</button>
+    @if (clientViewData.status.value === 'Active') {
+      <span
+        ><button mat-menu-item (click)="doAction('Close')">{{ 'labels.buttons.Close' | translate }}</button></span
+      >
+    }
     <button mat-menu-item (click)="doAction('Transfer Client')">
       {{ 'labels.buttons.Transfer Client' | translate }}
     </button>


### PR DESCRIPTION
## Description

Hid the Close action from the client Header Actions menu once a client's status is already Closed. Previously the menu item was rendered unconditionally, so it stayed visible after closure; clicking it opened the Close form and submission then failed with a server-side "client is already closed" error. The fix gates the button on clientViewData.status.value === 'Active', mirroring the existing pattern already used for Reactivate/Activate/Reject in the same menu. No new dependencies.

## Related issues and discussion

[WEB-1104](https://mifosforge.jira.com/browse/WEB-1104)

## Screenshots, if any
<img width="1540" height="759" alt="image" src="https://github.com/user-attachments/assets/a0ff8cad-de80-487c-934e-065fe245aa11" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1104]: https://mifosforge.jira.com/browse/WEB-1104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Close” action is now shown only for clients with an **Active** status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->