### PR TITLE
WEB-1107: Fix Charges table alignment in Loan Account Preview step

### DIFF
--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
@@ -405,7 +405,7 @@
       <div class="layout-row-wrap responsive-column flex-fill margin-t">
         <h3 class="mat-h3 flex-fill">{{ 'labels.heading.Charges' | translate }}</h3>
         <mat-divider class="flex-fill"></mat-divider>
-        <table class="flex-fill mat-elevation-z1" mat-table [dataSource]="loansAccount.charges">
+        <table class="mat-elevation-z1" mat-table [dataSource]="loansAccount.charges">
           <ng-container matColumnDef="name">
             <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.name' | translate }}</th>
             <td mat-cell *matCellDef="let charge">


### PR DESCRIPTION
## Description

The Charges table in the Loan Account Preview step was displaying header and data columns out of alignment, making it hard to tell which name, type, amount, collection timing, and date belonged to each charge.

The `<table>` element had a stray `flex-fill` class applied to it, forcing `display: flex` on the table itself. This broke the shared table layout algorithm that keeps column widths consistent across the header row and data rows, so each row ended up computing its own column widths independently and the cells no longer lined up under their headers.

Removed the `flex-fill` class from the table; full width is already handled by the existing `table { width: 100%; }` global style, so no other changes were needed.

## Related issues and discussion

[WEB-1107](https://mifosforge.jira.com/browse/WEB-1107)

## Screenshots, if any

<img width="1274" height="683" alt="image" src="https://github.com/user-attachments/assets/626c3055-0d7d-4275-a75f-0f4ab68b093a" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1107]: https://mifosforge.jira.com/browse/WEB-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout of the loan account charges table for a more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->