### PR TITLE
fix(WEB-1117): correct transaction page layout

### DIFF
--- a/src/app/savings/common-resolvers/savings-account-view.resolver.ts
+++ b/src/app/savings/common-resolvers/savings-account-view.resolver.ts
@@ -29,7 +29,7 @@ export class SavingsAccountViewResolver {
    * @returns {Observable<any>}
    */
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
-    const savingAccountId = route.paramMap.get('savingAccountId');
+    const savingAccountId = route.paramMap.get('savingAccountId') || route.parent?.paramMap.get('savingAccountId');
     return this.savingsService.getSavingsAccountData(savingAccountId);
   }
 }

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.html
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.html
@@ -7,128 +7,146 @@
 -->
 
 <div class="container">
-  @if (clientViewData) {
+  @if (savingsAccountData) {
     <mat-card class="account-card m-b-20">
-      <mifosx-account-header
-        [statusCode]="clientViewData.status?.code"
-        [statusTooltip]="'labels.status.' + clientViewData.status?.value | translate"
-      >
-        <img
-          accountImage
-          mat-card-md-image
-          class="profile-image"
-          matTooltip="{{ 'tooltips.Client' | translate }}"
-          [alt]="'labels.inputs.Client' | translate"
-          [src]="clientImage ? clientImage : 'assets/images/user_placeholder.png'"
-        />
-
-        <ng-container ngProjectAs="[accountTitle]">
-          <span class="customer-title">
-            <b>{{ 'labels.inputs.Client Name' | translate }} :</b>
-            <mifosx-entity-name [entityName]="clientViewData.displayName" [display]="'right'"></mifosx-entity-name>
-          </span>
-        </ng-container>
-
-        <div accountMetadata>
-          <div class="layout-row responsive-column customer-metadata">
-            <div class="customer-summary-column">
-              <table class="account-overview customer-summary">
-                <tbody>
-                  <tr>
-                    <td>
-                      <b>{{ 'labels.inputs.Office' | translate }}</b>
-                    </td>
-                    <td><mifosx-entity-name [entityName]="clientViewData.officeName"></mifosx-entity-name></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <b>{{ 'labels.inputs.Account No' | translate }}</b>
-                    </td>
-                    <td><mifosx-account-number accountNo="{{ clientViewData.accountNo }}"></mifosx-account-number></td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <b>{{ 'labels.inputs.External Id' | translate }}</b>
-                    </td>
-                    <td>
-                      <mifosx-external-identifier
-                        [externalId]="clientViewData.externalId"
-                        [completed]="true"
-                      ></mifosx-external-identifier>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <b>{{ 'labels.inputs.Staff' | translate }}</b>
-                    </td>
-                    <td>{{ clientViewData.staffName || ('labels.inputs.Unassigned' | translate) }}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <div class="customer-summary-column">
-              <table class="account-overview customer-summary">
-                <tbody>
-                  @if (clientViewData.groups?.length > 0) {
-                    <tr>
-                      <td>
-                        <b>{{ 'labels.inputs.Member Of' | translate }}</b>
-                      </td>
-                      <td>
-                        @for (group of clientViewData.groups; track group) {
-                          <span class="m-r-3">{{ group.name }}</span>
-                        }
-                      </td>
-                    </tr>
-                  }
-                  @if (clientViewData.clientType) {
-                    <tr>
-                      <td>
-                        <b>{{ 'labels.inputs.Client Type' | translate }}</b>
-                      </td>
-                      <td>{{ clientViewData.clientType.name }}</td>
-                    </tr>
-                  }
-                  @if (clientViewData.clientClassification) {
-                    <tr>
-                      <td>
-                        <b>{{ 'labels.inputs.Client Classification' | translate }}</b>
-                      </td>
-                      <td>{{ clientViewData.clientClassification.name }}</td>
-                    </tr>
-                  }
-                  @if (clientViewData.mobileNo) {
-                    <tr>
-                      <td>
-                        <b>{{ 'labels.inputs.Mobile Number' | translate }}</b>
-                      </td>
-                      <td>
-                        <mifosx-external-identifier
-                          [externalId]="clientViewData.mobileNo"
-                          [completed]="true"
-                        ></mifosx-external-identifier>
-                      </td>
-                    </tr>
-                  }
-                  @if (clientViewData.emailAddress) {
-                    <tr>
-                      <td>
-                        <b>{{ 'labels.inputs.Email' | translate }}</b>
-                      </td>
-                      <td>
-                        <mifosx-external-identifier
-                          [externalId]="clientViewData.emailAddress"
-                          [completed]="true"
-                        ></mifosx-external-identifier>
-                      </td>
-                    </tr>
-                  }
-                </tbody>
-              </table>
+      <mat-card-header class="header layout-column">
+        <mat-card-title-group class="header-title-group">
+          <div class="profile-image-container">
+            <div>
+              <img
+                mat-card-md-image
+                class="profile-image"
+                matTooltip="{{ 'tooltips.Savings Account' | translate }}"
+                [src]="'assets/images/savings_account_placeholder.png'"
+              />
             </div>
           </div>
-        </div>
-      </mifosx-account-header>
+
+          <div class="mat-typography account-card-title">
+            <mat-card-title class="layout-row layout-lt-md-column">
+              <div class="flex-60">
+                <h3>
+                  @if (!savingsAccountData.subStatus?.block) {
+                    <i
+                      class="fa fa-stop"
+                      [ngClass]="savingsAccountData.status?.code | statusLookup"
+                      [matTooltip]="savingsAccountData.status?.value"
+                    ></i>
+                  }
+                  @if (savingsAccountData.subStatus?.block) {
+                    <i
+                      class="fa fa-stop"
+                      [ngClass]="savingsAccountData.subStatus?.value | statusLookup"
+                      [matTooltip]="savingsAccountData.subStatus?.value"
+                    ></i>
+                  }
+                </h3>
+                <span class="product-row">
+                  <span class="m-r-5">{{ 'labels.inputs.Savings Product' | translate }} :</span>
+                  <span class="m-r-5">
+                    <mifosx-long-text textValue="{{ savingsAccountData.savingsProductName }}"></mifosx-long-text>
+                  </span>
+                </span>
+                <span class="account-number-row">
+                  <span class="m-r-5">{{ 'labels.inputs.Account Number' | translate }} :</span>
+                  <span class="m-r-5">
+                    <mifosx-account-number
+                      accountNo="{{ savingsAccountData.accountNo }}"
+                      display="left"
+                    ></mifosx-account-number>
+                  </span>
+                </span>
+                @if (savingsAccountData.externalId) {
+                  <span class="external-id-row">
+                    <span class="m-r-5">{{ 'labels.inputs.External Id' | translate }} :</span>
+                    <span>{{ savingsAccountData.externalId }}</span>
+                  </span>
+                }
+                <span class="account-overview">
+                  {{ 'labels.text.' + entityType | translate }} {{ 'labels.inputs.name' | translate }}:
+                  {{ savingsAccountData.clientName || savingsAccountData.groupName }}
+                  @if (savingsAccountData.clientAccountNo) {
+                    <span class="m-l-10">
+                      <mifosx-account-number
+                        accountNo="{{ savingsAccountData.clientAccountNo }}"
+                      ></mifosx-account-number>
+                    </span>
+                  }
+                </span>
+              </div>
+
+              @if (!savingsAccountData.status?.rejected && !savingsAccountData.status?.submittedAndPendingApproval) {
+                <div class="flex-30">
+                  <h3>{{ 'labels.heading.Account Overview' | translate }}</h3>
+                  <table class="account-overview">
+                    <tbody>
+                      <tr>
+                        <td>{{ 'labels.inputs.Current Balance' | translate }}</td>
+                        <td class="r-amount">
+                          {{
+                            savingsAccountData.summary?.accountBalance
+                              | currency: currency?.code : 'symbol-narrow' : '1.2-2'
+                          }}
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>{{ 'labels.inputs.Available Balance' | translate }}</td>
+                        <td class="r-amount">
+                          {{
+                            savingsAccountData.summary?.availableBalance
+                              | currency: currency?.code : 'symbol-narrow' : '1.2-2'
+                          }}
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              }
+
+              <div class="flex-5">
+                <button
+                  mat-icon-button
+                  [matMenuTriggerFor]="accountMenu"
+                  [attr.aria-label]="'labels.text.Savings Account Actions' | translate"
+                  yPosition="below"
+                >
+                  <mat-icon matListIcon class="actions-menu">
+                    <fa-icon icon="bars" size="sm"></fa-icon>
+                  </mat-icon>
+                </button>
+              </div>
+            </mat-card-title>
+          </div>
+
+          <mat-menu #accountMenu="matMenu">
+            @for (item of buttonConfig?.singleButtons; track item) {
+              <button mat-menu-item *mifosxHasPermission="item.taskPermissionName" (click)="doAction(item.name)">
+                <mat-icon matListIcon>
+                  <fa-icon icon="{{ item.icon }}" size="sm"></fa-icon>
+                </mat-icon>
+                <span> {{ 'labels.menus.' + item.name | translate }} </span>
+              </button>
+            }
+
+            @if (buttonConfig?.options && !savingsAccountData.subStatus?.block) {
+              <button mat-menu-item [matMenuTriggerFor]="More">{{ 'labels.menus.More' | translate }}</button>
+              <mat-menu #More="matMenu">
+                @for (option of buttonConfig?.options; track option) {
+                  <span>
+                    <button
+                      mat-menu-item
+                      *mifosxHasPermission="option.taskPermissionName"
+                      (click)="doAction(option.name)"
+                    >
+                      {{ 'labels.menus.' + option.name | translate }}
+                    </button>
+                  </span>
+                }
+              </mat-menu>
+            }
+          </mat-menu>
+        </mat-card-title-group>
+      </mat-card-header>
     </mat-card>
   }
 

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.scss
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.scss
@@ -6,64 +6,67 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-mifosx-account-header {
-  td,
-  th,
-  b,
-  span:not(.status-dot),
-  h3,
-  p,
-  a {
-    color: var(--md-sys-color-on-primary, #fff);
-  }
-
-  img.profile-image {
-    object-fit: cover;
-    border-radius: 8px;
-    display: block;
-    background-color: var(--md-sys-color-on-primary, #fff);
-  }
+/**
+ * Match the savings account header used by the parent Transactions page.
+ */
+.container {
+  max-width: 90rem;
+  width: 92%;
 }
 
-.customer-title,
-.customer-metadata,
-.customer-summary-column,
-.customer-summary td,
-mifosx-entity-name,
-mifosx-account-number,
-mifosx-external-identifier {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-.customer-metadata {
-  gap: 1rem;
-}
-
-.customer-summary-column {
-  flex: 1 1 0;
-  margin-bottom: 0;
-}
-
-.customer-summary {
+.account-card {
+  margin: 0 auto;
+  max-width: none;
   width: 100%;
-  margin: 0;
-  table-layout: fixed;
+  padding: 0;
 
-  td {
-    padding: 0.5rem 0;
-    vertical-align: top;
+  i,
+  img:hover {
+    cursor: pointer;
   }
 
-  td:first-child {
-    width: 9rem;
-    padding-right: 1rem;
-    white-space: nowrap;
+  .header {
+    background-color: var(--md-sys-color-primary, #1074b9);
+    padding: 1%;
+  }
+
+  .header-title-group {
+    .account-card-title {
+      color: var(--md-sys-color-on-primary, #fff);
+      width: 90%;
+    }
+
+    p {
+      color: var(--md-sys-color-on-primary, #fff);
+    }
+
+    .account-overview {
+      border: none;
+      max-width: 240px;
+      font-size: 14px;
+
+      tr:nth-child(even) {
+        background-color: transparent;
+      }
+    }
+  }
+
+  .profile-image-container {
+    margin: 1%;
+
+    .profile-image {
+      object-fit: cover;
+      border-radius: 20px;
+    }
   }
 }
 
-@media (width <=768px) {
-  .customer-summary-column {
-    flex-basis: auto;
-  }
+mat-card-title {
+  display: flex;
+}
+
+.product-row,
+.account-number-row,
+.external-id-row {
+  display: block;
 }

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.spec.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.spec.ts
@@ -12,83 +12,51 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { MatDialog } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { describe, expect, it, jest } from '@jest/globals';
 
-import { ClientsService } from 'app/clients/clients.service';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { IconsModule } from 'app/shared/icons.module';
 import { ViewTransactionComponent } from './view-transaction.component';
-
-interface ClientViewData {
-  id: string | number;
-  displayName: string;
-  officeName: string;
-  accountNo: string;
-  externalId?: string;
-  staffName?: string;
-  mobileNo?: string;
-  emailAddress?: string;
-  status: {
-    code: string;
-    value: string;
-  };
-  groups?: { name: string }[];
-}
-
-interface ClientsServiceStub {
-  getClientProfileImage: (clientId: string) => Observable<string | null>;
-}
-
-interface RouteStub {
-  snapshot: {
-    data: Record<string, unknown>;
-  };
-  parent: RouteStub | null;
-}
 
 describe('Savings ViewTransactionComponent', () => {
   let fixture: ComponentFixture<ViewTransactionComponent>;
-  let getClientProfileImage: jest.Mock<(clientId: string) => Observable<string | null>>;
-  let clientsService: ClientsServiceStub;
 
-  const clientViewData = (overrides: Partial<ClientViewData> = {}): ClientViewData => ({
-    id: 90,
-    displayName: 'Grace Hopper',
-    officeName: 'Head Office',
-    accountNo: '000000090',
-    externalId: 'EXT-90',
-    staffName: 'Ada Lovelace',
-    mobileNo: '5551234567',
-    emailAddress: 'grace@example.com',
-    status: { code: 'clientStatusType.active', value: 'Active' },
-    groups: [],
+  const savingsAccountData = (overrides: Record<string, unknown> = {}) => ({
+    id: 87,
+    accountNo: '000000001',
+    externalId: 'CR92037300110010000087',
+    savingsProductName: 'anvay',
+    clientName: 'an kh',
+    clientAccountNo: '000000001',
+    currency: {
+      code: 'USD'
+    },
+    status: {
+      code: 'savingsAccountStatusType.active',
+      value: 'Active',
+      rejected: false,
+      submittedAndPendingApproval: false
+    },
+    subStatus: {
+      block: false,
+      value: ''
+    },
+    summary: {
+      accountBalance: 180,
+      availableBalance: 180
+    },
     ...overrides
   });
 
-  const setup = async (clientData: ClientViewData = clientViewData()) => {
+  const setup = async (accountData = savingsAccountData()) => {
     localStorage.setItem('mifosXLanguage', JSON.stringify({ code: 'en-US' }));
-    getClientProfileImage = jest.fn(() => of(null));
-    clientsService = {
-      getClientProfileImage
-    };
-
-    const clientRoute: RouteStub = {
-      snapshot: {
-        data: {
-          clientViewData: clientData
-        }
-      },
-      parent: null
-    };
-    const savingsRoute: RouteStub = {
-      snapshot: { data: {} },
-      parent: clientRoute
-    };
 
     await TestBed.configureTestingModule({
       imports: [
         ViewTransactionComponent,
         RouterTestingModule,
+        IconsModule,
         NoopAnimationsModule,
         TranslateModule.forRoot()
       ],
@@ -96,18 +64,17 @@ describe('Savings ViewTransactionComponent', () => {
         {
           provide: ActivatedRoute,
           useValue: {
-            data: of({ transactionDatatables: [{ registeredTableName: 'Rastro valida credito' }] }),
+            data: of({
+              savingsAccountData: accountData,
+              transactionDatatables: [{ registeredTableName: 'Rastro valida credito' }]
+            }),
             snapshot: {
               params: {
                 savingAccountId: '87'
               }
             },
-            parent: savingsRoute
+            parent: null
           }
-        },
-        {
-          provide: ClientsService,
-          useValue: clientsService
         },
         {
           provide: MatDialog,
@@ -128,56 +95,29 @@ describe('Savings ViewTransactionComponent', () => {
 
   const text = () => fixture.nativeElement.textContent;
 
-  it('renders the customer header on the transaction detail page', async () => {
+  it('renders the savings account profile header on the transaction detail page', async () => {
     await setup();
 
-    expect(text()).toContain('labels.inputs.Client Name');
-    expect(text()).toContain('Grace Hopper');
-    expect(text()).toContain('Head Office');
-    expect(text()).toContain('000000090');
-    expect(text()).toContain('EXT-90');
-    expect(text()).toContain('Ada Lovelace');
-    expect(text()).toContain('5551234567');
-    expect(text()).toContain('grace@example.com');
-    expect(getClientProfileImage).toHaveBeenCalledWith('90');
+    expect(text()).toContain('labels.inputs.Savings Product');
+    expect(text()).toContain('anvay');
+    expect(text()).toContain('labels.inputs.Account Number');
+    expect(text()).toContain('000000001');
+    expect(text()).toContain('labels.inputs.External Id');
+    expect(text()).toContain('CR92037300110010000087');
+    expect(text()).toContain('an kh');
+    expect(text()).toContain('labels.heading.Account Overview');
+    expect(text()).toContain('labels.inputs.Current Balance');
+    expect(text()).toContain('labels.inputs.Available Balance');
   });
 
-  it('does not break when optional customer fields are missing', async () => {
-    await setup(
-      clientViewData({
-        externalId: undefined,
-        staffName: undefined,
-        mobileNo: undefined,
-        emailAddress: undefined,
-        groups: undefined
-      })
+  it('does not render the client avatar profile metadata on transaction detail', async () => {
+    await setup();
+
+    expect(text()).not.toContain('labels.inputs.Office');
+    expect(text()).not.toContain('labels.inputs.Staff');
+    expect(fixture.nativeElement.querySelector('img.profile-image')?.getAttribute('src')).toBe(
+      'assets/images/savings_account_placeholder.png'
     );
-
-    expect(text()).toContain('Grace Hopper');
-    expect(text()).toContain('labels.inputs.Unassigned');
-    expect(text()).toContain('labels.heading.General');
-  });
-
-  it('renders long customer values without dropping account header information', async () => {
-    const longName = 'Grace Brewster Murray Hopper With A Very Long Customer Name';
-    const longExternalId = 'EXT-90-0000000000000000000000000000000000000000000000000000';
-    const longMobileNo = '555123456789012345678901234567890';
-    const longEmail = 'grace.hopper.with.a.very.long.email.address@example-financial-institution.test';
-
-    await setup(
-      clientViewData({
-        displayName: longName,
-        externalId: longExternalId,
-        mobileNo: longMobileNo,
-        emailAddress: longEmail
-      })
-    );
-
-    expect(text()).toContain(longName);
-    expect(text()).toContain(longExternalId);
-    expect(text()).toContain(longMobileNo);
-    expect(text()).toContain(longEmail);
-    expect(text()).toContain('000000090');
   });
 
   it('keeps existing transaction tabs rendered', async () => {

--- a/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/view-transaction.component.ts
@@ -9,49 +9,25 @@
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
+import { ActivatedRoute, Router, RouterLinkActive, RouterLink, RouterOutlet } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
-import { MatCard, MatCardMdImage } from '@angular/material/card';
+import { MatCard, MatCardHeader, MatCardTitleGroup, MatCardMdImage, MatCardTitle } from '@angular/material/card';
 import { MatTooltip } from '@angular/material/tooltip';
 import { MatTabNav, MatTabLink, MatTabNavPanel } from '@angular/material/tabs';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
-import { ClientsService } from 'app/clients/clients.service';
-import { AccountHeaderComponent } from 'app/shared/account-header/account-header.component';
 import { AccountNumberComponent } from 'app/shared/account-number/account-number.component';
-import { EntityNameComponent } from 'app/shared/entity-name/entity-name.component';
-import { ExternalIdentifierComponent } from 'app/shared/external-identifier/external-identifier.component';
+import { CurrencyPipe, NgClass } from '@angular/common';
+import { Currency } from 'app/shared/models/general.model';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { LongTextComponent } from 'app/shared/long-text/long-text.component';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
+import { StatusLookupPipe } from 'app/pipes/status-lookup.pipe';
+import { SavingsButtonsConfiguration } from '../../savings-buttons.config';
 
 interface TransactionDatatable {
   registeredTableName: string;
-}
-
-interface ClientStatus {
-  code: string;
-  value: string;
-}
-
-interface ClientGroup {
-  name: string;
-}
-
-interface ClientClassification {
-  name: string;
-}
-
-interface ClientViewData {
-  id: string | number;
-  displayName: string;
-  officeName: string;
-  accountNo: string;
-  externalId?: string;
-  staffName?: string;
-  mobileNo?: string;
-  emailAddress?: string;
-  status?: ClientStatus;
-  groups?: ClientGroup[];
-  clientType?: ClientClassification;
-  clientClassification?: ClientClassification;
 }
 
 @Component({
@@ -60,32 +36,45 @@ interface ClientViewData {
   styleUrls: ['./view-transaction.component.scss'],
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
-    AccountHeaderComponent,
     AccountNumberComponent,
-    EntityNameComponent,
-    ExternalIdentifierComponent,
     MatCard,
+    MatCardHeader,
+    MatCardTitleGroup,
     MatCardMdImage,
+    MatCardTitle,
     MatTooltip,
+    NgClass,
+    LongTextComponent,
+    MatIconButton,
+    MatMenuTrigger,
+    MatIcon,
+    FaIconComponent,
+    MatMenu,
+    MatMenuItem,
     MatTabNav,
     MatTabLink,
     RouterLinkActive,
     MatTabNavPanel,
-    RouterOutlet
+    RouterOutlet,
+    CurrencyPipe,
+    StatusLookupPipe
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ViewTransactionComponent {
   private route = inject(ActivatedRoute);
-  private clientsService = inject(ClientsService);
-  private sanitizer = inject(DomSanitizer);
+  private router = inject(Router);
   dialog = inject(MatDialog);
   private destroyRef = inject(DestroyRef);
 
-  /** Client data inherited from the client route. */
-  clientViewData?: ClientViewData;
-  /** Client profile image. */
-  clientImage: SafeResourceUrl | null = null;
+  /** Savings account data resolved from the transaction detail route. */
+  savingsAccountData: any;
+  /** Button Configurations */
+  buttonConfig?: SavingsButtonsConfiguration;
+  /** Entity Type */
+  entityType = 'Client';
+  /** Currency. */
+  currency: Currency;
 
   accountId = '';
   /** Transaction Data Tables */
@@ -94,45 +83,55 @@ export class ViewTransactionComponent {
   constructor() {
     this.route.data
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((data: { transactionDatatables: TransactionDatatable[] }) => {
-        this.accountId = this.route.snapshot.params['savingAccountId'];
+      .subscribe((data: { savingsAccountData: any; transactionDatatables: TransactionDatatable[] }) => {
+        this.savingsAccountData = data.savingsAccountData;
+        this.currency = this.savingsAccountData?.currency;
+        if (this.savingsAccountData) {
+          this.setConditionalButtons();
+        }
+        this.accountId = this.getRouteParam('savingAccountId') || '';
         this.entityDatatables = data.transactionDatatables;
       });
-    this.setClientDataFromRoute();
+    if (this.router.url.includes('clients')) {
+      this.entityType = 'Client';
+    } else if (this.router.url.includes('groups')) {
+      this.entityType = 'Group';
+    } else if (this.router.url.includes('centers')) {
+      this.entityType = 'Center';
+    }
   }
 
   /**
-   * Finds resolved client data from the ancestor client route.
+   * Reads a route parameter from this route or any ancestor route.
    */
-  private setClientDataFromRoute(): void {
-    let route = this.route.parent;
-    while (route && !this.clientViewData) {
-      const clientViewData = route.snapshot.data['clientViewData'];
-      if (clientViewData) {
-        this.clientViewData = clientViewData;
-        this.loadClientImage();
+  private getRouteParam(paramName: string): string | null {
+    let route: ActivatedRoute | null = this.route;
+    while (route) {
+      const paramValue = route.snapshot.paramMap?.get(paramName) || route.snapshot.params?.[paramName];
+      if (paramValue) {
+        return paramValue;
       }
       route = route.parent;
     }
+    return null;
   }
 
   /**
-   * Loads the client profile image when available.
+   * Adds options to button config.
    */
-  private loadClientImage(): void {
-    if (!this.clientViewData?.id) {
-      return;
-    }
-    this.clientsService
-      .getClientProfileImage(String(this.clientViewData.id))
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (base64Image: string | null) => {
-          this.clientImage = base64Image ? this.sanitizer.bypassSecurityTrustResourceUrl(base64Image) : null;
-        },
-        error: () => {
-          this.clientImage = null;
-        }
-      });
+  private setConditionalButtons(): void {
+    const status = this.savingsAccountData.status?.value || '';
+    const subStatus = this.savingsAccountData.subStatus || {};
+    this.buttonConfig = new SavingsButtonsConfiguration(status, subStatus);
+  }
+
+  /**
+   * Performs action button/option action.
+   * @param name action name.
+   */
+  doAction(name: string): void {
+    const transactionsPathIndex = this.router.url.indexOf('/transactions');
+    const accountUrl = transactionsPathIndex > -1 ? this.router.url.slice(0, transactionsPathIndex) : this.router.url;
+    this.router.navigateByUrl(`${accountUrl}/actions/${name}`);
   }
 }

--- a/src/app/savings/savings-routing.module.ts
+++ b/src/app/savings/savings-routing.module.ts
@@ -161,6 +161,7 @@ const routes: Routes = [
             path: '',
             component: ViewTransactionComponent,
             resolve: {
+              savingsAccountData: SavingsAccountViewResolver,
               transactionDatatables: TransactionDatatablesResolver
             },
             children: [


### PR DESCRIPTION
## Description

Fixes the transaction detail page layout by reusing the existing Savings Account profile/header and its resolved account data.

The transaction detail page now displays the same Savings Product, Account Number, External Id, Client Name, Current Balance, and Available Balance shown on the parent transactions page, while preserving the existing transaction details and actions.

## Related issues and discussion

WEB-1117

## Screenshots, if any


https://github.com/user-attachments/assets/f9bd3805-49e4-4e91-a6a4-79371c518185



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a savings account overview card to transaction pages.
  * Displays product, account number, optional external ID, associated entity, status, and applicable balances.
  * Added account action menus with permission-based options.
  * Improved navigation for savings account actions.

* **Bug Fixes**
  * Updated transaction pages to load and display the correct savings account details instead of client profile information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->