### PR TITLE
fix(WEB-1111): display customer data on transaction page

### DIFF
--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.html
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.html
@@ -7,6 +7,128 @@
 -->
 
 <div class="container">
+  @if (clientViewData) {
+    <mat-card class="account-card m-b-20">
+      <mifosx-account-header
+        [statusCode]="clientViewData.status?.code"
+        [statusTooltip]="'labels.status.' + clientViewData.status?.value | translate"
+      >
+        <img
+          accountImage
+          mat-card-md-image
+          class="profile-image"
+          matTooltip="{{ 'tooltips.Client' | translate }}"
+          [src]="clientImage ? clientImage : 'assets/images/user_placeholder.png'"
+        />
+
+        <ng-container ngProjectAs="[accountTitle]">
+          <b>{{ 'labels.inputs.Client Name' | translate }} :</b>
+          <mifosx-entity-name [entityName]="clientViewData.displayName" [display]="'right'"></mifosx-entity-name>
+        </ng-container>
+
+        <div accountMetadata>
+          <div class="layout-row responsive-column">
+            <div class="flex-50">
+              <table class="account-overview">
+                <tbody>
+                  <tr>
+                    <td>
+                      <b>{{ 'labels.inputs.Office' | translate }}</b>
+                    </td>
+                    <td><mifosx-entity-name [entityName]="clientViewData.officeName"></mifosx-entity-name></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <b>{{ 'labels.inputs.Account No' | translate }}</b>
+                    </td>
+                    <td><mifosx-account-number accountNo="{{ clientViewData.accountNo }}"></mifosx-account-number></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <b>{{ 'labels.inputs.External Id' | translate }}</b>
+                    </td>
+                    <td>
+                      <mifosx-external-identifier
+                        [externalId]="clientViewData.externalId"
+                        [completed]="true"
+                      ></mifosx-external-identifier>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <b>{{ 'labels.inputs.Staff' | translate }}</b>
+                    </td>
+                    <td>{{ clientViewData.staffName || ('labels.inputs.Unassigned' | translate) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="flex-50">
+              <table class="account-overview">
+                <tbody>
+                  @if (clientViewData.groups?.length > 0) {
+                    <tr>
+                      <td>
+                        <b>{{ 'labels.inputs.Member Of' | translate }}</b>
+                      </td>
+                      <td>
+                        @for (group of clientViewData.groups; track group) {
+                          <span class="m-r-3">{{ group.name }}</span>
+                        }
+                      </td>
+                    </tr>
+                  }
+                  @if (clientViewData.clientType) {
+                    <tr>
+                      <td>
+                        <b>{{ 'labels.inputs.Client Type' | translate }}</b>
+                      </td>
+                      <td>{{ clientViewData.clientType.name }}</td>
+                    </tr>
+                  }
+                  @if (clientViewData.clientClassification) {
+                    <tr>
+                      <td>
+                        <b>{{ 'labels.inputs.Client Classification' | translate }}</b>
+                      </td>
+                      <td>{{ clientViewData.clientClassification.name }}</td>
+                    </tr>
+                  }
+                  @if (clientViewData.mobileNo) {
+                    <tr>
+                      <td>
+                        <b>{{ 'labels.inputs.Mobile Number' | translate }}</b>
+                      </td>
+                      <td>
+                        <mifosx-external-identifier
+                          [externalId]="clientViewData.mobileNo"
+                          [completed]="true"
+                        ></mifosx-external-identifier>
+                      </td>
+                    </tr>
+                  }
+                  @if (clientViewData.emailAddress) {
+                    <tr>
+                      <td>
+                        <b>{{ 'labels.inputs.Email' | translate }}</b>
+                      </td>
+                      <td>
+                        <mifosx-external-identifier
+                          [externalId]="clientViewData.emailAddress"
+                          [completed]="true"
+                        ></mifosx-external-identifier>
+                      </td>
+                    </tr>
+                  }
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </mifosx-account-header>
+    </mat-card>
+  }
+
   <nav mat-tab-nav-bar class="navigation-tabs" [tabPanel]="tabPanel">
     <a
       mat-tab-link

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.scss
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.scss
@@ -17,3 +17,29 @@
     }
   }
 }
+
+.account-overview {
+  min-width: 85%;
+  margin-left: 10px;
+}
+
+mifosx-account-header {
+  td,
+  th,
+  b,
+  span:not(.status-dot),
+  h3,
+  p,
+  a {
+    color: var(--md-sys-color-on-primary, #fff);
+  }
+
+  img.profile-image {
+    width: 110px;
+    height: 110px;
+    object-fit: cover;
+    border-radius: 8px;
+    display: block;
+    background-color: var(--md-sys-color-on-primary, #fff);
+  }
+}

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.spec.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { ClientsService } from 'app/clients/clients.service';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { ViewTransactionComponent } from './view-transaction.component';
+
+describe('Savings ViewTransactionComponent', () => {
+  let fixture: ComponentFixture<ViewTransactionComponent>;
+  let clientsService: { getClientProfileImage: jest.Mock };
+
+  const clientViewData = (overrides: any = {}) => ({
+    id: 90,
+    displayName: 'Grace Hopper',
+    officeName: 'Head Office',
+    accountNo: '000000090',
+    externalId: 'EXT-90',
+    staffName: 'Ada Lovelace',
+    mobileNo: '5551234567',
+    emailAddress: 'grace@example.com',
+    status: { code: 'clientStatusType.active', value: 'Active' },
+    groups: [],
+    ...overrides
+  });
+
+  const setup = async (clientData: any = clientViewData()) => {
+    localStorage.setItem('mifosXLanguage', JSON.stringify({ code: 'en-US' }));
+    clientsService = {
+      getClientProfileImage: jest.fn(() => of(null))
+    };
+
+    const clientRoute: any = {
+      snapshot: {
+        data: {
+          clientViewData: clientData
+        }
+      },
+      parent: null
+    };
+    const savingsRoute = {
+      snapshot: { data: {} },
+      parent: clientRoute
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ViewTransactionComponent,
+        RouterTestingModule,
+        NoopAnimationsModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({ transactionDatatables: [{ registeredTableName: 'Rastro valida credito' }] }),
+            snapshot: {
+              params: {
+                savingAccountId: '87'
+              }
+            },
+            parent: savingsRoute
+          }
+        },
+        {
+          provide: ClientsService,
+          useValue: clientsService
+        },
+        {
+          provide: MatDialog,
+          useValue: {}
+        },
+        {
+          provide: AuthenticationService,
+          useValue: {
+            getCredentials: jest.fn(() => ({ permissions: ['ALL_FUNCTIONS'] }))
+          }
+        }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ViewTransactionComponent);
+    fixture.detectChanges();
+  };
+
+  const text = () => fixture.nativeElement.textContent;
+
+  it('renders the customer header on the transaction detail page', async () => {
+    await setup();
+
+    expect(text()).toContain('labels.inputs.Client Name');
+    expect(text()).toContain('Grace Hopper');
+    expect(text()).toContain('Head Office');
+    expect(text()).toContain('000000090');
+    expect(text()).toContain('EXT-90');
+    expect(text()).toContain('Ada Lovelace');
+    expect(text()).toContain('5551234567');
+    expect(text()).toContain('grace@example.com');
+    expect(clientsService.getClientProfileImage).toHaveBeenCalledWith(90);
+  });
+
+  it('does not break when optional customer fields are missing', async () => {
+    await setup(
+      clientViewData({
+        externalId: undefined,
+        staffName: undefined,
+        mobileNo: undefined,
+        emailAddress: undefined,
+        groups: undefined
+      })
+    );
+
+    expect(text()).toContain('Grace Hopper');
+    expect(text()).toContain('labels.inputs.Unassigned');
+    expect(text()).toContain('labels.heading.General');
+  });
+
+  it('keeps existing transaction tabs rendered', async () => {
+    await setup();
+
+    expect(text()).toContain('labels.heading.General');
+    expect(text()).toContain('Rastro valida credito');
+  });
+});

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.ts
@@ -11,8 +11,16 @@ import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
+import { DomSanitizer } from '@angular/platform-browser';
+import { MatCard, MatCardMdImage } from '@angular/material/card';
+import { MatTooltip } from '@angular/material/tooltip';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { ClientsService } from 'app/clients/clients.service';
+import { AccountHeaderComponent } from 'app/shared/account-header/account-header.component';
+import { AccountNumberComponent } from 'app/shared/account-number/account-number.component';
+import { EntityNameComponent } from 'app/shared/entity-name/entity-name.component';
+import { ExternalIdentifierComponent } from 'app/shared/external-identifier/external-identifier.component';
 
 @Component({
   selector: 'mifosx-view-transaction',
@@ -20,6 +28,13 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   styleUrls: ['./view-transaction.component.scss'],
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
+    AccountHeaderComponent,
+    AccountNumberComponent,
+    EntityNameComponent,
+    ExternalIdentifierComponent,
+    MatCard,
+    MatCardMdImage,
+    MatTooltip,
     MatTabNav,
     MatTabLink,
     RouterLinkActive,
@@ -30,9 +45,15 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class ViewTransactionComponent {
   private route = inject(ActivatedRoute);
+  private clientsService = inject(ClientsService);
+  private sanitizer = inject(DomSanitizer);
   dialog = inject(MatDialog);
   private destroyRef = inject(DestroyRef);
 
+  /** Client data inherited from the client route. */
+  clientViewData: any;
+  /** Client profile image. */
+  clientImage: any;
   /** Transaction data. */
   transactionData: any;
 
@@ -49,5 +70,41 @@ export class ViewTransactionComponent {
       this.accountId = this.route.snapshot.params['savingAccountId'];
       this.entityDatatables = data.transactionDatatables;
     });
+    this.setClientDataFromRoute();
+  }
+
+  /**
+   * Finds resolved client data from the ancestor client route.
+   */
+  private setClientDataFromRoute(): void {
+    let route = this.route.parent;
+    while (route && !this.clientViewData) {
+      const clientViewData = route.snapshot.data['clientViewData'];
+      if (clientViewData) {
+        this.clientViewData = clientViewData;
+        this.loadClientImage();
+      }
+      route = route.parent;
+    }
+  }
+
+  /**
+   * Loads the client profile image when available.
+   */
+  private loadClientImage(): void {
+    if (!this.clientViewData?.id) {
+      return;
+    }
+    this.clientsService
+      .getClientProfileImage(this.clientViewData.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (base64Image: any) => {
+          this.clientImage = base64Image ? this.sanitizer.bypassSecurityTrustResourceUrl(base64Image) : null;
+        },
+        error: () => {
+          this.clientImage = null;
+        }
+      });
   }
 }


### PR DESCRIPTION
### Description
Adds the existing customer information section to the transaction detail page so client details are visible alongside transaction data, without affecting existing transaction functionality or navigation.

### Related issues and discussion
WEB-1111

### Screenshots, if any

<img width="1355" height="699" alt="Screenshot 2026-08-08 at 11 00 21 PM" src="https://github.com/user-attachments/assets/45126052-bae1-4f26-be55-78b763b5f6a8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a client account summary to the transaction view when client information is available.
  - Displays client status, profile image, name, office, account details, staff, groups, classification, contact information, and other relevant fields.
  - Loads and displays the client’s profile image when available.

- **Bug Fixes**
  - Improved handling of missing optional client information and unavailable profile images without disrupting transaction tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->