### PR TITLE
fix(WEB-1112): add pagination and sorting to data tables

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.html
@@ -28,7 +28,7 @@
         }
       </ng-container>
       <ng-container *mifosxHasPermission="'DELETE_' + datatableName">
-        @if (datatableData.length > 0) {
+        @if (datatableData.data.length > 0) {
           <span>
             <button class="delete-button" mat-raised-button color="warn" (click)="delete()">
               <fa-icon icon="trash" class="m-r-10"></fa-icon>
@@ -43,7 +43,7 @@
   <mat-card class="data-table-card m-t-10">
     <mat-card-content>
       <div class="table-scroll-wrapper">
-        <table #dataTable mat-table [dataSource]="datatableData" class="mat-elevation-z2 m-b-25">
+        <table #dataTable mat-table [dataSource]="datatableData" matSort class="mat-elevation-z2">
           @for (datatableColumn of datatableColumns; track datatableColumn; let i = $index) {
             <ng-container [matColumnDef]="datatableColumn">
               @if (i === 0) {
@@ -59,7 +59,9 @@
                 </td>
               }
               @if (i > 0) {
-                <th mat-header-cell class="right" *matHeaderCellDef>{{ getInputName(datatableColumn) }}</th>
+                <th mat-header-cell class="right" *matHeaderCellDef mat-sort-header>
+                  {{ getInputName(datatableColumn) }}
+                </th>
                 <td
                   mat-cell
                   class="right responsive-data-cell"
@@ -78,6 +80,7 @@
           <tr mat-row *matRowDef="let row; columns: datatableColumns" class="data-row"></tr>
         </table>
       </div>
+      <mat-paginator [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons></mat-paginator>
     </mat-card-content>
   </mat-card>
 </div>

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
@@ -8,6 +8,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatePipe, DecimalPipe } from '@angular/common';
+import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
@@ -28,27 +29,37 @@ describe('DatatableMultiRowComponent', () => {
   let fixture: ComponentFixture<DatatableMultiRowComponent>;
   let component: DatatableMultiRowComponent;
 
-  const dataObject = {
+  const row = (id: number, firstName: string, lastName: string, amount: number | null = id) => ({
+    row: [
+      id,
+      99,
+      firstName,
+      lastName,
+      amount,
+      null
+    ]
+  });
+
+  const createDataObject = (data: any[] = [row(7, 'Ada', 'Lovelace')]) => ({
     columnHeaders: [
       { columnName: 'id', columnDisplayType: 'INTEGER' },
       { columnName: 'client_id', columnDisplayType: 'INTEGER' },
       { columnName: 'first_name', columnDisplayType: 'STRING' },
       { columnName: 'last_name', columnDisplayType: 'STRING' },
-      { columnName: 'notes', columnDisplayType: 'TEXT' },
+      { columnName: 'amount', columnDisplayType: 'DECIMAL' },
       { columnName: 'empty_value', columnDisplayType: 'STRING' }
     ],
-    data: [
-      {
-        row: [
-          7,
-          99,
-          'Ada',
-          'Lovelace',
-          'A long datatable value that should remain readable when rendered in the responsive mobile row.',
-          null
-        ]
-      }
-    ]
+    data
+  });
+
+  const getRenderedRows = (): string[] =>
+    Array.from(fixture.nativeElement.querySelectorAll('tr.mat-mdc-row')).map((tableRow: Element) =>
+      tableRow.textContent.replace(/\s+/g, ' ').trim()
+    );
+
+  const detectChanges = () => {
+    fixture.detectChanges();
+    fixture.detectChanges();
   };
 
   beforeEach(async () => {
@@ -99,10 +110,10 @@ describe('DatatableMultiRowComponent', () => {
 
     fixture = TestBed.createComponent(DatatableMultiRowComponent);
     component = fixture.componentInstance;
-    component.dataObject = dataObject;
+    component.dataObject = createDataObject();
     component.entityId = '99';
     component.entityType = 'Client';
-    fixture.detectChanges();
+    detectChanges();
   });
 
   it('adds responsive labels to dynamic data cells', () => {
@@ -116,7 +127,7 @@ describe('DatatableMultiRowComponent', () => {
       'Id',
       'First name',
       'Last name',
-      'Notes',
+      'Amount',
       'Empty value'
     ]);
     expect(mobileLabels).toEqual(labels);
@@ -141,7 +152,7 @@ describe('DatatableMultiRowComponent', () => {
       'id',
       'first_name',
       'last_name',
-      'notes',
+      'amount',
       'empty_value'
     ]);
     expect(component.datatableColumns).not.toContain('client_id');
@@ -155,5 +166,181 @@ describe('DatatableMultiRowComponent', () => {
     expect(emptyValueCell).toBeTruthy();
     expect(emptyValue).toBeTruthy();
     expect(emptyValue.textContent.trim()).toBe('');
+  });
+
+  it('renders a paginator for multi row data tables', () => {
+    const paginator = fixture.nativeElement.querySelector('mat-paginator');
+
+    expect(paginator).toBeTruthy();
+    expect(component.datatableData.paginator).toBe(component.paginator);
+  });
+
+  it('displays the correct rows when changing pages', () => {
+    component.dataObject = createDataObject([
+      row(1, 'One', 'User'),
+      row(2, 'Two', 'User'),
+      row(3, 'Three', 'User')
+    ]);
+    component.ngOnChanges({ dataObject: { currentValue: component.dataObject } as any });
+    component.paginator._changePageSize(2);
+    detectChanges();
+
+    expect(getRenderedRows()[0]).toContain('One');
+    expect(getRenderedRows()[1]).toContain('Two');
+
+    component.paginator.pageIndex = 1;
+    component.paginator.page.emit({
+      pageIndex: 1,
+      previousPageIndex: 0,
+      pageSize: 2,
+      length: 3
+    });
+    detectChanges();
+
+    expect(getRenderedRows()).toHaveLength(1);
+    expect(getRenderedRows()[0]).toContain('Three');
+  });
+
+  it('updates rendered rows when page size changes', () => {
+    component.dataObject = createDataObject([
+      row(1, 'One', 'User'),
+      row(2, 'Two', 'User'),
+      row(3, 'Three', 'User')
+    ]);
+    component.ngOnChanges({ dataObject: { currentValue: component.dataObject } as any });
+    component.paginator._changePageSize(2);
+    detectChanges();
+
+    expect(getRenderedRows()).toHaveLength(2);
+
+    component.paginator._changePageSize(10);
+    detectChanges();
+
+    expect(getRenderedRows()).toHaveLength(3);
+  });
+
+  it('sorts dynamic columns ascending and descending', () => {
+    component.dataObject = createDataObject([
+      row(1, 'Charlie', 'Zephyr'),
+      row(2, 'Alice', 'Yellow'),
+      row(3, 'Bob', 'Xavier')
+    ]);
+    component.ngOnChanges({ dataObject: { currentValue: component.dataObject } as any });
+
+    component.sort.sort({ id: 'first_name', start: 'asc', disableClear: false });
+    detectChanges();
+
+    expect(getRenderedRows()[0]).toContain('Alice');
+    expect(getRenderedRows()[1]).toContain('Bob');
+
+    component.sort.active = 'first_name';
+    component.sort.direction = 'desc';
+    component.sort.sortChange.emit({ active: 'first_name', direction: 'desc' });
+    detectChanges();
+
+    expect(getRenderedRows()[0]).toContain('Charlie');
+    expect(getRenderedRows()[1]).toContain('Bob');
+  });
+
+  it('sorts and paginates together', () => {
+    component.dataObject = createDataObject([
+      row(1, 'Charlie', 'Zephyr'),
+      row(2, 'Alice', 'Yellow'),
+      row(3, 'Bob', 'Xavier')
+    ]);
+    component.ngOnChanges({ dataObject: { currentValue: component.dataObject } as any });
+    component.paginator._changePageSize(2);
+    component.sort.sort({ id: 'first_name', start: 'asc', disableClear: false });
+    detectChanges();
+
+    component.paginator.pageIndex = 1;
+    component.paginator.page.emit({
+      pageIndex: 1,
+      previousPageIndex: 0,
+      pageSize: 2,
+      length: 3
+    });
+    detectChanges();
+
+    expect(getRenderedRows()).toHaveLength(1);
+    expect(getRenderedRows()[0]).toContain('Charlie');
+  });
+
+  it('renders an empty data table without rows', () => {
+    component.dataObject = createDataObject([]);
+    component.ngOnChanges({ dataObject: { currentValue: component.dataObject } as any });
+    detectChanges();
+
+    expect(getRenderedRows()).toHaveLength(0);
+    expect(component.datatableData.paginator).toBe(component.paginator);
+  });
+
+  it('renders all rows for a dataset smaller than one page', () => {
+    component.dataObject = createDataObject([
+      row(1, 'One', 'User'),
+      row(2, 'Two', 'User')
+    ]);
+    component.ngOnChanges({ dataObject: { currentValue: component.dataObject } as any });
+    detectChanges();
+
+    expect(getRenderedRows()).toHaveLength(2);
+  });
+
+  it('keeps selection intact across pagination and sorting', () => {
+    component.dataObject = createDataObject([
+      row(1, 'Charlie', 'Zephyr'),
+      row(2, 'Alice', 'Yellow'),
+      row(3, 'Bob', 'Xavier')
+    ]);
+    component.ngOnChanges({ dataObject: { currentValue: component.dataObject } as any });
+    component.paginator._changePageSize(2);
+    detectChanges();
+    const selectedRow = component.datatableData.data[1];
+
+    component.itemToggle(selectedRow);
+    component.sort.sort({ id: 'first_name', start: 'asc', disableClear: false });
+    component.paginator.pageIndex = 1;
+    component.paginator.page.emit({
+      pageIndex: 1,
+      previousPageIndex: 0,
+      pageSize: 2,
+      length: 3
+    });
+    detectChanges();
+
+    expect(component.selection.isSelected(selectedRow)).toBe(true);
+    expect(component.selection.selected).toEqual([selectedRow]);
+    expect(component.isSelected).toBe(true);
+  });
+
+  it('keeps delete selected behavior functional', () => {
+    component.dataObject = createDataObject([
+      row(1, 'One', 'User'),
+      row(2, 'Two', 'User')
+    ]);
+    component.ngOnChanges({ dataObject: { currentValue: component.dataObject } as any });
+    const selectedRow = component.datatableData.data[0];
+
+    component.itemToggle(selectedRow);
+
+    expect(fixture.debugElement.query(By.css('.delete-button'))).toBeTruthy();
+    expect(component.selection.selected).toEqual([selectedRow]);
+  });
+
+  it('sorts numbers and null values safely', () => {
+    component.dataObject = createDataObject([
+      row(1, 'One', 'User', 30),
+      row(2, 'Two', 'User', null),
+      row(3, 'Three', 'User', 5)
+    ]);
+    component.ngOnChanges({ dataObject: { currentValue: component.dataObject } as any });
+
+    component.sort.sort({ id: 'amount', start: 'asc', disableClear: false });
+    detectChanges();
+
+    expect(getRenderedRows()[0]).toContain('Two');
+    expect(getRenderedRows()[1]).toContain('Three');
+    expect(getRenderedRows()[2]).toContain('One');
+    expect(component.getSortValue(row(4, 'Four', 'User', 'invalid' as any), 'amount')).toBe(Number.NEGATIVE_INFINITY);
   });
 });

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
@@ -12,6 +12,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  AfterViewInit,
   Input,
   OnChanges,
   OnDestroy,
@@ -22,9 +23,12 @@ import {
 } from '@angular/core';
 import { MatCheckboxChange as MatCheckboxChange, MatCheckbox } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort, MatSortHeader } from '@angular/material/sort';
 import { formatDatatableDisplayLabel } from '@pipes/datatable-display-label.pipe';
 import {
   MatTable,
+  MatTableDataSource,
   MatColumnDef,
   MatHeaderCellDef,
   MatHeaderCell,
@@ -66,6 +70,9 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatCellDef,
     MatCell,
     MatCheckbox,
+    MatPaginator,
+    MatSort,
+    MatSortHeader,
     NgClass,
     MatHeaderRowDef,
     MatHeaderRow,
@@ -74,7 +81,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges {
+export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDestroy, OnChanges {
   formatTabLabel(label: string): string {
     return formatDatatableDisplayLabel(label);
   }
@@ -100,7 +107,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
   /** Data Table Columns */
   datatableColumns: string[] = [];
   /** Data Table Data */
-  datatableData: any;
+  datatableData = new MatTableDataSource<any>([]);
 
   /** Toggle button visibility */
   showDeleteBotton: boolean;
@@ -111,6 +118,8 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
 
   /** Data Table Reference */
   @ViewChild('dataTable') dataTableRef: MatTable<Element>;
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
 
   /**
    * Fetches data table name from route params.
@@ -124,6 +133,12 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
     });
     this.setData();
     this.isSelected = false;
+  }
+
+  ngAfterViewInit(): void {
+    this.datatableData.paginator = this.paginator;
+    this.datatableData.sort = this.sort;
+    this.changeDetectorRef.markForCheck();
   }
 
   ngOnDestroy(): void {
@@ -151,7 +166,10 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
       }
     });
 
-    this.datatableData = this.dataObject.data;
+    this.datatableData = new MatTableDataSource(this.dataObject.data || []);
+    this.datatableData.sortingDataAccessor = (data: any, sortHeaderId: string) => this.getSortValue(data, sortHeaderId);
+    this.datatableData.paginator = this.paginator;
+    this.datatableData.sort = this.sort;
     if (this.dataTableRef) {
       this.dataTableRef.renderRows();
     }
@@ -160,7 +178,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
   resetData() {
     this.datatableName = null;
     this.datatableColumns = null;
-    this.datatableData = null;
+    this.datatableData = new MatTableDataSource<any>([]);
   }
 
   getData() {
@@ -242,9 +260,11 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
         this.isSelected = false;
         this.selection.selected.forEach((data) => {
           this.systemService.deleteDatatableEntry(this.entityId, data.row[0], this.datatableName).subscribe(() => {
-            this.datatableData.forEach((item: any, index: any) => {
+            this.datatableData.data.forEach((item: any, index: any) => {
               if (item.row[0] === data.row[0]) {
-                this.datatableData.splice(index, 1);
+                const datatableRows = this.datatableData.data;
+                datatableRows.splice(index, 1);
+                this.datatableData.data = datatableRows;
                 this.dataTableRef.renderRows();
                 this.selection = new SelectionModel(true, []);
                 this.isSelected = this.selection.selected.length > 0;
@@ -291,10 +311,49 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
     return value;
   }
 
+  getSortValue(data: any, columnName: string): string | number {
+    if (columnName === this.SELECT_NAME_FIELD || !this.dataObject?.columnHeaders) {
+      return '';
+    }
+    const columnIndex = this.dataObject.columnHeaders.findIndex(
+      (columnHeader: any) => columnHeader.columnName === columnName
+    );
+    if (columnIndex === -1) {
+      return '';
+    }
+    const columnHeader = this.dataObject.columnHeaders[columnIndex];
+    const value = data.row[columnIndex];
+    const isMissingValue = value === null || value === undefined || value === '';
+    switch (columnHeader.columnDisplayType) {
+      case 'INTEGER':
+      case 'DECIMAL': {
+        const numericValue = Number(value);
+        return isMissingValue || Number.isNaN(numericValue) ? Number.NEGATIVE_INFINITY : numericValue;
+      }
+      case 'DATE':
+      case 'DATETIME': {
+        const dateValue = new Date(value).getTime();
+        return isMissingValue || Number.isNaN(dateValue) ? Number.NEGATIVE_INFINITY : dateValue;
+      }
+      case 'CODELOOKUP': {
+        if (isMissingValue) {
+          return '';
+        }
+        const codeValue = columnHeader.columnValues?.find((cv: any) => cv.id === value);
+        return (codeValue ? codeValue.value : value).toString().toLocaleLowerCase();
+      }
+      default:
+        if (isMissingValue) {
+          return '';
+        }
+        return value.toString().toLocaleLowerCase();
+    }
+  }
+
   /** Whether the number of selected elements matches the total number of rows. */
   isAllSelected() {
-    const numSelected = this.selection.selected;
-    return this.datatableData.length === numSelected;
+    const numSelected = this.selection.selected.length;
+    return this.datatableData.data.length === numSelected;
   }
 
   isAnySelected() {
@@ -304,7 +363,7 @@ export class DatatableMultiRowComponent implements OnInit, OnDestroy, OnChanges 
   /** Selects all rows if they are not all selected; otherwise clear selection. */
   masterToggle(change: MatCheckboxChange): void {
     if (change.checked) {
-      this.datatableData.forEach((row: any) => this.selection.select(row));
+      this.datatableData.data.forEach((row: any) => this.selection.select(row));
     } else {
       this.selection = new SelectionModel(true, []);
     }


### PR DESCRIPTION
## Description

Adds pagination and sorting to Data Table views using the existing Web-App table patterns, improving navigation for larger datasets while preserving existing Data Table actions, selection, and functionality.

## Related issues and discussion

WEB-1112

## Screenshots, if any

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sortable columns with type-aware handling for numeric, date, lookup, and text values.
  * Added pagination with page sizes of 10, 25, 50, and 100.
  * Preserved row selections across sorting and pagination.
  * Enabled combined sorting and pagination for easier navigation of large tables.

* **Bug Fixes**
  * Improved empty-table and delete-button behavior.
  * Ensured row deletion and selection counts remain accurate after sorting or paging.
  * Improved sorting reliability for numeric and blank values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->