### PR TITLE
WEB-657: Working Capital Breach - Past Due Amount

### DIFF
--- a/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.html
@@ -21,6 +21,10 @@
       <span class="kpi-value peak">{{ kpis.peakOutstanding | formatNumber }}</span>
     </div>
     <div class="kpi">
+      <span class="kpi-label">{{ 'labels.heading.Past Due Amount' | translate }}</span>
+      <span class="kpi-value peak">{{ loanBalances.breachPastDueAmount | formatNumber }}</span>
+    </div>
+    <div class="kpi">
       <span class="kpi-label">{{ 'labels.heading.Average Gap' | translate }}</span>
       <span class="kpi-value">+{{ kpis.avgGapPercent | formatNumber: '' : '1' }}%</span>
     </div>

--- a/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.ts
@@ -29,6 +29,7 @@ import { BreachSchedule } from 'app/loans/models/working-capital-loan-account.mo
 import { DateFormatPipe } from 'app/pipes/date-format.pipe';
 import { FormatNumberPipe } from 'app/pipes/format-number.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { WorkingCapitalBalances } from 'app/loans/models/working-capital/working-capital-loan-account.model';
 
 type Severity = 'mild' | 'moderate' | 'severe';
 
@@ -108,6 +109,7 @@ export class LoanBreachScheduleTabComponent implements OnInit {
 
   dataSource = new MatTableDataSource<BreachPeriodView>();
   currencyCode: string = '';
+  loanBalances: WorkingCapitalBalances | null = null;
 
   readonly displayedColumns: string[] = [
     'periodNumber',
@@ -157,10 +159,11 @@ export class LoanBreachScheduleTabComponent implements OnInit {
     if (this.route.parent) {
       this.route.parent.data
         .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe((data: { loanDetailsData: { currency?: { code: string } } }) => {
+        .subscribe((data: { loanDetailsData: { currency?: { code: string }; balance: WorkingCapitalBalances } }) => {
           if (data?.loanDetailsData?.currency?.code) {
             this.currencyCode = data.loanDetailsData.currency.code;
           }
+          this.loanBalances = data?.loanDetailsData.balance;
         });
     }
   }

--- a/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
+++ b/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
@@ -87,6 +87,7 @@ export interface WorkingCapitalBalances {
   realizedIncome: number;
   unrealizedIncome: number;
   overpaymentAmount: number;
+  breachPastDueAmount: number | null | undefined;
 }
 
 export interface WorkingCapitalLoanDiscountUpdateRequest {

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1448,6 +1448,7 @@
       "Overdue": "Po splatnosti",
       "Overdue Charges": "Poplatky po splatnosti",
       "Password Preferences": "Předvolby hesla",
+      "Past Due Amount": "Částka po splatnosti",
       "Payment Receipt": "Potvrzení o platbě",
       "Payment Schedule": "Splátkový kalendář",
       "Payment Successful": "Platba úspěšná",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1450,6 +1450,7 @@
       "Overdue": "Überfällig",
       "Overdue Charges": "Überfällige Gebühren",
       "Password Preferences": "Passworteinstellungen",
+      "Past Due Amount": "Überfälliger Betrag",
       "Payment Receipt": "Zahlungsbeleg",
       "Payment Schedule": "Rückzahlungsplan",
       "Payment Successful": "Zahlung erfolgreich",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1466,6 +1466,7 @@
       "Overdue": "Overdue",
       "Overdue Charges": "Overdue Charges",
       "Password Preferences": "Password Preferences",
+      "Past Due Amount": "Past Due Amount",
       "Payment Receipt": "Payment Receipt",
       "Payment Schedule": "Payment Schedule",
       "Payment Successful": "Payment Successful",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1448,6 +1448,7 @@
       "Overdue": "Vencido",
       "Overdue Charges": "Comisiones Moratorias",
       "Password Preferences": "Preferencias de contraseña",
+      "Past Due Amount": "Monto vencido",
       "Payment Receipt": "Recibo de Pago",
       "Payment Schedule": "Cronograma de pagos",
       "Payment Successful": "Pago Exitoso",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1452,6 +1452,7 @@
       "Overdue": "Vencido",
       "Overdue Charges": "Comisiones Moratorias",
       "Password Preferences": "Preferencias de contraseña",
+      "Past Due Amount": "Monto vencido",
       "Payment Receipt": "Recibo de Pago",
       "Payment Schedule": "Cronograma de pagos del Crédito",
       "Payment Successful": "Pago Exitoso",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1451,6 +1451,7 @@
       "Overdue": "En retard",
       "Overdue Charges": "Frais de retard",
       "Password Preferences": "Préférences de mot de passe",
+      "Past Due Amount": "Montant en retard",
       "Payment Receipt": "Reçu de paiement",
       "Payment Schedule": "Calendrier de remboursement",
       "Payment Successful": "Paiement réussi",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1448,6 +1448,7 @@
       "Overdue": "Scaduto",
       "Overdue Charges": "Addebiti scaduti",
       "Password Preferences": "Preferenze password",
+      "Past Due Amount": "Importo scaduto",
       "Payment Receipt": "Ricevuta di pagamento",
       "Payment Schedule": "Programma di rimborso",
       "Payment Successful": "Pagamento riuscito",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1448,6 +1448,7 @@
       "Overdue": "연체",
       "Overdue Charges": "연체료",
       "Password Preferences": "비밀번호 기본 설정",
+      "Past Due Amount": "연체 금액",
       "Payment Receipt": "결제 영수증",
       "Payment Schedule": "상환 일정",
       "Payment Successful": "결제 완료",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1447,6 +1447,7 @@
       "Overdue": "Pradelstas",
       "Overdue Charges": "Pradelsti mokesčiai",
       "Password Preferences": "Slaptažodžio nuostatos",
+      "Past Due Amount": "Pradelsta suma",
       "Payment Receipt": "Mokėjimo kvitas",
       "Payment Schedule": "Mokėjimo grafikas",
       "Payment Successful": "Mokėjimas sėkmingas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1448,6 +1448,7 @@
       "Overdue": "Nokavējums",
       "Overdue Charges": "Nokavētas maksas",
       "Password Preferences": "Paroles preferences",
+      "Past Due Amount": "Nokavētā summa",
       "Payment Receipt": "Maksājuma kvīts",
       "Payment Schedule": "Maksājumu grafiks",
       "Payment Successful": "Maksājums veiksmīgs",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1447,6 +1447,7 @@
       "Overdue": "अतिदेय",
       "Overdue Charges": "ओभरड्यू चार्जहरू",
       "Password Preferences": "पासवर्ड प्राथमिकताहरू",
+      "Past Due Amount": "म्याद नाघेको रकम",
       "Payment Receipt": "भुक्तानी रसिद",
       "Payment Schedule": "भुक्तानी तालिका",
       "Payment Successful": "भुक्तानी सफल",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1447,6 +1447,7 @@
       "Overdue": "Vencido",
       "Overdue Charges": "Cobranças vencidas",
       "Password Preferences": "Preferências de senha",
+      "Past Due Amount": "Montante em atraso",
       "Payment Receipt": "Recibo de pagamento",
       "Payment Schedule": "Cronograma de pagamentos",
       "Payment Successful": "Pagamento bem-sucedido",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1445,6 +1445,7 @@
       "Overdue": "Zilizochelewa",
       "Overdue Charges": "Gharama Zilizopitwa na Wakati",
       "Password Preferences": "Mapendeleo ya Nenosiri",
+      "Past Due Amount": "Kiasi kilichochelewa",
       "Payment Receipt": "Risiti ya malipo",
       "Payment Schedule": "Ratiba ya Malipo",
       "Payment Successful": "Malipo yamefanikiwa",


### PR DESCRIPTION
## Description

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Past Due Amount” KPI to the loan breach schedule, displaying the overdue balance with standard number formatting.
  * The KPI reflects the latest available loan balance information.

* **Localization**
  * Added translations for the new KPI label across supported languages, including English, Czech, German, Spanish, French, Italian, Korean, Lithuanian, Latvian, Nepali, Portuguese, and Swahili.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->