### PR TITLE
WEB-1108: Read tenant branding without credentials

### DIFF
--- a/src/app/shared/theme-picker/branding.service.spec.ts
+++ b/src/app/shared/theme-picker/branding.service.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+
+import { SettingsService } from 'app/settings/settings.service';
+import { BrandingService } from './branding.service';
+import { BRANDING_API_PATH } from './theme.model';
+
+describe('BrandingService', () => {
+  let service: BrandingService;
+  let httpMock: HttpTestingController;
+
+  const serverUrl = 'https://core.example.org/fineract-provider/api/v1';
+  const brandingUrl = `${serverUrl}${BRANDING_API_PATH}`;
+  let tenantIdentifier: string;
+
+  beforeEach(() => {
+    tenantIdentifier = 'acme';
+
+    TestBed.configureTestingModule({
+      providers: [
+        BrandingService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: SettingsService,
+          useValue: {
+            get serverUrl() {
+              return serverUrl;
+            },
+            get tenantIdentifier() {
+              return tenantIdentifier;
+            }
+          }
+        }
+      ]
+    });
+
+    service = TestBed.inject(BrandingService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('reads branding without credentials', async () => {
+    // The endpoint is public and is served by a chain that authenticates
+    // against the self-service user store. Presenting the platform credentials
+    // the interceptor attaches to every other request fails authentication
+    // before the public rule is reached, so the read must carry none.
+    const result = firstValueFrom(service.getTenantBranding());
+
+    const request = httpMock.expectOne(brandingUrl);
+    expect(request.request.method).toBe('GET');
+    expect(request.request.headers.has('Authorization')).toBe(false);
+
+    request.flush({ primaryColor: 'green' });
+    expect(await result).toEqual({ primaryColor: 'green' });
+  });
+
+  it('identifies the tenant on the anonymous read', async () => {
+    // Without credentials the tenant header is the only thing saying whose
+    // branding to return.
+    const result = firstValueFrom(service.getTenantBranding());
+
+    const request = httpMock.expectOne(brandingUrl);
+    expect(request.request.headers.get('Fineract-Platform-TenantId')).toBe('acme');
+
+    request.flush({ primaryColor: 'green' });
+    await result;
+  });
+
+  it('falls back to the default tenant when none is selected', async () => {
+    tenantIdentifier = null;
+    const result = firstValueFrom(service.getTenantBranding());
+
+    const request = httpMock.expectOne(brandingUrl);
+    expect(request.request.headers.get('Fineract-Platform-TenantId')).toBe('default');
+
+    request.flush({ primaryColor: 'blue' });
+    await result;
+  });
+
+  it('sends the selected colour as primaryColor when saving', async () => {
+    // The write stays on the interceptor chain: it is authenticated and
+    // permissioned, so it must carry credentials and the API prefix.
+    const result = firstValueFrom(service.updateTenantBranding('purple'));
+
+    const request = httpMock.expectOne((req) => req.url === BRANDING_API_PATH && req.method === 'PUT');
+    expect(request.request.body).toEqual({ primaryColor: 'purple' });
+
+    request.flush({ primaryColor: 'purple' });
+    expect(await result).toEqual({ primaryColor: 'purple' });
+  });
+
+  it('surfaces a failed read to the caller so the theme can fall back', async () => {
+    const result = firstValueFrom(service.getTenantBranding());
+
+    httpMock.expectOne(brandingUrl).flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+
+    await expect(result).rejects.toMatchObject({ status: 401 });
+  });
+});

--- a/src/app/shared/theme-picker/branding.service.ts
+++ b/src/app/shared/theme-picker/branding.service.ts
@@ -8,10 +8,13 @@
 
 /** Angular Imports */
 import { Injectable, inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpBackend, HttpClient, HttpHeaders } from '@angular/common/http';
 
 /** rxjs Imports */
 import { Observable } from 'rxjs';
+
+/** Custom Services */
+import { SettingsService } from 'app/settings/settings.service';
 
 /** Custom Models */
 import { BRANDING_API_PATH } from './theme.model';
@@ -33,12 +36,26 @@ export interface TenantBranding {
 })
 export class BrandingService {
   private http = inject(HttpClient);
+  private httpBackend = inject(HttpBackend);
+  private settingsService = inject(SettingsService);
 
   /**
-   * @returns {Observable<TenantBranding>} Branding of the tenant the user is signed in to.
+   * Reads without credentials, bypassing the interceptor chain.
+   *
+   * The endpoint is public, and is served by the plugin's own security chain, which authenticates
+   * against the self-service user store. A platform user does not exist there, so presenting the
+   * credentials `AuthenticationInterceptor` attaches to every other request fails authentication
+   * before the endpoint's public rule is ever reached - the request has to carry none.
+   *
+   * Bypassing the chain also means supplying what those interceptors would have: the tenant, which
+   * is the only thing identifying whose branding to return, and the platform base URL.
+   * @returns {Observable<TenantBranding>} Branding of the current tenant.
    */
   getTenantBranding(): Observable<TenantBranding> {
-    return this.http.get<TenantBranding>(BRANDING_API_PATH);
+    const anonymousHttp = new HttpClient(this.httpBackend);
+    return anonymousHttp.get<TenantBranding>(`${this.settingsService.serverUrl}${BRANDING_API_PATH}`, {
+      headers: new HttpHeaders({ 'Fineract-Platform-TenantId': this.settingsService.tenantIdentifier || 'default' })
+    });
   }
 
   /**

--- a/src/app/shared/theme-picker/theme-storage.service.spec.ts
+++ b/src/app/shared/theme-picker/theme-storage.service.spec.ts
@@ -10,7 +10,7 @@ import { TestBed } from '@angular/core/testing';
 import { of, Subject, throwError } from 'rxjs';
 
 import { SettingsService } from 'app/settings/settings.service';
-import { BrandingService } from './branding.service';
+import { BrandingService, TenantBranding } from './branding.service';
 import { ThemeStorageService } from './theme-storage.service';
 import { PRIMARY_COLOR_THEMES } from './theme.model';
 
@@ -69,7 +69,7 @@ describe('ThemeStorageService', () => {
 
   it('falls back to blue when the branding endpoint is absent (plugin not installed)', () => {
     getTenantBranding.mockReturnValue(throwError(() => ({ status: 404 })));
-    let resolved: string;
+    let resolved: string | undefined;
     service.fetchTenantTheme().subscribe((theme) => (resolved = theme.id));
     expect(resolved).toBe('blue');
     expect(primaryHue()).toBe('');
@@ -77,14 +77,14 @@ describe('ThemeStorageService', () => {
 
   it('falls back to blue when the user lacks permission', () => {
     getTenantBranding.mockReturnValue(throwError(() => ({ status: 403 })));
-    let resolved: string;
+    let resolved: string | undefined;
     service.fetchTenantTheme().subscribe((theme) => (resolved = theme.id));
     expect(resolved).toBe('blue');
   });
 
   it('falls back to blue for an unrecognised colour', () => {
     getTenantBranding.mockReturnValue(of({ primaryColor: 'chartreuse' }));
-    let resolved: string;
+    let resolved: string | undefined;
     service.fetchTenantTheme().subscribe((theme) => (resolved = theme.id));
     expect(resolved).toBe('blue');
   });
@@ -95,6 +95,102 @@ describe('ThemeStorageService', () => {
 
     tenantIdentifier = 'other';
     expect(service.getCachedTheme().id).toBe('blue');
+  });
+
+  it('falls back to blue when the read is rejected as unauthorised', () => {
+    // The endpoint is reachable but refuses the caller: a deployment where the
+    // read is authenticated and the request carries no usable credentials.
+    // Branding is cosmetic, so this must be silent rather than disruptive.
+    getTenantBranding.mockReturnValue(throwError(() => ({ status: 401 })));
+    let resolved: string | undefined;
+    service.fetchTenantTheme().subscribe((theme) => (resolved = theme.id));
+    expect(resolved).toBe('blue');
+  });
+
+  it('falls back rather than throwing when the payload is not a string', () => {
+    // Nothing guarantees the wire type. Resolution runs before the error
+    // handler in the pipe, so a type error inside it has to be caught too.
+    // Cast through unknown: this models malformed wire data, and the service's
+    // response type stays honest about what the endpoint is meant to return.
+    getTenantBranding.mockReturnValue(of({ primaryColor: 42 } as unknown as TenantBranding));
+    let resolved: string | undefined;
+    let errored = false;
+    service.fetchTenantTheme().subscribe({
+      next: (theme) => (resolved = theme.id),
+      error: () => (errored = true)
+    });
+
+    expect(errored).toBe(false);
+    expect(resolved).toBe('blue');
+  });
+
+  it('does not overwrite a known colour when a later read fails', () => {
+    // An outage must not reset the tenant's branding to the default.
+    service.fetchTenantTheme().subscribe();
+    expect(service.getCachedTheme().id).toBe('green');
+
+    getTenantBranding.mockReturnValue(throwError(() => ({ status: 500 })));
+    service.fetchTenantTheme().subscribe();
+
+    expect(service.getCachedTheme().id).toBe('green');
+    expect(primaryHue()).toBe(green.primary);
+  });
+
+  it('reads a tenant once however many times it is asked to load', () => {
+    // Callers signal "the tenant may have changed" rather than "fetch now",
+    // and the authentication state replays on subscribe, so repeated loads
+    // must not each cost a request.
+    service.loadTenantTheme();
+    service.loadTenantTheme();
+    service.loadTenantTheme();
+
+    expect(getTenantBranding).toHaveBeenCalledTimes(1);
+  });
+
+  it('reads again only when the tenant changes', () => {
+    service.loadTenantTheme();
+    service.loadTenantTheme();
+    expect(getTenantBranding).toHaveBeenCalledTimes(1);
+
+    tenantIdentifier = 'other';
+    getTenantBranding.mockReturnValue(of({ primaryColor: 'red' }));
+    service.loadTenantTheme();
+    expect(getTenantBranding).toHaveBeenCalledTimes(2);
+
+    // The tenant is what drove the second read, not the changed stub: each
+    // colour landed under its own tenant's key.
+    expect(service.getCachedTheme('other').id).toBe('red');
+    expect(service.getCachedTheme('default').id).toBe('green');
+  });
+
+  it('does not apply a response that arrives after the tenant changed', () => {
+    // The tenant selector switches tenant without a reload, so a read can
+    // still be in flight when it does. The answer belongs to the tenant that
+    // was asked, and painting it now would show the wrong brand.
+    const pending = new Subject<TenantBranding>();
+    getTenantBranding.mockReturnValue(pending);
+    service.fetchTenantTheme().subscribe();
+
+    tenantIdentifier = 'other';
+    pending.next({ primaryColor: 'red' });
+    pending.complete();
+
+    expect(primaryHue()).toBe('');
+    expect(service.getCachedTheme('default').id).toBe('red');
+    expect(service.getCachedTheme('other').id).toBe('blue');
+  });
+
+  it('reads the new tenant colour after the tenant changes', () => {
+    service.fetchTenantTheme().subscribe();
+    expect(primaryHue()).toBe(green.primary);
+
+    tenantIdentifier = 'other';
+    getTenantBranding.mockReturnValue(of({ primaryColor: 'red' }));
+    service.fetchTenantTheme().subscribe();
+
+    const red = PRIMARY_COLOR_THEMES.find((theme) => theme.id === 'red');
+    expect(primaryHue()).toBe(red.primary);
+    expect(service.getCachedTheme().id).toBe('red');
   });
 
   it('paints the cached colour immediately, before the request resolves', () => {

--- a/src/app/shared/theme-picker/theme-storage.service.ts
+++ b/src/app/shared/theme-picker/theme-storage.service.ts
@@ -38,12 +38,28 @@ export class ThemeStorageService {
   /** Cache of the last known colour, keyed by tenant. */
   private themeCacheKey = 'mifosXTenantPrimaryColor';
 
+  /** Tenant whose branding has already been read from the server this session. */
+  private loadedTenant: string | null = null;
+
   /**
-   * Applies the cached colour immediately, then refreshes it from the server.
-   * Called after authentication and on startup.
+   * Applies the cached colour immediately, then refreshes it from the server
+   * once per tenant.
+   *
+   * Callers signal "the tenant may have changed" - startup, and signing in,
+   * which can switch tenant - rather than "fetch now", so repeated calls for a
+   * tenant already read cost nothing.
    */
   loadTenantTheme(): void {
     this.applyTheme(this.getCachedTheme());
+
+    const tenant = this.getTenantIdentifier();
+    if (this.loadedTenant === tenant) {
+      return;
+    }
+    // Recorded before the request rather than after, so a slow read cannot be
+    // issued twice; a failed one leaves the cached colour applied, which is
+    // what it would fall back to anyway.
+    this.loadedTenant = tenant;
     this.fetchTenantTheme().subscribe();
   }
 
@@ -53,14 +69,26 @@ export class ThemeStorageService {
    * Only a colour the server actually returned is cached: a failed read falls
    * back to the last known colour, so an outage cannot overwrite the tenant's
    * branding with the default.
+   *
+   * The tenant is captured when the request is issued rather than read again
+   * when it resolves, because it can change while the read is in flight - the
+   * tenant selector switches it without a reload. The answer belongs to the
+   * tenant that was asked, so it is cached under that one, and applied only
+   * while that tenant is still the current one.
    * @returns {Observable<Theme>} The applied theme; never errors.
    */
   fetchTenantTheme(): Observable<Theme> {
+    const requestedTenant = this.getTenantIdentifier();
+
     return this.brandingService.getTenantBranding().pipe(
       map((branding: TenantBranding) => resolvePrimaryColorTheme(branding?.primaryColor)),
-      tap((theme: Theme) => this.cacheTheme(theme)),
-      catchError(() => of(this.getCachedTheme())),
-      tap((theme: Theme) => this.applyTheme(theme))
+      tap((theme: Theme) => this.cacheTheme(theme, requestedTenant)),
+      catchError(() => of(this.getCachedTheme(requestedTenant))),
+      tap((theme: Theme) => {
+        if (requestedTenant === this.getTenantIdentifier()) {
+          this.applyTheme(theme);
+        }
+      })
     );
   }
 
@@ -84,10 +112,11 @@ export class ThemeStorageService {
   }
 
   /**
-   * @returns {Theme} Last known colour for the current tenant, else the default.
+   * @param {string} tenant Tenant to read; defaults to the current one.
+   * @returns {Theme} Last known colour for that tenant, else the default.
    */
-  getCachedTheme(): Theme {
-    return resolvePrimaryColorTheme(this.readCache()[this.getTenantIdentifier()]);
+  getCachedTheme(tenant: string = this.getTenantIdentifier()): Theme {
+    return resolvePrimaryColorTheme(this.readCache()[tenant]);
   }
 
   /**
@@ -110,12 +139,13 @@ export class ThemeStorageService {
   }
 
   /**
-   * @param {Theme} theme Theme to remember for the current tenant.
+   * @param {Theme} theme Theme to remember.
+   * @param {string} tenant Tenant it belongs to; defaults to the current one.
    */
-  private cacheTheme(theme: Theme): void {
+  private cacheTheme(theme: Theme, tenant: string = this.getTenantIdentifier()): void {
     try {
       const cache = this.readCache();
-      cache[this.getTenantIdentifier()] = theme.id;
+      cache[tenant] = theme.id;
       localStorage.setItem(this.themeCacheKey, JSON.stringify(cache));
     } catch {
       // Persistence is best effort: unavailable or full storage must not stop

--- a/src/app/web-app.component.ts
+++ b/src/app/web-app.component.ts
@@ -156,15 +156,6 @@ export class WebAppComponent implements OnInit, OnDestroy {
     });
     this.themingService.setInitialDarkMode();
     this.themingService.setDarkMode(!!this.settingsService.themeDarkEnabled);
-    // Apply the tenant's brand colour: cached value first so there is no flash,
-    // then refreshed from the server. Re-run whenever the session changes so a
-    // user signing in picks up their tenant's branding.
-    this.themeStorageService.loadTenantTheme();
-    this.authenticationService.isAuthenticated$.pipe(takeUntil(this.destroy$)).subscribe((isAuthenticated: boolean) => {
-      if (isAuthenticated) {
-        this.themeStorageService.loadTenantTheme();
-      }
-    });
 
     // Setup logger
     if (environment.production) {
@@ -252,6 +243,18 @@ export class WebAppComponent implements OnInit, OnDestroy {
       this.settingsService.setTenantIdentifier(environment.fineractPlatformTenantId || 'default');
     }
     this.settingsService.setTenantIdentifiers(environment.fineractPlatformTenantIds.split(','));
+
+    // Apply the tenant's brand colour: the cached value is painted first so
+    // there is no flash, then refreshed from the server. Read anonymously, so
+    // it does not wait for authentication and the login screen is branded too.
+    //
+    // Deliberately after the server and tenant are settled above: the read
+    // carries no credentials, so the tenant header is the only thing saying
+    // whose branding to return. Re-run when the session changes, since signing
+    // in can switch tenant; it is a no-op for a tenant already read.
+    this.authenticationService.isAuthenticated$
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.themeStorageService.loadTenantTheme());
 
     // Subscribe to session timeout If IdleTimeout is higher than 0 (zero)
     if (environment.session.timeout.idleTimeout > 0) {


### PR DESCRIPTION
## Description

The branding endpoint is public, but it is served by the plugin's security chain,
which authenticates against the self-service user store. The web-app attaches
platform credentials to every internal request, and those fail authentication
there before the endpoint's public rule is reached — so a logged-in user got a
401 on every refresh while an anonymous one succeeded.

The read now bypasses the interceptor chain so it carries no credentials, and
supplies what those interceptors would have: the platform base URL and the
tenant header, which without credentials is the only thing identifying whose
branding to return. Same approach as `PostalCodeLookupService`. Writes are
unchanged — still authenticated and permissioned.

Two consequences:

- the fetch moved to after server/tenant bootstrap. It was firing before the
  tenant identifier was set, which an anonymous read cannot tolerate.
- branding is read once per tenant rather than once eagerly and again on the
  replayed authentication state, removing a duplicate request per page load.

Server side is already in place (MX-390); no backend changes needed.

## Related issues and discussion

# WEB-1108

## Screenshots, if any

N/A — no visual change when branding resolves; the fix removes a failed request.

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant branding retrieval, including support for anonymous access and default-tenant fallback.
  * Branding now reloads correctly when the tenant changes.
  * Prevented duplicate branding requests while retaining cached themes during temporary failures.
  * Improved handling of unauthorized responses and malformed branding data.
* **Tests**
  * Added comprehensive coverage for branding requests, authentication states, tenant switching, caching, and request deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->