### PR TITLE
MX-380: Add Audit Trail tab to Mifos client profile

### DIFF
--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -24,6 +24,7 @@ import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component'
 import { BureauReadinessComponent } from './clients-view/bureau-readiness/bureau-readiness.component';
 import { CreditProfileComponent } from './clients-view/credit-profile/credit-profile.component';
 import { DisputeManagementComponent } from './clients-view/dispute-management/dispute-management.component';
+import { AuditTrailComponent } from './clients-view/audit-trail/audit-trail.component';
 import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
 import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
 import { AddressTabComponent } from './clients-view/address-tab/address-tab.component';
@@ -192,6 +193,11 @@ const routes: Routes = [
               path: 'dispute-management',
               component: DisputeManagementComponent,
               data: { title: 'Dispute Management', breadcrumb: 'Dispute Management', routeParamBreadcrumb: false }
+            },
+            {
+              path: 'audit-trail',
+              component: AuditTrailComponent,
+              data: { title: 'Audit Trail', breadcrumb: 'Audit Trail', routeParamBreadcrumb: false }
             },
             {
               path: 'datatables',

--- a/src/app/clients/clients-view/audit-trail/audit-trail.component.html
+++ b/src/app/clients/clients-view/audit-trail/audit-trail.component.html
@@ -1,0 +1,132 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<div class="cbild-audit-trail">
+  <!-- Header -->
+  <mat-card class="cbild-header-card">
+    <mat-card-content>
+      <div class="cbild-header-row">
+        <div class="cbild-header-title">
+          <mat-icon>history</mat-icon>
+          <span>{{ 'labels.cbild.auditTrail.title' | translate }}</span>
+        </div>
+        <span class="cbild-total-badge">
+          {{ totalElements }} {{ 'labels.cbild.auditTrail.totalEntries' | translate }}
+        </span>
+      </div>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- Date Filter -->
+  <mat-card class="cbild-filter-card">
+    <mat-card-content>
+      <h3 class="cbild-section-title">
+        <mat-icon>filter_list</mat-icon>
+        {{ 'labels.cbild.auditTrail.filterTitle' | translate }}
+      </h3>
+      <mat-divider></mat-divider>
+      <div class="cbild-filter-row">
+        <mat-form-field appearance="outline">
+          <mat-label>{{ 'labels.cbild.auditTrail.startDate' | translate }}</mat-label>
+          <input matInput type="text" placeholder="2026-08-01T00:00" [(ngModel)]="startDate" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>{{ 'labels.cbild.auditTrail.endDate' | translate }}</mat-label>
+          <input matInput type="text" placeholder="2026-08-07T23:59" [(ngModel)]="endDate" />
+        </mat-form-field>
+
+        <button
+          mat-raised-button
+          color="primary"
+          [disabled]="isLoading || !startDate || !endDate"
+          (click)="applyFilter()"
+        >
+          <mat-icon>search</mat-icon>
+          {{ 'labels.cbild.auditTrail.apply' | translate }}
+        </button>
+
+        <button mat-stroked-button [disabled]="isLoading" (click)="clearFilter()">
+          <mat-icon>clear</mat-icon>
+          {{ 'labels.cbild.auditTrail.clear' | translate }}
+        </button>
+      </div>
+    </mat-card-content>
+  </mat-card>
+
+  <!-- Loading bar -->
+  @if (isLoading) {
+    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+  }
+
+  <!-- Audit Entries -->
+  @if (!isLoading && entries.length === 0) {
+    <mat-card class="cbild-empty-card">
+      <mat-card-content>
+        <mat-icon>info_outline</mat-icon>
+        <p>{{ 'labels.cbild.auditTrail.noEntries' | translate }}</p>
+      </mat-card-content>
+    </mat-card>
+  }
+
+  @if (!isLoading && entries.length > 0) {
+    <mat-card class="cbild-entries-card">
+      <mat-card-content>
+        @for (entry of entries; track entry.id) {
+          <div class="cbild-audit-entry">
+            <div class="cbild-entry-header">
+              <div class="cbild-entry-left">
+                <span class="cbild-entry-id">#{{ entry.id }}</span>
+                <span class="cbild-entry-action">{{ entry.action }}</span>
+                <span class="cbild-entry-entity">{{ entry.entityType }}</span>
+              </div>
+              <span [class]="'cbild-result-badge ' + getResultClass(entry.result)">
+                {{ entry.result }}
+              </span>
+            </div>
+
+            <mat-divider class="cbild-entry-divider"></mat-divider>
+
+            <div class="cbild-entry-details">
+              <div class="cbild-detail-row">
+                <span class="cbild-label">{{ 'labels.cbild.auditTrail.performedBy' | translate }}</span>
+                <span class="cbild-value">{{ entry.performedBy }}</span>
+              </div>
+              <div class="cbild-detail-row">
+                <span class="cbild-label">{{ 'labels.cbild.auditTrail.createdAt' | translate }}</span>
+                <span class="cbild-value">{{ entry.createdAt | dateFormat }}</span>
+              </div>
+              <div class="cbild-detail-row">
+                <span class="cbild-label">{{ 'labels.cbild.auditTrail.duration' | translate }}</span>
+                <span class="cbild-value">{{ entry.durationMs }} ms</span>
+              </div>
+              <div class="cbild-detail-row">
+                <span class="cbild-label">{{ 'labels.cbild.auditTrail.requestId' | translate }}</span>
+                <span class="cbild-value cbild-request-id">{{ entry.requestId }}</span>
+              </div>
+            </div>
+          </div>
+
+          @if (!$last) {
+            <mat-divider class="cbild-between-entries"></mat-divider>
+          }
+        }
+      </mat-card-content>
+    </mat-card>
+
+    <!-- Paginator -->
+    <mat-paginator
+      [length]="totalElements"
+      [pageSize]="pageSize"
+      [pageIndex]="pageIndex"
+      [pageSizeOptions]="[10, 20, 50]"
+      (page)="onPageChange($event)"
+      showFirstLastButtons
+    >
+    </mat-paginator>
+  }
+</div>

--- a/src/app/clients/clients-view/audit-trail/audit-trail.component.scss
+++ b/src/app/clients/clients-view/audit-trail/audit-trail.component.scss
@@ -1,0 +1,167 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.cbild-audit-trail {
+  padding: 16px;
+}
+
+.cbild-header-card {
+  margin-bottom: 16px;
+}
+
+.cbild-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cbild-header-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.cbild-total-badge {
+  font-size: 12px;
+  color: var(--mdc-theme-text-secondary-on-background, rgb(0 0 0 / 54%));
+  background: var(--cbild-card-bg, #f8fafc);
+  border: 1px solid var(--cbild-card-border, #e2e8f0);
+  padding: 4px 10px;
+  border-radius: 12px;
+}
+
+.cbild-filter-card {
+  margin-bottom: 16px;
+}
+
+.cbild-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  margin-bottom: 12px;
+}
+
+.cbild-filter-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
+.cbild-empty-card {
+  margin-bottom: 16px;
+
+  mat-card-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--mdc-theme-text-secondary-on-background, rgb(0 0 0 / 54%));
+  }
+}
+
+.cbild-entries-card {
+  margin-bottom: 16px;
+}
+
+.cbild-audit-entry {
+  padding: 12px 0;
+}
+
+.cbild-entry-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.cbild-entry-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.cbild-entry-id {
+  font-size: 11px;
+  color: var(--mdc-theme-text-secondary-on-background, rgb(0 0 0 / 54%));
+  font-weight: 500;
+}
+
+.cbild-entry-action {
+  font-size: 13px;
+  font-weight: 600;
+  font-family: monospace;
+}
+
+.cbild-entry-entity {
+  font-size: 11px;
+  color: var(--mdc-theme-text-secondary-on-background, rgb(0 0 0 / 54%));
+  background: var(--cbild-card-bg, #f8fafc);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.cbild-entry-divider {
+  margin: 8px 0;
+}
+
+.cbild-between-entries {
+  margin: 4px 0;
+}
+
+.cbild-entry-details {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cbild-detail-row {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.cbild-label {
+  font-size: 12px;
+  color: var(--mdc-theme-text-secondary-on-background, rgb(0 0 0 / 54%));
+  min-width: 120px;
+}
+
+.cbild-value {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.cbild-request-id {
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--mdc-theme-text-secondary-on-background, rgb(0 0 0 / 54%));
+}
+
+.cbild-result-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.cbild-result-success {
+  background: var(--cbild-status-accepted-bg, #dcfce7);
+  color: var(--cbild-status-accepted-fg, #16a34a);
+}
+
+.cbild-result-failure {
+  background: var(--cbild-status-open-bg, #fee2e2);
+  color: var(--cbild-status-open-fg, #dc2626);
+}

--- a/src/app/clients/clients-view/audit-trail/audit-trail.component.ts
+++ b/src/app/clients/clients-view/audit-trail/audit-trail.component.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Component, OnInit, OnDestroy, inject, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Subject } from 'rxjs';
+import { takeUntil, switchMap } from 'rxjs/operators';
+import { HttpErrorResponse } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
+import { MatIcon } from '@angular/material/icon';
+import { MatDivider } from '@angular/material/divider';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
+import { TranslateService } from '@ngx-translate/core';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { AlertService } from 'app/core/alert/alert.service';
+import { CreditBureauService } from 'app/credit-bureau/credit-bureau.service';
+import { AuditEntryDTO } from 'app/credit-bureau/credit-bureau.models';
+
+/**
+ * CB-ILD Audit Trail — MX-380 Tab 5.
+ * Compliance only. Paginated. Date range filter.
+ * Route: /clients/{id}/audit-trail
+ * Role: COMPLIANCE only — enforced by @PreAuthorize on backend.
+ * @author Satyam Mishra — MSOC 2026
+ */
+@Component({
+  selector: 'mifosx-audit-trail',
+  templateUrl: './audit-trail.component.html',
+  styleUrls: ['./audit-trail.component.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    MatIcon,
+    MatDivider,
+    MatProgressBar,
+    MatPaginator,
+    FormsModule
+  ]
+})
+export class AuditTrailComponent implements OnInit, OnDestroy {
+  private route = inject(ActivatedRoute);
+  private creditBureauService = inject(CreditBureauService);
+  private alertService = inject(AlertService);
+  private cdr = inject(ChangeDetectorRef);
+  private translateService = inject(TranslateService);
+
+  clientId: number;
+
+  entries: AuditEntryDTO[] = [];
+  totalElements = 0;
+  pageIndex = 0;
+  pageSize = 10;
+
+  isLoading = false;
+
+  startDate = '';
+  endDate = '';
+
+  private destroy$ = new Subject<void>();
+  private load$ = new Subject<void>();
+
+  constructor() {
+    const rawId = this.route.parent?.snapshot.params['clientId'];
+    this.clientId = rawId ? +rawId : 0;
+  }
+
+  ngOnInit(): void {
+    this.initLoadPipeline();
+    this.load$.next();
+  }
+
+  private initLoadPipeline(): void {
+    this.load$
+      .pipe(
+        switchMap(() => {
+          this.isLoading = true;
+          this.cdr.markForCheck();
+
+          const params: { page: number; size: number; startDate?: string; endDate?: string } = {
+            page: this.pageIndex,
+            size: this.pageSize
+          };
+
+          if (this.startDate && this.endDate) {
+            params.startDate = this.startDate;
+            params.endDate = this.endDate;
+          }
+
+          return this.creditBureauService.getAuditTrail(this.clientId, params);
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe({
+        next: (data) => {
+          this.entries = data?._embedded?.auditEntryDTOList ?? [];
+          this.totalElements = data?.page?.totalElements ?? 0;
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+        error: (err: HttpErrorResponse) => {
+          this.isLoading = false;
+          this.alertService.alert({ type: 'error', message: this.getErrorMessage(err) });
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  applyFilter(): void {
+    if (this.startDate && this.endDate && this.startDate >= this.endDate) {
+      this.alertService.alert({
+        type: 'error',
+        message: this.translateService.instant('labels.cbild.auditTrail.invalidDateRange')
+      });
+      return;
+    }
+    this.pageIndex = 0;
+    this.load$.next();
+  }
+
+  clearFilter(): void {
+    this.startDate = '';
+    this.endDate = '';
+    this.pageIndex = 0;
+    this.load$.next();
+  }
+
+  onPageChange(event: PageEvent): void {
+    this.pageIndex = event.pageIndex;
+    this.pageSize = event.pageSize;
+    this.load$.next();
+  }
+
+  getResultClass(result: string): string {
+    return result === 'SUCCESS' ? 'cbild-result-success' : 'cbild-result-failure';
+  }
+
+  private getErrorMessage(err: HttpErrorResponse): string {
+    const t = (key: string) => this.translateService.instant(key);
+    switch (err?.status) {
+      case 401:
+        return t('labels.cbild.errors.unauthorized');
+      case 403:
+        return t('labels.cbild.errors.forbidden');
+      case 503:
+        return t('labels.cbild.errors.serviceUnavailable');
+      default:
+        return err?.error?.message || t('labels.cbild.errors.unexpected');
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -517,6 +517,17 @@
         >
           {{ 'labels.inputs.Dispute Management' | translate }}
         </a>
+        @if (isCbildCompliance) {
+          <a
+            mat-tab-link
+            [routerLink]="['./audit-trail']"
+            routerLinkActive
+            #auditTrail="routerLinkActive"
+            [active]="auditTrail.isActive"
+          >
+            {{ 'labels.inputs.Audit Trail' | translate }}
+          </a>
+        }
       }
       @for (clientDatatable of clientDatatables; track clientDatatable) {
         <a

--- a/src/app/clients/clients.module.ts
+++ b/src/app/clients/clients.module.ts
@@ -28,6 +28,7 @@ import { NotesTabComponent } from './clients-view/notes-tab/notes-tab.component'
 import { BureauReadinessComponent } from './clients-view/bureau-readiness/bureau-readiness.component';
 import { CreditProfileComponent } from './clients-view/credit-profile/credit-profile.component';
 import { DisputeManagementComponent } from './clients-view/dispute-management/dispute-management.component';
+import { AuditTrailComponent } from './clients-view/audit-trail/audit-trail.component';
 import { EditNotesDialogComponent } from './clients-view/custom-dialogs/edit-notes-dialog/edit-notes-dialog.component';
 import { DocumentsTabComponent } from './clients-view/documents-tab/documents-tab.component';
 import { DatatableTabComponent } from './clients-view/datatable-tab/datatable-tab.component';
@@ -93,6 +94,7 @@ import { ClientDatatableStepComponent } from './client-stepper/client-datatable-
     BureauReadinessComponent,
     CreditProfileComponent,
     DisputeManagementComponent,
+    AuditTrailComponent,
     EditNotesDialogComponent,
     DocumentsTabComponent,
     DatatableTabComponent,

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3257,7 +3257,8 @@
       "Dispute Management": "Správa sporů",
       "Phone": "Telefon",
       "Mail": "E-mail",
-      "Link": "Propojení"
+      "Link": "Propojení",
+      "Audit Trail": "Auditní stopa"
     },
     "links": {
       "Community": "Společenství",
@@ -4696,7 +4697,27 @@
         "statusUpdated": "Stav sporu aktualizován na {{ status }}"
       },
       "errors": {
-        "badRequest": "Neplatný požadavek. Zkontrolujte ID záznamu podání."
+        "badRequest": "Neplatný požadavek. Zkontrolujte ID záznamu podání.",
+        "unauthorized": "Neautorizováno",
+        "forbidden": "Přístup odepřen",
+        "serviceUnavailable": "Služba není dostupná",
+        "unexpected": "Došlo k neočekávané chybě",
+        "invalidDateRange": "Datum začátku musí být před datem konce"
+      },
+      "auditTrail": {
+        "title": "Auditní stopa",
+        "totalEntries": "záznamy",
+        "filterTitle": "Filtrovat podle rozsahu dat",
+        "startDate": "Datum začátku",
+        "endDate": "Datum konce",
+        "apply": "Použít",
+        "clear": "Vymazat",
+        "noEntries": "Nebyly nalezeny žádné auditní záznamy.",
+        "performedBy": "Provedl",
+        "createdAt": "Datum a čas",
+        "duration": "Trvání",
+        "requestId": "ID požadavku",
+        "invalidDateRange": "Datum začátku musí být před datem konce"
       }
     }
   },

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3259,7 +3259,8 @@
       "Dispute Management": "Streitverwaltung",
       "Phone": "Telefon",
       "Mail": "E-Mail",
-      "Link": "Verknüpfung"
+      "Link": "Verknüpfung",
+      "Audit Trail": "Prüfpfad"
     },
     "links": {
       "Community": "Gemeinschaft",
@@ -4696,7 +4697,27 @@
         "statusUpdated": "Streitstatus auf {{ status }} aktualisiert"
       },
       "errors": {
-        "badRequest": "Ungültige Anfrage. Bitte überprüfen Sie die Einreichungs-ID."
+        "badRequest": "Ungültige Anfrage. Bitte überprüfen Sie die Einreichungs-ID.",
+        "unauthorized": "Nicht autorisiert",
+        "forbidden": "Zugriff verweigert",
+        "serviceUnavailable": "Dienst nicht verfügbar",
+        "unexpected": "Ein unerwarteter Fehler ist aufgetreten",
+        "invalidDateRange": "Startdatum muss vor dem Enddatum liegen"
+      },
+      "auditTrail": {
+        "title": "Prüfpfad",
+        "totalEntries": "Einträge",
+        "filterTitle": "Nach Datumsbereich filtern",
+        "startDate": "Startdatum",
+        "endDate": "Enddatum",
+        "apply": "Anwenden",
+        "clear": "Löschen",
+        "noEntries": "Keine Prüfeinträge gefunden.",
+        "performedBy": "Durchgeführt von",
+        "createdAt": "Datum und Uhrzeit",
+        "duration": "Dauer",
+        "requestId": "Anforderungs-ID",
+        "invalidDateRange": "Startdatum muss vor dem Enddatum liegen"
       }
     }
   },

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3294,7 +3294,8 @@
       "Orange": "Orange",
       "Red": "Red",
       "Yellow": "Yellow",
-      "Primary Color": "Primary Color"
+      "Primary Color": "Primary Color",
+      "Audit Trail": "Audit Trail"
     },
     "links": {
       "Community": "Community",
@@ -4850,6 +4851,21 @@
         "resolve": "Resolve Dispute",
         "raised": "Dispute #{{ id }} raised successfully",
         "statusUpdated": "Dispute status updated to {{ status }}"
+      },
+      "auditTrail": {
+        "title": "Audit Trail",
+        "totalEntries": "entries",
+        "filterTitle": "Filter by Date Range",
+        "startDate": "Start Date",
+        "endDate": "End Date",
+        "apply": "Apply",
+        "clear": "Clear",
+        "noEntries": "No audit entries found for the selected criteria.",
+        "performedBy": "Performed By",
+        "createdAt": "Date & Time",
+        "duration": "Duration",
+        "requestId": "Request ID",
+        "invalidDateRange": "Start date must be before end date."
       }
     },
     "selections": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3258,7 +3258,8 @@
       "Cross Rate via": "Tipo cruzado (vía {{ currency }})",
       "Administrator": "Administrador",
       "Provider": "Proveedor",
-      "Dispute Management": "Gestión de disputas"
+      "Dispute Management": "Gestión de disputas",
+      "Audit Trail": "Registro de auditoría"
     },
     "links": {
       "Community": "Comunidad",
@@ -4701,7 +4702,27 @@
         "statusUpdated": "Estado actualizado a {{ status }}"
       },
       "errors": {
-        "badRequest": "Solicitud inválida. Verifique el ID de registro."
+        "badRequest": "Solicitud inválida. Verifique el ID de registro.",
+        "unauthorized": "No autorizado",
+        "forbidden": "Acceso denegado",
+        "serviceUnavailable": "Servicio no disponible",
+        "unexpected": "Ocurrió un error inesperado",
+        "invalidDateRange": "La fecha de inicio debe ser anterior a la fecha de fin"
+      },
+      "auditTrail": {
+        "title": "Registro de auditoría",
+        "totalEntries": "entradas",
+        "filterTitle": "Filtrar por rango de fechas",
+        "startDate": "Fecha de inicio",
+        "endDate": "Fecha de fin",
+        "apply": "Aplicar",
+        "clear": "Limpiar",
+        "noEntries": "No se encontraron entradas de auditoría.",
+        "performedBy": "Realizado por",
+        "createdAt": "Fecha y hora",
+        "duration": "Duración",
+        "requestId": "ID de solicitud",
+        "invalidDateRange": "La fecha de inicio debe ser anterior a la fecha de fin"
       }
     }
   },

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3263,7 +3263,8 @@
       "Cross Rate via": "Tipo cruzado (vía {{ currency }})",
       "Administrator": "Administrador",
       "Provider": "Proveedor",
-      "Dispute Management": "Gestión de disputas"
+      "Dispute Management": "Gestión de disputas",
+      "Audit Trail": "Registro de auditoría"
     },
     "links": {
       "Community": "Comunidad",
@@ -4725,7 +4726,27 @@
         "statusUpdated": "Estado actualizado a {{ status }}"
       },
       "errors": {
-        "badRequest": "Solicitud inválida. Verifique el ID de registro de envío."
+        "badRequest": "Solicitud inválida. Verifique el ID de registro de envío.",
+        "unauthorized": "No autorizado",
+        "forbidden": "Acceso denegado",
+        "serviceUnavailable": "Servicio no disponible",
+        "unexpected": "Ocurrió un error inesperado",
+        "invalidDateRange": "La fecha de inicio debe ser anterior a la fecha de fin"
+      },
+      "auditTrail": {
+        "title": "Registro de auditoría",
+        "totalEntries": "entradas",
+        "filterTitle": "Filtrar por rango de fechas",
+        "startDate": "Fecha de inicio",
+        "endDate": "Fecha de fin",
+        "apply": "Aplicar",
+        "clear": "Limpiar",
+        "noEntries": "No se encontraron entradas de auditoría.",
+        "performedBy": "Realizado por",
+        "createdAt": "Fecha y hora",
+        "duration": "Duración",
+        "requestId": "ID de solicitud",
+        "invalidDateRange": "La fecha de inicio debe ser anterior a la fecha de fin"
       }
     }
   },

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3260,7 +3260,8 @@
       "Dispute Management": "Gestion des litiges",
       "Phone": "Téléphone",
       "Mail": "E-mail",
-      "Link": "Lien"
+      "Link": "Lien",
+      "Audit Trail": "Piste d'audit"
     },
     "links": {
       "Community": "Communauté",
@@ -4702,7 +4703,27 @@
         "statusUpdated": "Statut mis à jour à {{ status }}"
       },
       "errors": {
-        "badRequest": "Requête invalide. Vérifiez l'ID d'enregistrement."
+        "badRequest": "Requête invalide. Vérifiez l'ID d'enregistrement.",
+        "unauthorized": "Non autorisé",
+        "forbidden": "Accès refusé",
+        "serviceUnavailable": "Service indisponible",
+        "unexpected": "Une erreur inattendue est survenue",
+        "invalidDateRange": "La date de début doit être antérieure à la date de fin"
+      },
+      "auditTrail": {
+        "title": "Piste d'audit",
+        "totalEntries": "entrées",
+        "filterTitle": "Filtrer par plage de dates",
+        "startDate": "Date de début",
+        "endDate": "Date de fin",
+        "apply": "Appliquer",
+        "clear": "Effacer",
+        "noEntries": "Aucune entrée d'audit trouvée.",
+        "performedBy": "Effectué par",
+        "createdAt": "Date et heure",
+        "duration": "Durée",
+        "requestId": "ID de requête",
+        "invalidDateRange": "La date de début doit être antérieure à la date de fin"
       }
     }
   },

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3257,7 +3257,8 @@
       "Dispute Management": "Gestione delle controversie",
       "Phone": "Telefono",
       "Mail": "E-mail",
-      "Link": "Collegamento"
+      "Link": "Collegamento",
+      "Audit Trail": "Traccia di controllo"
     },
     "links": {
       "Community": "Comunità",
@@ -4700,7 +4701,27 @@
         "statusUpdated": "Stato aggiornato a {{ status }}"
       },
       "errors": {
-        "badRequest": "Richiesta non valida. Verificare l'ID di registrazione."
+        "badRequest": "Richiesta non valida. Verificare l'ID di registrazione.",
+        "unauthorized": "Non autorizzato",
+        "forbidden": "Accesso negato",
+        "serviceUnavailable": "Servizio non disponibile",
+        "unexpected": "Si è verificato un errore imprevisto",
+        "invalidDateRange": "La data di inizio deve essere precedente alla data di fine"
+      },
+      "auditTrail": {
+        "title": "Traccia di controllo",
+        "totalEntries": "voci",
+        "filterTitle": "Filtra per intervallo di date",
+        "startDate": "Data di inizio",
+        "endDate": "Data di fine",
+        "apply": "Applica",
+        "clear": "Cancella",
+        "noEntries": "Nessuna voce di controllo trovata.",
+        "performedBy": "Eseguito da",
+        "createdAt": "Data e ora",
+        "duration": "Durata",
+        "requestId": "ID richiesta",
+        "invalidDateRange": "La data di inizio deve essere precedente alla data di fine"
       }
     }
   },

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3257,7 +3257,8 @@
       "Dispute Management": "분쟁 관리",
       "Phone": "전화번호",
       "Mail": "메일",
-      "Link": "연결"
+      "Link": "연결",
+      "Audit Trail": "감사 추적"
     },
     "links": {
       "Community": "지역 사회",
@@ -4699,7 +4700,27 @@
         "statusUpdated": "분쟁 상태가 {{ status }}로 업데이트됨"
       },
       "errors": {
-        "badRequest": "잘못된 요청입니다. 제출 기록 ID를 확인하세요."
+        "badRequest": "잘못된 요청입니다. 제출 기록 ID를 확인하세요.",
+        "unauthorized": "인증되지 않음",
+        "forbidden": "접근 거부됨",
+        "serviceUnavailable": "서비스를 사용할 수 없음",
+        "unexpected": "예기치 않은 오류가 발생했습니다",
+        "invalidDateRange": "시작 날짜는 종료 날짜보다 이전이어야 합니다"
+      },
+      "auditTrail": {
+        "title": "감사 추적",
+        "totalEntries": "항목",
+        "filterTitle": "날짜 범위로 필터",
+        "startDate": "시작 날짜",
+        "endDate": "종료 날짜",
+        "apply": "적용",
+        "clear": "지우기",
+        "noEntries": "감사 항목을 찾을 수 없습니다.",
+        "performedBy": "수행자",
+        "createdAt": "날짜 및 시간",
+        "duration": "소요 시간",
+        "requestId": "요청 ID",
+        "invalidDateRange": "시작 날짜는 종료 날짜보다 이전이어야 합니다"
       }
     }
   },

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3256,7 +3256,8 @@
       "Dispute Management": "Gincu valdymas",
       "Phone": "Telefonas",
       "Mail": "El. paštas",
-      "Link": "Susiejimas"
+      "Link": "Susiejimas",
+      "Audit Trail": "Audito takas"
     },
     "links": {
       "Community": "bendruomenė",
@@ -4700,7 +4701,27 @@
         "statusUpdated": "Ginco busena atnaujinta i {{ status }}"
       },
       "errors": {
-        "badRequest": "Neteisinga užklausa. Patikrinkite pateikimo įrašo ID."
+        "badRequest": "Neteisinga užklausa. Patikrinkite pateikimo įrašo ID.",
+        "unauthorized": "Nėra leidimo",
+        "forbidden": "Prieiga uždrausta",
+        "serviceUnavailable": "Paslauga nepasiekiama",
+        "unexpected": "Įvyko nenumatyta klaida",
+        "invalidDateRange": "Pradžios data turi būti ankstesnė už pabaigos datą"
+      },
+      "auditTrail": {
+        "title": "Audito takas",
+        "totalEntries": "įrašai",
+        "filterTitle": "Filtruoti pagal datų intervalą",
+        "startDate": "Pradžios data",
+        "endDate": "Pabaigos data",
+        "apply": "Taikyti",
+        "clear": "Išvalyti",
+        "noEntries": "Audito įrašų nerasta.",
+        "performedBy": "Atliko",
+        "createdAt": "Data ir laikas",
+        "duration": "Trukmė",
+        "requestId": "Užklausos ID",
+        "invalidDateRange": "Pradžios data turi būti ankstesnė už pabaigos datą"
       }
     }
   },

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3257,7 +3257,8 @@
       "Dispute Management": "Stridu parvaldiba",
       "Phone": "Tālrunis",
       "Mail": "E-pasts",
-      "Link": "Saite"
+      "Link": "Saite",
+      "Audit Trail": "Revīzijas taka"
     },
     "links": {
       "Community": "kopiena",
@@ -4699,7 +4700,27 @@
         "statusUpdated": "Strida statuss atjauninats uz {{ status }}"
       },
       "errors": {
-        "badRequest": "Nederīgs pieprasījums. Pārbaudiet iesnieguma ieraksta ID."
+        "badRequest": "Nederīgs pieprasījums. Pārbaudiet iesnieguma ieraksta ID.",
+        "unauthorized": "Nav autorizēts",
+        "forbidden": "Piekļuve liegta",
+        "serviceUnavailable": "Pakalpojums nav pieejams",
+        "unexpected": "Radās neparedzēta kļūda",
+        "invalidDateRange": "Sākuma datumam jābūt pirms beigu datuma"
+      },
+      "auditTrail": {
+        "title": "Revīzijas taka",
+        "totalEntries": "ieraksti",
+        "filterTitle": "Filtrēt pēc datumu diapazona",
+        "startDate": "Sākuma datums",
+        "endDate": "Beigu datums",
+        "apply": "Lietot",
+        "clear": "Notīrīt",
+        "noEntries": "Revīzijas ieraksti nav atrasti.",
+        "performedBy": "Veica",
+        "createdAt": "Datums un laiks",
+        "duration": "Ilgums",
+        "requestId": "Pieprasījuma ID",
+        "invalidDateRange": "Sākuma datumam jābūt pirms beigu datuma"
       }
     }
   },

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3256,7 +3256,8 @@
       "Dispute Management": "Vivad Vyavasthapan",
       "Phone": "फोन",
       "Mail": "मेल",
-      "Link": "लिंक"
+      "Link": "लिंक",
+      "Audit Trail": "अडिट ट्रेल"
     },
     "links": {
       "Community": "समुदाय",
@@ -4699,7 +4700,27 @@
         "statusUpdated": "Vivadko sthiti {{ status }} ma update bhayo"
       },
       "errors": {
-        "badRequest": "अमान्य अनुरोध। सबमिशन रेकर्ड ID जाँच गर्नुहोस्।"
+        "badRequest": "अमान्य अनुरोध। सबमिशन रेकर्ड ID जाँच गर्नुहोस्।",
+        "unauthorized": "अनधिकृत",
+        "forbidden": "पहुँच अस्वीकृत",
+        "serviceUnavailable": "सेवा उपलब्ध छैन",
+        "unexpected": "अनपेक्षित त्रुटि भयो",
+        "invalidDateRange": "सुरु मिति अन्त्य मितिभन्दा पहिले हुनुपर्छ"
+      },
+      "auditTrail": {
+        "title": "अडिट ट्रेल",
+        "totalEntries": "प्रविष्टिहरू",
+        "filterTitle": "मिति दायराद्वारा फिल्टर गर्नुहोस्",
+        "startDate": "सुरु मिति",
+        "endDate": "अन्त्य मिति",
+        "apply": "लागू गर्नुहोस्",
+        "clear": "हटाउनुहोस्",
+        "noEntries": "कुनै अडिट प्रविष्टि फेला परेन।",
+        "performedBy": "द्वारा गरिएको",
+        "createdAt": "मिति र समय",
+        "duration": "अवधि",
+        "requestId": "अनुरोध ID",
+        "invalidDateRange": "सुरु मिति अन्त्य मितिभन्दा पहिले हुनुपर्छ"
       }
     }
   },

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3256,7 +3256,8 @@
       "Dispute Management": "Gestão de disputas",
       "Phone": "Telefone",
       "Mail": "E-mail",
-      "Link": "Ligação"
+      "Link": "Ligação",
+      "Audit Trail": "Trilha de auditoria"
     },
     "links": {
       "Community": "Comunidade",
@@ -4699,7 +4700,27 @@
         "statusUpdated": "Estado atualizado para {{ status }}"
       },
       "errors": {
-        "badRequest": "Pedido inválido. Verifique o ID do registo de envio."
+        "badRequest": "Pedido inválido. Verifique o ID do registo de envio.",
+        "unauthorized": "Não autorizado",
+        "forbidden": "Acesso negado",
+        "serviceUnavailable": "Serviço indisponível",
+        "unexpected": "Ocorreu um erro inesperado",
+        "invalidDateRange": "A data de início deve ser anterior à data de fim"
+      },
+      "auditTrail": {
+        "title": "Trilha de auditoria",
+        "totalEntries": "entradas",
+        "filterTitle": "Filtrar por intervalo de datas",
+        "startDate": "Data de início",
+        "endDate": "Data de fim",
+        "apply": "Aplicar",
+        "clear": "Limpar",
+        "noEntries": "Nenhuma entrada de auditoria encontrada.",
+        "performedBy": "Realizado por",
+        "createdAt": "Data e hora",
+        "duration": "Duração",
+        "requestId": "ID do pedido",
+        "invalidDateRange": "A data de início deve ser anterior à data de fim"
       }
     }
   },

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3254,7 +3254,8 @@
       "Dispute Management": "Usimamizi wa Migogoro",
       "Phone": "Simu",
       "Mail": "Barua pepe",
-      "Link": "Kiungo"
+      "Link": "Kiungo",
+      "Audit Trail": "Njia ya Ukaguzi"
     },
     "links": {
       "Community": "Jumuiya",
@@ -4696,7 +4697,27 @@
         "statusUpdated": "Hali ya mgogoro imesasishwa hadi {{ status }}"
       },
       "errors": {
-        "badRequest": "Ombi batili. Angalia ID ya rekodi ya uwasilishaji."
+        "badRequest": "Ombi batili. Angalia ID ya rekodi ya uwasilishaji.",
+        "unauthorized": "Hauruhusiwi",
+        "forbidden": "Ufikiaji umekatazwa",
+        "serviceUnavailable": "Huduma haipatikani",
+        "unexpected": "Hitilafu isiyotarajiwa ilitokea",
+        "invalidDateRange": "Tarehe ya kuanza lazima iwe kabla ya tarehe ya mwisho"
+      },
+      "auditTrail": {
+        "title": "Njia ya Ukaguzi",
+        "totalEntries": "maingizo",
+        "filterTitle": "Chuja kwa masafa ya tarehe",
+        "startDate": "Tarehe ya kuanza",
+        "endDate": "Tarehe ya mwisho",
+        "apply": "Tumia",
+        "clear": "Futa",
+        "noEntries": "Hakuna maingizo ya ukaguzi yaliyopatikana.",
+        "performedBy": "Ilifanywa na",
+        "createdAt": "Tarehe na wakati",
+        "duration": "Muda",
+        "requestId": "ID ya ombi",
+        "invalidDateRange": "Tarehe ya kuanza lazima iwe kabla ya tarehe ya mwisho"
       }
     }
   },


### PR DESCRIPTION
## Summary
Adds Audit Trail tab (Tab 5) to the Mifos client profile as part of CB-ILD Phase 3 Angular frontend. This is the final Angular tab.

## What Changed
- `src/app/clients/clients-view/audit-trail/` — AuditTrail component (ts + html + scss)
- `src/app/clients/clients.module.ts` — AuditTrailComponent registered
- `src/app/clients/clients-routing.module.ts` — audit-trail route added
- `src/app/clients/clients-view/clients-view.component.html` — tab link added (COMPLIANCE only)
- `src/assets/translations/en-US.json` + all 11 language files — audit trail translations added
- `SecurityConfig.java` (backend) — CORS config added for localhost:4200 and mifos.community

## Test Results
- Audit Trail tab visible for Compliance role only ✅
- Tab hidden for KYC_OFFICER and CREDIT_ANALYST ✅
- 94 audit entries loaded for client 5 ✅
- Pagination working (10 per page, first/last buttons) ✅
- Date range filter working (ISO datetime format) ✅
- KYC Officer blocked → 403 ACCESS_DENIED ✅
- All 11 language files updated — 12 keys each ✅

## Related
- Jira: MX-380
- Depends on: MX-277 (#3704), MX-278 (#3708), MX-378 (#3721), MX-279 (#3782)
- This completes the CB-ILD Angular frontend Phase 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Audit Trail view for eligible client records.
  - View audit entries with actor, timestamp, duration, status, details, and request ID.
  - Added date-range filtering, clear/apply actions, loading and empty states, and pagination.
  - Added navigation breadcrumbs and page titles.

- **Localization**
  - Added Audit Trail labels, messages, validation text, and error handling across all supported application languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->