### PR TITLE
WEB-1105: Fix collateral edit Cancel button redirecting to blank screen

### DIFF
--- a/src/app/collaterals/edit-collateral/edit-collateral.component.html
+++ b/src/app/collaterals/edit-collateral/edit-collateral.component.html
@@ -42,7 +42,7 @@
       </mat-card-content>
 
       <mat-card-actions class="layout-row layout-xs-column layout-align-center gap-5px">
-        <button type="button" mat-raised-button [routerLink]="['../../']">
+        <button type="button" mat-raised-button [routerLink]="['../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
         <button mat-raised-button color="primary" [disabled]="!clientCollateralForm.valid">


### PR DESCRIPTION
## Description

The Cancel button on the client collateral edit form linked to `../../`, overshooting the collateral view route (only one level up) and landing on a path with no matching component. This produced a blank screen instead of returning the user to the collateral's details page.

Changed the Cancel button's `routerLink` from `['../../']` to `['../']` so it matches the same relative navigation already used by the Submit handler, correctly returning the user to the collateral view page without making any changes.

No new dependencies are required for this change.

## Related issues and discussion

[WEB-1105](https://mifosforge.jira.com/browse/WEB-1105)

## Screenshots, if any

**Before:** Clicking Cancel on the collateral edit form results in a blank screen.
<img width="1565" height="308" alt="image" src="https://github.com/user-attachments/assets/8d626941-11ab-4255-81ab-a14f64cd91f7" />


**After:** Clicking Cancel returns the user to the collateral's details/view page.


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1105]: https://mifosforge.jira.com/browse/WEB-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Cancel button in collateral editing to navigate to the correct previous page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->