### PR TITLE
WEB-657: Working Capital Loan - Breach Disable and Enable

### DIFF
--- a/src/app/loans/loans-routing.module.ts
+++ b/src/app/loans/loans-routing.module.ts
@@ -171,7 +171,8 @@ const routes: Routes = [
             component: LoanBreachScheduleTabComponent,
             data: { title: 'Breach Schedule', breadcrumb: 'Breach Schedule', routeParamBreadcrumb: false },
             resolve: {
-              breachSchedule: LoanBreachScheduleResolver
+              breachSchedule: LoanBreachScheduleResolver,
+              loanBreachActions: LoanBreachActionsResolver
             }
           },
           {

--- a/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.html
+++ b/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.html
@@ -6,73 +6,47 @@
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 
-<div class="container">
-  @if (loanProductService.isLoanProduct) {
-    <h3>{{ 'labels.heading.Loan Delinquency Tags' | translate }}</h3>
-
-    @if (loanDelinquencyTags.length > 0) {
-      <table mat-table [dataSource]="loanDelinquencyTags">
-        <ng-container matColumnDef="classification">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Delinquency Classification' | translate }}</th>
-          <td mat-cell *matCellDef="let item">
-            {{ item.delinquencyRange.classification }}
-            @if (item.delinquencyRange.maximumAgeDays) {
-              <span>( {{ item.delinquencyRange.minimumAgeDays }} - {{ item.delinquencyRange.maximumAgeDays }} )</span>
-            }
-            @if (!item.delinquencyRange.maximumAgeDays) {
-              <span>( {{ item.delinquencyRange.minimumAgeDays }} )</span>
-            }
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="addedOn">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Added On' | translate }}</th>
-          <td mat-cell *matCellDef="let item">
-            @if (item.addedOnDate) {
-              <span>
-                {{ item.addedOnDate | dateFormat }}
-              </span>
-            }
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="liftedOn">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Lifted On' | translate }}</th>
-          <td mat-cell *matCellDef="let item">
-            @if (item.liftedOnDate) {
-              <span>
-                {{ item.liftedOnDate | dateFormat }}
-              </span>
-            }
-          </td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="loanDelinquencyTagsColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: loanDelinquencyTagsColumns"></tr>
-      </table>
-    }
-
-    @if (installmentLevelDelinquency.length > 0) {
-      <div>
-        <h3>{{ 'labels.heading.Loan Delinquency Installment Tags' | translate }}</h3>
-        <table mat-table [dataSource]="installmentLevelDelinquency">
-          <ng-container matColumnDef="classification">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Delinquency Classification' | translate }}</th>
-            <td mat-cell *matCellDef="let item">{{ item.classification }}</td>
-          </ng-container>
-          <ng-container matColumnDef="minimumAgeDays">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Days' | translate }}</th>
-            <td mat-cell *matCellDef="let item">{{ item.minimumAgeDays | formatNumber }}</td>
-          </ng-container>
-          <ng-container matColumnDef="amount">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Amount' | translate }}</th>
-            <td mat-cell *matCellDef="let item">
-              {{ item.delinquentAmount | currency: currency.code : 'symbol-narrow' : '1.2-2' }}
-            </td>
-          </ng-container>
-          <tr mat-header-row *matHeaderRowDef="installmentDelinquencyTagsColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: installmentDelinquencyTagsColumns"></tr>
-        </table>
-      </div>
-    }
-  }
+<div class="dashboard-card">
+  <div class="kpi-strip">
+    <div class="kpi">
+      <span class="kpi-label">{{ 'labels.inputs.Total Actions' | translate }}</span>
+      <span class="kpi-value">{{ kpis().total }}</span>
+    </div>
+    <div class="kpi">
+      <span class="kpi-label">{{ 'labels.inputs.Active Pause' | translate }}</span>
+      <span class="kpi-value accent">{{ kpis().activePauses }}</span>
+    </div>
+    <div class="kpi">
+      <span class="kpi-label">{{ 'labels.inputs.Total Days Paused' | translate }}</span>
+      <span class="kpi-value">
+        {{ kpis().totalDaysPaused }}
+        <span class="unit">{{ 'labels.inputs.days' | translate }}</span>
+      </span>
+    </div>
+    <div class="kpi">
+      <span class="kpi-label">{{ 'labels.inputs.Last Action' | translate }}</span>
+      <span class="kpi-value">
+        @if (kpis().lastActionDate) {
+          {{ kpis().lastActionDate | dateFormat }}
+        } @else {
+          —
+        }
+      </span>
+    </div>
+    <div class="kpi-status">
+      @if (isDelinquencyDisabled()) {
+        <span class="status-chip status-chip--disabled">
+          <span class="dot"></span>
+          {{ 'labels.inputs.Delinquency evaluation disabled' | translate }}
+        </span>
+      } @else if (hasPauseActiveToday()) {
+        <span class="status-chip">
+          <span class="dot"></span>
+          {{ 'labels.inputs.Pause Active' | translate }}
+        </span>
+      }
+    </div>
+  </div>
 
   @if (timelineBars().length > 0) {
     <div class="timeline-section">
@@ -109,7 +83,7 @@
         </g>
 
         <g>
-          @for (bar of timelineBars(); track bar.label) {
+          @for (bar of timelineBars(); track trackByLabel($index, bar)) {
             <rect
               [attr.class]="'pause-bar-edge pause-bar-edge--' + bar.status"
               [attr.x]="bar.x"
@@ -142,241 +116,424 @@
     </div>
   }
 
-  @if (isDelinquencyDisabled()) {
-    <div class="delinquency-disabled-banner m-t-20">
-      <fa-icon icon="ban" class="m-r-10"></fa-icon>
-      <span>{{ 'labels.inputs.Delinquency evaluation disabled' | translate }}</span>
-    </div>
-  }
-
-  <div class="layout-row m-t-20 m-b-10 align-end align-items-center gap-5px">
-    @if (isDelinquencyDisabled()) {
-      @if (loanProductService.isWorkingCapital) {
-        <button
-          mat-raised-button
-          color="primary"
-          (click)="createDelinquencyEnable()"
-          *mifosxHasPermission="'CREATE_WC_DELINQUENCY_DISABLE'"
-        >
-          <fa-icon icon="play" class="m-r-10"></fa-icon>{{ 'labels.buttons.Enable Delinquency' | translate }}
-        </button>
-      }
-    } @else {
-      @if (allowPause()) {
-        <button
-          mat-raised-button
-          color="primary"
-          (click)="createDelinquencyAction()"
-          *mifosxHasPermission="'CREATE_DELINQUENCY_ACTION'"
-        >
-          <fa-icon icon="pause" class="m-r-10"></fa-icon
-          >{{ 'labels.buttons.Pause Delinquency Classification' | translate }}
-        </button>
-      }
-      @if (loanProductService.isWorkingCapital) {
-        <button
-          mat-raised-button
-          color="primary"
-          (click)="createDelinquencyActionReschedule()"
-          *mifosxHasPermission="'CREATE_WC_DELINQUENCY_ACTION'"
-        >
-          <fa-icon icon="calendar" class="m-r-10"></fa-icon>{{ 'labels.buttons.Reschedule' | translate }}
-        </button>
-        <button
-          mat-raised-button
-          color="primary"
-          (click)="createDelinquencyActionReset()"
-          *mifosxHasPermission="'CREATE_WC_DELINQUENCY_RESET'"
-        >
-          <fa-icon icon="calendar" class="m-r-10"></fa-icon>{{ 'labels.buttons.Reset' | translate }}
-        </button>
-        @if (hasActiveReset()) {
-          <button
-            mat-raised-button
-            color="primary"
-            (click)="createDelinquencyActionUndoReset()"
-            *mifosxHasPermission="'CREATE_WC_DELINQUENCY_UNDO_RESET'"
-          >
-            <fa-icon icon="calendar" class="m-r-10"></fa-icon>{{ 'labels.buttons.Undo Reset' | translate }}
-          </button>
+  <div class="table-section">
+    <div class="table-toolbar">
+      <div class="toolbar-left">
+        <span class="record-count">
+          {{ 'labels.inputs.Total Records' | translate }}: <strong>{{ filteredActionRows().length }}</strong>
+        </span>
+        @if (actionRows().length > 0) {
+          <div class="filter-group" role="group">
+            @for (option of filters; track option.value) {
+              <button
+                type="button"
+                class="filter-chip"
+                [class.is-active]="filter() === option.value"
+                (click)="selectFilter(option.value)"
+              >
+                {{ option.label | translate }}
+              </button>
+            }
+          </div>
         }
-        <button
-          mat-raised-button
-          color="primary"
-          (click)="createDelinquencyDisable()"
-          *mifosxHasPermission="'CREATE_WC_DELINQUENCY_DISABLE'"
-        >
-          <fa-icon icon="ban" class="m-r-10"></fa-icon>{{ 'labels.buttons.Disable Delinquency' | translate }}
-        </button>
-      }
+      </div>
+
+      <div class="toolbar-right">
+        @if (isDelinquencyDisabled()) {
+          @if (loanProductService.isWorkingCapital) {
+            <button
+              type="button"
+              class="btn btn-primary"
+              (click)="createDelinquencyEnable()"
+              *mifosxHasPermission="'CREATE_WC_DELINQUENCY_DISABLE'"
+            >
+              <fa-icon icon="play"></fa-icon>
+              {{ 'labels.buttons.Enable Delinquency' | translate }}
+            </button>
+          }
+        } @else {
+          @if (allowPause()) {
+            <button
+              type="button"
+              class="btn btn-primary"
+              (click)="createDelinquencyAction()"
+              *mifosxHasPermission="'CREATE_DELINQUENCY_ACTION'"
+            >
+              <fa-icon icon="pause"></fa-icon>
+              {{ 'labels.buttons.Pause Delinquency Classification' | translate }}
+            </button>
+          }
+          @if (loanProductService.isWorkingCapital) {
+            <button
+              type="button"
+              class="btn btn-ghost"
+              (click)="createDelinquencyActionReschedule()"
+              *mifosxHasPermission="'CREATE_WC_DELINQUENCY_ACTION'"
+            >
+              <fa-icon icon="calendar"></fa-icon>
+              {{ 'labels.buttons.Reschedule' | translate }}
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost"
+              (click)="createDelinquencyActionReset()"
+              *mifosxHasPermission="'CREATE_WC_DELINQUENCY_RESET'"
+            >
+              <fa-icon icon="calendar"></fa-icon>
+              {{ 'labels.buttons.Reset' | translate }}
+            </button>
+            @if (hasActiveReset()) {
+              <button
+                type="button"
+                class="btn btn-ghost"
+                (click)="createDelinquencyActionUndoReset()"
+                *mifosxHasPermission="'CREATE_WC_DELINQUENCY_UNDO_RESET'"
+              >
+                <fa-icon icon="calendar"></fa-icon>
+                {{ 'labels.buttons.Undo Reset' | translate }}
+              </button>
+            }
+            <button
+              type="button"
+              class="btn btn-ghost"
+              (click)="createDelinquencyDisable()"
+              *mifosxHasPermission="'CREATE_WC_DELINQUENCY_DISABLE'"
+            >
+              <fa-icon icon="ban"></fa-icon>
+              {{ 'labels.buttons.Disable Delinquency' | translate }}
+            </button>
+          }
+        }
+      </div>
+    </div>
+
+    @if (actionRows().length > 0) {
+      <div class="table-wrap">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th class="id-col">{{ 'labels.inputs.Id' | translate }}</th>
+              <th>{{ 'labels.inputs.Action' | translate }}</th>
+              <th>{{ 'labels.inputs.Status' | translate }}</th>
+              <th>{{ 'labels.inputs.Start Date' | translate }}</th>
+              <th>{{ 'labels.inputs.End Date' | translate }}</th>
+              <th>{{ 'labels.inputs.Duration' | translate }}</th>
+              @if (loanProductService.isWorkingCapital) {
+                <th>{{ 'labels.inputs.Minimum Payment' | translate }}</th>
+                <th>{{ 'labels.inputs.Frequency' | translate }}</th>
+              } @else {
+                <th>{{ 'labels.inputs.Created On' | translate }}</th>
+              }
+              <th>{{ 'labels.inputs.Actions' | translate }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (row of filteredActionRows(); track trackByRowId($index, row)) {
+              <tr [attr.class]="'row-' + row.status">
+                <td>
+                  <span class="id-cell">#{{ row.id }}</span>
+                </td>
+                <td>
+                  <span class="action-badge" [ngClass]="row.badgeClass">
+                    <fa-icon [icon]="row.icon"></fa-icon>
+                    {{ row.action | titlecase }}
+                  </span>
+                  @if (row.action === 'RESET') {
+                    <span class="reset-flag">
+                      {{ (row.raw.endDate === null ? 'labels.inputs.Active' : 'labels.inputs.Undone') | translate }}
+                    </span>
+                  }
+                </td>
+                <td>
+                  <span [attr.class]="'status-pill status-pill--' + row.status">
+                    <span class="dot"></span>
+                    {{ row.statusLabelKey | translate }}
+                  </span>
+                </td>
+                <td>
+                  <span class="date-cell">{{ row.startDateObj | dateFormat }}</span>
+                </td>
+                <td>
+                  @if (row.hasEndDate) {
+                    @if (row.endDateObj) {
+                      <span class="date-cell">{{ row.endDateObj | dateFormat }}</span>
+                    } @else {
+                      <span class="date-cell muted">{{ 'labels.inputs.Ongoing' | translate }}</span>
+                    }
+                  } @else {
+                    <span class="date-cell muted">—</span>
+                  }
+                </td>
+                <td>
+                  @if (row.hasEndDate) {
+                    <span class="duration">
+                      <span class="days">{{ row.durationDays }}{{ row.isOngoing ? '+' : '' }}</span>
+                      <span class="duration-unit">{{ 'labels.inputs.days' | translate }}</span>
+                      <span class="duration-bar">
+                        <span
+                          [attr.class]="'duration-bar-fill duration-bar-fill--' + row.status"
+                          [style.width.%]="durationBarWidth(row)"
+                        ></span>
+                      </span>
+                    </span>
+                  } @else {
+                    <span class="date-cell muted">—</span>
+                  }
+                </td>
+                @if (loanProductService.isWorkingCapital) {
+                  <td>
+                    @if (row.action === 'RESCHEDULE') {
+                      <span class="num-cell">
+                        {{ row.raw.minimumPayment | formatNumber: '' : 0 }}
+                        {{ row.raw.minimumPaymentType | translateKey: 'catalogs' }}
+                      </span>
+                    } @else {
+                      <span class="date-cell muted">—</span>
+                    }
+                  </td>
+                  <td>
+                    @if (row.action === 'RESCHEDULE') {
+                      <span class="num-cell">
+                        {{ row.raw.frequency | formatNumber: '' : 0 }}
+                        {{ row.raw.frequencyType | translateKey: 'catalogs' }}
+                      </span>
+                    } @else {
+                      <span class="date-cell muted">—</span>
+                    }
+                  </td>
+                } @else {
+                  <td>
+                    <span class="date-cell">{{ row.raw.createdOn | datetimeFormat }}</span>
+                  </td>
+                }
+                <td>
+                  @if (canResume(row)) {
+                    @if (loanProductService.isLoanProduct) {
+                      <button
+                        type="button"
+                        class="icon-btn"
+                        (click)="resumeDelinquencyClassification(row.raw)"
+                        *mifosxHasPermission="'CREATE_DELINQUENCY_ACTION'"
+                        matTooltip="{{ 'tooltips.Resume Delinquency Classification' | translate }}"
+                      >
+                        <fa-icon icon="play"></fa-icon>
+                      </button>
+                    }
+                    @if (loanProductService.isWorkingCapital) {
+                      <button
+                        type="button"
+                        class="icon-btn"
+                        (click)="resumeDelinquencyClassification(row.raw)"
+                        *mifosxHasPermission="'CREATE_WC_DELINQUENCY_ACTION'"
+                        matTooltip="{{ 'tooltips.Resume Delinquency Classification' | translate }}"
+                      >
+                        <fa-icon icon="play"></fa-icon>
+                      </button>
+                    }
+                  }
+                </td>
+              </tr>
+            }
+            @if (filteredActionRows().length === 0) {
+              <tr class="empty-row">
+                <td [attr.colspan]="loanProductService.isWorkingCapital ? 9 : 8">
+                  {{ 'labels.inputs.No records match the selected filter' | translate }}
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    } @else {
+      <div class="empty">
+        <div class="ico">
+          <fa-icon icon="pause"></fa-icon>
+        </div>
+        <h4>{{ 'labels.heading.No Delinquency Actions' | translate }}</h4>
+        <p>{{ 'labels.inputs.No delinquency actions have been recorded for this loan' | translate }}</p>
+      </div>
     }
   </div>
-
-  @if (loanDelinquencyActions().length > 0) {
-    <div class="m-t-10">
-      <h3>{{ 'labels.heading.Loan Delinquency Actions' | translate }}</h3>
-      <table mat-table [dataSource]="loanDelinquencyActions()">
-        <ng-container matColumnDef="identifier">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Id' | translate }}</th>
-          <td mat-cell *matCellDef="let item">{{ item.id }}</td>
-        </ng-container>
-        <ng-container matColumnDef="action">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Action' | translate }}</th>
-          <td mat-cell *matCellDef="let item" ngClass="{{ actionClass(item.action) }}">
-            {{ item.action }}
-            @if (item.action === 'RESET') {
-              <span class="reset-flag">
-                ({{ (item.endDate === null ? 'labels.inputs.Active' : 'labels.inputs.Undone') | translate }})
-              </span>
-            }
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="startDate">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Start Date' | translate }}</th>
-          <td mat-cell *matCellDef="let item">{{ item.startDate | dateFormat }}</td>
-        </ng-container>
-        <ng-container matColumnDef="endDate">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.End Date' | translate }}</th>
-          <td mat-cell *matCellDef="let item">
-            @if (item.effectiveEndDate ?? item.endDate; as endDate) {
-              {{ endDate | dateFormat }}
-            }
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="createdOn">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Created On' | translate }}</th>
-          <td mat-cell *matCellDef="let item">{{ item.createdOn | datetimeFormat }}</td>
-        </ng-container>
-        <ng-container matColumnDef="minimumPayment">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Minimum Payment' | translate }}</th>
-          <td mat-cell *matCellDef="let item">
-            @if (item.action === 'RESCHEDULE') {
-              {{ item.minimumPayment | formatNumber: '' : 0 }}
-              {{ item.minimumPaymentType | translateKey: 'catalogs' }}
-            }
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="frequency">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Frequency' | translate }}</th>
-          <td mat-cell *matCellDef="let item">
-            @if (item.action === 'RESCHEDULE') {
-              {{ item.frequency | formatNumber: '' : 0 }} {{ item.frequencyType | translateKey: 'catalogs' }}
-            }
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="actions">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Actions' | translate }}</th>
-          <td mat-cell *matCellDef="let item">
-            @if (isCurrentAndPauseAction(item) && !isDelinquencyDisabled()) {
-              @if (loanProductService.isLoanProduct) {
-                <span>
-                  <button
-                    mat-button
-                    color="primary"
-                    (click)="resumeDelinquencyClassification(item)"
-                    *mifosxHasPermission="'CREATE_DELINQUENCY_ACTION'"
-                    matTooltip="{{ 'tooltips.Resume Delinquency Classification' | translate }}"
-                  >
-                    <fa-icon icon="play" class="m-r-10"></fa-icon>
-                  </button>
-                </span>
-              }
-              @if (loanProductService.isWorkingCapital) {
-                <span>
-                  <button
-                    mat-button
-                    color="primary"
-                    (click)="resumeDelinquencyClassification(item)"
-                    *mifosxHasPermission="'CREATE_WC_DELINQUENCY_ACTION'"
-                    matTooltip="{{ 'tooltips.Resume Delinquency Classification' | translate }}"
-                  >
-                    <fa-icon icon="play" class="m-r-10"></fa-icon>
-                  </button>
-                </span>
-              }
-            }
-          </td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="loanDelinquencyActionsColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: loanDelinquencyActionsColumns"></tr>
-      </table>
-    </div>
-  }
-  @if (wcLoanDelinquencyRangeSchedule?.length > 0) {
-    <div class="m-t-10">
-      <h3>{{ 'labels.heading.Loan Delinquency Range Schedule' | translate }}</h3>
-      <table mat-table [dataSource]="wcLoanDelinquencyRangeSchedule">
-        <ng-container matColumnDef="periodNumber">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Period' | translate }}</th>
-          <td mat-cell *matCellDef="let item">{{ item.periodNumber }}</td>
-        </ng-container>
-        <ng-container matColumnDef="fromDate">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Start Date' | translate }}</th>
-          <td mat-cell *matCellDef="let item">{{ item.fromDate | dateFormat }}</td>
-        </ng-container>
-        <ng-container matColumnDef="toDate">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.End Date' | translate }}</th>
-          <td mat-cell *matCellDef="let item">{{ item.toDate | dateFormat }}</td>
-        </ng-container>
-        <ng-container matColumnDef="expectedAmount">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Expected Amount' | translate }}</th>
-          <td mat-cell *matCellDef="let item" class="r-amount">
-            @if (item.expectedAmount === null) {
-              <span class="reset-period" matTooltip="{{ 'tooltips.Reset delinquency period' | translate }}">
-                {{ 'labels.inputs.Reset' | translate }}
-              </span>
-            } @else {
-              {{ item.expectedAmount | formatNumber }}
-            }
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="paidAmount">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Paid Amount' | translate }}</th>
-          <td mat-cell *matCellDef="let item" class="r-amount">
-            {{ item.paidAmount === null ? '—' : (item.paidAmount | formatNumber) }}
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="outstandingAmount">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Outstanding Amount' | translate }}</th>
-          <td mat-cell *matCellDef="let item" class="r-amount">
-            {{ item.outstandingAmount === null ? '—' : (item.outstandingAmount | formatNumber) }}
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="delinquentDays">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Delinquent Days' | translate }}</th>
-          <td mat-cell *matCellDef="let item" class="r-amount">
-            {{ item.delinquentDays === null ? '—' : (item.delinquentDays | formatNumber) }}
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="delinquentAmount">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Delinquent Amount' | translate }}</th>
-          <td mat-cell *matCellDef="let item" class="r-amount">
-            {{ item.delinquentAmount === null ? '—' : (item.delinquentAmount | formatNumber) }}
-          </td>
-        </ng-container>
-        <ng-container matColumnDef="minPaymentCriteriaMet">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Minimum Payment Criteria Met' | translate }}</th>
-          <td mat-cell *matCellDef="let item" class="center">
-            <div
-              [ngClass]="
-                item.minPaymentCriteriaMet === null ? 'pending' : item.minPaymentCriteriaMet ? 'enabled' : 'disabled'
-              "
-              matTooltip="{{
-                (item.minPaymentCriteriaMet === null
-                  ? 'tooltips.Period not yet evaluated'
-                  : item.minPaymentCriteriaMet
-                    ? 'tooltips.Minimum payment criteria met'
-                    : 'tooltips.Minimum payment criteria not met'
-                ) | translate
-              }}"
-            >
-              <fa-icon [icon]="item.minPaymentCriteriaMet === null ? 'clock' : 'circle'" size="lg"></fa-icon>
-            </div>
-          </td>
-        </ng-container>
-        <tr mat-header-row *matHeaderRowDef="loanDelinquencyRangeScheduleColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: loanDelinquencyRangeScheduleColumns"></tr>
-      </table>
-    </div>
-  }
 </div>
+
+@if (wcLoanDelinquencyRangeSchedule?.length > 0) {
+  <section class="list-section">
+    <div class="list-section-header">
+      <h3>{{ 'labels.heading.Loan Delinquency Range Schedule' | translate }}</h3>
+    </div>
+    <div class="list-card">
+      <div class="table-wrap">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th class="id-col">{{ 'labels.inputs.Period' | translate }}</th>
+              <th>{{ 'labels.inputs.Start Date' | translate }}</th>
+              <th>{{ 'labels.inputs.End Date' | translate }}</th>
+              <th class="num-col">{{ 'labels.inputs.Expected Amount' | translate }}</th>
+              <th class="num-col">{{ 'labels.inputs.Paid Amount' | translate }}</th>
+              <th class="num-col">{{ 'labels.inputs.Outstanding Amount' | translate }}</th>
+              <th class="num-col">{{ 'labels.inputs.Delinquent Days' | translate }}</th>
+              <th class="num-col">{{ 'labels.inputs.Delinquent Amount' | translate }}</th>
+              <th class="center-col">{{ 'labels.inputs.Minimum Payment Criteria Met' | translate }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (item of wcLoanDelinquencyRangeSchedule; track item.periodNumber) {
+              <tr>
+                <td>
+                  <span class="id-cell">{{ item.periodNumber }}</span>
+                </td>
+                <td>
+                  <span class="date-cell">{{ item.fromDate | dateFormat }}</span>
+                </td>
+                <td>
+                  <span class="date-cell">{{ item.toDate | dateFormat }}</span>
+                </td>
+                <td class="num-col">
+                  @if (item.expectedAmount === null) {
+                    <span class="reset-period" matTooltip="{{ 'tooltips.Reset delinquency period' | translate }}">
+                      {{ 'labels.inputs.Reset' | translate }}
+                    </span>
+                  } @else {
+                    <span class="num-cell">{{ item.expectedAmount | formatNumber }}</span>
+                  }
+                </td>
+                <td class="num-col">
+                  <span class="num-cell" [class.muted]="item.paidAmount === null">
+                    {{ item.paidAmount === null ? '—' : (item.paidAmount | formatNumber) }}
+                  </span>
+                </td>
+                <td class="num-col">
+                  <span class="num-cell" [class.muted]="item.outstandingAmount === null">
+                    {{ item.outstandingAmount === null ? '—' : (item.outstandingAmount | formatNumber) }}
+                  </span>
+                </td>
+                <td class="num-col">
+                  <span class="num-cell" [class.muted]="item.delinquentDays === null">
+                    {{ item.delinquentDays === null ? '—' : (item.delinquentDays | formatNumber) }}
+                  </span>
+                </td>
+                <td class="num-col">
+                  <span class="num-cell" [class.muted]="item.delinquentAmount === null">
+                    {{ item.delinquentAmount === null ? '—' : (item.delinquentAmount | formatNumber) }}
+                  </span>
+                </td>
+                <td class="center-col">
+                  <span
+                    class="criteria-marker"
+                    [ngClass]="
+                      item.minPaymentCriteriaMet === null
+                        ? 'pending'
+                        : item.minPaymentCriteriaMet
+                          ? 'enabled'
+                          : 'disabled'
+                    "
+                    matTooltip="{{
+                      (item.minPaymentCriteriaMet === null
+                        ? 'tooltips.Period not yet evaluated'
+                        : item.minPaymentCriteriaMet
+                          ? 'tooltips.Minimum payment criteria met'
+                          : 'tooltips.Minimum payment criteria not met'
+                      ) | translate
+                    }}"
+                  >
+                    <fa-icon [icon]="item.minPaymentCriteriaMet === null ? 'clock' : 'circle'" size="lg"></fa-icon>
+                  </span>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+}
+
+@if (loanProductService.isLoanProduct) {
+  @if (loanDelinquencyTags.length > 0) {
+    <section class="list-section">
+      <div class="list-section-header">
+        <h3>{{ 'labels.heading.Loan Delinquency Tags' | translate }}</h3>
+      </div>
+      <div class="list-card">
+        <div class="table-wrap">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>{{ 'labels.inputs.Delinquency Classification' | translate }}</th>
+                <th>{{ 'labels.inputs.Added On' | translate }}</th>
+                <th>{{ 'labels.inputs.Lifted On' | translate }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (item of loanDelinquencyTags; track item.id) {
+                <tr>
+                  <td>
+                    {{ item.delinquencyRange.classification }}
+                    @if (item.delinquencyRange.maximumAgeDays) {
+                      <span class="num-cell muted">
+                        ({{ item.delinquencyRange.minimumAgeDays }} - {{ item.delinquencyRange.maximumAgeDays }})
+                      </span>
+                    } @else {
+                      <span class="num-cell muted">({{ item.delinquencyRange.minimumAgeDays }})</span>
+                    }
+                  </td>
+                  <td>
+                    @if (item.addedOnDate) {
+                      <span class="date-cell">{{ item.addedOnDate | dateFormat }}</span>
+                    } @else {
+                      <span class="date-cell muted">—</span>
+                    }
+                  </td>
+                  <td>
+                    @if (item.liftedOnDate) {
+                      <span class="date-cell">{{ item.liftedOnDate | dateFormat }}</span>
+                    } @else {
+                      <span class="date-cell muted">—</span>
+                    }
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  }
+
+  @if (installmentLevelDelinquency.length > 0) {
+    <section class="list-section">
+      <div class="list-section-header">
+        <h3>{{ 'labels.heading.Loan Delinquency Installment Tags' | translate }}</h3>
+      </div>
+      <div class="list-card">
+        <div class="table-wrap">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th>{{ 'labels.inputs.Delinquency Classification' | translate }}</th>
+                <th class="num-col">{{ 'labels.inputs.Days' | translate }}</th>
+                <th class="num-col">{{ 'labels.inputs.Amount' | translate }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (item of installmentLevelDelinquency; track item.rangeId) {
+                <tr>
+                  <td>{{ item.classification }}</td>
+                  <td class="num-col">
+                    <span class="num-cell">{{ item.minimumAgeDays | formatNumber }}</span>
+                  </td>
+                  <td class="num-col">
+                    <span class="num-cell">
+                      {{ item.delinquentAmount | currency: currency.code : 'symbol-narrow' : '1.2-2' }}
+                    </span>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  }
+}

--- a/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.scss
+++ b/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.scss
@@ -6,41 +6,33 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+@use 'assets/styles/action-dashboard';
 @use 'assets/styles/pause-timeline';
 @use 'assets/styles/colours' as *;
 
-table {
-  width: 100%;
-}
-
-.container {
-  padding-top: 1%;
-  padding-bottom: 2%;
-
-  .delete-button {
-    margin-left: 1%;
-  }
-}
-
-.delinquency-disabled-banner {
-  display: flex;
-  align-items: center;
-  padding: 0.75rem 1rem;
-  border-radius: 4px;
-  border-left: 4px solid $status-pending;
-  background-color: rgba($status-pending, 0.12);
-  color: $status-pending;
-  font-weight: 500;
+:host {
+  display: block;
+  padding: 12px 4px 24px;
 }
 
 // Reset delinquency period marker in the range schedule (expectedAmount === null)
 .reset-period {
   font-style: italic;
-  opacity: 0.6;
+  color: var(--ds-text-3);
 }
 
 // Active/undone flag next to a RESET row in the actions history
 .reset-flag {
-  font-size: 0.85em;
-  opacity: 0.7;
+  margin-left: 8px;
+  font-size: 11px;
+  color: var(--ds-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+// Minimum-payment-criteria marker: the shared .enabled/.disabled/.pending
+// colours carry the meaning, this only centres the glyph in its cell.
+.criteria-marker {
+  display: inline-grid;
+  place-items: center;
 }

--- a/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.ts
+++ b/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.ts
@@ -34,18 +34,6 @@ import { SettingsService } from 'app/settings/settings.service';
 import { ConfirmationDialogComponent } from 'app/shared/confirmation-dialog/confirmation-dialog.component';
 import { Currency } from 'app/shared/models/general.model';
 import { NgClass, CurrencyPipe } from '@angular/common';
-import {
-  MatTable,
-  MatColumnDef,
-  MatHeaderCellDef,
-  MatHeaderCell,
-  MatCellDef,
-  MatCell,
-  MatHeaderRowDef,
-  MatHeaderRow,
-  MatRowDef,
-  MatRow
-} from '@angular/material/table';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatTooltip } from '@angular/material/tooltip';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
@@ -60,6 +48,24 @@ import { LoanDelinquencyActionResetDialogComponent } from 'app/loans/custom-dial
 import { LoanDelinquencyActionDisableDialogComponent } from 'app/loans/custom-dialog/loan-delinquency-action-disable-dialog/loan-delinquency-action-disable-dialog.component';
 
 type DelinquencyActionStatus = 'active' | 'scheduled' | 'expired';
+type DelinquencyActionFilter = 'all' | DelinquencyActionStatus;
+
+interface DelinquencyActionRow {
+  /** The action as returned by the backend, for the cells that render raw fields */
+  raw: LoanDelinquencyAction;
+  id: number;
+  action: string;
+  startDateObj: Date;
+  endDateObj: Date | null;
+  /** Whether the action type defines an end date at all (point-in-time actions and RESCHEDULE do not) */
+  hasEndDate: boolean;
+  status: DelinquencyActionStatus;
+  statusLabelKey: string;
+  isOngoing: boolean;
+  durationDays: number;
+  icon: string;
+  badgeClass: string;
+}
 
 interface DelinquencyTimelineBar {
   label: string;
@@ -74,22 +80,19 @@ const TIMELINE_PADDING_LEFT = 60;
 const TIMELINE_INNER_WIDTH = 1140;
 const MS_PER_DAY = 86_400_000;
 
+/** Actions that record a moment rather than a window, so they never carry an end date. */
+const POINT_IN_TIME_ACTIONS = [
+  'RESUME',
+  'ENABLE',
+  'UNDO_RESET'
+];
+
 @Component({
   selector: 'mifosx-loan-delinquency-tags-tab',
   templateUrl: './loan-delinquency-tags-tab.component.html',
   styleUrls: ['./loan-delinquency-tags-tab.component.scss'],
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
-    MatTable,
-    MatColumnDef,
-    MatHeaderCellDef,
-    MatHeaderCell,
-    MatCellDef,
-    MatCell,
-    MatHeaderRowDef,
-    MatHeaderRow,
-    MatRowDef,
-    MatRow,
     FaIconComponent,
     NgClass,
     MatTooltip,
@@ -116,27 +119,14 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
   wcLoanDelinquencyRangeSchedule: DelinquencyRangeSchedule[] = [];
   currency: Currency;
   installmentLevelDelinquency: InstallmentLevelDelinquency[] = [];
-  loanDelinquencyTagsColumns: string[] = [
-    'classification',
-    'addedOn',
-    'liftedOn'
-  ];
-  loanDelinquencyActionsColumns: string[] = [];
-  installmentDelinquencyTagsColumns: string[] = [
-    'classification',
-    'minimumAgeDays',
-    'amount'
-  ];
-  loanDelinquencyRangeScheduleColumns: string[] = [
-    'periodNumber',
-    'fromDate',
-    'toDate',
-    'expectedAmount',
-    'paidAmount',
-    'outstandingAmount',
-    'delinquentDays',
-    'delinquentAmount',
-    'minPaymentCriteriaMet'
+
+  filter = signal<DelinquencyActionFilter>('all');
+
+  filters: { value: DelinquencyActionFilter; label: string }[] = [
+    { value: 'all', label: 'labels.buttons.All' },
+    { value: 'active', label: 'labels.inputs.Active' },
+    { value: 'scheduled', label: 'labels.inputs.Scheduled' },
+    { value: 'expired', label: 'labels.inputs.Expired' }
   ];
 
   loanId: any;
@@ -183,12 +173,86 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
     this.loanDelinquencyActions().some((item) => item.action === 'RESET' && item.endDate == null)
   );
 
+  /**
+   * The delinquency actions decorated with everything the dashboard renders:
+   * resolved dates, lifecycle status, duration and badge styling.
+   */
+  actionRows = computed<DelinquencyActionRow[]>(() => {
+    const businessDate = this.businessDate();
+    return this.loanDelinquencyActions().map((item) => {
+      const isPointInTime = POINT_IN_TIME_ACTIONS.includes(item.action);
+      const isReschedule = item.action === 'RESCHEDULE';
+      const isResumedPause = item.action === 'PAUSE' && !!item.effectiveEndDate;
+      const start = this.dateUtils.parseDate(item.startDate);
+      const rawEnd = item.effectiveEndDate ?? item.endDate;
+      // An action without an end date is an open window. parseDate turns a missing
+      // value into today, which would render an open window as closing now.
+      const end = isPointInTime || !rawEnd ? null : this.dateUtils.parseDate(rawEnd);
+      const reference = end ?? businessDate ?? start;
+      // Both boundary dates count: a pause from Jul 1st to Jul 16th lasts 16 days, not 15.
+      // A pause closed by a RESUME is the exception: the loan is already active on the resume
+      // date, so that day is not a paused day and must not be added.
+      const elapsedDays = Math.round((reference.getTime() - start.getTime()) / MS_PER_DAY);
+      const durationDays = Math.max(1, isResumedPause ? elapsedDays : elapsedDays + 1);
+      const status = this.actionStatus(start, end);
+
+      return {
+        raw: item,
+        id: item.id,
+        action: item.action,
+        startDateObj: start,
+        endDateObj: end,
+        hasEndDate: !isPointInTime && !isReschedule,
+        status,
+        statusLabelKey: this.statusKey(status),
+        isOngoing: !end && status === 'active',
+        durationDays,
+        icon: this.actionIcon(item.action),
+        badgeClass: this.actionBadgeClass(item.action)
+      };
+    });
+  });
+
+  filteredActionRows = computed<DelinquencyActionRow[]>(() => {
+    const filter = this.filter();
+    if (filter === 'all') {
+      return this.actionRows();
+    }
+    return this.actionRows().filter((row) => row.status === filter);
+  });
+
+  pauseRows = computed<DelinquencyActionRow[]>(() => this.actionRows().filter((row) => row.action === 'PAUSE'));
+
+  kpis = computed(() => {
+    const rows = this.actionRows();
+    const pauses = this.pauseRows();
+    const lastAction = rows.length
+      ? rows.reduce((latest, row) => (row.startDateObj.getTime() > latest.startDateObj.getTime() ? row : latest))
+      : null;
+    return {
+      total: rows.length,
+      activePauses: pauses.filter((row) => row.status === 'active').length,
+      totalDaysPaused: pauses.reduce((sum, row) => sum + row.durationDays, 0),
+      lastActionDate: lastAction?.startDateObj ?? null
+    };
+  });
+
+  hasPauseActiveToday = computed<boolean>(() => this.pauseRows().some((row) => row.status === 'active'));
+
+  maxDurationDays = computed<number>(() => {
+    const rows = this.actionRows();
+    if (rows.length === 0) {
+      return 1;
+    }
+    return Math.max(...rows.map((row) => row.durationDays));
+  });
+
   timelineYear = computed<number>(() => {
-    const actions = this.loanDelinquencyActions();
-    if (actions.length === 0) {
+    const rows = this.actionRows();
+    if (rows.length === 0) {
       return (this.businessDate() ?? new Date()).getFullYear();
     }
-    return this.dateUtils.parseDate(actions[0].startDate).getFullYear();
+    return rows[0].startDateObj.getFullYear();
   });
 
   timelineBars = computed<DelinquencyTimelineBar[]>(() => {
@@ -198,29 +262,25 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
     const pxPerDay = TIMELINE_INNER_WIDTH / daysInYear;
     const ongoingLabel = this.translateService.instant('labels.inputs.Ongoing');
 
-    return this.loanDelinquencyActions()
-      .filter((item) => item.action === 'PAUSE')
-      .map((item, index) => {
-        const start = this.dateUtils.parseDate(item.startDate);
-        const endDate = item.effectiveEndDate ?? item.endDate;
-        const end = endDate ? this.dateUtils.parseDate(endDate) : null;
-        const endRef = end ?? this.businessDate() ?? start;
-        const durationDays = Math.max(1, Math.round((endRef.getTime() - start.getTime()) / MS_PER_DAY));
-        const startDay = this.clamp(Math.floor((start.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
-        const endDay = this.clamp(Math.floor((endRef.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
-        const x = TIMELINE_PADDING_LEFT + startDay * pxPerDay;
-        const width = Math.max(8, (endDay - startDay) * pxPerDay);
-        const label = `P${index + 1}`;
-        const tooltip = `${label} · ${this.shortDate(start)} → ${end ? this.shortDate(end) : ongoingLabel} (${durationDays}d)`;
-        return {
-          label,
-          status: this.actionStatus(start, end),
-          x,
-          width,
-          midX: x + width / 2,
-          tooltip
-        };
-      });
+    return this.pauseRows().map((row, index) => {
+      const endRef = row.endDateObj ?? this.businessDate() ?? row.startDateObj;
+      const startDay = this.clamp(Math.floor((row.startDateObj.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
+      const endDay = this.clamp(Math.floor((endRef.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
+      const x = TIMELINE_PADDING_LEFT + startDay * pxPerDay;
+      const width = Math.max(8, (endDay - startDay) * pxPerDay);
+      // The lane charts pauses only, so it numbers them consecutively: the index
+      // within the full action list would skip numbers on every non-pause action.
+      const label = `P${index + 1}`;
+      const endLabel = row.endDateObj ? this.shortDate(row.endDateObj) : ongoingLabel;
+      return {
+        label,
+        status: row.status,
+        x,
+        width,
+        midX: x + width / 2,
+        tooltip: `${label} · ${this.shortDate(row.startDateObj)} → ${endLabel} (${row.durationDays}d)`
+      };
+    });
   });
 
   todayMarker = computed<number | null>(() => {
@@ -247,22 +307,6 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
   constructor() {
     super();
     this.loanId = this.route.parent.parent.snapshot.params['loanId'];
-    this.loanDelinquencyActionsColumns = this.loanProductService.isWorkingCapital ? [
-          'identifier',
-          'action',
-          'startDate',
-          'endDate',
-          'minimumPayment',
-          'frequency',
-          'actions'
-        ] : [
-          'identifier',
-          'action',
-          'startDate',
-          'endDate',
-          'createdOn',
-          'actions'
-        ];
 
     this.route.parent.data
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -302,6 +346,26 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
           this.minimumPaymentTypeOptions = response.delinquencyMinimumPaymentTypeOptions;
         });
     }
+  }
+
+  selectFilter(value: DelinquencyActionFilter): void {
+    this.filter.set(value);
+  }
+
+  durationBarWidth(row: DelinquencyActionRow): number {
+    const max = this.maxDurationDays();
+    if (max === 0) {
+      return 0;
+    }
+    return Math.min(100, Math.round((row.durationDays / max) * 100));
+  }
+
+  trackByRowId(_index: number, row: DelinquencyActionRow): number {
+    return row.id;
+  }
+
+  trackByLabel(_index: number, bar: DelinquencyTimelineBar): string {
+    return bar.label;
   }
 
   createDelinquencyAction(): void {
@@ -522,11 +586,37 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
     );
   }
 
-  actionClass(action: string): string {
-    if (action === 'PAUSE' || action === 'DISABLE') {
-      return 'status-pending';
+  /** Whether the row offers the inline resume button. */
+  canResume(row: DelinquencyActionRow): boolean {
+    return this.isCurrentAndPauseAction(row.raw) && !this.isDelinquencyDisabled();
+  }
+
+  private actionIcon(action: string): string {
+    switch (action) {
+      case 'PAUSE':
+        return 'pause';
+      case 'RESUME':
+      case 'ENABLE':
+        return 'play';
+      case 'DISABLE':
+        return 'ban';
+      default:
+        return 'calendar';
     }
-    return 'status-active';
+  }
+
+  /**
+   * Badge tint by intent: suppressing evaluation reads as an alert, restoring it
+   * reads as positive, and everything else keeps the neutral blue.
+   */
+  private actionBadgeClass(action: string): string {
+    if (action === 'DISABLE') {
+      return 'action-badge--alert';
+    }
+    if (action === 'ENABLE' || action === 'RESUME') {
+      return 'action-badge--positive';
+    }
+    return '';
   }
 
   private actionStatus(start: Date, end: Date | null): DelinquencyActionStatus {
@@ -541,6 +631,17 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
       return 'expired';
     }
     return 'active';
+  }
+
+  private statusKey(status: DelinquencyActionStatus): string {
+    switch (status) {
+      case 'active':
+        return 'labels.inputs.Active';
+      case 'scheduled':
+        return 'labels.inputs.Scheduled';
+      case 'expired':
+        return 'labels.inputs.Expired';
+    }
   }
 
   private isLeapYear(year: number): boolean {

--- a/src/app/loans/loans-view/working-capital/breach-error-messages.ts
+++ b/src/app/loans/loans-view/working-capital/breach-error-messages.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { HttpErrorResponse } from '@angular/common/http';
+
+/**
+ * Validation codes the breach-actions resource returns as
+ * "Failed data validation due to: <code>", mapped to translation keys.
+ */
+const BREACH_ERROR_KEYS: Record<string, string> = {
+  'breach.already.disabled': 'errors.breach.alreadyDisabled',
+  'no.active.breach.disable.to.enable': 'errors.breach.noActiveDisableToEnable',
+  'must.be.current.business.date': 'errors.breach.mustBeCurrentBusinessDate',
+  'must.not.be.provided.for.disable.or.enable': 'errors.breach.endDateNotAllowed',
+  'no.breach.configuration': 'errors.breach.noBreachConfiguration',
+  'loan.is.not.active': 'errors.breach.loanIsNotActive',
+  'breach.is.disabled': 'errors.breach.breachIsDisabled'
+};
+
+/**
+ * Resolves the translation key for a breach validation error.
+ *
+ * The code shows up in different places depending on how the backend wraps the
+ * failure, so every text-bearing field of the payload is scanned rather than
+ * relying on one shape. Returns null when the error is not a known breach
+ * validation, letting the caller fall back to the generic handler.
+ * @param error Failed HTTP response
+ * @returns Translation key, or null when the error is not recognised
+ */
+export function resolveBreachErrorKey(error: HttpErrorResponse): string | null {
+  const body = error?.error;
+  if (!body) {
+    return null;
+  }
+  const haystack = [
+    body.defaultUserMessage,
+    body.developerMessage,
+    body.userMessageGlobalisationCode,
+    ...(Array.isArray(body.errors)
+      ? body.errors.flatMap((item: any) => [
+          item?.userMessageGlobalisationCode,
+          item?.defaultUserMessage,
+          item?.developerMessage
+        ])
+      : [])
+  ]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ');
+
+  // Longest codes first: several of them share a prefix with a shorter one.
+  const match = Object.keys(BREACH_ERROR_KEYS)
+    .sort((a, b) => b.length - a.length)
+    .find((code) => haystack.includes(code));
+  return match ? BREACH_ERROR_KEYS[match] : null;
+}

--- a/src/app/loans/loans-view/working-capital/breach-evaluation.ts
+++ b/src/app/loans/loans-view/working-capital/breach-evaluation.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Minimal parsed shape of a breach action needed to evaluate the disable state. */
+export interface BreachDisableWindow {
+  action: string;
+  startDateObj: Date;
+  endDateObj: Date | null;
+}
+
+/**
+ * Finds the DISABLE window covering the business date, if any.
+ *
+ * A loan can chain several DISABLE→ENABLE cycles, so this looks for the one
+ * window that contains the business date rather than trusting the order of
+ * the array.
+ */
+export function findActiveBreachDisable<T extends BreachDisableWindow>(rows: T[], businessDate: Date): T | null {
+  const time = businessDate.getTime();
+  return (
+    rows.find(
+      (row) =>
+        row.action === 'DISABLE' &&
+        row.startDateObj.getTime() <= time &&
+        (row.endDateObj === null || row.endDateObj.getTime() >= time)
+    ) ?? null
+  );
+}

--- a/src/app/loans/loans-view/working-capital/loan-account-actions/breach-toggle-dialog/breach-toggle-dialog.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-account-actions/breach-toggle-dialog/breach-toggle-dialog.component.html
@@ -1,0 +1,34 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<h1 mat-dialog-title>
+  @if (isDisabling) {
+    {{ 'labels.heading.Disable Breach Evaluation' | translate }}
+  } @else {
+    {{ 'labels.heading.Enable Breach Evaluation' | translate }}
+  }
+</h1>
+<div mat-dialog-content class="breach-toggle-content">
+  <div class="effective-date">
+    <span class="effective-date-label">{{ 'labels.inputs.Effective Date' | translate }}</span>
+    <span class="effective-date-value">{{ businessDate | dateFormat }}</span>
+  </div>
+  <p class="breach-toggle-warning">
+    @if (isDisabling) {
+      {{ 'labels.dialogContext.Breach evaluation will stop' | translate: { date: (businessDate | dateFormat) } }}
+    } @else {
+      {{ 'labels.dialogContext.Breach evaluation will resume' | translate: { date: (businessDate | dateFormat) } }}
+    }
+  </p>
+</div>
+<mat-dialog-actions align="end">
+  <button mat-raised-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>
+  <button mat-raised-button color="warn" (click)="confirm()">
+    {{ 'labels.buttons.Confirm' | translate }}
+  </button>
+</mat-dialog-actions>

--- a/src/app/loans/loans-view/working-capital/loan-account-actions/breach-toggle-dialog/breach-toggle-dialog.component.scss
+++ b/src/app/loans/loans-view/working-capital/loan-account-actions/breach-toggle-dialog/breach-toggle-dialog.component.scss
@@ -1,0 +1,39 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.breach-toggle-content {
+  max-width: 32rem;
+}
+
+// The date is read-only, so it is presented as a fact rather than as a field.
+.effective-date {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.effective-date-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.effective-date-value {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.breach-toggle-warning {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  opacity: 0.85;
+}

--- a/src/app/loans/loans-view/working-capital/loan-account-actions/breach-toggle-dialog/breach-toggle-dialog.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-account-actions/breach-toggle-dialog/breach-toggle-dialog.component.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+  MatDialogTitle,
+  MatDialogContent,
+  MatDialogActions,
+  MatDialogClose
+} from '@angular/material/dialog';
+import { CdkScrollable } from '@angular/cdk/scrolling';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+/** Input of the breach evaluation toggle dialog. */
+export interface BreachToggleDialogData {
+  /** Action to perform when the user confirms. */
+  action: 'disable' | 'enable';
+  /** Current business date, the only date the backend accepts. */
+  businessDate: Date;
+}
+
+/** Result emitted when the user confirms the breach evaluation toggle dialog. */
+export interface BreachToggleDialogResult {
+  confirm: boolean;
+}
+
+/**
+ * Confirmation dialog for suspending or resuming breach evaluation.
+ *
+ * The date is shown but never editable: the backend only accepts the current
+ * business date, so offering a picker would only produce rejected requests.
+ */
+@Component({
+  selector: 'mifosx-breach-toggle-dialog',
+  templateUrl: './breach-toggle-dialog.component.html',
+  styleUrls: ['./breach-toggle-dialog.component.scss'],
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    MatDialogTitle,
+    CdkScrollable,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class BreachToggleDialogComponent {
+  private dialogRef = inject<MatDialogRef<BreachToggleDialogComponent, BreachToggleDialogResult>>(MatDialogRef);
+  protected data = inject<BreachToggleDialogData>(MAT_DIALOG_DATA);
+
+  /** True when the dialog suspends evaluation, false when it resumes it. */
+  get isDisabling(): boolean {
+    return this.data.action === 'disable';
+  }
+
+  get businessDate(): Date {
+    return this.data.businessDate;
+  }
+
+  confirm(): void {
+    this.dialogRef.close({ confirm: true });
+  }
+}

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.html
@@ -34,6 +34,15 @@
       </span>
     </div>
     <div class="kpi-status">
+      @if (activeBreachDisable(); as activeDisable) {
+        <span class="status-chip status-chip--disabled">
+          <span class="dot"></span>
+          {{
+            'labels.inputs.Breach evaluation disabled since'
+              | translate: { date: (activeDisable.startDateObj | dateFormat) }
+          }}
+        </span>
+      }
       @if (hasPauseActiveToday()) {
         <span class="status-chip">
           <span class="dot"></span>
@@ -133,35 +142,61 @@
         }
       </div>
       <div class="toolbar-right">
-        @if (hasActivePause()) {
+        <!-- While a DISABLE window is active every breach action other than
+             Enable is removed, not just disabled (WEB-657 agreement). -->
+        @if (!breachEvaluationDisabled()) {
+          @if (hasActivePause()) {
+            <button
+              type="button"
+              class="btn btn-warn"
+              (click)="resumeBreachAction()"
+              *mifosxHasPermission="'CREATE_WC_BREACH_ACTION'"
+            >
+              <fa-icon icon="play"></fa-icon>
+              {{ 'labels.buttons.Resume Breach' | translate }}
+            </button>
+          }
           <button
             type="button"
-            class="btn btn-warn"
-            (click)="resumeBreachAction()"
+            class="btn btn-primary"
+            (click)="createBreachActionPause()"
             *mifosxHasPermission="'CREATE_WC_BREACH_ACTION'"
           >
-            <fa-icon icon="play"></fa-icon>
-            {{ 'labels.buttons.Resume Breach' | translate }}
+            <fa-icon icon="pause"></fa-icon>
+            {{ 'labels.buttons.Pause Breach' | translate }}
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            (click)="createBreachActionReset()"
+            *mifosxHasPermission="'CREATE_WC_BREACH_RESET'"
+          >
+            <fa-icon icon="calendar"></fa-icon>
+            {{ 'labels.buttons.Reset' | translate }}
           </button>
         }
-        <button
-          type="button"
-          class="btn btn-primary"
-          (click)="createBreachActionPause()"
-          *mifosxHasPermission="'CREATE_WC_BREACH_ACTION'"
-        >
-          <fa-icon icon="pause"></fa-icon>
-          {{ 'labels.buttons.Pause Breach' | translate }}
-        </button>
-        <button
-          type="button"
-          class="btn btn-primary"
-          (click)="createBreachActionReset()"
-          *mifosxHasPermission="'CREATE_WC_BREACH_RESET'"
-        >
-          <fa-icon icon="calendar"></fa-icon>
-          {{ 'labels.buttons.Reset' | translate }}
-        </button>
+        @if (breachToggleAvailable) {
+          <!-- Both permissions are required; nesting the directive ANDs them,
+               whereas passing an array would only require one of the two. -->
+          <span *mifosxHasPermission="'CREATE_WC_BREACH_ACTION'">
+            <span *mifosxHasPermission="'CREATE_WC_BREACH_DISABLE'">
+              <button
+                type="button"
+                class="btn"
+                [class.btn-warn]="!breachEvaluationDisabled()"
+                [class.btn-primary]="breachEvaluationDisabled()"
+                (click)="toggleBreachEvaluation()"
+              >
+                <fa-icon [icon]="breachEvaluationDisabled() ? 'play' : 'ban'"></fa-icon>
+                @if (breachEvaluationDisabled()) {
+                  {{ 'labels.buttons.Enable Breach' | translate }}
+                } @else {
+                  {{ 'labels.buttons.Disable Breach' | translate }}
+                }
+              </button>
+            </span>
+          </span>
+        }
       </div>
     </div>
 
@@ -185,10 +220,8 @@
                   <span class="id-cell">#{{ row.id }}</span>
                 </td>
                 <td>
-                  <span class="action-badge">
-                    <fa-icon
-                      [icon]="row.action === 'RESUME' ? 'play' : row.action === 'RESCHEDULE' ? 'calendar' : 'pause'"
-                    ></fa-icon>
+                  <span class="action-badge" [class.action-badge--disable]="row.action === 'DISABLE'">
+                    <fa-icon [icon]="actionIcon(row.action)"></fa-icon>
                     {{ row.action | titlecase }}
                   </span>
                 </td>
@@ -213,7 +246,7 @@
                   }
                 </td>
                 <td>
-                  @if (row.action !== 'RESUME') {
+                  @if (row.action !== 'RESUME' && row.action !== 'ENABLE') {
                     <span class="duration">
                       <span class="days">{{ row.durationDays }}{{ row.isOngoing ? '+' : '' }}</span>
                       <span class="duration-unit">{{ 'labels.inputs.days' | translate }}</span>
@@ -257,15 +290,17 @@
     <div class="list-section">
       <div class="list-section-header">
         <h3>{{ 'labels.heading.Breach Actions' | translate }}</h3>
-        <button
-          type="button"
-          class="btn btn-primary"
-          (click)="loanAction('Update Breach')"
-          *mifosxHasPermission="'CREATE_WC_BREACH_ACTION'"
-        >
-          <fa-icon icon="not-equal"></fa-icon>
-          {{ 'labels.menus.Update Breach' | translate }}
-        </button>
+        @if (!breachEvaluationDisabled()) {
+          <button
+            type="button"
+            class="btn btn-primary"
+            (click)="loanAction('Update Breach')"
+            *mifosxHasPermission="'CREATE_WC_BREACH_ACTION'"
+          >
+            <fa-icon icon="not-equal"></fa-icon>
+            {{ 'labels.menus.Update Breach' | translate }}
+          </button>
+        }
       </div>
 
       @if (breachActionsList.length > 0) {
@@ -314,15 +349,17 @@
     <div class="list-section">
       <div class="list-section-header">
         <h3>{{ 'labels.heading.Near Breach Actions' | translate }}</h3>
-        <button
-          type="button"
-          class="btn btn-primary"
-          (click)="loanAction('Update Near Breach')"
-          *mifosxHasPermission="'CREATE_WC_NEAR_BREACH_ACTION'"
-        >
-          <fa-icon icon="not-equal"></fa-icon>
-          {{ 'labels.menus.Update Near Breach' | translate }}
-        </button>
+        @if (!breachEvaluationDisabled()) {
+          <button
+            type="button"
+            class="btn btn-primary"
+            (click)="loanAction('Update Near Breach')"
+            *mifosxHasPermission="'CREATE_WC_NEAR_BREACH_ACTION'"
+          >
+            <fa-icon icon="not-equal"></fa-icon>
+            {{ 'labels.menus.Update Near Breach' | translate }}
+          </button>
+        }
       </div>
 
       @if (nearBreachActions.length > 0) {

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.scss
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.scss
@@ -137,6 +137,20 @@
   }
 }
 
+// Breach evaluation suspended. Uses the alert tokens instead of the blue of the
+// pause chip, and drops the pulse: a disable is a standing state, not activity.
+.status-chip--disabled {
+  border-color: var(--ch-alert);
+  background: var(--ch-alert-bg);
+  color: var(--ch-alert);
+
+  .dot {
+    background: var(--ch-alert);
+    box-shadow: none;
+    animation: none;
+  }
+}
+
 @keyframes ba-pulse {
   0%,
   100% {
@@ -507,6 +521,14 @@
   fa-icon {
     font-size: 10px;
   }
+}
+
+// A DISABLE row stands out from pauses and reschedules: it suppresses
+// evaluation entirely rather than adjusting it.
+.action-badge--disable {
+  background: var(--ch-alert-bg);
+  color: var(--ch-alert);
+  border-color: var(--ch-alert);
 }
 
 .status-pill {

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.ts
@@ -6,7 +6,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  inject,
+  signal
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
@@ -36,9 +45,22 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { LoanProductBaseComponent } from 'app/products/loan-products/common/loan-product-base.component';
 import {
   WorkingCapitalBreachAction,
+  WorkingCapitalBreachToggleRequest,
   WorkingCapitalNearBreachActions
 } from 'app/loans/models/working-capital/working-capital-loan-account.model';
 import { ConfirmationDialogComponent } from 'app/shared/confirmation-dialog/confirmation-dialog.component';
+import { ErrorHandlerService } from 'app/core/error-handler/error-handler.service';
+import { AlertService } from 'app/core/alert/alert.service';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import {
+  BreachToggleDialogComponent,
+  BreachToggleDialogData,
+  BreachToggleDialogResult
+} from '../loan-account-actions/breach-toggle-dialog/breach-toggle-dialog.component';
+import { resolveBreachErrorKey } from '../breach-error-messages';
+import { findActiveBreachDisable } from '../breach-evaluation';
 
 type BreachActionStatus = 'active' | 'scheduled' | 'expired';
 type BreachActionFilter = 'all' | BreachActionStatus;
@@ -57,7 +79,6 @@ interface BreachActionRow {
   isOngoing: boolean;
   isResumedPause: boolean;
   durationDays: number;
-  label: string;
 }
 
 interface TimelineBar {
@@ -102,6 +123,9 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
+  private errorHandler = inject(ErrorHandlerService);
+  private alertService = inject(AlertService);
+  private changeDetectorRef = inject(ChangeDetectorRef);
   dialog = inject(MatDialog);
 
   // Pause dashboard state
@@ -134,12 +158,18 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
 
   rows = computed<BreachActionRow[]>(() => {
     const businessDate = this.settingsService.businessDate;
-    return this.breachActions().map((item, index) => {
-      const isResumeAction = item.action === 'RESUME';
+    return this.breachActions().map((item) => {
+      // RESUME and ENABLE mark a moment rather than a window.
+      const isPointInTime = item.action === 'RESUME' || item.action === 'ENABLE';
       const isRescheduleAction = item.action === 'RESCHEDULE';
       const isResumedPause = item.action === 'PAUSE' && !!item.effectiveEndDate;
       const start = this.dateUtils.parseDate(item.startDate);
-      const end = isResumeAction ? null : this.dateUtils.parseDate(item.effectiveEndDate ?? item.endDate);
+      const rawEnd = item.effectiveEndDate ?? item.endDate;
+      // Any action without an end date is an open window: an open DISABLE, but also
+      // a RESCHEDULE, which never carries one. Parsing the missing value would yield
+      // today for an absent field and an invalid date for an explicit null, and the
+      // resulting NaN propagates through the status and the duration bars.
+      const end = isPointInTime || !rawEnd ? null : this.dateUtils.parseDate(rawEnd);
       const reference = end ?? businessDate;
       // Both boundary dates count: a pause from Jul 1st to Jul 16th lasts 16 days, not 15.
       // A pause closed by a RESUME is the exception: the loan is already active on the resume
@@ -148,8 +178,10 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
       const durationDays = Math.max(1, isResumedPause ? elapsedDays : elapsedDays + 1);
 
       let status: BreachActionStatus;
-      if (isResumeAction) {
+      if (isPointInTime) {
         status = 'active';
+      } else if (!end) {
+        status = start.getTime() <= businessDate.getTime() ? 'active' : 'scheduled';
       } else if (start.getTime() < businessDate.getTime() && end.getTime() < businessDate.getTime()) {
         status = 'expired';
       } else if (start.getTime() > businessDate.getTime() && end.getTime() > businessDate.getTime()) {
@@ -167,13 +199,12 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
         endDate: item.endDate,
         startDateObj: start,
         endDateObj: end,
-        hasEndDate: !isResumeAction && !isRescheduleAction,
+        hasEndDate: !isPointInTime && !isRescheduleAction,
         status,
         statusLabelKey: this.statusKey(status),
         isOngoing: !end && status === 'active',
         isResumedPause: isResumedPause,
-        durationDays,
-        label: `P${index + 1}`
+        durationDays
       };
     });
   });
@@ -214,6 +245,14 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
 
   hasPauseActiveToday = computed<boolean>(() => this.rows().some((r) => r.action === 'PAUSE' && r.status === 'active'));
 
+  /** DISABLE window covering the business date, if any. */
+  activeBreachDisable = computed<BreachActionRow | null>(() =>
+    findActiveBreachDisable(this.rows(), this.settingsService.businessDate)
+  );
+
+  /** True while breach evaluation is suspended for this loan. */
+  breachEvaluationDisabled = computed<boolean>(() => this.activeBreachDisable() !== null);
+
   timelineYear = computed<number>(() => {
     const rows = this.rows();
     if (rows.length === 0) return new Date().getFullYear();
@@ -230,20 +269,23 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
 
     return this.rows()
       .filter((row) => row.action === 'PAUSE')
-      .map((row) => {
+      .map((row, index) => {
         const endRef = row.endDateObj ?? today;
         const startDay = this.clamp(Math.floor((row.startDateObj.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
         const endDay = this.clamp(Math.floor((endRef.getTime() - yearStart) / MS_PER_DAY), 0, daysInYear);
         const x = TIMELINE_PADDING_LEFT + startDay * pxPerDay;
         const width = Math.max(8, (endDay - startDay) * pxPerDay);
-        const tooltip = `${row.label} · ${this.shortDate(row.startDateObj)} → ${row.endDateObj ? this.shortDate(row.endDateObj) : ongoingLabel} (${row.durationDays}d)`;
+        // The lane charts pauses only, so it numbers them consecutively: the index
+        // within the full action list would skip numbers on every non-pause action.
+        const label = `P${index + 1}`;
+        const endLabel = row.endDateObj ? this.shortDate(row.endDateObj) : ongoingLabel;
         return {
-          label: row.label,
+          label,
           status: row.status,
           x,
           width,
           midX: x + width / 2,
-          tooltip
+          tooltip: `${label} · ${this.shortDate(row.startDateObj)} → ${endLabel} (${row.durationDays}d)`
         };
       });
   });
@@ -308,6 +350,15 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
 
   get nearBreachEnabled(): boolean {
     return this.loanProductService.isWorkingCapital && this.loanDetails?.nearBreach != null;
+  }
+
+  /**
+   * Whether disabling or enabling breach evaluation applies at all. The backend
+   * rejects the action with loan.is.not.active or no.breach.configuration, so
+   * both conditions are checked here instead of surfacing an avoidable error.
+   */
+  get breachToggleAvailable(): boolean {
+    return this.breachEnabled && this.loanDetails?.status?.active === true;
   }
 
   loanAction(actionName: string): void {
@@ -416,11 +467,121 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
     });
   }
 
+  /**
+   * Opens the confirmation dialog and suspends or resumes breach evaluation.
+   *
+   * The action is derived from the current state so the two are never offered
+   * at the same time.
+   */
+  toggleBreachEvaluation(): void {
+    const action: 'disable' | 'enable' = this.breachEvaluationDisabled() ? 'enable' : 'disable';
+    const businessDate = this.settingsService.businessDate;
+    this.dialog
+      .open<BreachToggleDialogComponent, BreachToggleDialogData, BreachToggleDialogResult>(
+        BreachToggleDialogComponent,
+        {
+          data: { action, businessDate }
+        }
+      )
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        if (!result?.confirm) {
+          return;
+        }
+        // endDate is deliberately absent: the backend rejects it for both actions.
+        const payload: WorkingCapitalBreachToggleRequest = {
+          action,
+          startDate: this.dateUtils.formatDate(businessDate, this.dateFormat),
+          dateFormat: this.dateFormat,
+          locale: this.locale
+        };
+        this.loansService
+          .toggleWorkingCapitalBreachEvaluation(this.loanId, payload)
+          .pipe(
+            catchError((error) => this.handleBreachError(error)),
+            takeUntilDestroyed(this.destroyRef)
+          )
+          .subscribe({
+            next: () => this.refreshBreachData(),
+            // Already surfaced by the error handler.
+            error: () => undefined
+          });
+      });
+  }
+
+  /**
+   * Reloads the breach actions and the breach schedule after a successful
+   * toggle, so the history, the disabled badge and the schedule all reflect the
+   * recalculation the backend performs on enable.
+   *
+   * The breach and near-breach result lists are reloaded too: they arrive from
+   * the route resolver, which does not re-run on a toggle, so without this they
+   * would keep showing the evaluation from before the action.
+   */
+  private refreshBreachData(): void {
+    this.loansService
+      .getBreachActions(this.loanId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((breachActions: LoanDelinquencyAction[]) => {
+        this.breachActionsList = (breachActions as WorkingCapitalBreachAction[]) || [];
+        this.setBreachActions(breachActions);
+        // breachActionsList is a plain field, so OnPush needs to be told it changed.
+        this.changeDetectorRef.markForCheck();
+      });
+    this.loansService
+      .getWorkingCapitalLoanNearBreachActions(this.loanId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((nearBreachActions: WorkingCapitalNearBreachActions[]) => {
+        this.nearBreachActions = nearBreachActions || [];
+        this.changeDetectorRef.markForCheck();
+      });
+    this.loansService
+      .getWorkingCapitalLoanBreachSchedule(this.loanId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+  }
+
+  /**
+   * Reports a breach failure.
+   *
+   * Known validation codes become a translated business rule alert; anything
+   * else falls back to the shared HTTP handler, which already covers
+   * connectivity, authorisation and server errors.
+   * @param error Failed HTTP response
+   */
+  private handleBreachError(error: HttpErrorResponse): Observable<never> {
+    const key = resolveBreachErrorKey(error);
+    if (!key) {
+      return this.errorHandler.handleError(error, 'Breach Evaluation');
+    }
+    this.alertService.alert({
+      type: this.translateService.instant('errors.loans.businessRule'),
+      message: this.translateService.instant(key)
+    });
+    return throwError(() => error);
+  }
+
   setBreachActions(breachActions: LoanDelinquencyAction[]): void {
     const sorted = [...(breachActions || [])].sort(
       (a, b) => this.dateUtils.parseDate(a.startDate).getTime() - this.dateUtils.parseDate(b.startDate).getTime()
     );
     this.breachActions.set(sorted);
+  }
+
+  /** Icon representing a breach action type in the history table. */
+  actionIcon(action: string): string {
+    switch (action) {
+      case 'RESUME':
+      case 'ENABLE':
+        return 'play';
+      case 'RESCHEDULE':
+        return 'calendar';
+      case 'DISABLE':
+        return 'ban';
+      default:
+        return 'pause';
+    }
   }
 
   durationBarWidth(row: BreachActionRow): number {

--- a/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.html
@@ -7,213 +7,222 @@
 -->
 
 <div class="breach-container">
-  <div class="kpi-strip">
-    <div class="kpi">
-      <span class="kpi-label">{{ 'labels.heading.Breach Periods' | translate }}</span>
-      <span class="kpi-value">{{ kpis.count }}</span>
-    </div>
-    <div class="kpi">
-      <span class="kpi-label">{{ 'labels.heading.Total Days in Breach' | translate }}</span>
-      <span class="kpi-value">{{ kpis.totalDays }}</span>
-    </div>
-    <div class="kpi">
-      <span class="kpi-label">{{ 'labels.heading.Peak Outstanding' | translate }}</span>
-      <span class="kpi-value peak">{{ kpis.peakOutstanding | formatNumber }}</span>
-    </div>
-    <div class="kpi">
-      <span class="kpi-label">{{ 'labels.heading.Past Due Amount' | translate }}</span>
-      <span class="kpi-value peak">{{ loanBalances.breachPastDueAmount | formatNumber }}</span>
-    </div>
-    <div class="kpi">
-      <span class="kpi-label">{{ 'labels.heading.Average Gap' | translate }}</span>
-      <span class="kpi-value">+{{ kpis.avgGapPercent | formatNumber: '' : '1' }}%</span>
-    </div>
-    <div class="kpi-status">
-      @switch (kpis.status) {
-        @case ('in-breach') {
-          <span class="status-chip in-breach">
-            <span class="dot"></span>
-            {{ 'labels.text.In Breach' | translate }}
-          </span>
-        }
-        @case ('resolved') {
-          <span class="status-chip resolved">
-            <span class="dot"></span>
-            {{ 'labels.text.Resolved' | translate }}
-          </span>
-        }
-        @default {
-          <span class="status-chip compliant">
-            <span class="dot"></span>
-            {{ 'labels.text.Compliant' | translate }}
-          </span>
-        }
-      }
-    </div>
-  </div>
-
-  @if (breachPeriods.length > 0) {
-    <div class="timeline-section">
-      <div class="section-header">
-        <span class="section-title">{{ 'labels.text.Breach Timeline' | translate }} · {{ timelineYearLabel }}</span>
-        <div class="legend">
-          <span class="legend-item">
-            <span class="legend-swatch mild"></span>
-            {{ 'labels.text.Mild' | translate }} ({{ mildLabel }})
-          </span>
-          <span class="legend-item">
-            <span class="legend-swatch moderate"></span>
-            {{ 'labels.text.Moderate' | translate }} ({{ moderateLabel }})
-          </span>
-          <span class="legend-item">
-            <span class="legend-swatch severe"></span>
-            {{ 'labels.text.Severe' | translate }} ({{ severeLabel }})
-          </span>
-        </div>
+  <!-- While breach evaluation is disabled no evaluation (KPIs, timeline or
+       periods) is rendered, per the WEB-657 agreement. -->
+  @if (breachEvaluationDisabled) {
+    <p class="disabled-notice">
+      <fa-icon icon="ban"></fa-icon>
+      {{ 'labels.inputs.Breach evaluation disabled since' | translate: { date: (breachDisabledSince | dateFormat) } }}
+    </p>
+  } @else {
+    <div class="kpi-strip">
+      <div class="kpi">
+        <span class="kpi-label">{{ 'labels.heading.Breach Periods' | translate }}</span>
+        <span class="kpi-value">{{ kpis.count }}</span>
       </div>
-
-      <svg class="timeline" [attr.viewBox]="'0 0 ' + viewBoxWidth + ' ' + viewBoxHeight" preserveAspectRatio="none">
-        @for (mark of monthMarks; track $index) {
-          <line
-            class="month-grid"
-            [attr.x1]="mark.gridX"
-            [attr.y1]="topY"
-            [attr.x2]="mark.gridX"
-            [attr.y2]="baselineY"
-          ></line>
-          <text class="month-label" [attr.x]="mark.labelX" [attr.y]="monthLabelY" text-anchor="middle">
-            {{ mark.label }}
-          </text>
-        }
-
-        <line
-          class="baseline"
-          [attr.x1]="leftPad"
-          [attr.y1]="baselineY"
-          [attr.x2]="viewBoxWidth - rightPad"
-          [attr.y2]="baselineY"
-        ></line>
-
-        @for (period of breachPeriods; track period.id) {
-          <rect
-            class="breach-bar-edge"
-            [ngClass]="period.severity"
-            [attr.x]="period.barX"
-            [attr.y]="period.barY"
-            [attr.width]="period.barWidth"
-            [attr.height]="period.barHeight"
-            rx="2"
-          ></rect>
-          <rect
-            class="breach-bar"
-            [ngClass]="period.severity"
-            [attr.x]="period.barX"
-            [attr.y]="period.barY"
-            [attr.width]="period.barWidth"
-            [attr.height]="period.barHeight"
-            rx="2"
-          >
-            <title>{{ buildTooltip(period) }}</title>
-          </rect>
-          @if (period.showLabel) {
-            <text
-              class="bar-period"
-              [attr.x]="period.barX + period.barWidth / 2"
-              [attr.y]="period.barY + period.barHeight / 2 + 4"
-              text-anchor="middle"
-            >
-              P{{ period.periodNumber }}
-            </text>
+      <div class="kpi">
+        <span class="kpi-label">{{ 'labels.heading.Total Days in Breach' | translate }}</span>
+        <span class="kpi-value">{{ kpis.totalDays }}</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">{{ 'labels.heading.Peak Outstanding' | translate }}</span>
+        <span class="kpi-value peak">{{ kpis.peakOutstanding | formatNumber }}</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">{{ 'labels.heading.Past Due Amount' | translate }}</span>
+        <span class="kpi-value peak">{{ loanBalances.breachPastDueAmount | formatNumber }}</span>
+      </div>
+      <div class="kpi">
+        <span class="kpi-label">{{ 'labels.heading.Average Gap' | translate }}</span>
+        <span class="kpi-value">+{{ kpis.avgGapPercent | formatNumber: '' : '1' }}%</span>
+      </div>
+      <div class="kpi-status">
+        @switch (kpis.status) {
+          @case ('in-breach') {
+            <span class="status-chip in-breach">
+              <span class="dot"></span>
+              {{ 'labels.text.In Breach' | translate }}
+            </span>
+          }
+          @case ('resolved') {
+            <span class="status-chip resolved">
+              <span class="dot"></span>
+              {{ 'labels.text.Resolved' | translate }}
+            </span>
+          }
+          @default {
+            <span class="status-chip compliant">
+              <span class="dot"></span>
+              {{ 'labels.text.Compliant' | translate }}
+            </span>
           }
         }
+      </div>
+    </div>
 
-        @if (todayX !== null) {
+    @if (breachPeriods.length > 0) {
+      <div class="timeline-section">
+        <div class="section-header">
+          <span class="section-title">{{ 'labels.text.Breach Timeline' | translate }} · {{ timelineYearLabel }}</span>
+          <div class="legend">
+            <span class="legend-item">
+              <span class="legend-swatch mild"></span>
+              {{ 'labels.text.Mild' | translate }} ({{ mildLabel }})
+            </span>
+            <span class="legend-item">
+              <span class="legend-swatch moderate"></span>
+              {{ 'labels.text.Moderate' | translate }} ({{ moderateLabel }})
+            </span>
+            <span class="legend-item">
+              <span class="legend-swatch severe"></span>
+              {{ 'labels.text.Severe' | translate }} ({{ severeLabel }})
+            </span>
+          </div>
+        </div>
+
+        <svg class="timeline" [attr.viewBox]="'0 0 ' + viewBoxWidth + ' ' + viewBoxHeight" preserveAspectRatio="none">
+          @for (mark of monthMarks; track $index) {
+            <line
+              class="month-grid"
+              [attr.x1]="mark.gridX"
+              [attr.y1]="topY"
+              [attr.x2]="mark.gridX"
+              [attr.y2]="baselineY"
+            ></line>
+            <text class="month-label" [attr.x]="mark.labelX" [attr.y]="monthLabelY" text-anchor="middle">
+              {{ mark.label }}
+            </text>
+          }
+
           <line
-            class="today-line"
-            [attr.x1]="todayX"
-            [attr.y1]="topY"
-            [attr.x2]="todayX"
-            [attr.y2]="todayLineBottomY"
+            class="baseline"
+            [attr.x1]="leftPad"
+            [attr.y1]="baselineY"
+            [attr.x2]="viewBoxWidth - rightPad"
+            [attr.y2]="baselineY"
           ></line>
-          <text class="today-label" [attr.x]="todayX" [attr.y]="todayLabelY" text-anchor="middle">
-            {{ 'labels.text.Today' | translate }}
-          </text>
-        }
-      </svg>
+
+          @for (period of breachPeriods; track period.id) {
+            <rect
+              class="breach-bar-edge"
+              [ngClass]="period.severity"
+              [attr.x]="period.barX"
+              [attr.y]="period.barY"
+              [attr.width]="period.barWidth"
+              [attr.height]="period.barHeight"
+              rx="2"
+            ></rect>
+            <rect
+              class="breach-bar"
+              [ngClass]="period.severity"
+              [attr.x]="period.barX"
+              [attr.y]="period.barY"
+              [attr.width]="period.barWidth"
+              [attr.height]="period.barHeight"
+              rx="2"
+            >
+              <title>{{ buildTooltip(period) }}</title>
+            </rect>
+            @if (period.showLabel) {
+              <text
+                class="bar-period"
+                [attr.x]="period.barX + period.barWidth / 2"
+                [attr.y]="period.barY + period.barHeight / 2 + 4"
+                text-anchor="middle"
+              >
+                P{{ period.periodNumber }}
+              </text>
+            }
+          }
+
+          @if (todayX !== null) {
+            <line
+              class="today-line"
+              [attr.x1]="todayX"
+              [attr.y1]="topY"
+              [attr.x2]="todayX"
+              [attr.y2]="todayLineBottomY"
+            ></line>
+            <text class="today-label" [attr.x]="todayX" [attr.y]="todayLabelY" text-anchor="middle">
+              {{ 'labels.text.Today' | translate }}
+            </text>
+          }
+        </svg>
+      </div>
+    }
+
+    <div class="table-section">
+      <div class="table-toolbar"></div>
+
+      <div class="table-wrap">
+        <table mat-table [dataSource]="dataSource" id="breachSchedule" class="breach-table">
+          <ng-container matColumnDef="periodNumber">
+            <th mat-header-cell class="col-c col-narrow" *matHeaderCellDef>#</th>
+            <td mat-cell class="col-c col-narrow" *matCellDef="let item">{{ item.periodNumber }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="severity">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.text.Severity' | translate }}</th>
+            <td mat-cell *matCellDef="let item">
+              <span class="severity-pill" [ngClass]="item.severity">
+                <span class="dot"></span>
+                {{ 'labels.text.' + severityLabel(item.severity) | translate }}
+              </span>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="fromDate">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.From Date' | translate }}</th>
+            <td mat-cell *matCellDef="let item">{{ item.fromDateObj | dateFormat }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="toDate">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.To Date' | translate }}</th>
+            <td mat-cell *matCellDef="let item">{{ item.toDateObj | dateFormat }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="numberOfDays">
+            <th mat-header-cell class="col-r" *matHeaderCellDef>{{ 'labels.inputs.Days' | translate }}</th>
+            <td mat-cell class="col-r" *matCellDef="let item">{{ item.numberOfDays | formatNumber }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="minPaymentAmount">
+            <th mat-header-cell class="col-r" *matHeaderCellDef>
+              {{ 'labels.inputs.Minimum Payment' | translate }}
+            </th>
+            <td mat-cell class="col-r" *matCellDef="let item">
+              {{ item.minPaymentAmount | formatNumber }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="outstandingAmount">
+            <th mat-header-cell class="col-r" *matHeaderCellDef>
+              {{ 'labels.inputs.Outstanding Amount' | translate }}
+            </th>
+            <td mat-cell class="col-r" *matCellDef="let item">
+              {{ item.outstandingAmount | formatNumber }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="gap">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.text.Gap' | translate }}</th>
+            <td mat-cell *matCellDef="let item">
+              <span class="gap-value">+{{ item.gapPercent | formatNumber: '' : '1' }}%</span>
+              <span class="gap-bar">
+                <span class="gap-bar-fill" [ngClass]="item.severity" [style.width.%]="item.gapBarWidth"></span>
+              </span>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
+          <tr
+            mat-row
+            *matRowDef="let row; columns: displayedColumns"
+            class="table-row"
+            [ngClass]="'row-' + row.severity"
+          ></tr>
+        </table>
+      </div>
     </div>
   }
-
-  <div class="table-section">
-    <div class="table-toolbar"></div>
-
-    <div class="table-wrap">
-      <table mat-table [dataSource]="dataSource" id="breachSchedule" class="breach-table">
-        <ng-container matColumnDef="periodNumber">
-          <th mat-header-cell class="col-c col-narrow" *matHeaderCellDef>#</th>
-          <td mat-cell class="col-c col-narrow" *matCellDef="let item">{{ item.periodNumber }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="severity">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.text.Severity' | translate }}</th>
-          <td mat-cell *matCellDef="let item">
-            <span class="severity-pill" [ngClass]="item.severity">
-              <span class="dot"></span>
-              {{ 'labels.text.' + severityLabel(item.severity) | translate }}
-            </span>
-          </td>
-        </ng-container>
-
-        <ng-container matColumnDef="fromDate">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.From Date' | translate }}</th>
-          <td mat-cell *matCellDef="let item">{{ item.fromDateObj | dateFormat }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="toDate">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.To Date' | translate }}</th>
-          <td mat-cell *matCellDef="let item">{{ item.toDateObj | dateFormat }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="numberOfDays">
-          <th mat-header-cell class="col-r" *matHeaderCellDef>{{ 'labels.inputs.Days' | translate }}</th>
-          <td mat-cell class="col-r" *matCellDef="let item">{{ item.numberOfDays | formatNumber }}</td>
-        </ng-container>
-
-        <ng-container matColumnDef="minPaymentAmount">
-          <th mat-header-cell class="col-r" *matHeaderCellDef>
-            {{ 'labels.inputs.Minimum Payment' | translate }}
-          </th>
-          <td mat-cell class="col-r" *matCellDef="let item">
-            {{ item.minPaymentAmount | formatNumber }}
-          </td>
-        </ng-container>
-
-        <ng-container matColumnDef="outstandingAmount">
-          <th mat-header-cell class="col-r" *matHeaderCellDef>
-            {{ 'labels.inputs.Outstanding Amount' | translate }}
-          </th>
-          <td mat-cell class="col-r" *matCellDef="let item">
-            {{ item.outstandingAmount | formatNumber }}
-          </td>
-        </ng-container>
-
-        <ng-container matColumnDef="gap">
-          <th mat-header-cell *matHeaderCellDef>{{ 'labels.text.Gap' | translate }}</th>
-          <td mat-cell *matCellDef="let item">
-            <span class="gap-value">+{{ item.gapPercent | formatNumber: '' : '1' }}%</span>
-            <span class="gap-bar">
-              <span class="gap-bar-fill" [ngClass]="item.severity" [style.width.%]="item.gapBarWidth"></span>
-            </span>
-          </td>
-        </ng-container>
-
-        <tr mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></tr>
-        <tr
-          mat-row
-          *matRowDef="let row; columns: displayedColumns"
-          class="table-row"
-          [ngClass]="'row-' + row.severity"
-        ></tr>
-      </table>
-    </div>
-  </div>
 </div>

--- a/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.scss
+++ b/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.scss
@@ -490,3 +490,17 @@
 .gap-bar-fill.severe {
   background: var(--br-severe);
 }
+
+// Stands in for the whole evaluation while breach evaluation is disabled.
+.disabled-notice {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0;
+  padding: 14px 16px;
+  border-radius: 4px;
+  border-left: 3px solid var(--ch-alert);
+  background: var(--ch-alert-bg);
+  color: var(--ch-alert);
+  font-size: 13px;
+}

--- a/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.ts
@@ -29,7 +29,12 @@ import { BreachSchedule } from 'app/loans/models/working-capital-loan-account.mo
 import { DateFormatPipe } from 'app/pipes/date-format.pipe';
 import { FormatNumberPipe } from 'app/pipes/format-number.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
-import { WorkingCapitalBalances } from 'app/loans/models/working-capital/working-capital-loan-account.model';
+import {
+  WorkingCapitalBalances,
+  WorkingCapitalBreachAction
+} from 'app/loans/models/working-capital/working-capital-loan-account.model';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { findActiveBreachDisable } from '../breach-evaluation';
 
 type Severity = 'mild' | 'moderate' | 'severe';
 
@@ -96,6 +101,7 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24;
     MatHeaderRow,
     MatRowDef,
     MatRow,
+    FaIconComponent,
     DateFormatPipe,
     FormatNumberPipe
   ],
@@ -110,6 +116,10 @@ export class LoanBreachScheduleTabComponent implements OnInit {
   dataSource = new MatTableDataSource<BreachPeriodView>();
   currencyCode: string = '';
   loanBalances: WorkingCapitalBalances | null = null;
+
+  /** True while a DISABLE window covers the business date; no evaluations are shown then. */
+  breachEvaluationDisabled = false;
+  breachDisabledSince: Date | null = null;
 
   readonly displayedColumns: string[] = [
     'periodNumber',
@@ -151,7 +161,21 @@ export class LoanBreachScheduleTabComponent implements OnInit {
   ngOnInit(): void {
     this.route.data
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((data: { breachSchedule: BreachSchedule[] }) => {
+      .subscribe((data: { breachSchedule: BreachSchedule[]; loanBreachActions: WorkingCapitalBreachAction[] }) => {
+        const activeDisable = findActiveBreachDisable(
+          (data.loanBreachActions ?? []).map((action) => {
+            // An ENABLE closes the window through effectiveEndDate, mirroring the actions tab rows.
+            const rawEnd = action.effectiveEndDate ?? action.endDate;
+            return {
+              action: action.action,
+              startDateObj: this.toDate(action.startDate),
+              endDateObj: rawEnd ? this.toDate(rawEnd) : null
+            };
+          }),
+          this.settingsService.businessDate
+        );
+        this.breachEvaluationDisabled = activeDisable !== null;
+        this.breachDisabledSince = activeDisable?.startDateObj ?? null;
         this.processBreachPeriods(data.breachSchedule ?? []);
         this.dataSource.data = this.breachPeriods;
       });

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -23,6 +23,7 @@ import {
   WorkingCapitalBreachAction,
   WorkingCapitalBreachActionRequest,
   WorkingCapitalMarkAsFraudRequest,
+  WorkingCapitalBreachToggleRequest,
   WorkingCapitalNearBreachActionRequest,
   WorkingCapitalNearBreachActions
 } from './models/working-capital/working-capital-loan-account.model';
@@ -191,6 +192,20 @@ export class LoansService {
   }
 
   createBreachAction(loanId: string, payload: any) {
+    return this.http.post(`/working-capital-loans/${loanId}/breach-actions`, payload);
+  }
+
+  /**
+   * Suspends or resumes breach evaluation for a Working Capital loan.
+   *
+   * Shares the breach-actions resource with pause and resume, but the payload
+   * carries no endDate: disable opens an open-ended window and enable closes
+   * the one currently open.
+   * @param {string} loanId Loan Id
+   * @param {WorkingCapitalBreachToggleRequest} payload Action and business date
+   * @returns {Observable<any>}
+   */
+  toggleWorkingCapitalBreachEvaluation(loanId: string, payload: WorkingCapitalBreachToggleRequest): Observable<any> {
     return this.http.post(`/working-capital-loans/${loanId}/breach-actions`, payload);
   }
 

--- a/src/app/loans/models/loan-account.model.ts
+++ b/src/app/loans/models/loan-account.model.ts
@@ -53,6 +53,11 @@ export interface LoanDelinquencyAction {
   createdOn: Date;
   updatedById: number;
   lastModifiedOn: Date;
+  /** Payment rule, returned only for RESCHEDULE actions on working capital loans */
+  minimumPayment?: number;
+  minimumPaymentType?: string;
+  frequency?: number;
+  frequencyType?: string;
 }
 
 export interface DelinquencyPausePeriod {

--- a/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
+++ b/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
@@ -120,6 +120,22 @@ export interface WorkingCapitalBreachAction {
   frequencyType?: string;
 }
 
+/**
+ * Request body for POST /working-capital-loans/{loanId}/breach-actions with
+ * action disable or enable.
+ *
+ * `startDate` must be exactly the current business date; any other date is
+ * rejected with must.be.current.business.date. `endDate` must never be sent,
+ * not even as null, or the backend answers
+ * must.not.be.provided.for.disable.or.enable.
+ */
+export interface WorkingCapitalBreachToggleRequest {
+  action: 'disable' | 'enable';
+  startDate: string;
+  dateFormat: string;
+  locale: string;
+}
+
 export interface WorkingCapitalNearBreachActionRequest {
   action: string;
   nearBreachThreshold: number;

--- a/src/assets/styles/_action-dashboard.scss
+++ b/src/assets/styles/_action-dashboard.scss
@@ -1,0 +1,645 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Shared "action dashboard" shell: a card that stacks a KPI strip, an optional
+ * chart section, a filter toolbar and a data table with status-coded rows.
+ *
+ * Consumed by loan tabs that present a timeline of dated actions
+ * (e.g. delinquency tags). Pairs with 'assets/styles/pause-timeline' for the
+ * SVG chart itself. Every colour comes from the shared --ds-* tokens, which are
+ * declared globally for both themes, so no per-theme override is needed here.
+ *
+ * Usage:
+ *
+ *   @use 'assets/styles/action-dashboard';
+ *   @use 'assets/styles/pause-timeline';
+ */
+
+/* ───────────── Card shell ───────────── */
+.dashboard-card {
+  background: var(--ds-surface-alt);
+  border: 1px solid var(--ds-border);
+  border-radius: var(--ds-radius);
+  overflow: hidden;
+  box-shadow: var(--ds-shadow-xs);
+  color: var(--ds-text-1);
+  font-family: 'DM Sans', system-ui, sans-serif;
+}
+
+/* ───────────── KPI strip ───────────── */
+.kpi-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  background: var(--ds-surface-head);
+  border-bottom: 1px solid var(--ds-border);
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, transparent 60%, var(--ds-blue-50));
+    pointer-events: none;
+    opacity: 0.5;
+  }
+}
+
+.kpi {
+  padding: 16px 22px;
+  border-right: 1px solid var(--ds-border);
+  display: flex;
+  flex: 1 1 0;
+  min-width: 160px;
+  flex-direction: column;
+  gap: 4px;
+  position: relative;
+  z-index: 1;
+}
+
+.kpi-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ds-text-3);
+}
+
+.kpi-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 22px;
+  font-weight: 500;
+  color: var(--ds-text-1);
+  line-height: 1.1;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+
+  &.accent {
+    color: var(--ds-blue-700);
+  }
+
+  .unit {
+    font-family: 'DM Sans', sans-serif;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--ds-text-3);
+    letter-spacing: 0.04em;
+  }
+}
+
+.kpi-status {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 14px 22px;
+  margin-left: auto;
+  position: relative;
+  z-index: 1;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 100px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid var(--ds-blue-700);
+  background: var(--ds-blue-50);
+  color: var(--ds-blue-700);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+
+  .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--ds-blue-700);
+    animation: ad-pulse 1.8s ease-in-out infinite;
+  }
+}
+
+// A suspended evaluation is a standing state, not activity: it borrows the
+// alert tokens and drops the pulse of the live chip.
+.status-chip--disabled {
+  border-color: var(--ds-alert);
+  background: var(--ds-alert-bg);
+  color: var(--ds-alert);
+
+  .dot {
+    background: var(--ds-alert);
+    animation: none;
+  }
+}
+
+@keyframes ad-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.35;
+  }
+}
+
+/* ───────────── Toolbar ───────────── */
+.table-section {
+  background: var(--ds-surface);
+  border-top: 1px solid var(--ds-border);
+}
+
+.table-toolbar {
+  padding: 12px 24px;
+  background: var(--ds-surface-head);
+  border-bottom: 1px solid var(--ds-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.record-count {
+  font-size: 12.5px;
+  color: var(--ds-text-2);
+
+  strong {
+    color: var(--ds-text-1);
+    font-weight: 700;
+  }
+}
+
+.filter-group {
+  display: inline-flex;
+  gap: 4px;
+  padding: 3px;
+  background: var(--ds-surface);
+  border: 1px solid var(--ds-border);
+  border-radius: var(--ds-radius-sm);
+}
+
+.filter-chip {
+  font:
+    600 11px 'DM Sans',
+    sans-serif;
+  padding: 5px 10px;
+  border-radius: 3px;
+  color: var(--ds-text-2);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: all 0.12s ease;
+
+  &:hover {
+    color: var(--ds-text-1);
+  }
+
+  &.is-active {
+    background: var(--ds-blue-700);
+    color: #fff;
+  }
+}
+
+.btn {
+  font:
+    600 13px 'DM Sans',
+    sans-serif;
+  padding: 7px 14px;
+  border-radius: var(--ds-radius-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: all 0.15s ease;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.btn-primary {
+  background: var(--ds-blue-700);
+  color: #fff;
+
+  &:hover:not(:disabled) {
+    background: var(--ds-blue-600);
+    box-shadow: var(--ds-shadow-sm);
+  }
+}
+
+.btn-ghost {
+  background: var(--ds-surface);
+  border-color: var(--ds-border);
+  color: var(--ds-text-2);
+
+  &:hover:not(:disabled) {
+    border-color: var(--ds-border-strong);
+    background: var(--ds-surface-alt);
+    color: var(--ds-text-1);
+  }
+}
+
+/* ───────────── Table ───────────── */
+.table-wrap {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+
+  thead th {
+    background: var(--ds-surface-head);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--ds-text-2);
+    border-bottom: 2px solid var(--ds-border);
+    padding: 11px 16px;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  thead th.id-col {
+    width: 90px;
+  }
+
+  thead th.num-col,
+  tbody td.num-col {
+    text-align: right;
+  }
+
+  thead th.center-col,
+  tbody td.center-col {
+    text-align: center;
+  }
+
+  tbody td {
+    padding: 13px 16px;
+    font-size: 13.5px;
+    color: var(--ds-text-1);
+    background: var(--ds-surface);
+    border-bottom: 1px solid var(--ds-border);
+    vertical-align: middle;
+  }
+
+  tbody tr {
+    animation: ad-fade-row 0.36s ease both;
+  }
+
+  @for $i from 1 through 12 {
+    tbody tr:nth-child(#{$i}) {
+      animation-delay: #{0.05 + ($i - 1) * 0.06}s;
+    }
+  }
+
+  tbody tr:hover td {
+    background: var(--ds-blue-20);
+  }
+
+  tbody tr td:first-child {
+    position: relative;
+  }
+
+  tbody tr.row-active td:first-child {
+    border-left: 3px solid var(--ds-paid);
+  }
+
+  tbody tr.row-scheduled td:first-child {
+    border-left: 3px solid var(--ds-blue-700);
+  }
+
+  tbody tr.row-expired td:first-child {
+    border-left: 3px solid var(--ds-zero);
+  }
+
+  tbody tr.empty-row td {
+    text-align: center;
+    color: var(--ds-text-3);
+    font-style: italic;
+    padding: 28px 16px;
+  }
+}
+
+@keyframes ad-fade-row {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .data-table tbody tr {
+    animation: none;
+  }
+
+  .status-chip .dot,
+  .status-pill--active .dot {
+    animation: none;
+  }
+}
+
+/* ───────────── Cell primitives ───────────── */
+.id-cell {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--ds-text-2);
+}
+
+.action-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  background: var(--ds-blue-50);
+  color: var(--ds-blue-700);
+  border: 1px solid var(--ds-blue-100);
+
+  fa-icon {
+    font-size: 10px;
+  }
+}
+
+// Suppressing evaluation altogether reads differently from adjusting it.
+.action-badge--alert {
+  background: var(--ds-alert-bg);
+  color: var(--ds-alert);
+  border-color: var(--ds-alert);
+}
+
+// Actions that restore normal evaluation.
+.action-badge--positive {
+  background: var(--ds-paid-bg);
+  color: var(--ds-paid);
+  border-color: var(--ds-paid);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 100px;
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+  }
+
+  &--active {
+    background: var(--ds-paid-bg);
+    color: var(--ds-paid);
+    border-color: var(--ds-paid);
+
+    .dot {
+      background: var(--ds-paid);
+      animation: ad-pulse 2s ease-in-out infinite;
+    }
+  }
+
+  &--scheduled {
+    background: var(--ds-blue-50);
+    color: var(--ds-blue-700);
+    border-color: var(--ds-blue-700);
+
+    .dot {
+      background: var(--ds-blue-700);
+    }
+  }
+
+  &--expired {
+    background: var(--ds-surface-alt);
+    color: var(--ds-text-2);
+    border-color: var(--ds-border-strong);
+
+    .dot {
+      background: var(--ds-zero);
+    }
+  }
+}
+
+.date-cell {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  color: var(--ds-text-1);
+  white-space: nowrap;
+
+  &.muted {
+    color: var(--ds-text-3);
+    font-style: italic;
+  }
+}
+
+.num-cell {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  color: var(--ds-text-1);
+
+  &.muted {
+    color: var(--ds-text-3);
+  }
+}
+
+.duration {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+
+  .days {
+    min-width: 38px;
+    text-align: right;
+    color: var(--ds-text-1);
+  }
+
+  .duration-unit {
+    font-family: 'DM Sans', sans-serif;
+    font-size: 10.5px;
+    color: var(--ds-text-3);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+}
+
+.duration-bar {
+  position: relative;
+  width: 72px;
+  height: 4px;
+  background: var(--ds-border);
+  border-radius: 2px;
+  overflow: hidden;
+  display: inline-block;
+}
+
+.duration-bar-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: 2px;
+
+  &--active {
+    background: var(--ds-paid);
+  }
+
+  &--scheduled {
+    background: repeating-linear-gradient(
+      45deg,
+      var(--ds-blue-700),
+      var(--ds-blue-700) 4px,
+      transparent 4px,
+      transparent 8px
+    );
+  }
+
+  &--expired {
+    background: var(--ds-zero);
+  }
+}
+
+.icon-btn {
+  width: 30px;
+  height: 30px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: var(--ds-radius-sm);
+  border: 1px solid var(--ds-border);
+  background: var(--ds-surface);
+  color: var(--ds-blue-700);
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    border-color: var(--ds-blue-700);
+    background: var(--ds-blue-50);
+  }
+}
+
+/* ───────────── Empty state ───────────── */
+.empty {
+  padding: 56px 24px;
+  text-align: center;
+  background: var(--ds-surface);
+
+  .ico {
+    width: 48px;
+    height: 48px;
+    margin: 0 auto 12px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    background: var(--ds-blue-50);
+    color: var(--ds-blue-700);
+    font-size: 18px;
+  }
+
+  h4 {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--ds-text-1);
+    margin-bottom: 4px;
+  }
+
+  p {
+    font-size: 12.5px;
+    color: var(--ds-text-2);
+    max-width: 420px;
+    margin: 0 auto;
+  }
+}
+
+/* ───────────── Secondary list sections ───────────── */
+.list-section {
+  margin-top: 24px;
+}
+
+.list-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+
+  h3 {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--ds-text-1);
+    font-family: 'DM Sans', system-ui, sans-serif;
+  }
+}
+
+.list-card {
+  background: var(--ds-surface);
+  border: 1px solid var(--ds-border);
+  border-radius: var(--ds-radius);
+  overflow: hidden;
+  box-shadow: var(--ds-shadow-xs);
+}
+
+/* ───────────── Responsive ───────────── */
+@media (width <= 880px) {
+  .kpi {
+    flex-basis: 50%;
+    min-width: 0;
+  }
+
+  .kpi:nth-of-type(2) {
+    border-right: none;
+  }
+
+  .kpi-status {
+    flex-basis: 100%;
+    justify-content: flex-start;
+    margin-left: 0;
+    padding: 12px 22px;
+    border-top: 1px solid var(--ds-border);
+  }
+}

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -428,7 +428,16 @@
     "validation.emailInvalid": "E-mail není platný",
     "validation.requiredField": "{{label}} je povinné pole.",
     "validation.mustBeAtLeast": "{{field}} musí být alespoň {{min}}",
-    "validation.mustBePositive": "{{field}} musí být kladné číslo."
+    "validation.mustBePositive": "{{field}} musí být kladné číslo.",
+    "breach": {
+      "alreadyDisabled": "Hodnocení porušení je pro tento úvěr již zakázáno.",
+      "noActiveDisableToEnable": "Pro tento úvěr neexistuje aktivní zákaz, který by šlo povolit.",
+      "mustBeCurrentBusinessDate": "Datum účinnosti musí být aktuální obchodní datum.",
+      "endDateNotAllowed": "Při zakázání nebo povolení hodnocení porušení nelze odeslat datum konce.",
+      "noBreachConfiguration": "Tento úvěr nemá konfiguraci porušení.",
+      "loanIsNotActive": "Hodnocení porušení lze změnit pouze tehdy, když je úvěr aktivní.",
+      "breachIsDisabled": "Hodnocení porušení je pro tento úvěr zakázáno. Povolte je, abyste mohli tuto akci provést."
+    }
   },
   "labels": {
     "version": {
@@ -785,7 +794,9 @@
       "Create Exchange Rate": "Vytvořit směnný kurz",
       "Create Transfer Fee": "Vytvořit poplatek za převod",
       "Requesting": "Probíhá požadavek",
-      "Delink": "Odpojit"
+      "Delink": "Odpojit",
+      "Disable Breach": "Zakázat porušení",
+      "Enable Breach": "Povolit porušení"
     },
     "catalogs": {
       "% Amount": "% Amount",
@@ -1612,6 +1623,7 @@
       "undo_account_transfer": "Vrátit převod účtu",
       "Loan Breach Actions": "Akce porušení úvěru",
       "No Breach Actions": "Žádné akce při porušení",
+      "No Delinquency Actions": "Žádné akce delikvence",
       "Pause Timeline": "Časová osa pauz",
       "Location Map": "Mapa polohy",
       "Exchange Rates": "Směnné kurzy",
@@ -1623,7 +1635,9 @@
       "Exchange Rate": "Směnný kurz",
       "Create Exchange Rate": "Vytvořit směnný kurz",
       "View Exchange Rate": "Zobrazit směnný kurz",
-      "Edit Exchange Rate": "Upravit směnný kurz"
+      "Edit Exchange Rate": "Upravit směnný kurz",
+      "Disable Breach Evaluation": "Zakázat hodnocení porušení",
+      "Enable Breach Evaluation": "Povolit hodnocení porušení"
     },
     "inputs": {
       "Annual interest rate": "Roční úroková sazba",
@@ -3210,6 +3224,7 @@
       "Expired": "Vypršela",
       "Last Action": "Poslední akce",
       "No breach actions have been recorded for this loan": "Pro tento úvěr nebyly zaznamenány žádné akce při porušení",
+      "No delinquency actions have been recorded for this loan": "Pro tento úvěr nebyly zaznamenány žádné akce delikvence",
       "No records match the selected filter": "Žádné záznamy neodpovídají vybranému filtru",
       "Ongoing": "Probíhá",
       "Pause Active": "Pauza aktivní",
@@ -3260,7 +3275,8 @@
       "Mail": "E-mail",
       "Link": "Propojení",
       "Audit Trail": "Auditní stopa",
-      "Restart Period from Reset Date": "Restartovat období od data resetu"
+      "Restart Period from Reset Date": "Restartovat období od data resetu",
+      "Breach evaluation disabled since": "Hodnocení porušení zakázáno od {{date}}"
     },
     "links": {
       "Community": "Společenství",
@@ -3484,7 +3500,9 @@
       "the Transaction Type": "typ transakce",
       "undo_account_transfer": "Opravdu chcete vrátit tento převod účtu?",
       "Are you sure you want to undo the charge-off": "Opravdu chcete zrušit odpis?",
-      "Restart Period from Reset Date splits the current period": "Pokud je povoleno, aktuální období porušení se rozdělí k datu resetu a nové období začne od tohoto data."
+      "Restart Period from Reset Date splits the current period": "Pokud je povoleno, aktuální období porušení se rozdělí k datu resetu a nové období začne od tohoto data.",
+      "Breach evaluation will stop": "Hodnocení porušení se zastaví {{date}}. Předchozí výsledky zůstanou uloženy, ale budou skryty až do opětovného povolení.",
+      "Breach evaluation will resume": "Hodnocení porušení bude obnoveno {{date}}. Úvěr bude od tohoto data znovu hodnocen."
     },
     "text": {
       "Agriculture Loan": "Zemědělský úvěr",
@@ -3498,6 +3516,7 @@
       "Max": "Max",
       "Hidden variables and predefined values are included in the final payload automatically.": "Skryté proměnné a předdefinované hodnoty jsou automaticky zahrnuty do konečného payloadu.",
       "No Breach Actions": "Žádné Porušení Akce",
+      "Previous results are hidden while breach evaluation is disabled": "Předchozí výsledky jsou skryty, dokud je hodnocení porušení zakázáno",
       "No Near Breach Actions": "Žádné Blížící se porušení Akce",
       "A": "A",
       "Ability to manage holidays for individual offices": "Schopnost spravovat svátky pro jednotlivé kanceláře je velmi užitečným nástrojem pro organizaci zahrnující více míst. Tuto možnost použijte k přizpůsobení svátků pro každou kancelář vaší organizace.",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -428,7 +428,16 @@
     "validation.emailInvalid": "E-Mail ist ungültig",
     "validation.requiredField": "{{label}} ist ein Pflichtfeld.",
     "validation.mustBeAtLeast": "{{field}} muss mindestens {{min}} betragen",
-    "validation.mustBePositive": "{{field}} muss eine positive Zahl sein."
+    "validation.mustBePositive": "{{field}} muss eine positive Zahl sein.",
+    "breach": {
+      "alreadyDisabled": "Die Verstoßbewertung ist für dieses Darlehen bereits deaktiviert.",
+      "noActiveDisableToEnable": "Es gibt keine aktive Deaktivierung, die für dieses Darlehen aktiviert werden könnte.",
+      "mustBeCurrentBusinessDate": "Das Wirksamkeitsdatum muss das aktuelle Geschäftsdatum sein.",
+      "endDateNotAllowed": "Beim Deaktivieren oder Aktivieren der Verstoßbewertung darf kein Enddatum gesendet werden.",
+      "noBreachConfiguration": "Dieses Darlehen hat keine Verstoßkonfiguration.",
+      "loanIsNotActive": "Die Verstoßbewertung kann nur geändert werden, solange das Darlehen aktiv ist.",
+      "breachIsDisabled": "Die Verstoßbewertung ist für dieses Darlehen deaktiviert. Aktivieren Sie sie, um diese Aktion auszuführen."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -786,7 +795,9 @@
       "Create Exchange Rate": "Wechselkurs erstellen",
       "Create Transfer Fee": "Transfergebühr erstellen",
       "Requesting": "Wird angefordert",
-      "Delink": "Verknüpfung entfernen"
+      "Delink": "Verknüpfung entfernen",
+      "Disable Breach": "Verstoß deaktivieren",
+      "Enable Breach": "Verstoß aktivieren"
     },
     "catalogs": {
       "% Amount": "Menge",
@@ -1614,6 +1625,7 @@
       "undo_account_transfer": "Kontotransfer rückgängig machen",
       "Loan Breach Actions": "Kredit-Verstoß-Aktionen",
       "No Breach Actions": "Keine Verstoßaktionen",
+      "No Delinquency Actions": "Keine Verzugsaktionen",
       "Pause Timeline": "Pausen-Zeitleiste",
       "Location Map": "Standortkarte",
       "Exchange Rates": "Wechselkurse",
@@ -1625,7 +1637,9 @@
       "Exchange Rate": "Wechselkurs",
       "Create Exchange Rate": "Wechselkurs erstellen",
       "View Exchange Rate": "Wechselkurs anzeigen",
-      "Edit Exchange Rate": "Wechselkurs bearbeiten"
+      "Edit Exchange Rate": "Wechselkurs bearbeiten",
+      "Disable Breach Evaluation": "Verstoßbewertung deaktivieren",
+      "Enable Breach Evaluation": "Verstoßbewertung aktivieren"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3212,6 +3226,7 @@
       "Expired": "Abgelaufen",
       "Last Action": "Letzte Aktion",
       "No breach actions have been recorded for this loan": "Für dieses Darlehen wurden keine Verstoßaktionen erfasst",
+      "No delinquency actions have been recorded for this loan": "Für dieses Darlehen wurden keine Verzugsaktionen erfasst",
       "No records match the selected filter": "Keine Einträge entsprechen dem ausgewählten Filter",
       "Ongoing": "Laufend",
       "Pause Active": "Pause aktiv",
@@ -3262,7 +3277,8 @@
       "Mail": "E-Mail",
       "Link": "Verknüpfung",
       "Audit Trail": "Prüfpfad",
-      "Restart Period from Reset Date": "Periode ab Reset-Datum neu starten"
+      "Restart Period from Reset Date": "Periode ab Reset-Datum neu starten",
+      "Breach evaluation disabled since": "Verstoßbewertung deaktiviert seit {{date}}"
     },
     "links": {
       "Community": "Gemeinschaft",
@@ -3486,7 +3502,9 @@
       "the Transaction Type": "der Transaktionstyp",
       "undo_account_transfer": "Möchten Sie diesen Kontotransfer wirklich rückgängig machen?",
       "Are you sure you want to undo the charge-off": "Sind Sie sicher, dass Sie das Abladen rückgängig machen möchten?",
-      "Restart Period from Reset Date splits the current period": "Wenn aktiviert, wird die aktuelle Verstoßperiode zum Reset-Datum geteilt und eine neue Periode beginnt ab diesem Datum."
+      "Restart Period from Reset Date splits the current period": "Wenn aktiviert, wird die aktuelle Verstoßperiode zum Reset-Datum geteilt und eine neue Periode beginnt ab diesem Datum.",
+      "Breach evaluation will stop": "Die Verstoßbewertung endet am {{date}}. Frühere Ergebnisse bleiben erhalten, werden aber bis zur erneuten Aktivierung ausgeblendet.",
+      "Breach evaluation will resume": "Die Verstoßbewertung wird am {{date}} fortgesetzt. Das Darlehen wird ab diesem Datum wieder bewertet."
     },
     "text": {
       "Agriculture Loan": "Agrarkredit",
@@ -3500,6 +3518,7 @@
       "Max": "Max",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Keine Verstoßaktionen",
+      "Previous results are hidden while breach evaluation is disabled": "Frühere Ergebnisse sind ausgeblendet, solange die Verstoßbewertung deaktiviert ist",
       "No Near Breach Actions": "Keine Beinahe-Verstoß-Aktionen",
       "A": "A",
       "Ability to manage holidays for individual offices": "Die Möglichkeit, Feiertage für einzelne Büros zu verwalten, ist ein sehr nützliches Werkzeug für eine Organisation mit mehreren Standorten. Verwenden Sie diese Option, um Feiertage für jedes Büro Ihrer Organisation anzupassen.",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -430,7 +430,16 @@
     "validation.requiredField": "{{label}} is a required field.",
     "validation.mustBeAtLeast": "{{field}} must be at least {{min}}",
     "validation.mustBePositive": "{{field}} must be a positive number.",
-    "validation.openingTimeBeforeClosingTime": "Opening time must be before closing time."
+    "validation.openingTimeBeforeClosingTime": "Opening time must be before closing time.",
+    "breach": {
+      "alreadyDisabled": "Breach evaluation is already disabled for this loan.",
+      "noActiveDisableToEnable": "There is no active disable to enable for this loan.",
+      "mustBeCurrentBusinessDate": "The effective date must be the current business date.",
+      "endDateNotAllowed": "An end date cannot be sent when disabling or enabling breach evaluation.",
+      "noBreachConfiguration": "This loan has no breach configuration.",
+      "loanIsNotActive": "Breach evaluation can only be changed while the loan is active.",
+      "breachIsDisabled": "Breach evaluation is disabled for this loan. Enable it to run this action."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -796,7 +805,9 @@
       "All": "All",
       "Pause Breach": "Pause Breach",
       "Resume Breach": "Resume Breach",
-      "Currency Conversion": "Currency Conversion"
+      "Currency Conversion": "Currency Conversion",
+      "Disable Breach": "Disable Breach",
+      "Enable Breach": "Enable Breach"
     },
     "catalogs": {
       "% Amount": "% Amount",
@@ -1631,6 +1642,7 @@
       "undo_account_transfer": "Undo Account Transfer",
       "Loan Breach Actions": "Loan Breach Actions",
       "No Breach Actions": "No Breach Actions",
+      "No Delinquency Actions": "No Delinquency Actions",
       "Pause Timeline": "Pause Timeline",
       "Location Map": "Location Map",
       "Services": "Services",
@@ -1643,7 +1655,9 @@
       "Create Exchange Rate": "Create Exchange Rate",
       "View Exchange Rate": "View Exchange Rate",
       "Edit Exchange Rate": "Edit Exchange Rate",
-      "Theme": "Theme"
+      "Theme": "Theme",
+      "Disable Breach Evaluation": "Disable Breach Evaluation",
+      "Enable Breach Evaluation": "Enable Breach Evaluation"
     },
     "inputs": {
       "Breach Actions": "Breach Actions",
@@ -3268,6 +3282,7 @@
       "Expired": "Expired",
       "Last Action": "Last Action",
       "No breach actions have been recorded for this loan": "No breach actions have been recorded for this loan",
+      "No delinquency actions have been recorded for this loan": "No delinquency actions have been recorded for this loan",
       "No records match the selected filter": "No records match the selected filter",
       "Ongoing": "Ongoing",
       "Pause Active": "Pause Active",
@@ -3297,7 +3312,8 @@
       "Red": "Red",
       "Yellow": "Yellow",
       "Primary Color": "Primary Color",
-      "Audit Trail": "Audit Trail"
+      "Audit Trail": "Audit Trail",
+      "Breach evaluation disabled since": "Breach evaluation disabled since {{date}}"
     },
     "links": {
       "Community": "Community",
@@ -3522,7 +3538,9 @@
       "the productmix component with id": "the productmix component with id",
       "the Reschedule Loan": " the Reschedule Loan",
       "the Transaction Type": "the Transaction Type",
-      "Are you sure you want to undo the charge-off": "Are you sure you want to undo the charge-off"
+      "Are you sure you want to undo the charge-off": "Are you sure you want to undo the charge-off",
+      "Breach evaluation will stop": "Breach evaluation stops on {{date}}. Previous results stay on record but are hidden until you enable it again.",
+      "Breach evaluation will resume": "Breach evaluation resumes on {{date}}. The loan is evaluated again from that date."
     },
     "text": {
       "Agriculture Loan": "Agriculture Loan",
@@ -3544,6 +3562,7 @@
       "No additional filters": "No additional filters",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "No Breach Actions",
+      "Previous results are hidden while breach evaluation is disabled": "Previous results are hidden while breach evaluation is disabled",
       "No Near Breach Actions": "No Near Breach Actions",
       "A": "A",
       "Ability to manage holidays for individual offices": "The ability to manage holidays for individual offices is a very useful tool for an organization spanning multiple locations.Use this option to customize holidays for each office of your organization.",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -426,7 +426,16 @@
     "validation.emailInvalid": "Correo electrónico no válido",
     "validation.requiredField": "{{label}} es un campo obligatorio.",
     "validation.mustBeAtLeast": "{{field}} debe ser al menos {{min}}",
-    "validation.mustBePositive": "{{field}} debe ser un número positivo."
+    "validation.mustBePositive": "{{field}} debe ser un número positivo.",
+    "breach": {
+      "alreadyDisabled": "La evaluación de incumplimiento ya está deshabilitada para este préstamo.",
+      "noActiveDisableToEnable": "No hay una deshabilitación activa que habilitar para este préstamo.",
+      "mustBeCurrentBusinessDate": "La fecha efectiva debe ser la fecha de negocio actual.",
+      "endDateNotAllowed": "No se puede enviar una fecha fin al deshabilitar o habilitar la evaluación de incumplimiento.",
+      "noBreachConfiguration": "Este préstamo no tiene configuración de incumplimiento.",
+      "loanIsNotActive": "La evaluación de incumplimiento solo se puede cambiar mientras el préstamo está activo.",
+      "breachIsDisabled": "La evaluación de incumplimiento está deshabilitada para este préstamo. Habilítala para ejecutar esta acción."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -784,7 +793,9 @@
       "Resume Breach": "Reanudar Incumplimiento",
       "Currency Conversion": "Conversión de moneda",
       "Create Exchange Rate": "Crear tipo de cambio",
-      "Create Transfer Fee": "Crear comisión de transferencia"
+      "Create Transfer Fee": "Crear comisión de transferencia",
+      "Disable Breach": "Deshabilitar Incumplimiento",
+      "Enable Breach": "Habilitar Incumplimiento"
     },
     "catalogs": {
       "% Amount": "% Monto",
@@ -1612,6 +1623,7 @@
       "undo_account_transfer": "Revertir transferencia de cuenta",
       "Loan Breach Actions": "Acciones de Incumplimiento del Préstamo",
       "No Breach Actions": "Sin Acciones sobre Brechas",
+      "No Delinquency Actions": "Sin Acciones de Morosidad",
       "Pause Timeline": "Línea de Tiempo de Pausas",
       "Location Map": "Mapa de ubicación",
       "Exchange Rates": "Tipos de cambio",
@@ -1623,7 +1635,9 @@
       "Exchange Rate": "Tipo de cambio",
       "Create Exchange Rate": "Crear tipo de cambio",
       "View Exchange Rate": "Ver tipo de cambio",
-      "Edit Exchange Rate": "Editar tipo de cambio"
+      "Edit Exchange Rate": "Editar tipo de cambio",
+      "Disable Breach Evaluation": "Deshabilitar Evaluación de Incumplimiento",
+      "Enable Breach Evaluation": "Habilitar Evaluación de Incumplimiento"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3214,6 +3228,7 @@
       "Expired": "Expirada",
       "Last Action": "Última Acción",
       "No breach actions have been recorded for this loan": "No se han registrado acciones sobre brechas para este préstamo",
+      "No delinquency actions have been recorded for this loan": "No se han registrado acciones de morosidad para este préstamo",
       "No records match the selected filter": "Ningún registro coincide con el filtro seleccionado",
       "Ongoing": "En curso",
       "Pause Active": "Pausa Activa",
@@ -3261,7 +3276,8 @@
       "Provider": "Proveedor",
       "Dispute Management": "Gestión de disputas",
       "Audit Trail": "Registro de auditoría",
-      "Restart Period from Reset Date": "Reiniciar el período desde la fecha de reinicio"
+      "Restart Period from Reset Date": "Reiniciar el período desde la fecha de reinicio",
+      "Breach evaluation disabled since": "Evaluación de incumplimiento deshabilitada desde el {{date}}"
     },
     "links": {
       "Community": "Comunidad",
@@ -3485,7 +3501,9 @@
       "the Transaction Type": "el tipo de transacción",
       "undo_account_transfer": "¿Está seguro de que desea revertir esta transferencia de cuenta?",
       "Are you sure you want to undo the charge-off": "¿Está seguro de que desea deshacer la cancelación?",
-      "Restart Period from Reset Date splits the current period": "Si se activa, el periodo de incumplimiento actual se corta en la fecha de reinicio y arranca un periodo nuevo desde esa fecha."
+      "Restart Period from Reset Date splits the current period": "Si se activa, el periodo de incumplimiento actual se corta en la fecha de reinicio y arranca un periodo nuevo desde esa fecha.",
+      "Breach evaluation will stop": "La evaluación de incumplimiento se detiene el {{date}}. Los resultados anteriores se conservan pero quedan ocultos hasta que la habilites de nuevo.",
+      "Breach evaluation will resume": "La evaluación de incumplimiento se reanuda el {{date}}. El préstamo se vuelve a evaluar a partir de esa fecha."
     },
     "text": {
       "Agriculture Loan": "Crédito Agrícola",
@@ -3499,6 +3517,7 @@
       "Max": "Máx",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Sin acciones de incumplimiento",
+      "Previous results are hidden while breach evaluation is disabled": "Los resultados anteriores están ocultos mientras la evaluación de incumplimiento está deshabilitada",
       "No Near Breach Actions": "Sin acciones de incumplimiento inminente",
       "A": "Una",
       "Ability to manage holidays for individual offices": "La capacidad de gestionar días festivos para oficinas individuales es una herramienta muy útil para una organización que abarca varias ubicaciones. Utilice esta opción para personalizar los días festivos para cada oficina de su organización.",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -427,7 +427,16 @@
     "validation.emailInvalid": "Correo electrónico no válido",
     "validation.requiredField": "{{label}} es un campo obligatorio.",
     "validation.mustBeAtLeast": "{{field}} debe ser al menos {{min}}",
-    "validation.mustBePositive": "{{field}} debe ser un número positivo."
+    "validation.mustBePositive": "{{field}} debe ser un número positivo.",
+    "breach": {
+      "alreadyDisabled": "La evaluación de incumplimiento ya está deshabilitada para este préstamo.",
+      "noActiveDisableToEnable": "No hay una deshabilitación activa que habilitar para este préstamo.",
+      "mustBeCurrentBusinessDate": "La fecha efectiva debe ser la fecha de negocio actual.",
+      "endDateNotAllowed": "No se puede enviar una fecha fin al deshabilitar o habilitar la evaluación de incumplimiento.",
+      "noBreachConfiguration": "Este préstamo no tiene configuración de incumplimiento.",
+      "loanIsNotActive": "La evaluación de incumplimiento solo se puede cambiar mientras el préstamo está activo.",
+      "breachIsDisabled": "La evaluación de incumplimiento está deshabilitada para este préstamo. Habilítala para ejecutar esta acción."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -786,7 +795,9 @@
       "Resume Breach": "Reanudar Incumplimiento",
       "Currency Conversion": "Conversión de moneda",
       "Create Exchange Rate": "Crear tipo de cambio",
-      "Create Transfer Fee": "Crear comisión de transferencia"
+      "Create Transfer Fee": "Crear comisión de transferencia",
+      "Disable Breach": "Deshabilitar Incumplimiento",
+      "Enable Breach": "Habilitar Incumplimiento"
     },
     "catalogs": {
       "% Amount": "% Monto",
@@ -1617,6 +1628,7 @@
       "undo_account_transfer": "Revertir transferencia de cuenta",
       "Loan Breach Actions": "Acciones de Incumplimiento del Préstamo",
       "No Breach Actions": "Sin Acciones sobre Brechas",
+      "No Delinquency Actions": "Sin Acciones de Morosidad",
       "Pause Timeline": "Línea de Tiempo de Pausas",
       "Location Map": "Mapa de ubicación",
       "Exchange Rates": "Tipos de cambio",
@@ -1628,7 +1640,9 @@
       "Exchange Rate": "Tipo de cambio",
       "Create Exchange Rate": "Crear tipo de cambio",
       "View Exchange Rate": "Ver tipo de cambio",
-      "Edit Exchange Rate": "Editar tipo de cambio"
+      "Edit Exchange Rate": "Editar tipo de cambio",
+      "Disable Breach Evaluation": "Deshabilitar Evaluación de Incumplimiento",
+      "Enable Breach Evaluation": "Habilitar Evaluación de Incumplimiento"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3219,6 +3233,7 @@
       "Expired": "Expirada",
       "Last Action": "Última Acción",
       "No breach actions have been recorded for this loan": "No se han registrado acciones sobre brechas para este préstamo",
+      "No delinquency actions have been recorded for this loan": "No se han registrado acciones de morosidad para este préstamo",
       "No records match the selected filter": "Ningún registro coincide con el filtro seleccionado",
       "Ongoing": "En curso",
       "Pause Active": "Pausa Activa",
@@ -3266,7 +3281,8 @@
       "Provider": "Proveedor",
       "Dispute Management": "Gestión de disputas",
       "Audit Trail": "Registro de auditoría",
-      "Restart Period from Reset Date": "Reiniciar el período desde la fecha de reinicio"
+      "Restart Period from Reset Date": "Reiniciar el período desde la fecha de reinicio",
+      "Breach evaluation disabled since": "Evaluación de incumplimiento deshabilitada desde el {{date}}"
     },
     "links": {
       "Community": "Comunidad",
@@ -3489,7 +3505,9 @@
       "the Transaction Type": "el tipo de transacción",
       "undo_account_transfer": "¿Está seguro de que desea revertir esta transferencia de cuenta?",
       "Are you sure you want to undo the charge-off": "¿Está seguro de que desea reversar la cancelación?",
-      "Restart Period from Reset Date splits the current period": "Si se activa, el periodo de incumplimiento actual se corta en la fecha de reinicio y arranca un periodo nuevo desde esa fecha."
+      "Restart Period from Reset Date splits the current period": "Si se activa, el periodo de incumplimiento actual se corta en la fecha de reinicio y arranca un periodo nuevo desde esa fecha.",
+      "Breach evaluation will stop": "La evaluación de incumplimiento se detiene el {{date}}. Los resultados anteriores se conservan pero quedan ocultos hasta que la habilites de nuevo.",
+      "Breach evaluation will resume": "La evaluación de incumplimiento se reanuda el {{date}}. El préstamo se vuelve a evaluar a partir de esa fecha."
     },
     "text": {
       "Agriculture Loan": "Crédito Agrícola",
@@ -3503,6 +3521,7 @@
       "Max": "Máx",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Sin acciones de incumplimiento",
+      "Previous results are hidden while breach evaluation is disabled": "Los resultados anteriores están ocultos mientras la evaluación de incumplimiento está deshabilitada",
       "No Near Breach Actions": "Sin acciones de incumplimiento inminente",
       "A": "Una",
       "Ability to manage holidays for individual offices": "La capacidad de gestionar días festivos para sucursales individuales es una herramienta muy útil para una organización que abarca varias ubicaciones. Utilice esta opción para personalizar los días festivos para cada sucursal de su organización.",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -426,7 +426,16 @@
     "validation.emailInvalid": "E-mail non valide",
     "validation.requiredField": "{{label}} est un champ obligatoire.",
     "validation.mustBeAtLeast": "{{field}} doit être au moins {{min}}",
-    "validation.mustBePositive": "{{field}} doit être un nombre positif."
+    "validation.mustBePositive": "{{field}} doit être un nombre positif.",
+    "breach": {
+      "alreadyDisabled": "L'évaluation des manquements est déjà désactivée pour ce prêt.",
+      "noActiveDisableToEnable": "Aucune désactivation active à réactiver pour ce prêt.",
+      "mustBeCurrentBusinessDate": "La date d'effet doit être la date d'exercice actuelle.",
+      "endDateNotAllowed": "Aucune date de fin ne peut être envoyée lors de la désactivation ou de l'activation de l'évaluation des manquements.",
+      "noBreachConfiguration": "Ce prêt n'a aucune configuration de manquement.",
+      "loanIsNotActive": "L'évaluation des manquements ne peut être modifiée que lorsque le prêt est actif.",
+      "breachIsDisabled": "L'évaluation des manquements est désactivée pour ce prêt. Activez-la pour exécuter cette action."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -784,7 +793,9 @@
       "Create Exchange Rate": "Créer un taux de change",
       "Create Transfer Fee": "Créer des frais de transfert",
       "Requesting": "Demande en cours",
-      "Delink": "Délier"
+      "Delink": "Délier",
+      "Disable Breach": "Désactiver le Manquement",
+      "Enable Breach": "Activer le Manquement"
     },
     "catalogs": {
       "% Amount": "Montant",
@@ -1615,6 +1626,7 @@
       "undo_account_transfer": "Annuler le transfert de compte",
       "Loan Breach Actions": "Actions de Manquement du Prêt",
       "No Breach Actions": "Aucune Action sur Brèches",
+      "No Delinquency Actions": "Aucune Action sur Impayés",
       "Pause Timeline": "Chronologie des Pauses",
       "Location Map": "Carte de localisation",
       "Exchange Rates": "Taux de change",
@@ -1626,7 +1638,9 @@
       "Exchange Rate": "Taux de change",
       "Create Exchange Rate": "Créer un taux de change",
       "View Exchange Rate": "Afficher le taux de change",
-      "Edit Exchange Rate": "Modifier le taux de change"
+      "Edit Exchange Rate": "Modifier le taux de change",
+      "Disable Breach Evaluation": "Désactiver l'évaluation des manquements",
+      "Enable Breach Evaluation": "Activer l'évaluation des manquements"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3213,6 +3227,7 @@
       "Expired": "Expirée",
       "Last Action": "Dernière Action",
       "No breach actions have been recorded for this loan": "Aucune action sur brèches n'a été enregistrée pour ce prêt",
+      "No delinquency actions have been recorded for this loan": "Aucune action sur impayés n'a été enregistrée pour ce prêt",
       "No records match the selected filter": "Aucun enregistrement ne correspond au filtre sélectionné",
       "Ongoing": "En cours",
       "Pause Active": "Pause Active",
@@ -3263,7 +3278,8 @@
       "Mail": "E-mail",
       "Link": "Lien",
       "Audit Trail": "Piste d'audit",
-      "Restart Period from Reset Date": "Redémarrer la période à partir de la date de réinitialisation"
+      "Restart Period from Reset Date": "Redémarrer la période à partir de la date de réinitialisation",
+      "Breach evaluation disabled since": "Évaluation des manquements désactivée depuis le {{date}}"
     },
     "links": {
       "Community": "Communauté",
@@ -3487,7 +3503,9 @@
       "the Transaction Type": "le type de transaction",
       "undo_account_transfer": "Êtes-vous sûr de vouloir annuler ce transfert de compte ?",
       "Are you sure you want to undo the charge-off": "Êtes-vous sûr de vouloir annuler l'amortissement ?",
-      "Restart Period from Reset Date splits the current period": "Si activé, la période de manquement actuelle est scindée à la date de réinitialisation et une nouvelle période commence à cette date."
+      "Restart Period from Reset Date splits the current period": "Si activé, la période de manquement actuelle est scindée à la date de réinitialisation et une nouvelle période commence à cette date.",
+      "Breach evaluation will stop": "L'évaluation des manquements s'arrête le {{date}}. Les résultats précédents sont conservés mais masqués jusqu'à sa réactivation.",
+      "Breach evaluation will resume": "L'évaluation des manquements reprend le {{date}}. Le prêt est de nouveau évalué à partir de cette date."
     },
     "text": {
       "Agriculture Loan": "Prêt agricole",
@@ -3501,6 +3519,7 @@
       "Max": "Max",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Aucune action de violation",
+      "Previous results are hidden while breach evaluation is disabled": "Les résultats précédents sont masqués tant que l'évaluation des dépassements est désactivée",
       "No Near Breach Actions": "Aucune action de violation proche",
       "A": "UN",
       "Ability to manage holidays for individual offices": "La possibilité de gérer les congés de chaque bureau est un outil très utile pour une organisation répartie sur plusieurs sites. Utilisez cette option pour personnaliser les congés de chaque bureau de votre organisation.",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -426,7 +426,16 @@
     "validation.emailInvalid": "Email non valida",
     "validation.requiredField": "{{label}} è un campo obbligatorio.",
     "validation.mustBeAtLeast": "{{field}} deve essere almeno {{min}}",
-    "validation.mustBePositive": "{{field}} deve essere un numero positivo."
+    "validation.mustBePositive": "{{field}} deve essere un numero positivo.",
+    "breach": {
+      "alreadyDisabled": "La valutazione delle violazioni è già disabilitata per questo prestito.",
+      "noActiveDisableToEnable": "Non esiste una disabilitazione attiva da abilitare per questo prestito.",
+      "mustBeCurrentBusinessDate": "La data di efficacia deve essere la data operativa corrente.",
+      "endDateNotAllowed": "Non è possibile inviare una data di fine quando si disabilita o abilita la valutazione delle violazioni.",
+      "noBreachConfiguration": "Questo prestito non ha una configurazione delle violazioni.",
+      "loanIsNotActive": "La valutazione delle violazioni può essere modificata solo mentre il prestito è attivo.",
+      "breachIsDisabled": "La valutazione delle violazioni è disabilitata per questo prestito. Abilitala per eseguire questa azione."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -784,7 +793,9 @@
       "Create Exchange Rate": "Crea tasso di cambio",
       "Create Transfer Fee": "Crea commissione di trasferimento",
       "Requesting": "Richiesta in corso",
-      "Delink": "Scollega"
+      "Delink": "Scollega",
+      "Disable Breach": "Disabilita Violazione",
+      "Enable Breach": "Abilita Violazione"
     },
     "catalogs": {
       "% Amount": "Quantità",
@@ -1612,6 +1623,7 @@
       "undo_account_transfer": "Annulla trasferimento conto",
       "Loan Breach Actions": "Azioni di Violazione del Prestito",
       "No Breach Actions": "Nessuna Azione sulle Violazioni",
+      "No Delinquency Actions": "Nessuna Azione sulla Morosità",
       "Pause Timeline": "Cronologia Pause",
       "Location Map": "Mappa della posizione",
       "Exchange Rates": "Tassi di cambio",
@@ -1623,7 +1635,9 @@
       "Exchange Rate": "Tasso di cambio",
       "Create Exchange Rate": "Crea tasso di cambio",
       "View Exchange Rate": "Visualizza tasso di cambio",
-      "Edit Exchange Rate": "Modifica tasso di cambio"
+      "Edit Exchange Rate": "Modifica tasso di cambio",
+      "Disable Breach Evaluation": "Disabilita Valutazione delle Violazioni",
+      "Enable Breach Evaluation": "Abilita Valutazione delle Violazioni"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3210,6 +3224,7 @@
       "Expired": "Scaduta",
       "Last Action": "Ultima Azione",
       "No breach actions have been recorded for this loan": "Nessuna azione sulle violazioni è stata registrata per questo prestito",
+      "No delinquency actions have been recorded for this loan": "Nessuna azione sulla morosità è stata registrata per questo prestito",
       "No records match the selected filter": "Nessun record corrisponde al filtro selezionato",
       "Ongoing": "In corso",
       "Pause Active": "Pausa Attiva",
@@ -3260,7 +3275,8 @@
       "Mail": "E-mail",
       "Link": "Collegamento",
       "Audit Trail": "Traccia di controllo",
-      "Restart Period from Reset Date": "Riavvia periodo dalla data di ripristino"
+      "Restart Period from Reset Date": "Riavvia periodo dalla data di ripristino",
+      "Breach evaluation disabled since": "Valutazione delle violazioni disabilitata dal {{date}}"
     },
     "links": {
       "Community": "Comunità",
@@ -3483,7 +3499,9 @@
       "the Transaction Type": "il tipo di transazione",
       "undo_account_transfer": "Sei sicuro di voler annullare questo trasferimento conto?",
       "Are you sure you want to undo the charge-off": "Sei sicuro di voler annullare l'addebito?",
-      "Restart Period from Reset Date splits the current period": "Se abilitato, il periodo di violazione corrente viene suddiviso alla data di ripristino e un nuovo periodo inizia da quella data."
+      "Restart Period from Reset Date splits the current period": "Se abilitato, il periodo di violazione corrente viene suddiviso alla data di ripristino e un nuovo periodo inizia da quella data.",
+      "Breach evaluation will stop": "La valutazione delle violazioni si interrompe il {{date}}. I risultati precedenti restano registrati ma vengono nascosti fino a una nuova abilitazione.",
+      "Breach evaluation will resume": "La valutazione delle violazioni riprende il {{date}}. Il prestito viene valutato di nuovo a partire da quella data."
     },
     "text": {
       "Agriculture Loan": "Prestito agricolo",
@@ -3497,6 +3515,7 @@
       "Max": "Max",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Nessuna azione di violazione",
+      "Previous results are hidden while breach evaluation is disabled": "I risultati precedenti sono nascosti mentre la valutazione delle violazioni è disabilitata",
       "No Near Breach Actions": "Nessuna azione di violazione prossima",
       "A": "UN",
       "Ability to manage holidays for individual offices": "La possibilità di gestire le ferie per i singoli uffici è uno strumento molto utile per un'organizzazione che si estende su più sedi. Utilizza questa opzione per personalizzare le ferie per ciascun ufficio della tua organizzazione.",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -426,7 +426,16 @@
     "validation.emailInvalid": "유효하지 않은 이메일",
     "validation.requiredField": "{{label}}은(는) 필수 필드입니다.",
     "validation.mustBeAtLeast": "{{field}}은(는) 최소 {{min}}이어야 합니다",
-    "validation.mustBePositive": "{{field}}은(는) 양수여야 합니다."
+    "validation.mustBePositive": "{{field}}은(는) 양수여야 합니다.",
+    "breach": {
+      "alreadyDisabled": "이 대출의 위반 평가는 이미 비활성화되어 있습니다.",
+      "noActiveDisableToEnable": "이 대출에는 활성화할 수 있는 비활성화 상태가 없습니다.",
+      "mustBeCurrentBusinessDate": "적용 날짜는 현재 영업일이어야 합니다.",
+      "endDateNotAllowed": "위반 평가를 비활성화하거나 활성화할 때는 종료 날짜를 보낼 수 없습니다.",
+      "noBreachConfiguration": "이 대출에는 위반 구성이 없습니다.",
+      "loanIsNotActive": "위반 평가는 대출이 활성 상태일 때만 변경할 수 있습니다.",
+      "breachIsDisabled": "이 대출의 위반 평가가 비활성화되어 있습니다. 이 작업을 실행하려면 활성화하세요."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -784,7 +793,9 @@
       "Create Exchange Rate": "환율 생성",
       "Create Transfer Fee": "송금 수수료 생성",
       "Requesting": "요청 중",
-      "Delink": "연결 해제"
+      "Delink": "연결 해제",
+      "Disable Breach": "위반 비활성화",
+      "Enable Breach": "위반 활성화"
     },
     "catalogs": {
       "% Amount": "양",
@@ -1613,6 +1624,7 @@
       "undo_account_transfer": "계좌 이체 취소",
       "Loan Breach Actions": "대출 위반 작업",
       "No Breach Actions": "위반 작업 없음",
+      "No Delinquency Actions": "연체 작업 없음",
       "Pause Timeline": "일시중지 타임라인",
       "Location Map": "위치 지도",
       "Exchange Rates": "환율",
@@ -1624,7 +1636,9 @@
       "Exchange Rate": "환율",
       "Create Exchange Rate": "환율 생성",
       "View Exchange Rate": "환율 보기",
-      "Edit Exchange Rate": "환율 편집"
+      "Edit Exchange Rate": "환율 편집",
+      "Disable Breach Evaluation": "위반 평가 비활성화",
+      "Enable Breach Evaluation": "위반 평가 활성화"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3210,6 +3224,7 @@
       "Expired": "만료됨",
       "Last Action": "마지막 작업",
       "No breach actions have been recorded for this loan": "이 대출에 대한 위반 작업이 기록되지 않았습니다",
+      "No delinquency actions have been recorded for this loan": "이 대출에 대한 연체 작업이 기록되지 않았습니다",
       "No records match the selected filter": "선택한 필터와 일치하는 기록이 없습니다",
       "Ongoing": "진행 중",
       "Pause Active": "일시중지 활성",
@@ -3260,7 +3275,8 @@
       "Mail": "메일",
       "Link": "연결",
       "Audit Trail": "감사 추적",
-      "Restart Period from Reset Date": "리셋 날짜부터 기간 다시 시작"
+      "Restart Period from Reset Date": "리셋 날짜부터 기간 다시 시작",
+      "Breach evaluation disabled since": "{{date}}부터 위반 평가 비활성화됨"
     },
     "links": {
       "Community": "지역 사회",
@@ -3483,7 +3499,9 @@
       "the Transaction Type": "거래 유형",
       "undo_account_transfer": "이 계좌 이체를 취소하시겠습니까?",
       "Are you sure you want to undo the charge-off": "상각을 취소하시겠습니까?",
-      "Restart Period from Reset Date splits the current period": "활성화하면 현재 위반 기간이 리셋 날짜로 분할되고 해당 날짜부터 새 기간이 시작됩니다."
+      "Restart Period from Reset Date splits the current period": "활성화하면 현재 위반 기간이 리셋 날짜로 분할되고 해당 날짜부터 새 기간이 시작됩니다.",
+      "Breach evaluation will stop": "{{date}}부터 위반 평가가 중지됩니다. 이전 결과는 보존되지만 다시 활성화할 때까지 표시되지 않습니다.",
+      "Breach evaluation will resume": "{{date}}부터 위반 평가가 재개됩니다. 해당 날짜부터 대출이 다시 평가됩니다."
     },
     "text": {
       "Agriculture Loan": "농업 대출",
@@ -3497,6 +3515,7 @@
       "Max": "최대",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "위반 행위 없음",
+      "Previous results are hidden while breach evaluation is disabled": "위반 평가가 비활성화된 동안 이전 결과는 표시되지 않습니다",
       "No Near Breach Actions": "위반 임박 행위 없음",
       "A": "ㅏ",
       "Ability to manage holidays for individual offices": "개별 사무실의 휴일을 관리하는 기능은 여러 위치에 걸쳐 있는 조직에 매우 유용한 도구입니다. 조직의 각 사무실에 대한 휴일을 사용자 정의하려면 이 옵션을 사용하십시오.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -426,7 +426,16 @@
     "validation.emailInvalid": "El. paštas neteisingas",
     "validation.requiredField": "{{label}} yra privalomas laukas.",
     "validation.mustBeAtLeast": "{{field}} turi būti bent {{min}}",
-    "validation.mustBePositive": "{{field}} turi būti teigiamas skaičius."
+    "validation.mustBePositive": "{{field}} turi būti teigiamas skaičius.",
+    "breach": {
+      "alreadyDisabled": "Šios paskolos pažeidimų vertinimas jau išjungtas.",
+      "noActiveDisableToEnable": "Šiai paskolai nėra aktyvaus išjungimo, kurį būtų galima įjungti.",
+      "mustBeCurrentBusinessDate": "Įsigaliojimo data turi būti dabartinė veiklos data.",
+      "endDateNotAllowed": "Išjungiant arba įjungiant pažeidimų vertinimą negalima siųsti pabaigos datos.",
+      "noBreachConfiguration": "Ši paskola neturi pažeidimų konfigūracijos.",
+      "loanIsNotActive": "Pažeidimų vertinimą galima keisti tik tada, kai paskola aktyvi.",
+      "breachIsDisabled": "Šios paskolos pažeidimų vertinimas išjungtas. Įjunkite jį, kad galėtumėte atlikti šį veiksmą."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -784,7 +793,9 @@
       "Create Exchange Rate": "Sukurti valiutos kursą",
       "Create Transfer Fee": "Sukurti pervedimo mokestį",
       "Requesting": "Prašoma",
-      "Delink": "Atsieti"
+      "Delink": "Atsieti",
+      "Disable Breach": "Išjungti pažeidimą",
+      "Enable Breach": "Įjungti pažeidimą"
     },
     "catalogs": {
       "% Amount": "Suma",
@@ -1611,6 +1622,7 @@
       "undo_account_transfer": "Atšaukti sąskaitos pervedimą",
       "Loan Breach Actions": "Paskolos pažeidimo veiksmai",
       "No Breach Actions": "Nėra pažeidimo veiksmų",
+      "No Delinquency Actions": "Nėra įsiskolinimo veiksmų",
       "Pause Timeline": "Pauzių laiko juosta",
       "Location Map": "Vietos žemėlapis",
       "Exchange Rates": "Valiutų kursai",
@@ -1622,7 +1634,9 @@
       "Exchange Rate": "Valiutos kursas",
       "Create Exchange Rate": "Sukurti valiutos kursą",
       "View Exchange Rate": "Peržiūrėti valiutos kursą",
-      "Edit Exchange Rate": "Redaguoti valiutos kursą"
+      "Edit Exchange Rate": "Redaguoti valiutos kursą",
+      "Disable Breach Evaluation": "Išjungti pažeidimų vertinimą",
+      "Enable Breach Evaluation": "Įjungti pažeidimų vertinimą"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3209,6 +3223,7 @@
       "Expired": "Pasibaigė",
       "Last Action": "Paskutinis veiksmas",
       "No breach actions have been recorded for this loan": "Šiai paskolai nebuvo užregistruota jokių pažeidimo veiksmų",
+      "No delinquency actions have been recorded for this loan": "Šiai paskolai nebuvo užregistruota jokių įsiskolinimo veiksmų",
       "No records match the selected filter": "Joks įrašas neatitinka pasirinkto filtro",
       "Ongoing": "Vyksta",
       "Pause Active": "Pauzė aktyvi",
@@ -3259,7 +3274,8 @@
       "Mail": "El. paštas",
       "Link": "Susiejimas",
       "Audit Trail": "Audito takas",
-      "Restart Period from Reset Date": "Iš naujo paleisti laikotarpį nuo atstatymo datos"
+      "Restart Period from Reset Date": "Iš naujo paleisti laikotarpį nuo atstatymo datos",
+      "Breach evaluation disabled since": "Pažeidimų vertinimas išjungtas nuo {{date}}"
     },
     "links": {
       "Community": "bendruomenė",
@@ -3483,7 +3499,9 @@
       "the Transaction Type": "operacijos tipas",
       "undo_account_transfer": "Ar tikrai norite atšaukti šį sąskaitos pervedimą?",
       "Are you sure you want to undo the charge-off": "Ar tikrai norite anuliuoti Atsakingas už?",
-      "Restart Period from Reset Date splits the current period": "Jei įjungta, dabartinis pažeidimo laikotarpis padalijamas atstatymo data, o naujas laikotarpis prasideda nuo šios datos."
+      "Restart Period from Reset Date splits the current period": "Jei įjungta, dabartinis pažeidimo laikotarpis padalijamas atstatymo data, o naujas laikotarpis prasideda nuo šios datos.",
+      "Breach evaluation will stop": "Pažeidimų vertinimas sustabdomas {{date}}. Ankstesni rezultatai išsaugomi, bet paslepiami, kol vėl įjungsite.",
+      "Breach evaluation will resume": "Pažeidimų vertinimas atnaujinamas {{date}}. Nuo tos dienos paskola vėl vertinama."
     },
     "text": {
       "Agriculture Loan": "Žemės ūkio paskola",
@@ -3497,6 +3515,7 @@
       "Max": "Maks",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Nėra Pažeidimas Veiksmai",
+      "Previous results are hidden while breach evaluation is disabled": "Ankstesni rezultatai paslėpti, kol pažeidimų vertinimas išjungtas",
       "No Near Breach Actions": "Nėra Artėjantis pažeidimas Veiksmai",
       "A": "A",
       "Ability to manage holidays for individual offices": "Galimybė tvarkyti atskirų biurų atostogas yra labai naudingas įrankis organizacijai, kuri veikia keliose vietose. Naudokite šią parinktį, kad tinkintumėte atostogas kiekvienam savo organizacijos biurui.",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -426,7 +426,16 @@
     "validation.emailInvalid": "E-pasts nav derīgs",
     "validation.requiredField": "{{label}} ir obligāts lauks.",
     "validation.mustBeAtLeast": "{{field}} jābūt vismaz {{min}}",
-    "validation.mustBePositive": "{{field}} jābūt pozitīvam skaitlim."
+    "validation.mustBePositive": "{{field}} jābūt pozitīvam skaitlim.",
+    "breach": {
+      "alreadyDisabled": "Šim aizdevumam pārkāpumu novērtēšana jau ir atspējota.",
+      "noActiveDisableToEnable": "Šim aizdevumam nav aktīvas atspējošanas, ko iespējot.",
+      "mustBeCurrentBusinessDate": "Spēkā stāšanās datumam jābūt pašreizējam darbības datumam.",
+      "endDateNotAllowed": "Atspējojot vai iespējojot pārkāpumu novērtēšanu, beigu datumu nedrīkst nosūtīt.",
+      "noBreachConfiguration": "Šim aizdevumam nav pārkāpumu konfigurācijas.",
+      "loanIsNotActive": "Pārkāpumu novērtēšanu var mainīt tikai tad, kad aizdevums ir aktīvs.",
+      "breachIsDisabled": "Šim aizdevumam pārkāpumu novērtēšana ir atspējota. Iespējojiet to, lai veiktu šo darbību."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -784,7 +793,9 @@
       "Create Exchange Rate": "Izveidot valūtas kursu",
       "Create Transfer Fee": "Izveidot pārskaitījuma maksu",
       "Requesting": "Pieprasa",
-      "Delink": "Atsaistīt"
+      "Delink": "Atsaistīt",
+      "Disable Breach": "Atspējot pārkāpumu",
+      "Enable Breach": "Iespējot pārkāpumu"
     },
     "catalogs": {
       "% Amount": "Summa",
@@ -1612,6 +1623,7 @@
       "undo_account_transfer": "Atcelt konta pārskaitījumu",
       "Loan Breach Actions": "Aizdevuma pārkāpuma darbības",
       "No Breach Actions": "Nav pārkāpuma darbību",
+      "No Delinquency Actions": "Nav kavējuma darbību",
       "Pause Timeline": "Pauzes laika līnija",
       "Location Map": "Atrašanās vietas karte",
       "Exchange Rates": "Valūtas kursi",
@@ -1623,7 +1635,9 @@
       "Exchange Rate": "Valūtas kurss",
       "Create Exchange Rate": "Izveidot valūtas kursu",
       "View Exchange Rate": "Skatīt valūtas kursu",
-      "Edit Exchange Rate": "Rediģēt valūtas kursu"
+      "Edit Exchange Rate": "Rediģēt valūtas kursu",
+      "Disable Breach Evaluation": "Atspējot pārkāpumu novērtēšanu",
+      "Enable Breach Evaluation": "Iespējot pārkāpumu novērtēšanu"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3210,6 +3224,7 @@
       "Expired": "Beidzies",
       "Last Action": "Pēdējā darbība",
       "No breach actions have been recorded for this loan": "Šim aizdevumam nav reģistrētas pārkāpuma darbības",
+      "No delinquency actions have been recorded for this loan": "Šim aizdevumam nav reģistrētas kavējuma darbības",
       "No records match the selected filter": "Neviens ieraksts neatbilst atlasītajam filtram",
       "Ongoing": "Notiekoša",
       "Pause Active": "Pauze aktīva",
@@ -3260,7 +3275,8 @@
       "Mail": "E-pasts",
       "Link": "Saite",
       "Audit Trail": "Revīzijas taka",
-      "Restart Period from Reset Date": "Restartēt periodu no atiestatīšanas datuma"
+      "Restart Period from Reset Date": "Restartēt periodu no atiestatīšanas datuma",
+      "Breach evaluation disabled since": "Pārkāpumu novērtēšana atspējota kopš {{date}}"
     },
     "links": {
       "Community": "kopiena",
@@ -3483,7 +3499,9 @@
       "the Transaction Type": "Darījuma veids",
       "undo_account_transfer": "Vai tiešām vēlaties atcelt šo konta pārskaitījumu?",
       "Are you sure you want to undo the charge-off": "Vai tiešām vēlaties atcelt norakstīšanu?",
-      "Restart Period from Reset Date splits the current period": "Ja iespējots, pašreizējais pārkāpuma periods tiek sadalīts atiestatīšanas datumā un jauns periods sākas no šī datuma."
+      "Restart Period from Reset Date splits the current period": "Ja iespējots, pašreizējais pārkāpuma periods tiek sadalīts atiestatīšanas datumā un jauns periods sākas no šī datuma.",
+      "Breach evaluation will stop": "Pārkāpumu novērtēšana tiek pārtraukta {{date}}. Iepriekšējie rezultāti tiek saglabāti, bet paslēpti līdz atkārtotai iespējošanai.",
+      "Breach evaluation will resume": "Pārkāpumu novērtēšana atsākas {{date}}. No šī datuma aizdevums tiek novērtēts atkārtoti."
     },
     "text": {
       "Agriculture Loan": "Lauksaimniecības aizdevums",
@@ -3497,6 +3515,7 @@
       "Max": "Maks",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Nav Pārkāpums Darbības",
+      "Previous results are hidden while breach evaluation is disabled": "Iepriekšējie rezultāti ir paslēpti, kamēr pārkāpumu novērtēšana ir atspējota",
       "No Near Breach Actions": "Nav Tuvu pārkāpumam Darbības",
       "A": "A",
       "Ability to manage holidays for individual offices": "Iespēja pārvaldīt brīvdienas atsevišķiem birojiem ir ļoti noderīgs rīks organizācijai, kas aptver vairākas atrašanās vietas. Izmantojiet šo opciju, lai pielāgotu brīvdienas katram savas organizācijas birojam.",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -426,7 +426,16 @@
     "validation.emailInvalid": "इमेल मान्य छैन",
     "validation.requiredField": "{{label}} एक आवश्यक फिल्ड हो।",
     "validation.mustBeAtLeast": "{{field}} कम्तिमा {{min}} हुनुपर्छ",
-    "validation.mustBePositive": "{{field}} धनात्मक संख्या हुनुपर्छ।"
+    "validation.mustBePositive": "{{field}} धनात्मक संख्या हुनुपर्छ।",
+    "breach": {
+      "alreadyDisabled": "यो ऋणको उल्लंघन मूल्यांकन पहिले नै असक्षम छ।",
+      "noActiveDisableToEnable": "यो ऋणको लागि सक्षम गर्न मिल्ने कुनै सक्रिय असक्षमता छैन।",
+      "mustBeCurrentBusinessDate": "प्रभावकारी मिति हालको कारोबार मिति हुनुपर्छ।",
+      "endDateNotAllowed": "उल्लंघन मूल्यांकन असक्षम वा सक्षम गर्दा अन्त्य मिति पठाउन मिल्दैन।",
+      "noBreachConfiguration": "यो ऋणमा उल्लंघन कन्फिगरेसन छैन।",
+      "loanIsNotActive": "ऋण सक्रिय हुँदा मात्र उल्लंघन मूल्यांकन परिवर्तन गर्न सकिन्छ।",
+      "breachIsDisabled": "यो ऋणको उल्लंघन मूल्यांकन असक्षम छ। यो कार्य चलाउन यसलाई सक्षम गर्नुहोस्।"
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -784,7 +793,9 @@
       "Create Exchange Rate": "विनिमय दर सिर्जना गर्नुहोस्",
       "Create Transfer Fee": "स्थानान्तरण शुल्क सिर्जना गर्नुहोस्",
       "Requesting": "अनुरोध गर्दै",
-      "Delink": "लिंक हटाउनुहोस्"
+      "Delink": "लिंक हटाउनुहोस्",
+      "Disable Breach": "उल्लंघन असक्षम गर्नुहोस्",
+      "Enable Breach": "उल्लंघन सक्षम गर्नुहोस्"
     },
     "catalogs": {
       "% Amount": "रकम",
@@ -1611,6 +1622,7 @@
       "undo_account_transfer": "खाता स्थानान्तरण रद्द गर्नुहोस्",
       "Loan Breach Actions": "ऋण उल्लङ्घन कार्यहरू",
       "No Breach Actions": "कुनै उल्लंघन कार्यहरू छैनन्",
+      "No Delinquency Actions": "कुनै अपराध कार्यहरू छैनन्",
       "Pause Timeline": "रोकावट समयरेखा",
       "Location Map": "स्थान नक्सा",
       "Exchange Rates": "विनिमय दरहरू",
@@ -1622,7 +1634,9 @@
       "Exchange Rate": "विनिमय दर",
       "Create Exchange Rate": "विनिमय दर सिर्जना गर्नुहोस्",
       "View Exchange Rate": "विनिमय दर हेर्नुहोस्",
-      "Edit Exchange Rate": "विनिमय दर सम्पादन गर्नुहोस्"
+      "Edit Exchange Rate": "विनिमय दर सम्पादन गर्नुहोस्",
+      "Disable Breach Evaluation": "उल्लंघन मूल्यांकन असक्षम गर्नुहोस्",
+      "Enable Breach Evaluation": "उल्लंघन मूल्यांकन सक्षम गर्नुहोस्"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3209,6 +3223,7 @@
       "Expired": "समाप्त",
       "Last Action": "अन्तिम कार्य",
       "No breach actions have been recorded for this loan": "यो ऋणको लागि कुनै उल्लंघन कार्यहरू रेकर्ड गरिएको छैन",
+      "No delinquency actions have been recorded for this loan": "यो ऋणको लागि कुनै अपराध कार्यहरू रेकर्ड गरिएको छैन",
       "No records match the selected filter": "कुनै पनि रेकर्ड चयन गरिएको फिल्टरसँग मेल खाँदैन",
       "Ongoing": "जारी",
       "Pause Active": "रोकावट सक्रिय",
@@ -3259,7 +3274,8 @@
       "Mail": "मेल",
       "Link": "लिंक",
       "Audit Trail": "अडिट ट्रेल",
-      "Restart Period from Reset Date": "रिसेट मितिबाट अवधि पुनः सुरु गर्नुहोस्"
+      "Restart Period from Reset Date": "रिसेट मितिबाट अवधि पुनः सुरु गर्नुहोस्",
+      "Breach evaluation disabled since": "{{date}} देखि उल्लंघन मूल्यांकन असक्षम"
     },
     "links": {
       "Community": "समुदाय",
@@ -3483,7 +3499,9 @@
       "the Transaction Type": "लेनदेन प्रकार",
       "undo_account_transfer": "के तपाईं यो खाता स्थानान्तरण रद्द गर्न निश्चित हुनुहुन्छ?",
       "Are you sure you want to undo the charge-off": "के तपाईं चार्ज-अफ पूर्ववत गर्न निश्चित हुनुहुन्छ?",
-      "Restart Period from Reset Date splits the current period": "सक्षम पारेमा, हालको उल्लंघन अवधि रिसेट मितिमा विभाजन हुन्छ र सो मितिबाट नयाँ अवधि सुरु हुन्छ।"
+      "Restart Period from Reset Date splits the current period": "सक्षम पारेमा, हालको उल्लंघन अवधि रिसेट मितिमा विभाजन हुन्छ र सो मितिबाट नयाँ अवधि सुरु हुन्छ।",
+      "Breach evaluation will stop": "{{date}} देखि उल्लंघन मूल्यांकन रोकिन्छ। अघिल्ला नतिजाहरू रेकर्डमा रहन्छन् तर पुनः सक्षम नगरेसम्म लुकाइन्छन्।",
+      "Breach evaluation will resume": "{{date}} देखि उल्लंघन मूल्यांकन पुनः सुरु हुन्छ। त्यो मितिदेखि ऋणको पुनः मूल्यांकन गरिन्छ।"
     },
     "text": {
       "Agriculture Loan": "कृषि ऋण",
@@ -3497,6 +3515,7 @@
       "Max": "अधिकतम",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "कुनै उल्लंघन कार्यहरू छैन",
+      "Previous results are hidden while breach evaluation is disabled": "उल्लंघन मूल्यांकन असक्षम भएको बेला अघिल्ला नतिजाहरू लुकाइएका छन्",
       "No Near Breach Actions": "कुनै नजिकको उल्लंघन कार्यहरू छैन",
       "A": "ए",
       "Ability to manage holidays for individual offices": "व्यक्तिगत कार्यालयहरूको लागि छुट्टिहरू व्यवस्थापन गर्ने क्षमता धेरै स्थानहरूमा फैलिएको संगठनको लागि एक धेरै उपयोगी उपकरण हो। तपाईंको संगठनको प्रत्येक कार्यालयको लागि छुट्टिहरू अनुकूलन गर्न यो विकल्प प्रयोग गर्नुहोस्।",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -426,7 +426,16 @@
     "validation.emailInvalid": "Email inválido",
     "validation.requiredField": "{{label}} é um campo obrigatório.",
     "validation.mustBeAtLeast": "{{field}} deve ser pelo menos {{min}}",
-    "validation.mustBePositive": "{{field}} deve ser um número positivo."
+    "validation.mustBePositive": "{{field}} deve ser um número positivo.",
+    "breach": {
+      "alreadyDisabled": "A avaliação de violações já está desativada para este empréstimo.",
+      "noActiveDisableToEnable": "Não existe uma desativação ativa para ativar neste empréstimo.",
+      "mustBeCurrentBusinessDate": "A data efetiva tem de ser a data de negócio atual.",
+      "endDateNotAllowed": "Não pode ser enviada uma data de fim ao desativar ou ativar a avaliação de violações.",
+      "noBreachConfiguration": "Este empréstimo não tem configuração de violações.",
+      "loanIsNotActive": "A avaliação de violações só pode ser alterada enquanto o empréstimo estiver ativo.",
+      "breachIsDisabled": "A avaliação de violações está desativada para este empréstimo. Ative-a para executar esta ação."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -784,7 +793,9 @@
       "Create Exchange Rate": "Criar taxa de câmbio",
       "Create Transfer Fee": "Criar taxa de transferência",
       "Requesting": "A solicitar",
-      "Delink": "Desligar"
+      "Delink": "Desligar",
+      "Disable Breach": "Desativar Violação",
+      "Enable Breach": "Ativar Violação"
     },
     "catalogs": {
       "% Amount": "Quantia",
@@ -1611,6 +1622,7 @@
       "undo_account_transfer": "Reverter transferência de conta",
       "Loan Breach Actions": "Ações de Violação do Empréstimo",
       "No Breach Actions": "Sem Ações de Violação",
+      "No Delinquency Actions": "Sem Ações de Inadimplência",
       "Pause Timeline": "Cronologia de Pausas",
       "Location Map": "Mapa de localização",
       "Exchange Rates": "Taxas de câmbio",
@@ -1622,7 +1634,9 @@
       "Exchange Rate": "Taxa de câmbio",
       "Create Exchange Rate": "Criar taxa de câmbio",
       "View Exchange Rate": "Ver taxa de câmbio",
-      "Edit Exchange Rate": "Editar taxa de câmbio"
+      "Edit Exchange Rate": "Editar taxa de câmbio",
+      "Disable Breach Evaluation": "Desativar Avaliação de Violações",
+      "Enable Breach Evaluation": "Ativar Avaliação de Violações"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3209,6 +3223,7 @@
       "Expired": "Expirada",
       "Last Action": "Última Ação",
       "No breach actions have been recorded for this loan": "Não foram registadas ações de violação para este empréstimo",
+      "No delinquency actions have been recorded for this loan": "Não foram registadas ações de inadimplência para este empréstimo",
       "No records match the selected filter": "Nenhum registo corresponde ao filtro selecionado",
       "Ongoing": "Em curso",
       "Pause Active": "Pausa Ativa",
@@ -3259,7 +3274,8 @@
       "Mail": "E-mail",
       "Link": "Ligação",
       "Audit Trail": "Trilha de auditoria",
-      "Restart Period from Reset Date": "Reiniciar período a partir da data de reinício"
+      "Restart Period from Reset Date": "Reiniciar período a partir da data de reinício",
+      "Breach evaluation disabled since": "Avaliação de violações desativada desde {{date}}"
     },
     "links": {
       "Community": "Comunidade",
@@ -3483,7 +3499,9 @@
       "the Transaction Type": "o tipo de transação",
       "undo_account_transfer": "Tem a certeza de que pretende reverter esta transferência de conta?",
       "Are you sure you want to undo the charge-off": "Tem a certeza de que pretende desfazer a cobrança?",
-      "Restart Period from Reset Date splits the current period": "Se ativado, o período de incumprimento atual é dividido na data de reinício e um novo período começa a partir dessa data."
+      "Restart Period from Reset Date splits the current period": "Se ativado, o período de incumprimento atual é dividido na data de reinício e um novo período começa a partir dessa data.",
+      "Breach evaluation will stop": "A avaliação de violações para em {{date}}. Os resultados anteriores são mantidos, mas ficam ocultos até voltar a ativá-la.",
+      "Breach evaluation will resume": "A avaliação de violações recomeça em {{date}}. O empréstimo volta a ser avaliado a partir dessa data."
     },
     "text": {
       "Agriculture Loan": "Empréstimo agrícola",
@@ -3497,6 +3515,7 @@
       "Max": "Máx",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Nenhuma ação de violação",
+      "Previous results are hidden while breach evaluation is disabled": "Os resultados anteriores estão ocultos enquanto a avaliação de violações estiver desativada",
       "No Near Breach Actions": "Nenhuma ação de violação próxima",
       "A": "A",
       "Ability to manage holidays for individual offices": "A capacidade de gerenciar feriados para escritórios individuais é uma ferramenta muito útil para uma organização que abrange vários locais. Use esta opção para personalizar feriados para cada escritório da sua organização.",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -426,7 +426,16 @@
     "validation.emailInvalid": "Barua pepe si sahihi",
     "validation.requiredField": "{{label}} ni sehemu inayohitajika.",
     "validation.mustBeAtLeast": "{{field}} lazima iwe angalau {{min}}",
-    "validation.mustBePositive": "{{field}} lazima iwe nambari chanya."
+    "validation.mustBePositive": "{{field}} lazima iwe nambari chanya.",
+    "breach": {
+      "alreadyDisabled": "Tathmini ya ukiukaji tayari imezimwa kwa mkopo huu.",
+      "noActiveDisableToEnable": "Hakuna uzimaji unaoendelea wa kuwasha kwa mkopo huu.",
+      "mustBeCurrentBusinessDate": "Tarehe ya kuanza kutumika lazima iwe tarehe ya sasa ya biashara.",
+      "endDateNotAllowed": "Tarehe ya mwisho haiwezi kutumwa wakati wa kuzima au kuwasha tathmini ya ukiukaji.",
+      "noBreachConfiguration": "Mkopo huu hauna usanidi wa ukiukaji.",
+      "loanIsNotActive": "Tathmini ya ukiukaji inaweza kubadilishwa tu wakati mkopo uko hai.",
+      "breachIsDisabled": "Tathmini ya ukiukaji imezimwa kwa mkopo huu. Iwashe ili kutekeleza kitendo hiki."
+    }
   },
   "labels": {
     "Mifos Reporting Plugin for Eclipse Birt": "Mifos Reporting Plugin for Eclipse Birt",
@@ -784,7 +793,9 @@
       "Create Exchange Rate": "Unda kiwango cha ubadilishaji",
       "Create Transfer Fee": "Unda ada ya uhamisho",
       "Requesting": "Inaomba",
-      "Delink": "Tenganisha"
+      "Delink": "Tenganisha",
+      "Disable Breach": "Zima Ukiukaji",
+      "Enable Breach": "Washa Ukiukaji"
     },
     "catalogs": {
       "% Amount": "Kiasi",
@@ -1609,6 +1620,7 @@
       "undo_account_transfer": "Futa uhamisho wa akaunti",
       "Loan Breach Actions": "Vitendo vya Ukiukaji wa Mkopo",
       "No Breach Actions": "Hakuna Vitendo vya Ukiukaji",
+      "No Delinquency Actions": "Hakuna Vitendo vya Udaiwa",
       "Pause Timeline": "Mfuatano wa Pumziko",
       "Location Map": "Ramani ya eneo",
       "Exchange Rates": "Viwango vya ubadilishaji",
@@ -1620,7 +1632,9 @@
       "Exchange Rate": "Kiwango cha ubadilishaji",
       "Create Exchange Rate": "Unda kiwango cha ubadilishaji",
       "View Exchange Rate": "Tazama kiwango cha ubadilishaji",
-      "Edit Exchange Rate": "Hariri kiwango cha ubadilishaji"
+      "Edit Exchange Rate": "Hariri kiwango cha ubadilishaji",
+      "Disable Breach Evaluation": "Zima Tathmini ya Ukiukaji",
+      "Enable Breach Evaluation": "Washa Tathmini ya Ukiukaji"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3207,6 +3221,7 @@
       "Expired": "Imeisha",
       "Last Action": "Kitendo cha Mwisho",
       "No breach actions have been recorded for this loan": "Hakuna vitendo vya ukiukaji vilivyorekodiwa kwa mkopo huu",
+      "No delinquency actions have been recorded for this loan": "Hakuna vitendo vya udaiwa vilivyorekodiwa kwa mkopo huu",
       "No records match the selected filter": "Hakuna rekodi zinazolingana na kichujio kilichochaguliwa",
       "Ongoing": "Inaendelea",
       "Pause Active": "Pumziko Linaendelea",
@@ -3257,7 +3272,8 @@
       "Mail": "Barua pepe",
       "Link": "Kiungo",
       "Audit Trail": "Njia ya Ukaguzi",
-      "Restart Period from Reset Date": "Anza upya kipindi kutoka tarehe ya uwekaji upya"
+      "Restart Period from Reset Date": "Anza upya kipindi kutoka tarehe ya uwekaji upya",
+      "Breach evaluation disabled since": "Tathmini ya ukiukaji imezimwa tangu {{date}}"
     },
     "links": {
       "Community": "Jumuiya",
@@ -3480,7 +3496,9 @@
       "the Transaction Type": "Aina ya Muamala",
       "undo_account_transfer": "Una uhakika unataka kufuta uhamisho huu wa akaunti?",
       "Are you sure you want to undo the charge-off": "Una uhakika unataka kutendua Chaji-Zima?",
-      "Restart Period from Reset Date splits the current period": "Ikiwashwa, kipindi cha sasa cha ukiukaji hugawanywa katika tarehe ya uwekaji upya na kipindi kipya huanza kuanzia tarehe hiyo."
+      "Restart Period from Reset Date splits the current period": "Ikiwashwa, kipindi cha sasa cha ukiukaji hugawanywa katika tarehe ya uwekaji upya na kipindi kipya huanza kuanzia tarehe hiyo.",
+      "Breach evaluation will stop": "Tathmini ya ukiukaji itasimama tarehe {{date}}. Matokeo ya awali yatahifadhiwa lakini yatafichwa hadi uwashe tena.",
+      "Breach evaluation will resume": "Tathmini ya ukiukaji itaanza tena tarehe {{date}}. Mkopo utatathminiwa upya kuanzia tarehe hiyo."
     },
     "text": {
       "Agriculture Loan": "Mkopo wa Kilimo",
@@ -3494,6 +3512,7 @@
       "Max": "Upeo",
       "Hidden variables and predefined values are included in the final payload automatically.": "Hidden variables and predefined values are included in the final payload automatically.",
       "No Breach Actions": "Hakuna Ukiukaji Vitendo",
+      "Previous results are hidden while breach evaluation is disabled": "Matokeo ya awali yamefichwa wakati tathmini ya ukiukaji imezimwa",
       "No Near Breach Actions": "Hakuna Ukiukaji unaokaribia Vitendo",
       "A": "A",
       "Ability to manage holidays for individual offices": "Uwezo wa kudhibiti likizo kwa ofisi binafsi ni zana muhimu sana kwa shirika linalotumia maeneo mengi.Tumia chaguo hili kubinafsisha likizo kwa kila ofisi ya shirika lako.",


### PR DESCRIPTION
## Description

Authorised User should be able to disable the breach evaluation. UI should display that the breach is disabled and no previous evaluation to be shown on the UI

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots

https://github.com/user-attachments/assets/3be98dae-f73a-4b9d-b696-86a55e2fe653


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a loan delinquency dashboard with KPI metrics, timelines, filters, statuses, and controls.
  * Added working-capital breach evaluation enable/disable controls with confirmation dialogs and effective-date details.
  * Added delinquency schedules, installment tags, payment criteria, status indicators, and informative empty states.
* **Bug Fixes**
  * Improved action duration, status, timeline, and resume eligibility calculations.
  * Added clearer handling and translated messages for breach validation errors.
  * Breach actions and existing results are now hidden while evaluation is disabled.
* **Localization**
  * Added translations for breach evaluation, delinquency actions, statuses, controls, confirmations, and empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->