### PR TITLE
WEB-1095: [Playwright] Loan account E2E specs — create, approve/disburse, reject & undo

### DIFF
--- a/playwright/pages/index.ts
+++ b/playwright/pages/index.ts
@@ -63,3 +63,9 @@ export { TransferClientPage } from './client-actions/transfer-client.page';
 export { AddChargePage } from './charges/add-charge.page';
 export { ClientChargesPage } from './charges/client-charges.page';
 export { ChargeViewPage } from './charges/charge-view.page';
+
+// ── Loan account page objects ──────────────────────────────────────
+
+export { CreateLoanAccountPage } from './loans/create-loan-account.page';
+export { LoanAccountViewPage } from './loans/loan-account-view.page';
+export { LoanAccountActionPage, type LoanAccountAction } from './loans/loan-account-action.page';

--- a/playwright/pages/loans/create-loan-account.page.ts
+++ b/playwright/pages/loans/create-loan-account.page.ts
@@ -1,0 +1,315 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../BasePage';
+import { CREATE_LOAN_ACCOUNT_SELECTORS } from '../../config/selectors';
+import { ROUTES } from '../../config/routes';
+import { fillDateField, fillIfVisible } from '../material-form-helpers';
+
+/** Default wait for the server-computed repayment schedule. */
+const SCHEDULE_TIMEOUT_MS = 30000;
+
+/**
+ * CreateLoanAccountPage — Page Object for the create-loan-account
+ * stepper (`/#/clients/:id/loans-accounts/create`).
+ *
+ * Consumes Layer-2 contracts:
+ *   - selectors: `CREATE_LOAN_ACCOUNT_SELECTORS`
+ *   - routes:    `ROUTES.loanAccountCreate(clientId)`
+ *
+ * This is the most fragile form in the client module, for three
+ * reasons that are all worth stating explicitly because each one
+ * produces a different, misleading failure if ignored.
+ *
+ * **1. The product dropdown is a search-select, keyed by short name.**
+ * It embeds `ngx-mat-select-search`, and each `mat-option`'s *value*
+ * is the product short name while its *visible label* is the product
+ * name prefixed by product type ("LOAN : E2E Loan Product"). Clicking
+ * by exact name misses. {@link selectProduct} types into the search box
+ * to narrow the list, then matches the option by substring.
+ *
+ * **2. Downstream steps do not exist until a product is chosen.**
+ * TERMS/CHARGES are wrapped in `@if (productId)`; REPAYMENT SCHEDULE
+ * and PREVIEW additionally in `@if (loansAccountFormValid)`. Filling
+ * the principal before the product resolves targets nothing.
+ *
+ * **3. The repayment schedule is server-computed.**
+ * Advancing past TERMS triggers a `/loans/template` round-trip that
+ * builds the schedule. Clicking Next again immediately walks past an
+ * empty table and reaches a Preview built from stale state.
+ * {@link waitForSchedule} waits on a populated row, not on the step
+ * header — the header appears before the data arrives.
+ *
+ * Cross-framework portability: all Material-overlay interaction is
+ * delegated to `material-form-helpers`; the React port swaps that one
+ * import and keeps this class byte-identical otherwise.
+ */
+export class CreateLoanAccountPage extends BasePage {
+  readonly url: string;
+
+  /**
+   * @param page - The Playwright Page instance.
+   * @param clientId - Owning client id.
+   */
+  constructor(
+    page: Page,
+    private readonly clientId: number
+  ) {
+    super(page);
+    this.url = ROUTES.loanAccountCreate(clientId);
+  }
+
+  // ── Locators ───────────────────────────────────────────────────────
+
+  /** The loan product search-select. */
+  get productDropdown(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.productDropdown);
+  }
+
+  /** The `ngx-mat-select-search` filter input inside the open overlay. */
+  get productSearchInput(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.productSearchInput).first();
+  }
+
+  /** Submitted-on date input on the DETAILS step. */
+  get submittedOnDateInput(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.submittedOnDateInput);
+  }
+
+  /** Expected disbursement date input on the DETAILS step. */
+  get expectedDisbursementDateInput(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.expectedDisbursementDateInput);
+  }
+
+  /** Optional external id input. */
+  get externalIdInput(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.externalIdInput);
+  }
+
+  /** Principal amount, rendered by `mifosx-input-amount`. */
+  get principalInput(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.principalInput).first();
+  }
+
+  /** Number of repayments input on the TERMS step. */
+  get numberOfRepaymentsInput(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.numberOfRepaymentsInput);
+  }
+
+  /** Nominal interest rate per period on the TERMS step. */
+  get interestRatePerPeriodInput(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.interestRatePerPeriodInput);
+  }
+
+  /** Rows of the server-computed repayment schedule table. */
+  get scheduleRows(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.scheduleRow);
+  }
+
+  /** Button that requests the repayment schedule from the server. */
+  get generateScheduleButton(): Locator {
+    return this.page.getByRole('button', { name: CREATE_LOAN_ACCOUNT_SELECTORS.generateScheduleButton });
+  }
+
+  /**
+   * The Next button of the currently selected step. See the savings
+   * counterpart for why this is scoped rather than visibility-filtered.
+   */
+  get nextButton(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.activeStepNextButton);
+  }
+
+  /** The final Submit button on the PREVIEW step. */
+  get submitButton(): Locator {
+    return this.page.getByRole('button', { name: CREATE_LOAN_ACCOUNT_SELECTORS.submitButton });
+  }
+
+  /** Validation errors rendered by the reactive form. */
+  get validationErrors(): Locator {
+    return this.page.locator(CREATE_LOAN_ACCOUNT_SELECTORS.validationError);
+  }
+
+  /** A step header addressed by its visible label. */
+  stepHeader(label: string): Locator {
+    return this.page.getByRole(CREATE_LOAN_ACCOUNT_SELECTORS.stepHeaderRole, { name: label });
+  }
+
+  // ── Actions ────────────────────────────────────────────────────────
+
+  /** Waits until the stepper is mounted and the product select is interactive. */
+  async waitForLoad(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/loans-accounts/create`));
+    await this.waitForVisible(this.productDropdown, 30000);
+  }
+
+  /**
+   * Select a loan product by its visible name.
+   *
+   * Not delegated to `selectFilteredOption` because that helper opens
+   * the trigger and locates the search box in one shot, whereas this
+   * dropdown renders its search box *inside* a `mat-option`, so the
+   * overlay has to be open before the input can be found. The option
+   * is then matched by substring, since the rendered label is prefixed
+   * with the product type.
+   *
+   * Waits for the TERMS-step principal field afterwards — that is the
+   * observable signal that `productId` is set and the gated steps have
+   * rendered.
+   *
+   * @param productName - Visible loan product name.
+   */
+  async selectProduct(productName: string): Promise<void> {
+    await this.productDropdown.click();
+
+    // The search box is only *usable* above ngx-mat-select-search's
+    // option-count threshold; below it the input still renders but
+    // carries `mat-select-search-hidden`. Treating it as required made
+    // the page object fail on exactly the small product catalogue a
+    // fresh test tenant has. Filtering is an optimisation here — the
+    // option match below is what actually selects the product — so a
+    // hidden box is skipped rather than waited on.
+    if (await this.productSearchInput.isVisible().catch(() => false)) {
+      await this.productSearchInput.fill(productName);
+    }
+
+    const option = this.page.getByRole('option').filter({ hasText: productName }).first();
+    await option.waitFor({ state: 'visible', timeout: 15000 });
+    await option.click();
+
+    await this.waitForVisible(this.submittedOnDateInput, 15000);
+  }
+
+  /**
+   * Fill the DETAILS step. Assumes a product is already selected.
+   *
+   * @param data.submittedOnDate - Submitted-on date, display format.
+   * @param data.expectedDisbursementDate - Expected disbursement date.
+   * @param data.externalId - Optional external id.
+   */
+  async fillDetailsStep(data: {
+    submittedOnDate: string;
+    expectedDisbursementDate: string;
+    externalId?: string;
+  }): Promise<void> {
+    await fillDateField(this.submittedOnDateInput, data.submittedOnDate);
+    await fillDateField(this.expectedDisbursementDateInput, data.expectedDisbursementDate);
+    await fillIfVisible(this.externalIdInput, data.externalId);
+  }
+
+  /**
+   * Fill the TERMS step, overriding only what the caller supplies.
+   *
+   * Every field here is pre-populated from the product template, so
+   * the happy path can pass an empty object and still produce a valid
+   * application.
+   *
+   * @param data.principal - Optional principal override.
+   * @param data.numberOfRepayments - Optional repayment count override.
+   * @param data.interestRate - Optional nominal interest rate override.
+   */
+  async fillTermsStep(
+    data: { principal?: string; numberOfRepayments?: string; interestRate?: string } = {}
+  ): Promise<void> {
+    await this.waitForVisible(this.principalInput, 15000);
+    if (data.principal) {
+      await this.principalInput.fill(data.principal);
+      await this.principalInput.blur();
+    }
+    await fillIfVisible(this.numberOfRepaymentsInput, data.numberOfRepayments);
+    await fillIfVisible(this.interestRatePerPeriodInput, data.interestRate);
+  }
+
+  /**
+   * Advance one step using the visible Next button.
+   *
+   * Asserts enabled first so an invalid step reports "expected
+   * enabled" rather than timing out several steps later on an element
+   * that was never going to appear.
+   */
+  async goToNextStep(): Promise<void> {
+    const next = this.nextButton.first();
+    await next.waitFor({ state: 'visible', timeout: 15000 });
+    await expect(next).toBeEnabled({ timeout: 15000 });
+    await next.click();
+  }
+
+  /**
+   * Request the repayment schedule and wait until it has rendered at
+   * least one row.
+   *
+   * ── Why the button click is required ────────────────────────────
+   *
+   * The schedule step renders its table shell — headers and a zeroed
+   * total row — immediately, but the body stays empty until
+   * "Generate Repayment Schedule" triggers the server round-trip.
+   * Waiting on the step header alone is therefore doubly wrong: the
+   * header appears as soon as `loansAccountFormValid` flips, and the
+   * schedule would never arrive regardless.
+   *
+   * The click is skipped only when a schedule already exists, so this
+   * method stays safe to call more than once.
+   */
+  async waitForSchedule(): Promise<void> {
+    const firstRow = this.scheduleRows.first();
+    // Skip the trigger only when a schedule already exists (rows are
+    // present) — the button is removed after generation, so this stays
+    // safe to call more than once. Crucially, WAIT for the trigger to
+    // appear rather than probing its visibility once: the schedule step
+    // mounts asynchronously after Next, so a one-shot check races the
+    // mount, skips the required click, and leaves the body empty — the
+    // exact failure this method exists to prevent, and one that only
+    // surfaces on slower (CI) runners.
+    if (!(await firstRow.isVisible().catch(() => false))) {
+      await this.generateScheduleButton.waitFor({ state: 'visible', timeout: SCHEDULE_TIMEOUT_MS });
+      await this.generateScheduleButton.click();
+    }
+    await expect(firstRow).toBeVisible({ timeout: SCHEDULE_TIMEOUT_MS });
+  }
+
+  /**
+   * Drive the full happy path: product → details → terms → charges →
+   * repayment schedule → preview → submit.
+   *
+   * @param data.productName - Visible loan product name.
+   * @param data.submittedOnDate - Submitted-on date, display format.
+   * @param data.expectedDisbursementDate - Expected disbursement date.
+   * @param data.principal - Optional principal override.
+   * @param data.numberOfRepayments - Optional repayment count override.
+   * @param data.interestRate - Optional interest rate override.
+   * @param data.externalId - Optional external id.
+   */
+  async submitApplication(data: {
+    productName: string;
+    submittedOnDate: string;
+    expectedDisbursementDate: string;
+    principal?: string;
+    numberOfRepayments?: string;
+    interestRate?: string;
+    externalId?: string;
+  }): Promise<void> {
+    await this.selectProduct(data.productName);
+    await this.fillDetailsStep(data);
+    await this.goToNextStep();
+
+    await this.fillTermsStep(data);
+    await this.goToNextStep();
+
+    // CHARGES — optional, skipped on the happy path.
+    await this.goToNextStep();
+
+    // REPAYMENT SCHEDULE — server-computed, must be populated first.
+    await this.waitForSchedule();
+    await this.goToNextStep();
+
+    // PREVIEW.
+    await this.waitForVisible(this.submitButton, 15000);
+    await this.submitButton.click();
+  }
+}

--- a/playwright/pages/loans/loan-account-action.page.ts
+++ b/playwright/pages/loans/loan-account-action.page.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../BasePage';
+import { LOAN_ACCOUNT_ACTION_SELECTORS } from '../../config/selectors';
+import { ROUTES } from '../../config/routes';
+import { fillDateField, fillIfVisible } from '../material-form-helpers';
+
+/**
+ * Loan lifecycle actions this page object covers.
+ *
+ * These strings are also the URL segment Angular reads as the
+ * `:action` route param.
+ */
+export type LoanAccountAction = 'Approve' | 'Disburse' | 'Reject' | 'Undo Approval' | 'Undo Disbursal';
+
+/**
+ * LoanAccountActionPage — Page Object for the loan lifecycle action
+ * forms (`/#/clients/:cid/loans-accounts/:lid/actions/:action`).
+ *
+ * Consumes Layer-2 contracts:
+ *   - selectors: `LOAN_ACCOUNT_ACTION_SELECTORS`
+ *   - routes:    `ROUTES.loanAccountAction(...)`
+ *
+ * ── Two app inconsistencies this class absorbs ──────────────────────
+ *
+ * **The submit control is labelled "Submit" here but "Confirm" on the
+ * savings action forms.** Same logical control, different copy. Both
+ * labels live in their respective Layer-2 contracts so no spec has to
+ * remember which module it is in.
+ *
+ * **Undo Approval and Undo Disbursal render no form fields at all** —
+ * just a submit button. `waitForLoad()` therefore waits on the submit
+ * button rather than on a date input, since that is the only control
+ * common to every action in the union.
+ *
+ * Note also that `loanAction()` navigates with a `productType` query
+ * parameter, so the URL assertion deliberately stops at the action
+ * segment rather than anchoring on `$`.
+ */
+export class LoanAccountActionPage extends BasePage {
+  readonly url: string;
+
+  /**
+   * @param page - The Playwright Page instance.
+   * @param clientId - Owning client id.
+   * @param loanId - Loan account id.
+   * @param action - Which lifecycle action this form represents.
+   */
+  constructor(
+    page: Page,
+    private readonly clientId: number,
+    private readonly loanId: number,
+    private readonly action: LoanAccountAction
+  ) {
+    super(page);
+    this.url = ROUTES.loanAccountAction(clientId, loanId, action);
+  }
+
+  // ── Locators ───────────────────────────────────────────────────────
+
+  /**
+   * The primary date input for this action, or `null` for the undo
+   * actions which have no fields.
+   */
+  get dateInput(): Locator | null {
+    switch (this.action) {
+      case 'Approve':
+        return this.page.locator(LOAN_ACCOUNT_ACTION_SELECTORS.approvedOnDateInput);
+      case 'Disburse':
+        return this.page.locator(LOAN_ACCOUNT_ACTION_SELECTORS.actualDisbursementDateInput);
+      case 'Reject':
+        return this.page.locator(LOAN_ACCOUNT_ACTION_SELECTORS.rejectedOnDateInput);
+      case 'Undo Approval':
+      case 'Undo Disbursal':
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Expected disbursement date — rendered on the Approve form only,
+   * alongside `approvedOnDate`.
+   */
+  get expectedDisbursementDateInput(): Locator {
+    return this.page.locator(LOAN_ACCOUNT_ACTION_SELECTORS.expectedDisbursementDateInput);
+  }
+
+  /** Amount input, rendered by `mifosx-input-amount` on the Disburse form. */
+  get amountInput(): Locator {
+    return this.page.locator(LOAN_ACCOUNT_ACTION_SELECTORS.amountInput).first();
+  }
+
+  /** Optional note textarea. */
+  get noteInput(): Locator {
+    return this.page.locator(LOAN_ACCOUNT_ACTION_SELECTORS.noteInput);
+  }
+
+  /** The Submit button. Loan forms label this "Submit", not "Confirm". */
+  get submitButton(): Locator {
+    return this.page.getByRole('button', { name: LOAN_ACCOUNT_ACTION_SELECTORS.submitButton });
+  }
+
+  /** The Cancel button, which routes back to the loan view. */
+  get cancelButton(): Locator {
+    return this.page.getByRole('button', { name: LOAN_ACCOUNT_ACTION_SELECTORS.cancelButton });
+  }
+
+  // ── Actions ────────────────────────────────────────────────────────
+
+  /** Waits for the action form to load. */
+  async waitForLoad(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/loans-accounts/${this.loanId}/actions/`));
+    await this.waitForVisible(this.submitButton, 30000);
+  }
+
+  /**
+   * Fill and submit the action form, and wait until the app has
+   * navigated away from the action route.
+   *
+   * The navigation wait is what makes the command *observable*:
+   * clicking Submit only starts the request, and every action
+   * component navigates solely from its success handler. Without it a
+   * spec can read the loan back before Fineract has applied the
+   * command and fail with a stale-status message that looks like a
+   * broken transition rather than a race.
+   *
+   * @param data.date - Primary date (approved-on / disbursement-on /
+   *   rejected-on) in the tenant display format. Ignored for the undo
+   *   actions.
+   * @param data.expectedDisbursementDate - Approve form only.
+   * @param data.amount - Disburse form only.
+   * @param data.note - Optional note.
+   */
+  async submit(
+    data: { date?: string; expectedDisbursementDate?: string; amount?: string; note?: string } = {}
+  ): Promise<void> {
+    const dateInput = this.dateInput;
+    if (dateInput && data.date) {
+      await fillDateField(dateInput, data.date);
+    }
+
+    if (data.expectedDisbursementDate && (await this.expectedDisbursementDateInput.isVisible())) {
+      await fillDateField(this.expectedDisbursementDateInput, data.expectedDisbursementDate);
+    }
+
+    if (data.amount && (await this.amountInput.isVisible())) {
+      await this.amountInput.fill(data.amount);
+      await this.amountInput.blur();
+    }
+
+    await fillIfVisible(this.noteInput, data.note);
+
+    await expect(this.submitButton).toBeEnabled({ timeout: 15000 });
+    await this.submitButton.click();
+
+    await this.page.waitForURL((url) => !url.hash.includes('/actions/'), { timeout: 30000 });
+  }
+}

--- a/playwright/pages/loans/loan-account-view.page.ts
+++ b/playwright/pages/loans/loan-account-view.page.ts
@@ -1,0 +1,164 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { expect, Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../BasePage';
+import { LOAN_ACCOUNT_VIEW_SELECTORS } from '../../config/selectors';
+import { ROUTES } from '../../config/routes';
+import { BEHAVIOR } from '../../config/behavior';
+
+/**
+ * LoanAccountViewPage — Page Object for the loan account general view
+ * (`/#/clients/:cid/loans-accounts/:lid/general`).
+ *
+ * Consumes Layer-2 contracts:
+ *   - selectors: `LOAN_ACCOUNT_VIEW_SELECTORS`
+ *   - routes:    `ROUTES.loanAccountView(clientId, loanId)`
+ *   - behavior:  `BEHAVIOR.overlayDismissNeeded`
+ *
+ * ── Why `chooseAction()` searches three menus ───────────────────────
+ *
+ * `LoansAccountButtonConfiguration` spreads actions across a top-level
+ * menu plus nested "Payments" and "More" submenus, and which bucket an
+ * action lands in changes with account status. `Approve` is top-level
+ * when pending; `Write Off` is under "More" when active. Encoding that
+ * table into specs would make them break whenever the app reshuffles
+ * its menu, so `chooseAction()` probes top-level, then Payments, then
+ * More, and callers just name the action.
+ */
+export class LoanAccountViewPage extends BasePage {
+  readonly url: string;
+
+  /**
+   * @param page - The Playwright Page instance.
+   * @param clientId - Owning client id.
+   * @param loanId - Loan account id.
+   */
+  constructor(
+    page: Page,
+    private readonly clientId: number,
+    private readonly loanId: number
+  ) {
+    super(page);
+    this.url = ROUTES.loanAccountView(clientId, loanId);
+  }
+
+  // ── Locators ───────────────────────────────────────────────────────
+
+  /** The account actions (hamburger) menu trigger. */
+  get actionsButton(): Locator {
+    return this.page.locator(LOAN_ACCOUNT_VIEW_SELECTORS.actionsButton);
+  }
+
+  /** The nested "More" submenu trigger. */
+  get moreMenuItem(): Locator {
+    return this.page.getByRole('menuitem', { name: LOAN_ACCOUNT_VIEW_SELECTORS.moreSubmenuTrigger });
+  }
+
+  /** The nested "Payments" submenu trigger. */
+  get paymentsMenuItem(): Locator {
+    return this.page.getByRole('menuitem', { name: LOAN_ACCOUNT_VIEW_SELECTORS.paymentsSubmenuTrigger });
+  }
+
+  /** A menu item addressed by its visible label. */
+  actionMenuItem(name: string): Locator {
+    return this.page.getByRole('menuitem', { name, exact: true });
+  }
+
+  /** The colour-coded status dot; its tooltip carries the status text. */
+  get statusBadge(): Locator {
+    return this.page.locator(LOAN_ACCOUNT_VIEW_SELECTORS.statusBadge);
+  }
+
+  /** Success/error snackbar container. */
+  get successSnackbar(): Locator {
+    return this.page.locator(LOAN_ACCOUNT_VIEW_SELECTORS.successSnackbar);
+  }
+
+  /** The Material overlay backdrop. */
+  get overlayBackdrop(): Locator {
+    return this.page.locator(LOAN_ACCOUNT_VIEW_SELECTORS.overlayBackdrop);
+  }
+
+  /** A tab in the account-view navigation, by accessible name. */
+  tab(name: string): Locator {
+    return this.page.getByRole(LOAN_ACCOUNT_VIEW_SELECTORS.tabRole, { name });
+  }
+
+  // ── Actions ────────────────────────────────────────────────────────
+
+  /** Waits until the loan general view is loaded and interactive. */
+  async waitForLoad(): Promise<void> {
+    await expect(this.page).toHaveURL(new RegExp(`/clients/${this.clientId}/loans-accounts/${this.loanId}/general`));
+    await this.waitForVisible(this.actionsButton, 30000);
+  }
+
+  /**
+   * Dismisses an open Material overlay so subsequent clicks land.
+   * No-op where `BEHAVIOR.overlayDismissNeeded` is false (React).
+   */
+  async dismissOverlay(): Promise<void> {
+    if (!BEHAVIOR.overlayDismissNeeded) {
+      return;
+    }
+    if (await this.overlayBackdrop.isVisible()) {
+      await this.overlayBackdrop.click({ force: true });
+      await this.overlayBackdrop.waitFor({ state: 'hidden', timeout: 10000 });
+    }
+  }
+
+  /** Opens the account actions menu. */
+  async openActionsMenu(): Promise<void> {
+    await this.actionsButton.click();
+    await this.page.getByRole('menu').first().waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  /**
+   * Opens the requested action, probing the top-level menu and then
+   * each nested submenu in turn.
+   *
+   * @param name - Action label, e.g. `'Approve'`, `'Disburse'`,
+   *   `'Undo Approval'`, `'Undo Disbursal'`, `'Reject'`.
+   */
+  async chooseAction(name: string): Promise<void> {
+    await this.openActionsMenu();
+
+    const target = this.actionMenuItem(name);
+    if (await target.isVisible().catch(() => false)) {
+      await target.click();
+      return;
+    }
+
+    for (const submenu of [
+      this.paymentsMenuItem,
+      this.moreMenuItem
+    ]) {
+      if (!(await submenu.isVisible().catch(() => false))) {
+        continue;
+      }
+      await submenu.click();
+      if (await target.isVisible().catch(() => false)) {
+        await target.click();
+        return;
+      }
+    }
+
+    throw new Error(
+      `LoanAccountViewPage.chooseAction: "${name}" was not found in the top-level menu, Payments, or More. ` +
+        `Check the account status — LoansAccountButtonConfiguration only renders actions valid for the current state.`
+    );
+  }
+
+  /** Activates a tab by its visible label. */
+  async gotoTab(name: string): Promise<void> {
+    const tab = this.tab(name);
+    await this.waitForVisible(tab, 10000);
+    await tab.click();
+  }
+}

--- a/playwright/tests/loans/create-loan-account.spec.ts
+++ b/playwright/tests/loans/create-loan-account.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '../../fixtures/test-fixtures';
+import { createActiveTestClient } from '../../factories/client.factory';
+import { E2E_LOAN_PRODUCT_NAME } from '../../factories/loan.factory';
+import { ClientViewPage } from '../../pages/client-view.page';
+import { CreateLoanAccountPage } from '../../pages/loans/create-loan-account.page';
+import { LoanAccountViewPage } from '../../pages/loans/loan-account-view.page';
+
+/**
+ * Loan account creation happy path — the other flow Alberto called
+ * out, and the harder of the two.
+ *
+ * The stepper differs from savings in ways that shape these tests:
+ *   - the product picker is a search-select keyed by short name;
+ *   - TERMS/CHARGES/SCHEDULE/PREVIEW are gated on product selection;
+ *   - the repayment schedule is computed server-side, so the flow has
+ *     to wait on data, not on a step header.
+ *
+ * All three are handled inside `CreateLoanAccountPage`, which is why
+ * these specs read as plainly as the savings ones.
+ */
+const SUBMITTED_ON_DATE = '03 January 2024';
+const EXPECTED_DISBURSEMENT_DATE = '03 January 2024';
+
+test.describe('Loan account · Create', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      const creds = localStorage.getItem('mifosXCredentials');
+      if (creds) {
+        sessionStorage.setItem('mifosXCredentials', creds);
+      }
+    });
+  });
+
+  test('creates a loan account from the client applications menu', async ({
+    page,
+    fineractApi,
+    apiSetup,
+    cleanupGuard
+  }) => {
+    await apiSetup.ensureMinimalLoanProduct();
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+
+    const clientViewPage = new ClientViewPage(page, client.resourceId);
+    const createPage = new CreateLoanAccountPage(page, client.resourceId);
+
+    await clientViewPage.navigate();
+    await clientViewPage.waitForLoad();
+    await clientViewPage.openNewLoanApplication();
+
+    await createPage.waitForLoad();
+    await createPage.submitApplication({
+      productName: E2E_LOAN_PRODUCT_NAME,
+      submittedOnDate: SUBMITTED_ON_DATE,
+      expectedDisbursementDate: EXPECTED_DISBURSEMENT_DATE
+    });
+
+    await page.waitForURL(/\/loans-accounts\/\d+\/general/, { timeout: 30000 });
+    const loanId = Number(page.url().match(/loans-accounts\/(\d+)\/general/)?.[1]);
+    expect(Number.isInteger(loanId)).toBe(true);
+
+    cleanupGuard.register(`loan:${loanId}`, async () => {
+      await fineractApi.deleteLoan(loanId);
+    });
+
+    const viewPage = new LoanAccountViewPage(page, client.resourceId, loanId);
+    await viewPage.waitForLoad();
+
+    const loan = await fineractApi.getLoan(loanId);
+    expect(loan.status?.value).toBe('Submitted and pending approval');
+    expect(loan.clientId).toBe(client.resourceId);
+    expect(loan.loanProductName).toBe(E2E_LOAN_PRODUCT_NAME);
+    expect(loan.principal).toBeGreaterThan(0);
+  });
+
+  test('renders a server-computed repayment schedule before preview', async ({ page, apiSetup, cleanupGuard }) => {
+    await apiSetup.ensureMinimalLoanProduct();
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+
+    const createPage = new CreateLoanAccountPage(page, client.resourceId);
+    await createPage.navigate();
+
+    await createPage.selectProduct(E2E_LOAN_PRODUCT_NAME);
+    await createPage.fillDetailsStep({
+      submittedOnDate: SUBMITTED_ON_DATE,
+      expectedDisbursementDate: EXPECTED_DISBURSEMENT_DATE
+    });
+    await createPage.goToNextStep();
+
+    await createPage.fillTermsStep();
+    await createPage.goToNextStep();
+    await createPage.goToNextStep();
+
+    // The schedule table is populated from a /loans/template round
+    // trip. Asserting on a row rather than the step header is the
+    // whole point: the header appears before the data arrives, so a
+    // header-only wait would let the flow race ahead of the response.
+    await createPage.waitForSchedule();
+    await expect(createPage.scheduleRows.first()).toBeVisible();
+    expect(await createPage.scheduleRows.count()).toBeGreaterThan(0);
+  });
+
+  test('gates the terms step behind product selection', async ({ page, apiSetup, cleanupGuard }) => {
+    await apiSetup.ensureMinimalLoanProduct();
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+
+    const createPage = new CreateLoanAccountPage(page, client.resourceId);
+    await createPage.navigate();
+
+    // `@if (productId)` — the TERMS step and everything after it are
+    // absent from the DOM, not merely hidden.
+    await expect(createPage.stepHeader('TERMS')).toHaveCount(0);
+    await expect(createPage.principalInput).toHaveCount(0);
+
+    await createPage.selectProduct(E2E_LOAN_PRODUCT_NAME);
+    await expect(createPage.stepHeader('TERMS')).toBeVisible();
+  });
+});

--- a/playwright/tests/loans/lifecycle/approve-disburse.spec.ts
+++ b/playwright/tests/loans/lifecycle/approve-disburse.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '../../../fixtures/test-fixtures';
+import { createActiveTestClient } from '../../../factories/client.factory';
+import { createTestLoan, createApprovedLoan } from '../../../factories/loan.factory';
+import { LoanAccountViewPage } from '../../../pages/loans/loan-account-view.page';
+import { LoanAccountActionPage } from '../../../pages/loans/loan-account-action.page';
+
+/**
+ * Loan lifecycle happy path: Pending → Approved → Active.
+ *
+ * The disbursement test is the one that would have caught the factory
+ * bug fixed alongside this work: Fineract's approve response is a thin
+ * command envelope with no principal, so a factory projecting off it
+ * disbursed zero. Asserting `principalDisbursed` against the approved
+ * principal pins that down at the UI level too.
+ */
+const SUBMITTED_ON_DATE = '03 January 2024';
+const APPROVED_ON_DATE = '04 January 2024';
+const DISBURSEMENT_DATE = '05 January 2024';
+
+test.describe('Loan lifecycle · Approve and Disburse', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      const creds = localStorage.getItem('mifosXCredentials');
+      if (creds) {
+        sessionStorage.setItem('mifosXCredentials', creds);
+      }
+    });
+  });
+
+  test('approves a pending loan', async ({ page, fineractApi, apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const loan = await createTestLoan(apiSetup, cleanupGuard, client.resourceId, {
+      submittedOnDate: SUBMITTED_ON_DATE
+    });
+
+    const viewPage = new LoanAccountViewPage(page, client.resourceId, loan.resourceId);
+    const approvePage = new LoanAccountActionPage(page, client.resourceId, loan.resourceId, 'Approve');
+
+    await viewPage.navigate();
+    await viewPage.waitForLoad();
+    await viewPage.chooseAction('Approve');
+
+    await approvePage.waitForLoad();
+    // The approve form binds `[min]="approvedOnDate"` on the expected
+    // disbursement date, and that field is prefilled from the loan's
+    // submitted value. Moving approval later therefore invalidates the
+    // prefill and leaves Submit disabled, so the disbursement date has
+    // to move with it.
+    await approvePage.submit({ date: APPROVED_ON_DATE, expectedDisbursementDate: APPROVED_ON_DATE });
+
+    await viewPage.waitForLoad();
+
+    const details = await fineractApi.getLoan(loan.resourceId);
+    expect(details.status?.value).toBe('Approved');
+    expect(details.timeline?.approvedOnDate).toEqual([
+      2024,
+      1,
+      4
+    ]);
+  });
+
+  test('disburses an approved loan at its full principal', async ({ page, fineractApi, apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const loan = await createApprovedLoan(apiSetup, cleanupGuard, client.resourceId, {
+      submittedOnDate: SUBMITTED_ON_DATE,
+      approvedOnDate: APPROVED_ON_DATE
+    });
+
+    const viewPage = new LoanAccountViewPage(page, client.resourceId, loan.resourceId);
+    const disbursePage = new LoanAccountActionPage(page, client.resourceId, loan.resourceId, 'Disburse');
+
+    await viewPage.navigate();
+    await viewPage.waitForLoad();
+    await viewPage.chooseAction('Disburse');
+
+    await disbursePage.waitForLoad();
+    // The amount field is pre-filled from the approved principal, so
+    // the happy path submits without overriding it.
+    await disbursePage.submit({ date: DISBURSEMENT_DATE });
+
+    const details = await fineractApi.getLoan(loan.resourceId);
+    expect(details.status?.value).toBe('Active');
+    expect(details.timeline?.actualDisbursementDate).toEqual([
+      2024,
+      1,
+      5
+    ]);
+    expect(details.summary?.principalDisbursed).toBe(loan.principal);
+  });
+});

--- a/playwright/tests/loans/lifecycle/reject.spec.ts
+++ b/playwright/tests/loans/lifecycle/reject.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '../../../fixtures/test-fixtures';
+import { createActiveTestClient } from '../../../factories/client.factory';
+import { createTestLoan } from '../../../factories/loan.factory';
+import { LoanAccountViewPage } from '../../../pages/loans/loan-account-view.page';
+import { LoanAccountActionPage } from '../../../pages/loans/loan-account-action.page';
+
+/**
+ * Loan lifecycle terminal path: Pending → Rejected.
+ *
+ * Unlike savings, `Reject` is a TOP-LEVEL entry on the loan action
+ * menu rather than a "More" submenu item. That asymmetry between the
+ * two modules is exactly why `chooseAction()` probes both instead of
+ * hard-coding a menu location per action.
+ */
+const SUBMITTED_ON_DATE = '03 January 2024';
+const REJECTED_ON_DATE = '04 January 2024';
+
+test.describe('Loan lifecycle · Reject', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      const creds = localStorage.getItem('mifosXCredentials');
+      if (creds) {
+        sessionStorage.setItem('mifosXCredentials', creds);
+      }
+    });
+  });
+
+  test('rejects a pending loan', async ({ page, fineractApi, apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const loan = await createTestLoan(apiSetup, cleanupGuard, client.resourceId, {
+      submittedOnDate: SUBMITTED_ON_DATE
+    });
+
+    const viewPage = new LoanAccountViewPage(page, client.resourceId, loan.resourceId);
+    const rejectPage = new LoanAccountActionPage(page, client.resourceId, loan.resourceId, 'Reject');
+
+    await viewPage.navigate();
+    await viewPage.waitForLoad();
+    await viewPage.chooseAction('Reject');
+
+    await rejectPage.waitForLoad();
+    await rejectPage.submit({ date: REJECTED_ON_DATE, note: 'Rejected by E2E suite' });
+
+    const details = await fineractApi.getLoan(loan.resourceId);
+    expect(details.status?.value).toBe('Rejected');
+    expect(details.timeline?.rejectedOnDate).toEqual([
+      2024,
+      1,
+      4
+    ]);
+  });
+});

--- a/playwright/tests/loans/lifecycle/undo-transitions.spec.ts
+++ b/playwright/tests/loans/lifecycle/undo-transitions.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { test, expect } from '../../../fixtures/test-fixtures';
+import { createActiveTestClient } from '../../../factories/client.factory';
+import { createApprovedLoan, createActiveLoan } from '../../../factories/loan.factory';
+import { LoanAccountViewPage } from '../../../pages/loans/loan-account-view.page';
+import { LoanAccountActionPage } from '../../../pages/loans/loan-account-action.page';
+
+/**
+ * Loan lifecycle reversals: Undo Approval and Undo Disbursal.
+ *
+ * Both forms render no fields at all — just a submit button — which is
+ * the case a page object built only against Approve/Disburse would get
+ * wrong. Covering them separately keeps that assumption honest.
+ */
+const SUBMITTED_ON_DATE = '03 January 2024';
+const APPROVED_ON_DATE = '04 January 2024';
+const DISBURSEMENT_DATE = '05 January 2024';
+
+test.describe('Loan lifecycle · Undo transitions', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      const creds = localStorage.getItem('mifosXCredentials');
+      if (creds) {
+        sessionStorage.setItem('mifosXCredentials', creds);
+      }
+    });
+  });
+
+  test('returns an approved loan to pending', async ({ page, fineractApi, apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const loan = await createApprovedLoan(apiSetup, cleanupGuard, client.resourceId, {
+      submittedOnDate: SUBMITTED_ON_DATE,
+      approvedOnDate: APPROVED_ON_DATE
+    });
+
+    const viewPage = new LoanAccountViewPage(page, client.resourceId, loan.resourceId);
+    const undoPage = new LoanAccountActionPage(page, client.resourceId, loan.resourceId, 'Undo Approval');
+
+    await viewPage.navigate();
+    await viewPage.waitForLoad();
+    await viewPage.chooseAction('Undo Approval');
+
+    await undoPage.waitForLoad();
+    await undoPage.submit();
+
+    const details = await fineractApi.getLoan(loan.resourceId);
+    expect(details.status?.value).toBe('Submitted and pending approval');
+    expect(details.timeline?.approvedOnDate).toBeFalsy();
+  });
+
+  test('returns a disbursed loan to approved', async ({ page, fineractApi, apiSetup, cleanupGuard }) => {
+    const client = await createActiveTestClient(apiSetup, cleanupGuard);
+    const loan = await createActiveLoan(apiSetup, cleanupGuard, client.resourceId, {
+      submittedOnDate: SUBMITTED_ON_DATE,
+      approvedOnDate: APPROVED_ON_DATE,
+      disbursementDate: DISBURSEMENT_DATE
+    });
+
+    const viewPage = new LoanAccountViewPage(page, client.resourceId, loan.resourceId);
+    const undoPage = new LoanAccountActionPage(page, client.resourceId, loan.resourceId, 'Undo Disbursal');
+
+    await viewPage.navigate();
+    await viewPage.waitForLoad();
+    await viewPage.chooseAction('Undo Disbursal');
+
+    await undoPage.waitForLoad();
+    await undoPage.submit();
+
+    const details = await fineractApi.getLoan(loan.resourceId);
+    // Undoing a disbursal returns the loan to Approved, NOT to pending —
+    // the approval survives.
+    expect(details.status?.value).toBe('Approved');
+    expect(details.timeline?.actualDisbursementDate).toBeFalsy();
+    expect(details.timeline?.approvedOnDate).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Description

Adds the Playwright E2E page objects and specs for the **loan-account domain**, built on the WEB-1094 test infrastructure (selectors, routes, `fineract-api` loan surface, loan factory, Material form helpers).

**Page objects (L3):** `create-loan-account`, `loan-account-view`, `loan-account-action`.

**Specs (L5):**
- `create-loan-account` — happy-path loan application through the UI.
- `lifecycle/approve-disburse` — approve a submitted loan, then disburse it to Active.
- `lifecycle/reject` — reject a submitted loan application.
- `lifecycle/undo-transitions` — undo approval / undo disbursal back to the prior state.

Preconditions (active client, submitted/approved/active loan) are arranged through the WEB-1094 API factories, so each spec exercises only the UI transition under test rather than re-driving setup through forms.

**Verification:** `prettier --check` and `eslint` clean; all loan specs pass as chromium UI tests against the running app + live Fineract.

**Dependencies:** WEB-1094 (test infrastructure) — merged. Independent of the savings PR (WEB-1092); no cross-domain coupling.

## Related issues and discussion

WEB-1095

## Screenshots, if any

N/A — test-only change; no application code is modified.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for creating loan accounts, including product selection, loan details, terms, repayment schedules, and submission.
  * Added coverage for approving, disbursing, rejecting, and reversing loan account lifecycle transitions.
  * Added validation for repayment schedules, dates, statuses, notifications, tabs, menus, and resulting account state.
  * Added reusable test support for navigating loan account views and completing lifecycle actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->