### PR TITLE
WEB-657: Working Capital Loan - Multiple Breach Reset

### DIFF
--- a/src/app/loans/loans-view/_loan-tab-shared.scss
+++ b/src/app/loans/loans-view/_loan-tab-shared.scss
@@ -173,6 +173,58 @@
   }
 }
 
+/* Toolbar action buttons (charges-tab design system) */
+@mixin btn-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  font:
+    600 13px 'DM Sans',
+    sans-serif;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ch-blue-600);
+    outline-offset: 1px;
+  }
+}
+
+@mixin btn-action-primary {
+  @include btn-action;
+
+  background: var(--ch-blue-700);
+  color: #fff;
+
+  &:hover:not(:disabled) {
+    background: var(--ch-blue-600);
+  }
+}
+
+@mixin btn-action-ghost {
+  @include btn-action;
+
+  background: var(--ch-surface);
+  color: var(--ch-text-2);
+  border-color: var(--ch-border);
+
+  &:hover:not(:disabled) {
+    color: var(--ch-text-1);
+    border-color: var(--ch-text-3);
+  }
+}
+
 @mixin btn-export {
   display: inline-flex;
   align-items: center;

--- a/src/app/loans/loans-view/working-capital/breach-action-error.helper.ts
+++ b/src/app/loans/loans-view/working-capital/breach-action-error.helper.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { TranslateService } from '@ngx-translate/core';
+
+const BREACH_ACTION_ERROR_PREFIX = 'error.msg.workingCapitalLoanBreachAction.';
+
+/**
+ * Maps a failed breach-action command (reset / undo_reset) to a translated,
+ * user-friendly message. The backend reports domain-rule violations as HTTP 400
+ * with a `userMessageGlobalisationCode` (top level or inside `errors[]`); every
+ * code under the breach-action prefix has an entry in the `errors` section of
+ * the translation files. Returns null when the error is not a breach-action
+ * domain error or no translation exists, so callers can fall back to the
+ * generic handling done by the error interceptor.
+ */
+export function resolveBreachActionErrorMessage(error: unknown, translate: TranslateService): string | null {
+  const body = (error as HttpErrorResponse)?.error;
+  const code: string | undefined =
+    body?.errors?.[0]?.userMessageGlobalisationCode ?? body?.userMessageGlobalisationCode;
+  if (!code || !code.startsWith(BREACH_ACTION_ERROR_PREFIX)) {
+    return null;
+  }
+  const key = `errors.${code}`;
+  const translated = translate.instant(key);
+  return translated !== key ? translated : null;
+}

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.html
@@ -169,6 +169,7 @@
             type="button"
             class="btn btn-primary"
             (click)="createBreachActionReset()"
+            [disabled]="resetInFlight()"
             *mifosxHasPermission="'CREATE_WC_BREACH_RESET'"
           >
             <fa-icon icon="calendar"></fa-icon>

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.scss
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.scss
@@ -400,6 +400,11 @@
   align-items: center;
   gap: 8px;
   transition: all 0.15s ease;
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
 }
 
 .btn-primary {

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.ts
@@ -33,6 +33,7 @@ import {
 } from '@angular/material/table';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { TranslateService } from '@ngx-translate/core';
+import { AlertService } from 'app/core/alert/alert.service';
 import { Dates } from 'app/core/utils/dates';
 import { LoanBreachActionResetDialogComponent } from 'app/loans/custom-dialog/loan-breach-action-reset-dialog/loan-breach-action-reset-dialog.component';
 import { LoanDelinquencyActionDialogComponent } from 'app/loans/custom-dialog/loan-delinquency-action-dialog/loan-delinquency-action-dialog.component';
@@ -50,7 +51,6 @@ import {
 } from 'app/loans/models/working-capital/working-capital-loan-account.model';
 import { ConfirmationDialogComponent } from 'app/shared/confirmation-dialog/confirmation-dialog.component';
 import { ErrorHandlerService } from 'app/core/error-handler/error-handler.service';
-import { AlertService } from 'app/core/alert/alert.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -61,6 +61,7 @@ import {
 } from '../loan-account-actions/breach-toggle-dialog/breach-toggle-dialog.component';
 import { resolveBreachErrorKey } from '../breach-error-messages';
 import { findActiveBreachDisable } from '../breach-evaluation';
+import { resolveBreachActionErrorMessage } from '../breach-action-error.helper';
 
 type BreachActionStatus = 'active' | 'scheduled' | 'expired';
 type BreachActionFilter = 'all' | BreachActionStatus;
@@ -131,6 +132,7 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
   // Pause dashboard state
   breachActions = signal<LoanDelinquencyAction[]>([]);
   filter = signal<BreachActionFilter>('all');
+  resetInFlight = signal(false);
 
   loanId: string;
   locale: string;
@@ -462,8 +464,24 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
       restartPeriodFromResetDate
     };
 
-    this.loansService.createBreachAction(this.loanId, payload).subscribe(() => {
-      this.reload();
+    this.resetInFlight.set(true);
+    this.loansService.createBreachAction(this.loanId, payload).subscribe({
+      // resetInFlight is intentionally not released on success: reload()
+      // re-navigates and recreates the component, so releasing it earlier
+      // would re-enable the button against stale state before the reload lands.
+      next: () => this.reload(),
+      error: (error: unknown) => {
+        // The interceptor already alerts with the raw backend message; this
+        // supersedes it with the translated breach-action message when one exists.
+        const message = resolveBreachActionErrorMessage(error, this.translateService);
+        if (message) {
+          this.alertService.alert({
+            type: this.translateService.instant('errors.error.bad.request.type'),
+            message
+          });
+        }
+        this.resetInFlight.set(false);
+      }
     });
   }
 

--- a/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.html
@@ -152,7 +152,33 @@
     }
 
     <div class="table-section">
-      <div class="table-toolbar"></div>
+      <div class="table-toolbar">
+        <div class="toolbar-left"></div>
+        <div class="toolbar-actions" *mifosxHasPermission="'CREATE_WC_BREACH_RESET'">
+          <span [matTooltip]="undoDisabledTooltip" [matTooltipDisabled]="hasActiveReset()">
+            <button
+              type="button"
+              class="btn btn-ghost"
+              (click)="openUndoResetDialog()"
+              [disabled]="actionInFlight() || !hasActiveReset()"
+            >
+              <fa-icon icon="undo"></fa-icon>
+              {{ 'labels.buttons.Undo Reset' | translate }}
+            </button>
+          </span>
+          <span [matTooltip]="resetDisabledTooltip" [matTooltipDisabled]="!currentPeriodAlreadyReset">
+            <button
+              type="button"
+              class="btn btn-primary"
+              (click)="openResetDialog()"
+              [disabled]="actionInFlight() || currentPeriodAlreadyReset"
+            >
+              <fa-icon icon="calendar"></fa-icon>
+              {{ 'labels.buttons.Reset' | translate }}
+            </button>
+          </span>
+        </div>
+      </div>
 
       <div class="table-wrap">
         <table mat-table [dataSource]="dataSource" id="breachSchedule" class="breach-table">
@@ -166,8 +192,14 @@
             <td mat-cell *matCellDef="let item">
               <span class="severity-pill" [ngClass]="item.severity">
                 <span class="dot"></span>
-                {{ 'labels.text.' + severityLabel(item.severity) | translate }}
+                {{ severityLabelKey(item.severity) | translate }}
               </span>
+              @if (item.reset) {
+                <span class="reset-badge">
+                  <fa-icon icon="undo"></fa-icon>
+                  {{ 'labels.inputs.Reset' | translate }}
+                </span>
+              }
             </td>
           </ng-container>
 
@@ -223,6 +255,61 @@
           ></tr>
         </table>
       </div>
+    </div>
+
+    <div class="history-section">
+      <div class="section-header">
+        <span class="section-title">{{ 'labels.heading.Reset History' | translate }}</span>
+      </div>
+
+      @if (resetHistory().length > 0) {
+        <div class="table-wrap">
+          <table mat-table [dataSource]="resetHistory()" class="reset-history-table">
+            <ng-container matColumnDef="id">
+              <th mat-header-cell class="id-col" *matHeaderCellDef>{{ 'labels.inputs.Id' | translate }}</th>
+              <td mat-cell *matCellDef="let row">
+                <span class="id-cell">#{{ row.id }}</span>
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="action">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Action' | translate }}</th>
+              <td mat-cell *matCellDef="let row">
+                <span class="action-badge">
+                  <fa-icon [icon]="row.icon"></fa-icon>
+                  {{ row.labelKey | translate }}
+                </span>
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="date">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Date' | translate }}</th>
+              <td mat-cell *matCellDef="let row">
+                <span class="date-cell">{{ row.date | dateFormat }}</span>
+              </td>
+            </ng-container>
+
+            <ng-container matColumnDef="status">
+              <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Status' | translate }}</th>
+              <td mat-cell *matCellDef="let row">
+                @if (row.action === 'RESET') {
+                  <span class="status-pill" [ngClass]="row.undone ? 'status-pill--undone' : 'status-pill--active'">
+                    <span class="dot"></span>
+                    {{ (row.undone ? 'labels.inputs.Undone' : 'labels.inputs.Active') | translate }}
+                  </span>
+                } @else {
+                  <span class="date-cell muted">—</span>
+                }
+              </td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="resetHistoryColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: resetHistoryColumns"></tr>
+          </table>
+        </div>
+      } @else {
+        <p class="empty-history">{{ 'labels.text.No resets have been recorded for this loan' | translate }}</p>
+      }
     </div>
   }
 </div>

--- a/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.scss
+++ b/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.scss
@@ -319,6 +319,21 @@
   }
 }
 
+.toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.btn-primary {
+  @include shared.btn-action-primary;
+}
+
+.btn-ghost {
+  @include shared.btn-action-ghost;
+}
+
 .table-wrap {
   overflow-x: auto;
 }
@@ -329,11 +344,13 @@
 }
 
 :host ::ng-deep {
-  .breach-table .mat-mdc-header-row {
+  .breach-table .mat-mdc-header-row,
+  .reset-history-table .mat-mdc-header-row {
     background: var(--ch-surface-h);
   }
 
-  .breach-table .mat-mdc-header-cell {
+  .breach-table .mat-mdc-header-cell,
+  .reset-history-table .mat-mdc-header-cell {
     background: var(--ch-surface-h);
     font-size: 11px;
     font-weight: 700;
@@ -345,12 +362,17 @@
     white-space: nowrap;
   }
 
-  .breach-table .mat-mdc-row .mat-mdc-cell {
+  .breach-table .mat-mdc-row .mat-mdc-cell,
+  .reset-history-table .mat-mdc-row .mat-mdc-cell {
     border-bottom-color: var(--ch-border);
     padding: 12px 16px;
     font-size: 13.5px;
     color: var(--ch-text-1);
     background: var(--ch-surface);
+  }
+
+  .reset-history-table .mat-mdc-header-cell.id-col {
+    width: 90px;
   }
 
   .breach-table .mat-mdc-row:hover .mat-mdc-cell {
@@ -503,4 +525,114 @@
   background: var(--ch-alert-bg);
   color: var(--ch-alert);
   font-size: 13px;
+}
+
+/* ── Reset badge (periods flagged by a breach reset) ────────── */
+.reset-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: 8px;
+  padding: 3px 9px;
+  border-radius: 100px;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+  background: var(--ch-blue-50);
+  color: var(--ch-blue-700);
+  border: 1px solid var(--ch-blue-100);
+
+  fa-icon {
+    font-size: 10px;
+  }
+}
+
+/* ── Reset history section ──────────────────────────────────── */
+.history-section {
+  background: var(--ch-surface);
+  border-top: 1px solid var(--ch-border);
+
+  .section-header {
+    padding: 16px 20px 0;
+    margin-bottom: 10px;
+  }
+}
+
+/* Shares the mat-table cell styling with .breach-table (see :host ::ng-deep above). */
+.reset-history-table {
+  width: 100%;
+  background: var(--ch-surface);
+}
+
+.id-cell {
+  font-family: 'JetBrains Mono', 'Cascadia Code', monospace;
+  font-size: 12.5px;
+  color: var(--ch-text-2);
+}
+
+.action-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-weight: 600;
+  font-size: 13px;
+
+  fa-icon {
+    color: var(--ch-text-3);
+    font-size: 12px;
+  }
+}
+
+.date-cell {
+  font-size: 13px;
+
+  &.muted {
+    color: var(--ch-text-3);
+  }
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 9px;
+  border-radius: 100px;
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  white-space: nowrap;
+
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+}
+
+.status-pill--active {
+  background: var(--ch-paid-bg);
+  color: var(--ch-paid);
+  border-color: var(--ch-paid);
+
+  .dot {
+    background: var(--ch-paid);
+  }
+}
+
+.status-pill--undone {
+  background: var(--ch-surface-h);
+  color: var(--ch-text-3);
+  border-color: var(--ch-border);
+
+  .dot {
+    background: var(--ch-text-3);
+  }
+}
+
+.empty-history {
+  margin: 0;
+  padding: 14px 20px 18px;
+  font-size: 13px;
+  color: var(--ch-text-3);
 }

--- a/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-breach-schedule-tab/loan-breach-schedule-tab.component.ts
@@ -6,10 +6,25 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  OnInit,
+  signal
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { NgClass } from '@angular/common';
+import { MatDialog } from '@angular/material/dialog';
+import { MatTooltip } from '@angular/material/tooltip';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { TranslateService } from '@ngx-translate/core';
+import { forkJoin, of, Observable } from 'rxjs';
+import { catchError, finalize, switchMap } from 'rxjs/operators';
 import {
   MatCell,
   MatCellDef,
@@ -23,18 +38,23 @@ import {
   MatTable,
   MatTableDataSource
 } from '@angular/material/table';
+import { AlertService } from 'app/core/alert/alert.service';
 import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
+import { LoansService } from 'app/loans/loans.service';
 import { BreachSchedule } from 'app/loans/models/working-capital-loan-account.model';
+import { LoanBreachActionResetDialogComponent } from 'app/loans/custom-dialog/loan-breach-action-reset-dialog/loan-breach-action-reset-dialog.component';
+import { ConfirmationDialogComponent } from 'app/shared/confirmation-dialog/confirmation-dialog.component';
 import { DateFormatPipe } from 'app/pipes/date-format.pipe';
 import { FormatNumberPipe } from 'app/pipes/format-number.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import {
   WorkingCapitalBalances,
-  WorkingCapitalBreachAction
+  WorkingCapitalBreachAction,
+  WorkingCapitalBreachCommandRequest
 } from 'app/loans/models/working-capital/working-capital-loan-account.model';
-import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { findActiveBreachDisable } from '../breach-evaluation';
+import { resolveBreachActionErrorMessage } from '../breach-action-error.helper';
 
 type Severity = 'mild' | 'moderate' | 'severe';
 
@@ -63,6 +83,16 @@ interface BreachKpis {
   peakOutstanding: number;
   avgGapPercent: number;
   status: 'in-breach' | 'resolved' | 'compliant';
+}
+
+interface ResetHistoryRow {
+  id: number;
+  action: 'RESET' | 'UNDO_RESET';
+  date: Date;
+  /** Only meaningful for RESET rows: true once a later UNDO_RESET popped it */
+  undone: boolean;
+  icon: string;
+  labelKey: string;
 }
 
 const SEVERITY_MILD_THRESHOLD = 25;
@@ -101,6 +131,7 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24;
     MatHeaderRow,
     MatRowDef,
     MatRow,
+    MatTooltip,
     FaIconComponent,
     DateFormatPipe,
     FormatNumberPipe
@@ -112,10 +143,60 @@ export class LoanBreachScheduleTabComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
+  private loansService = inject(LoansService);
+  private translateService = inject(TranslateService);
+  private alertService = inject(AlertService);
+  private cdr = inject(ChangeDetectorRef);
+  private dialog = inject(MatDialog);
 
   dataSource = new MatTableDataSource<BreachPeriodView>();
   currencyCode: string = '';
   loanBalances: WorkingCapitalBalances | null = null;
+  loanId: string;
+
+  breachActions = signal<WorkingCapitalBreachAction[]>([]);
+  actionInFlight = signal(false);
+
+  /**
+   * Every RESET / UNDO_RESET breach action, newest first. Undo does not delete
+   * history on the backend; it appends a compensating UNDO_RESET row, so the
+   * "Active"/"Undone" state of each RESET is derived client-side with stack
+   * semantics: iterating in id order, a RESET pushes and an UNDO_RESET pops the
+   * most recent still-open reset.
+   */
+  resetHistory = computed<ResetHistoryRow[]>(() => {
+    const relevant = this.breachActions()
+      .filter((item) => item.action === 'RESET' || item.action === 'UNDO_RESET')
+      .sort((a, b) => a.id - b.id);
+    const openResets: ResetHistoryRow[] = [];
+    const rows = relevant.map((item) => {
+      const isReset = item.action === 'RESET';
+      const row: ResetHistoryRow = {
+        id: item.id,
+        action: item.action as ResetHistoryRow['action'],
+        date: this.dateUtils.parseDate(item.startDate),
+        undone: false,
+        icon: isReset ? 'calendar' : 'undo',
+        labelKey: isReset ? 'labels.inputs.Reset' : 'labels.buttons.Undo Reset'
+      };
+      if (item.action === 'RESET') {
+        openResets.push(row);
+      } else {
+        const popped = openResets.pop();
+        if (popped) {
+          popped.undone = true;
+        }
+      }
+      return row;
+    });
+    return rows.reverse();
+  });
+
+  activeResets = computed<ResetHistoryRow[]>(() =>
+    this.resetHistory().filter((row) => row.action === 'RESET' && !row.undone)
+  );
+
+  hasActiveReset = computed<boolean>(() => this.activeResets().length > 0);
 
   /** True while a DISABLE window covers the business date; no evaluations are shown then. */
   breachEvaluationDisabled = false;
@@ -130,6 +211,13 @@ export class LoanBreachScheduleTabComponent implements OnInit {
     'minPaymentAmount',
     'outstandingAmount',
     'gap'
+  ];
+
+  readonly resetHistoryColumns: string[] = [
+    'id',
+    'action',
+    'date',
+    'status'
   ];
 
   breachPeriods: BreachPeriodView[] = [];
@@ -157,8 +245,11 @@ export class LoanBreachScheduleTabComponent implements OnInit {
 
   todayX: number | null = null;
   timelineYearLabel = '';
+  currentPeriod: BreachPeriodView | null = null;
 
   ngOnInit(): void {
+    this.loanId = this.route.parent?.snapshot.params['loanId'];
+
     this.route.data
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((data: { breachSchedule: BreachSchedule[]; loanBreachActions: WorkingCapitalBreachAction[] }) => {
@@ -180,6 +271,13 @@ export class LoanBreachScheduleTabComponent implements OnInit {
         this.dataSource.data = this.breachPeriods;
       });
 
+    this.loansService
+      .getWorkingCapitalLoanBreachActions(this.loanId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((actions: WorkingCapitalBreachAction[]) => {
+        this.breachActions.set(actions ?? []);
+      });
+
     if (this.route.parent) {
       this.route.parent.data
         .pipe(takeUntilDestroyed(this.destroyRef))
@@ -194,6 +292,115 @@ export class LoanBreachScheduleTabComponent implements OnInit {
 
   severityLabel(severity: Severity): string {
     return severity.charAt(0).toUpperCase() + severity.slice(1);
+  }
+
+  severityLabelKey(severity: Severity): string {
+    return `labels.text.${this.severityLabel(severity)}`;
+  }
+
+  /**
+   * Proactive guard for AC-2: the backend allows a single active reset per
+   * evaluation period, so the Reset button is disabled when the current period
+   * is already flagged (`reset === true`) or the client-side stack shows an
+   * active reset dated inside the current period. The 400 from the backend is
+   * still handled, since state can change server-side (COB, another user).
+   */
+  get currentPeriodAlreadyReset(): boolean {
+    const current = this.currentPeriod;
+    if (!current) {
+      return false;
+    }
+    if (current.reset) {
+      return true;
+    }
+    return this.activeResets().some((row) => row.date >= current.fromDateObj && row.date <= current.toDateObj);
+  }
+
+  get resetDisabledTooltip(): string {
+    return this.translateService.instant(
+      'errors.error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period'
+    );
+  }
+
+  get undoDisabledTooltip(): string {
+    return this.translateService.instant('errors.error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo');
+  }
+
+  openResetDialog(): void {
+    const dialogRef = this.dialog.open(LoanBreachActionResetDialogComponent, {
+      data: { action: 'reset' }
+    });
+    dialogRef.afterClosed().subscribe((response: { data: any }) => {
+      if (response?.data) {
+        this.executeBreachAction({
+          action: 'reset',
+          restartPeriodFromResetDate: !!response.data.value.restartPeriodFromResetDate
+        });
+      }
+    });
+  }
+
+  openUndoResetDialog(): void {
+    const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+      data: {
+        heading: this.translateService.instant('labels.heading.Undo Reset'),
+        dialogContext: this.translateService.instant(
+          'labels.dialogContext.Are you sure you want to undo the last breach reset'
+        )
+      }
+    });
+    dialogRef.afterClosed().subscribe((response: { confirm: any }) => {
+      if (response?.confirm) {
+        this.executeBreachAction({ action: 'undo_reset' });
+      }
+    });
+  }
+
+  /**
+   * Posts a breach action command and re-reads both the breach schedule and the
+   * breach actions list. Data is also re-read on failure: a domain-rule 400
+   * usually means the server-side state moved under us (COB, another user), so
+   * the screen must catch up with it. `actionInFlight` stays true until the
+   * refresh completes, so the buttons cannot re-enable against stale state.
+   */
+  private executeBreachAction(command: { action: string; restartPeriodFromResetDate?: boolean }): void {
+    const payload: WorkingCapitalBreachCommandRequest = {
+      ...command,
+      locale: this.settingsService.language.code,
+      dateFormat: this.settingsService.dateFormat
+    };
+    this.actionInFlight.set(true);
+    this.loansService
+      .createBreachAction(this.loanId, payload)
+      .pipe(
+        catchError((error: unknown) => {
+          const message = resolveBreachActionErrorMessage(error, this.translateService);
+          if (message) {
+            this.alertService.alert({
+              type: this.translateService.instant('errors.error.bad.request.type'),
+              message
+            });
+          }
+          // Swallow the command error so the chain still refreshes.
+          return of(null);
+        }),
+        switchMap(() => this.refreshData()),
+        finalize(() => this.actionInFlight.set(false)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(({ schedule, actions }) => {
+        this.processBreachPeriods(schedule ?? []);
+        this.dataSource.data = this.breachPeriods;
+        this.breachActions.set(actions ?? []);
+        this.cdr.markForCheck();
+      });
+  }
+
+  private refreshData(): Observable<{ schedule: BreachSchedule[]; actions: WorkingCapitalBreachAction[] }> {
+    return forkJoin({
+      schedule: this.loansService.getWorkingCapitalLoanBreachSchedule(this.loanId),
+      actions: this.loansService.getWorkingCapitalLoanBreachActions(this.loanId)
+    });
   }
 
   buildTooltip(period: BreachPeriodView): string {
@@ -214,6 +421,7 @@ export class LoanBreachScheduleTabComponent implements OnInit {
       this.kpis = { count: 0, totalDays: 0, peakOutstanding: 0, avgGapPercent: 0, status: 'compliant' };
       this.todayX = null;
       this.timelineYearLabel = '';
+      this.currentPeriod = null;
       return;
     }
 
@@ -280,6 +488,8 @@ export class LoanBreachScheduleTabComponent implements OnInit {
         showLabel: barWidth >= LABEL_MIN_BAR_WIDTH
       };
     });
+
+    this.currentPeriod = this.breachPeriods.find((p) => today >= p.fromDateObj && today <= p.toDateObj) ?? null;
 
     this.kpis = {
       count: this.breachPeriods.length,

--- a/src/app/loans/loans.service.ts
+++ b/src/app/loans/loans.service.ts
@@ -23,6 +23,7 @@ import { BreachSchedule } from './models/working-capital-loan-account.model';
 import {
   WorkingCapitalBreachAction,
   WorkingCapitalBreachActionRequest,
+  WorkingCapitalBreachCommandRequest,
   WorkingCapitalMarkAsFraudRequest,
   WorkingCapitalBreachToggleRequest,
   WorkingCapitalNearBreachActionRequest,
@@ -192,7 +193,7 @@ export class LoansService {
     return this.http.get(`/working-capital-loans/${loanId}/breach-actions`);
   }
 
-  createBreachAction(loanId: string, payload: any) {
+  createBreachAction(loanId: string, payload: WorkingCapitalBreachCommandRequest) {
     return this.http.post(`/working-capital-loans/${loanId}/breach-actions`, payload);
   }
 

--- a/src/app/loans/models/working-capital-loan-account.model.ts
+++ b/src/app/loans/models/working-capital-loan-account.model.ts
@@ -25,4 +25,8 @@ export interface BreachSchedule {
   numberOfDays: number;
   minPaymentAmount: number;
   outstandingAmount: number;
+  nearBreach?: boolean;
+  breach?: boolean;
+  /** True when the evaluation period was flagged by a breach reset action */
+  reset?: boolean;
 }

--- a/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
+++ b/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
@@ -108,6 +108,20 @@ export interface WorkingCapitalBreachActionRequest {
   locale: string;
 }
 
+/**
+ * Command payload for POST /working-capital-loans/{loanId}/breach-actions
+ * (pause, resume, disable, enable, reset, undo_reset). Distinct from
+ * WorkingCapitalBreachActionRequest, which carries the RESCHEDULE configuration.
+ */
+export interface WorkingCapitalBreachCommandRequest {
+  action: string;
+  locale: string;
+  dateFormat: string;
+  startDate?: string;
+  endDate?: string;
+  restartPeriodFromResetDate?: boolean;
+}
+
 export interface WorkingCapitalBreachAction {
   id: number;
   action: string;

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -8,6 +8,14 @@
     "accountingRule": {
       "duplicateName": "Omlouváme se, ale účetní pravidlo s tímto názvem již existuje."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "Vyhodnocování porušení je pro tento úvěr zakázáno.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "Tato akce vyžaduje aktivní úvěr.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "Úvěr dosud nebyl vyplacen.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "Úvěr nemá konfiguraci porušení.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "Pro aktuální datum neexistuje žádné období vyhodnocení porušení.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "Neexistuje žádný aktivní reset, který by bylo možné vrátit.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "Úvěr nemá plán porušení.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "Toto období porušení již bylo resetováno. Před dalším resetem vraťte stávající reset.",
     "linkedSavingsAccountOwnership": "Propojený spořicí účet nepatří vybranému klientovi.",
     "clientNotInGSIM": "Klient s ID {{id}} není přítomen v GSIM.",
     "Capitalized Income amount adjusted already adjusted": "Výše kapitalizovaného příjmu již upravená",
@@ -1541,6 +1549,7 @@
       "Report Parameter": "Parametr sestavy",
       "Reports Catalog": "Katalog sestav",
       "Reschedule Loan": "Přeplánovací půjčka",
+      "Reset History": "Historie resetů",
       "Revert Transaction": "Vrátit transakci",
       "S3 Amazon External Service": "Externí služba S3 Amazon",
       "SMS": "SMS",
@@ -3647,6 +3656,7 @@
     "dialogContext": {
       "A new clean period will start today": "Ode dneška začne nové čisté období.",
       "Are you sure you want to resume the breach pause": "Opravdu chcete obnovit porušení?",
+      "Are you sure you want to undo the last breach reset": "Opravdu chcete vrátit poslední reset porušení? Tím se vrátí označení resetu a přepočet dlužné částky; rozdělení období vytvořené restartem období od data resetu se nevrátí.",
       "Are you sure you want Unassign Staff": "Opravdu chcete odebrat přiřazení zaměstnance?",
       "Are you sure you want to calculate interest ?": "Jste si jisti, že chcete spočítat zájem?",
       "Are you sure you want to post interest ?": "Jste si jisti, že chcete zveřejnit zájem?",
@@ -3709,6 +3719,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Dlouhodobé financování na koupi, výstavbu nebo rekonstrukci nemovitosti určené k bydlení.",
       "Merchant Cash Advance": "Záloha pro obchodníky",
       "Mortgage Loan (LAP)": "Hypoteční úvěr (LAP)",
+      "No resets have been recorded for this loan": "Pro tento úvěr nebyly zaznamenány žádné resety.",
       "Personal Loan": "Osobní úvěr",
       "Custom / Advanced": "Vlastní / pokročilé",
       "Two Wheeler Loan": "Úvěr na motocykly a skútry",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -8,6 +8,14 @@
     "accountingRule": {
       "duplicateName": "Entschuldigung, aber eine Buchungsregel mit diesem Namen existiert bereits."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "Die Verstoßprüfung ist für dieses Darlehen deaktiviert.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "Diese Aktion erfordert ein aktives Darlehen.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "Das Darlehen wurde noch nicht ausgezahlt.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "Das Darlehen hat keine Verstoßkonfiguration.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "Für das aktuelle Datum existiert kein Verstoßprüfungszeitraum.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "Es gibt keine aktive Zurücksetzung, die rückgängig gemacht werden kann.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "Das Darlehen hat keinen Verstoßplan.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "Diese Verstoßperiode wurde bereits zurückgesetzt. Machen Sie die bestehende Zurücksetzung rückgängig, bevor Sie erneut zurücksetzen.",
     "linkedSavingsAccountOwnership": "Verknüpftes Sparkonto gehört nicht zum ausgewählten Kunden.",
     "clientNotInGSIM": "Kunde mit der ID {{id}} ist nicht in GSIM vorhanden.",
     "Capitalized Income amount adjusted already adjusted": "Kapitalisiertes Einkommen Betrag angepasst bereits angepasst",
@@ -1543,6 +1551,7 @@
       "Report Parameter": "Berichtsparameter",
       "Reports Catalog": "Berichtskatalog",
       "Reschedule Loan": "Darlehen neu plant",
+      "Reset History": "Zurücksetzungsverlauf",
       "Revert Transaction": "Transaktion rückgängig machen",
       "S3 Amazon External Service": "S3 Amazon Externer Service",
       "SMS": "SMS",
@@ -3649,6 +3658,7 @@
     "dialogContext": {
       "A new clean period will start today": "Ab heute beginnt eine neue, saubere Periode.",
       "Are you sure you want to resume the breach pause": "Sind Sie sicher, dass Sie den Verstoß wirklich fortsetzen",
+      "Are you sure you want to undo the last breach reset": "Sind Sie sicher, dass Sie die letzte Zurücksetzung des Verstoßes rückgängig machen möchten? Dies macht die Zurücksetzungsmarkierung und die Neuberechnung des überfälligen Betrags rückgängig; eine Aufteilung der Periode durch den Neustart ab dem Zurücksetzungsdatum wird nicht rückgängig gemacht.",
       "Are you sure you want Unassign Staff": "Sind Sie sicher, dass Sie das Personal freistellen möchten",
       "Are you sure you want to calculate interest ?": "Sind Sie sicher, dass Sie Zinsen berechnen möchten ?",
       "Are you sure you want to post interest ?": "Sind Sie sicher, dass Sie Zinsen buchen möchten ?",
@@ -3711,6 +3721,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Langfristige Finanzierung für den Kauf, den Bau oder die Renovierung einer Wohnimmobilie.",
       "Merchant Cash Advance": "Händlervorschuss",
       "Mortgage Loan (LAP)": "Hypothekendarlehen (LAP)",
+      "No resets have been recorded for this loan": "Für dieses Darlehen wurden keine Zurücksetzungen erfasst.",
       "Personal Loan": "Privatkredit",
       "Custom / Advanced": "Benutzerdefiniert / Erweitert",
       "Two Wheeler Loan": "Zweiradkredit",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -8,6 +8,14 @@
     "accountingRule": {
       "duplicateName": "Sorry, but an Accounting Rule with this Name exists already."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "Breach evaluation is disabled for this loan.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "This action requires an active loan.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "The loan has not been disbursed yet.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "The loan has no breach configuration.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "There is no breach evaluation period for the current date.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "There is no active breach reset to undo.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "The loan has no breach schedule.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "This breach period has already been reset. Undo the existing reset before resetting again.",
     "linkedSavingsAccountOwnership": "Linked savings account does not belong to the selected client.",
     "clientNotInGSIM": "Client with ID {{id}} is not present in GSIM.",
     "Capitalized Income amount adjusted already adjusted": "Capitalized Income amount already adjusted",
@@ -1560,6 +1568,7 @@
       "Report Parameter": "Report Parameter",
       "Reports Catalog": "Reports Catalog",
       "Reschedule Loan": "Reschedule Loan",
+      "Reset History": "Reset History",
       "Revert Transaction": "Revert Transaction",
       "S3 Amazon External Service": "S3 Amazon External Service",
       "SMS Campaigns": "SMS Campaigns",
@@ -3677,6 +3686,7 @@
     "dialogContext": {
       "A new clean period will start today": "A new clean period will start from today.",
       "Are you sure you want to resume the breach pause": "Are you sure you want to resume the breach pause",
+      "Are you sure you want to undo the last breach reset": "Are you sure you want to undo the last breach reset? This reverts the reset flag and the past-due recalculation; a period split created by restarting the period from the reset date is not reverted.",
       "Are you sure you want Unassign Staff": "Are you sure you want Unassign Staff",
       "Are you sure you want to calculate interest ?": "Are you sure you want to calculate interest ?",
       "Are you sure you want to post interest ?": "Are you sure you want to post interest ?",
@@ -3740,6 +3750,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Long-tenure financing to purchase, construct, or renovate a residential property.",
       "Merchant Cash Advance": "Merchant Cash Advance",
       "Mortgage Loan (LAP)": "Mortgage Loan (LAP)",
+      "No resets have been recorded for this loan": "No resets have been recorded for this loan.",
       "Personal Loan": "Personal Loan",
       "Custom / Advanced": "Custom / Advanced",
       "Two Wheeler Loan": "Two Wheeler Loan",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -6,6 +6,14 @@
     "accountingRule": {
       "duplicateName": "Lo sentimos, pero ya existe una regla contable con este nombre."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "La evaluación de incumplimiento está deshabilitada para este préstamo.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "Esta acción requiere un préstamo activo.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "El préstamo aún no ha sido desembolsado.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "El préstamo no tiene configuración de incumplimiento.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "No existe un período de evaluación de incumplimiento para la fecha actual.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "No hay un reinicio de incumplimiento activo para deshacer.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "El préstamo no tiene calendario de incumplimiento.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "Este período de incumplimiento ya fue reiniciado. Deshaz el reinicio existente antes de volver a reiniciar.",
     "error.resource.notImplemented.type": "No implementado",
     "error.resource.notImplemented.message": "¡Funcionalidad no implementada!",
     "linkedSavingsAccountOwnership": "La cuenta de ahorro vinculada no pertenece al cliente seleccionado.",
@@ -1541,6 +1549,7 @@
       "Report Parameter": "Parámetro de reporte",
       "Reports Catalog": "Catálogo de reportes",
       "Reschedule Loan": "Reprogramación del Crédito",
+      "Reset History": "Historial de Reinicios",
       "Revert Transaction": "Revertir transacción",
       "S3 Amazon External Service": "Servicio externo de Amazon S3",
       "SMS": "SMS",
@@ -3648,6 +3657,7 @@
     "dialogContext": {
       "A new clean period will start today": "Se abrirá un periodo nuevo y limpio a partir de hoy.",
       "Are you sure you want to resume the breach pause": "¿Estás seguro de que quieres reanudar la pausa del incumplimiento?",
+      "Are you sure you want to undo the last breach reset": "¿Estás seguro de que quieres deshacer el último reinicio de incumplimiento? Esto revierte la marca de reinicio y el recálculo del monto vencido; una división de período creada al reiniciar el período desde la fecha de reinicio no se revierte.",
       "Are you sure you want Unassign Staff": "¿Estás seguro de que deseas desasignar al asesor?",
       "Are you sure you want to calculate interest ?": "¿Estás seguro de que deseas calcular los intereses?",
       "Are you sure you want to post interest ?": "¿Estás seguro de que deseas contabilizar los intereses?",
@@ -3710,6 +3720,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Financiamiento a largo plazo para comprar, construir o renovar una propiedad residencial.",
       "Merchant Cash Advance": "Adelanto de Efectivo para Comercios",
       "Mortgage Loan (LAP)": "Crédito Hipotecario (LAP)",
+      "No resets have been recorded for this loan": "No se han registrado reinicios para este préstamo.",
       "Personal Loan": "Crédito Personal",
       "Custom / Advanced": "Personalizado / Avanzado",
       "Two Wheeler Loan": "Crédito para Motos",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -6,6 +6,14 @@
     "accountingRule": {
       "duplicateName": "Lo sentimos, pero ya existe una regla contable con este nombre."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "La evaluación de incumplimiento está deshabilitada para este préstamo.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "Esta acción requiere un préstamo activo.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "El préstamo aún no ha sido desembolsado.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "El préstamo no tiene configuración de incumplimiento.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "No existe un período de evaluación de incumplimiento para la fecha actual.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "No hay un reinicio de incumplimiento activo para deshacer.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "El préstamo no tiene calendario de incumplimiento.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "Este período de incumplimiento ya fue reiniciado. Deshaz el reinicio existente antes de volver a reiniciar.",
     "error.resource.notImplemented.type": "No implementado",
     "error.resource.notImplemented.message": "¡Funcionalidad no implementada!",
     "linkedSavingsAccountOwnership": "La cuenta de ahorro vinculada no pertenece al cliente seleccionado.",
@@ -1546,6 +1554,7 @@
       "Report Parameter": "Parámetro de reporte",
       "Reports Catalog": "Catálogo de reportes",
       "Reschedule Loan": "Reprogramación del Crédito",
+      "Reset History": "Historial de Reinicios",
       "Revert Transaction": "Revertir transacción",
       "S3 Amazon External Service": "Servicio externo de Amazon S3",
       "SMS": "SMS",
@@ -3652,6 +3661,7 @@
     "dialogContext": {
       "A new clean period will start today": "Se abrirá un periodo nuevo y limpio a partir de hoy.",
       "Are you sure you want to resume the breach pause": "¿Estás seguro de que quieres reanudar la pausa del incumplimiento?",
+      "Are you sure you want to undo the last breach reset": "¿Estás seguro de que quieres deshacer el último reinicio de incumplimiento? Esto revierte la marca de reinicio y el recálculo del monto vencido; una división de período creada al reiniciar el período desde la fecha de reinicio no se revierte.",
       "Are you sure you want Unassign Staff": "¿Estás seguro de que deseas desasignar al asesor?",
       "Are you sure you want to calculate interest ?": "¿Estás seguro de que deseas calcular los intereses?",
       "Are you sure you want to post interest ?": "¿Estás seguro de que deseas contabilizar los intereses?",
@@ -3714,6 +3724,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Financiamiento a largo plazo para comprar, construir o renovar una propiedad residencial.",
       "Merchant Cash Advance": "Adelanto de Efectivo para Comercios",
       "Mortgage Loan (LAP)": "Crédito Hipotecario (LAP)",
+      "No resets have been recorded for this loan": "No se han registrado reinicios para este préstamo.",
       "Personal Loan": "Crédito Personal",
       "Custom / Advanced": "Personalizado / Avanzado",
       "Two Wheeler Loan": "Crédito para Motos",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -6,6 +6,14 @@
     "accountingRule": {
       "duplicateName": "Désolé, mais une règle comptable portant ce nom existe déjà."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "L'évaluation du manquement est désactivée pour ce prêt.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "Cette action nécessite un prêt actif.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "Le prêt n'a pas encore été décaissé.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "Le prêt n'a pas de configuration de manquement.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "Il n'existe aucune période d'évaluation du manquement pour la date actuelle.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "Il n'y a aucune réinitialisation active à annuler.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "Le prêt n'a pas de calendrier de manquement.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "Cette période de manquement a déjà été réinitialisée. Annulez la réinitialisation existante avant de réinitialiser à nouveau.",
     "error.resource.notImplemented.type": "Non implémenté",
     "error.resource.notImplemented.message": "Fonctionnalité non implémentée !",
     "linkedSavingsAccountOwnership": "Le compte d'épargne lié n'appartient pas au client sélectionné.",
@@ -1544,6 +1552,7 @@
       "Report Parameter": "Paramètre de rapport",
       "Reports Catalog": "Catalogue de rapports",
       "Reschedule Loan": "Prêt de reproduction",
+      "Reset History": "Historique des réinitialisations",
       "Revert Transaction": "Annuler la transaction",
       "S3 Amazon External Service": "Service externe S3 Amazon",
       "SMS": "SMS",
@@ -3650,6 +3659,7 @@
     "dialogContext": {
       "A new clean period will start today": "Une nouvelle période vierge commencera aujourd’hui.",
       "Are you sure you want to resume the breach pause": "Êtes-vous sûr de vouloir reprendre le manquement après sa mise en pause ?",
+      "Are you sure you want to undo the last breach reset": "Êtes-vous sûr de vouloir annuler la dernière réinitialisation du manquement ? Cela annule l'indicateur de réinitialisation et le recalcul du montant en retard ; une division de période créée par le redémarrage de la période à la date de réinitialisation n'est pas annulée.",
       "Are you sure you want Unassign Staff": "Êtes-vous sûr de vouloir désassigner le personnel",
       "Are you sure you want to calculate interest ?": "Êtes-vous sûr de vouloir calculer les intérêts ?",
       "Are you sure you want to post interest ?": "Êtes-vous sûr de vouloir enregistrer les intérêts ?",
@@ -3712,6 +3722,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Financement à long terme pour l'achat, la construction ou la rénovation d'un bien résidentiel.",
       "Merchant Cash Advance": "Avance de trésorerie commerçant",
       "Mortgage Loan (LAP)": "Prêt hypothécaire (LAP)",
+      "No resets have been recorded for this loan": "Aucune réinitialisation n'a été enregistrée pour ce prêt.",
       "Personal Loan": "Prêt personnel",
       "Custom / Advanced": "Personnalisé / Avancé",
       "Two Wheeler Loan": "Prêt deux-roues",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -6,6 +6,14 @@
     "accountingRule": {
       "duplicateName": "Spiacenti, ma esiste già una regola contabile con questo nome."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "La valutazione della violazione è disabilitata per questo prestito.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "Questa azione richiede un prestito attivo.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "Il prestito non è ancora stato erogato.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "Il prestito non ha una configurazione di violazione.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "Non esiste un periodo di valutazione della violazione per la data corrente.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "Non c'è alcun ripristino attivo da annullare.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "Il prestito non ha un piano di violazione.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "Questo periodo di violazione è già stato ripristinato. Annulla il ripristino esistente prima di ripristinare di nuovo.",
     "error.resource.notImplemented.type": "Non implementato",
     "error.resource.notImplemented.message": "Funzionalità non implementata!",
     "linkedSavingsAccountOwnership": "Il conto di risparmio collegato non appartiene al cliente selezionato.",
@@ -1541,6 +1549,7 @@
       "Report Parameter": "Parametro del report",
       "Reports Catalog": "Catalogo report",
       "Reschedule Loan": "Prestito riprogrammato",
+      "Reset History": "Cronologia dei ripristini",
       "Revert Transaction": "Annulla transazione",
       "S3 Amazon External Service": "Servizio esterno Amazon S3",
       "SMS": "sms",
@@ -3646,6 +3655,7 @@
     "dialogContext": {
       "A new clean period will start today": "Da oggi inizierà un nuovo periodo pulito.",
       "Are you sure you want to resume the breach pause": "Sei sicuro di voler riprendere la violazione dopo la pausa ?",
+      "Are you sure you want to undo the last breach reset": "Sei sicuro di voler annullare l'ultimo ripristino della violazione? Questo annulla il contrassegno di ripristino e il ricalcolo dell'importo scaduto; una divisione del periodo creata riavviando il periodo dalla data di ripristino non viene annullata.",
       "Are you sure you want Unassign Staff": "Sei sicuro di voler deassegnare il personale",
       "Are you sure you want to calculate interest ?": "Sei sicuro di voler calcolare gli interessi ?",
       "Are you sure you want to post interest ?": "Sei sicuro di voler registrare gli interessi ?",
@@ -3708,6 +3718,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Finanziamento a lungo termine per acquistare, costruire o ristrutturare un immobile residenziale.",
       "Merchant Cash Advance": "Anticipo di cassa per esercenti",
       "Mortgage Loan (LAP)": "Prestito ipotecario (LAP)",
+      "No resets have been recorded for this loan": "Nessun ripristino è stato registrato per questo prestito.",
       "Personal Loan": "Prestito personale",
       "Custom / Advanced": "Personalizzato / Avanzato",
       "Two Wheeler Loan": "Prestito per veicoli a due ruote",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -6,6 +6,14 @@
     "accountingRule": {
       "duplicateName": "죄송합니다. 이미 동일한 이름의 회계 규칙이 존재합니다."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "이 대출에 대한 위반 평가가 비활성화되어 있습니다.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "이 작업에는 활성 상태의 대출이 필요합니다.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "대출이 아직 실행되지 않았습니다.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "대출에 위반 구성이 없습니다.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "현재 날짜에 해당하는 위반 평가 기간이 없습니다.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "실행 취소할 활성 초기화가 없습니다.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "대출에 위반 일정이 없습니다.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "이 위반 기간은 이미 초기화되었습니다. 다시 초기화하려면 기존 초기화를 먼저 실행 취소하세요.",
     "error.resource.notImplemented.type": "구현되지 않음",
     "error.resource.notImplemented.message": "구현되지 않은 기능입니다!",
     "linkedSavingsAccountOwnership": "연결된 저축 계좌가 선택한 클라이언트에 속하지 않습니다.",
@@ -1542,6 +1550,7 @@
       "Report Parameter": "보고서 매개변수",
       "Reports Catalog": "보고서 카탈로그",
       "Reschedule Loan": "일정 조정 대출",
+      "Reset History": "초기화 이력",
       "Revert Transaction": "거래 되돌리기",
       "S3 Amazon External Service": "S3 Amazon 외부 서비스",
       "SMS": "SMS",
@@ -3646,6 +3655,7 @@
     "dialogContext": {
       "A new clean period will start today": "오늘부터 새로운 깨끗한 기간이 시작됩니다.",
       "Are you sure you want to resume the breach pause": "중단된 작업을 재개하시겠습니까?",
+      "Are you sure you want to undo the last breach reset": "마지막 위반 초기화를 실행 취소하시겠습니까? 초기화 표시와 연체 금액 재계산이 되돌려집니다. 초기화 날짜부터 기간을 다시 시작하여 생성된 기간 분할은 되돌려지지 않습니다.",
       "Are you sure you want Unassign Staff": "직원 해제를 하시겠습니까?",
       "Are you sure you want to calculate interest ?": "이자를 계산하시겠습니까?",
       "Are you sure you want to post interest ?": "이자를 등록하시겠습니까?",
@@ -3708,6 +3718,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "주거용 부동산의 구입, 건축 또는 개보수를 위한 장기 금융.",
       "Merchant Cash Advance": "가맹점 매출 선지급",
       "Mortgage Loan (LAP)": "부동산 담보 대출 (LAP)",
+      "No resets have been recorded for this loan": "이 대출에 기록된 초기화가 없습니다.",
       "Personal Loan": "개인 대출",
       "Custom / Advanced": "사용자 지정 / 고급",
       "Two Wheeler Loan": "이륜차 대출",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -6,6 +6,14 @@
     "accountingRule": {
       "duplicateName": "Atsiprašome, bet apskaitos taisyklė su šiuo pavadinimu jau egzistuoja."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "Šiai paskolai pažeidimo vertinimas yra išjungtas.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "Šiam veiksmui reikalinga aktyvi paskola.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "Paskola dar nebuvo išmokėta.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "Paskola neturi pažeidimo konfigūracijos.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "Nėra pažeidimo vertinimo laikotarpio dabartinei datai.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "Nėra aktyvaus atstatymo, kurį būtų galima atšaukti.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "Paskola neturi pažeidimo grafiko.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "Šis pažeidimo laikotarpis jau buvo atstatytas. Prieš atstatydami dar kartą, atšaukite esamą atstatymą.",
     "error.resource.notImplemented.type": "Neįgyvendinta",
     "error.resource.notImplemented.message": "Neįgyvendinta funkcija!",
     "linkedSavingsAccountOwnership": "Susieta taupomoji sąskaita nepriklauso pasirinktam klientui.",
@@ -1540,6 +1548,7 @@
       "Report Parameter": "Ataskaitos parametras",
       "Reports Catalog": "Ataskaitų katalogas",
       "Reschedule Loan": "Paskelbta paskola",
+      "Reset History": "Atstatymų istorija",
       "Revert Transaction": "Grąžinti operaciją",
       "S3 Amazon External Service": "S3 Amazon išorinė paslauga",
       "SMS": "trumpoji žinutė",
@@ -3646,6 +3655,7 @@
     "dialogContext": {
       "A new clean period will start today": "Nuo šiandien prasidės naujas švarus laikotarpis.",
       "Are you sure you want to resume the breach pause": "Ar tikrai norite atnaujinti pažeidimo sustabdymą?",
+      "Are you sure you want to undo the last breach reset": "Ar tikrai norite atšaukti paskutinį pažeidimo atstatymą? Tai atšaukia atstatymo žymą ir pradelstos sumos perskaičiavimą; laikotarpio padalijimas, sukurtas iš naujo pradedant laikotarpį nuo atstatymo datos, nėra atšaukiamas.",
       "Are you sure you want Unassign Staff": "Ar tikrai norite atšaukti darbuotojo priskyrimą?",
       "Are you sure you want to calculate interest ?": "Ar tikrai norite skaičiuoti palūkanas?",
       "Are you sure you want to post interest ?": "Ar tikrai norite paskelbti palūkanas?",
@@ -3708,6 +3718,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Ilgalaikis finansavimas gyvenamajam būstui įsigyti, statyti ar renovuoti.",
       "Merchant Cash Advance": "Prekybininko grynųjų avansas",
       "Mortgage Loan (LAP)": "Hipotekos paskola (LAP)",
+      "No resets have been recorded for this loan": "Šiai paskolai neužregistruota jokių atstatymų.",
       "Personal Loan": "Vartojimo paskola",
       "Custom / Advanced": "Pasirinktinė / išplėstinė",
       "Two Wheeler Loan": "Motociklų ir motorolerių paskola",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -6,6 +6,14 @@
     "accountingRule": {
       "duplicateName": "Atvainojiet, bet grāmatvedības noteikums ar šo nosaukumu jau pastāv."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "Šim aizdevumam pārkāpuma novērtēšana ir atspējota.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "Šai darbībai ir nepieciešams aktīvs aizdevums.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "Aizdevums vēl nav izmaksāts.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "Aizdevumam nav pārkāpuma konfigurācijas.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "Pašreizējam datumam nav pārkāpuma novērtēšanas perioda.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "Nav aktīvas atiestatīšanas, ko atsaukt.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "Aizdevumam nav pārkāpuma grafika.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "Šis pārkāpuma periods jau ir atiestatīts. Pirms atkārtotas atiestatīšanas atsauciet esošo atiestatīšanu.",
     "error.resource.notImplemented.type": "Nav ieviests",
     "error.resource.notImplemented.message": "Neieviesta funkcionalitāte!",
     "linkedSavingsAccountOwnership": "Saistītais krājkonts nepieder izvēlētajam klientam.",
@@ -1541,6 +1549,7 @@
       "Report Parameter": "Pārskata parametrs",
       "Reports Catalog": "Pārskatu katalogs",
       "Reschedule Loan": "Pārplānot aizdevumu",
+      "Reset History": "Atiestatīšanas vēsture",
       "Revert Transaction": "Atsaukt darījumu",
       "S3 Amazon External Service": "S3 Amazon ārējais pakalpojums",
       "SMS": "īsziņa",
@@ -3646,6 +3655,7 @@
     "dialogContext": {
       "A new clean period will start today": "No šodienas sāksies jauns, tīrs periods.",
       "Are you sure you want to resume the breach pause": "Vai esat pārliecināts, ka vēlaties atsākt pārtraukumu?",
+      "Are you sure you want to undo the last breach reset": "Vai tiešām vēlaties atsaukt pēdējo pārkāpuma atiestatīšanu? Tas atceļ atiestatīšanas atzīmi un kavētās summas pārrēķinu; perioda sadalījums, kas izveidots, restartējot periodu no atiestatīšanas datuma, netiek atcelts.",
       "Are you sure you want Unassign Staff": "Vai tiešām vēlaties atcelt darbinieka piešķiršanu?",
       "Are you sure you want to calculate interest ?": "Vai tiešām vēlaties aprēķināt procentus?",
       "Are you sure you want to post interest ?": "Vai tiešām vēlaties reģistrēt procentus?",
@@ -3708,6 +3718,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Ilgtermiņa finansējums mājokļa iegādei, būvniecībai vai renovācijai.",
       "Merchant Cash Advance": "Tirgotāja naudas avanss",
       "Mortgage Loan (LAP)": "Hipotekārais aizdevums (LAP)",
+      "No resets have been recorded for this loan": "Šim aizdevumam nav reģistrēta neviena atiestatīšana.",
       "Personal Loan": "Patēriņa aizdevums",
       "Custom / Advanced": "Pielāgots / paplašināts",
       "Two Wheeler Loan": "Divriteņu transportlīdzekļa aizdevums",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -6,6 +6,14 @@
     "accountingRule": {
       "duplicateName": "माफ गर्नुहोस्, यो नामको लेखा नियम पहिले नै अवस्थित छ।"
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "यस ऋणका लागि उल्लंघन मूल्याङ्कन असक्षम गरिएको छ।",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "यस कार्यका लागि सक्रिय ऋण आवश्यक छ।",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "ऋण अझै वितरण गरिएको छैन।",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "ऋणमा उल्लंघन कन्फिगरेसन छैन।",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "हालको मितिका लागि उल्लंघन मूल्याङ्कन अवधि छैन।",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "पूर्ववत गर्न सकिने कुनै सक्रिय रिसेट छैन।",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "ऋणमा उल्लंघन तालिका छैन।",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "यो उल्लंघन अवधि पहिले नै रिसेट गरिएको छ। फेरि रिसेट गर्नु अघि अवस्थित रिसेट पूर्ववत गर्नुहोस्।",
     "error.resource.notImplemented.type": "कार्यान्वयन भएको छैन",
     "error.resource.notImplemented.message": "कार्यान्वयन नभएको कार्यक्षमता!",
     "linkedSavingsAccountOwnership": "लिंक गरिएको बचत खाता चयनित ग्राहकको होइन।",
@@ -1540,6 +1548,7 @@
       "Report Parameter": "रिपोर्ट प्यारामिटर",
       "Reports Catalog": "रिपोर्ट सूची",
       "Reschedule Loan": "Receplate ण लिएको",
+      "Reset History": "रिसेट इतिहास",
       "Revert Transaction": "लेनदेन उल्टाउनुहोस्",
       "S3 Amazon External Service": "S3 Amazon बाह्य सेवा",
       "SMS": "एस एम एस",
@@ -3646,6 +3655,7 @@
     "dialogContext": {
       "A new clean period will start today": "आजबाट नयाँ सफा अवधि सुरु हुनेछ।",
       "Are you sure you want to resume the breach pause": "के तपाईं उल्लंघन रोकी राखिएको अवस्था पुनः सुरु गर्न चाहनुहुन्छ?",
+      "Are you sure you want to undo the last breach reset": "के तपाईं पछिल्लो उल्लंघन रिसेट पूर्ववत गर्न निश्चित हुनुहुन्छ? यसले रिसेट चिन्ह र भुक्तानी बाँकी रकमको पुनर्गणना फिर्ता गर्छ; रिसेट मितिबाट अवधि पुनः सुरु गरेर बनेको अवधि विभाजन फिर्ता हुँदैन।",
       "Are you sure you want Unassign Staff": "के तपाईं निश्चित हुनुहुन्छ कि तपाईंले कर्मचारीलाई अनपाइन्ट गर्न चाहनुहुन्छ?",
       "Are you sure you want to calculate interest ?": "के तपाईं निश्चित हुनुहुन्छ कि तपाईं ब्याजहरू गणना गर्न चाहनुहुन्छ?",
       "Are you sure you want to post interest ?": "के तपाईं निश्चित हुनुहुन्छ कि तपाईं ब्याज पोस्ट गर्न चाहनुहुन्छ?",
@@ -3708,6 +3718,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "आवासीय सम्पत्ति किन्न, निर्माण गर्न वा मर्मत गर्न दीर्घकालीन वित्तपोषण।",
       "Merchant Cash Advance": "व्यापारी नगद अग्रिम",
       "Mortgage Loan (LAP)": "धितो ऋण (LAP)",
+      "No resets have been recorded for this loan": "यस ऋणका लागि कुनै रिसेट रेकर्ड गरिएको छैन।",
       "Personal Loan": "व्यक्तिगत ऋण",
       "Custom / Advanced": "अनुकूलित / उन्नत",
       "Two Wheeler Loan": "दुई पाङ्ग्रे सवारी ऋण",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -6,6 +6,14 @@
     "accountingRule": {
       "duplicateName": "Desculpe, mas já existe uma regra contabilística com este nome."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "A avaliação de incumprimento está desativada para este empréstimo.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "Esta ação requer um empréstimo ativo.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "O empréstimo ainda não foi desembolsado.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "O empréstimo não tem configuração de incumprimento.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "Não existe um período de avaliação de incumprimento para a data atual.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "Não há nenhuma redefinição ativa para desfazer.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "O empréstimo não tem calendário de incumprimento.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "Este período de incumprimento já foi redefinido. Desfaça a redefinição existente antes de redefinir novamente.",
     "error.resource.notImplemented.type": "Não implementado",
     "error.resource.notImplemented.message": "Funcionalidade não implementada!",
     "linkedSavingsAccountOwnership": "A conta poupança vinculada não pertence ao cliente selecionado.",
@@ -1540,6 +1548,7 @@
       "Report Parameter": "Parâmetro de relatório",
       "Reports Catalog": "Catálogo de relatórios",
       "Reschedule Loan": "Empréstimo de remarcado",
+      "Reset History": "Histórico de redefinições",
       "Revert Transaction": "Reverter transação",
       "S3 Amazon External Service": "Serviço externo S3 Amazon",
       "SMS": "SMS",
@@ -3646,6 +3655,7 @@
     "dialogContext": {
       "A new clean period will start today": "Um novo período limpo começará a partir de hoje.",
       "Are you sure you want to resume the breach pause": "Tem a certeza de que quer retomar a violação?",
+      "Are you sure you want to undo the last breach reset": "Tem a certeza de que quer desfazer a última redefinição do incumprimento? Isto desfaz a marca de redefinição e o recálculo do montante vencido; uma divisão de período criada pelo reinício do período a partir da data de redefinição não é revertida.",
       "Are you sure you want Unassign Staff": "Tem a certeza que deseja desassociar o funcionário?",
       "Are you sure you want to calculate interest ?": "Tem a certeza que deseja calcular juros?",
       "Are you sure you want to post interest ?": "Tem a certeza que deseja registar juros?",
@@ -3708,6 +3718,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Financiamento de longo prazo para comprar, construir ou renovar um imóvel residencial.",
       "Merchant Cash Advance": "Adiantamento de tesouraria a comerciantes",
       "Mortgage Loan (LAP)": "Crédito hipotecário (LAP)",
+      "No resets have been recorded for this loan": "Não foram registadas redefinições para este empréstimo.",
       "Personal Loan": "Empréstimo pessoal",
       "Custom / Advanced": "Personalizado / Avançado",
       "Two Wheeler Loan": "Empréstimo para veículos de duas rodas",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -6,6 +6,14 @@
     "accountingRule": {
       "duplicateName": "Samahani, lakini Kanuni ya Uhasibu yenye jina hili tayari ipo."
     },
+    "error.msg.workingCapitalLoanBreachAction.breach.is.disabled": "Tathmini ya ukiukaji imezimwa kwa mkopo huu.",
+    "error.msg.workingCapitalLoanBreachAction.loan.is.not.active": "Kitendo hiki kinahitaji mkopo unaotumika.",
+    "error.msg.workingCapitalLoanBreachAction.loan.not.disbursed": "Mkopo bado haujatolewa.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.configuration": "Mkopo hauna usanidi wa ukiukaji.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.evaluation.period": "Hakuna kipindi cha tathmini ya ukiukaji kwa tarehe ya sasa.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.reset.to.undo": "Hakuna uwekaji upya unaotumika wa kutengua.",
+    "error.msg.workingCapitalLoanBreachAction.no.breach.schedule": "Mkopo hauna ratiba ya ukiukaji.",
+    "error.msg.workingCapitalLoanBreachAction.reset.already.exists.in.current.period": "Kipindi hiki cha ukiukaji tayari kimewekwa upya. Tengua uwekaji upya uliopo kabla ya kuweka upya tena.",
     "error.resource.notImplemented.type": "Haijatekelezwa",
     "error.resource.notImplemented.message": "Utendaji haujatekelezwa!",
     "linkedSavingsAccountOwnership": "Akaunti ya akiba iliyounganishwa haimilikiwi na mteja aliyechaguliwa.",
@@ -1538,6 +1546,7 @@
       "Report Parameter": "Ripoti Parameta",
       "Reports Catalog": "Katalogi ya ripoti",
       "Reschedule Loan": "Rejesha mkopo",
+      "Reset History": "Historia ya uwekaji upya",
       "Revert Transaction": "Rejesha Muamala",
       "S3 Amazon External Service": "Huduma ya Nje ya S3 Amazon",
       "SMS": "SMS",
@@ -3643,6 +3652,7 @@
     "dialogContext": {
       "A new clean period will start today": "Kipindi kipya safi kitaanza kuanzia leo.",
       "Are you sure you want to resume the breach pause": "Je, una hakika unataka kuendelea na kusitishwa kwa ukiukaji?",
+      "Are you sure you want to undo the last breach reset": "Je, una hakika unataka kutengua uwekaji upya wa mwisho wa ukiukaji? Hii inatengua alama ya uwekaji upya na ukokotoaji upya wa kiasi kilichochelewa; mgawanyo wa kipindi ulioundwa kwa kuanzisha upya kipindi kuanzia tarehe ya uwekaji upya haurejeshwi.",
       "Are you sure you want Unassign Staff": "Je, una uhakika unataka kuondoa wafanyakazi?",
       "Are you sure you want to calculate interest ?": "Je, una uhakika unataka kuhesabu riba?",
       "Are you sure you want to post interest ?": "Je, una uhakika unataka kuchapisha riba?",
@@ -3705,6 +3715,7 @@
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Ufadhili wa muda mrefu wa kununua, kujenga, au kukarabati nyumba ya makazi.",
       "Merchant Cash Advance": "Malipo ya Awali kwa Wafanyabiashara",
       "Mortgage Loan (LAP)": "Mkopo wa Rehani (LAP)",
+      "No resets have been recorded for this loan": "Hakuna uwekaji upya uliorekodiwa kwa mkopo huu.",
       "Personal Loan": "Mkopo wa Binafsi",
       "Custom / Advanced": "Maalum / wa Kina",
       "Two Wheeler Loan": "Mkopo wa Pikipiki",


### PR DESCRIPTION
## Description

Working Capital Loan with Multiple Breach Reset, now the user should be able to do Multiple reset on the breach schedule

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added permission-aware working-capital breach reset and undo-reset actions with confirmation dialogs.
  - Added reset-history details, status indicators, breach reset badges, and empty-state messaging.
  - Improved severity labels and indicators for breach periods.
- **Bug Fixes**
  - Prevented duplicate resets for the current period.
  - Disabled reset controls while requests are processing.
  - Added translated error messages and refreshed loan data after actions.
- **Localization**
  - Added translations for breach actions, confirmations, errors, and reset history across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->