### PR TITLE
WEB-1120: Show translated Deferred income tab label

### DIFF
--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -425,10 +425,10 @@
               productType: loanProductService.productType.value
             }"
             routerLinkActive
-            #accountdetail="routerLinkActive"
-            [active]="accountdetail.isActive"
+            #deferredIncome="routerLinkActive"
+            [active]="deferredIncome.isActive"
           >
-            {{ 'labels.inputs.Deferred Income' | translate }}
+            {{ 'labels.inputs.Deferred income' | translate }}
           </a>
         }
         @if (loanProductService.isLoanProduct && loanDetailsData.enableBuyDownFee) {


### PR DESCRIPTION
## Description

The **Deferred income** tab on the loan account view rendered the raw translation key `labels.inputs.Deferred Income` instead of a label.

The template requested `labels.inputs.Deferred Income` (capital *I*), but the key that exists is `labels.inputs.Deferred income` (lowercase *i*). No `MissingTranslationHandler` is configured, so ngx-translate falls back to printing the key.

The fix points the template at the existing key, which is already populated in all 13 locale files — no translation work needed.

While in the same block, renamed the tab's `routerLinkActive` template reference variable from `#accountdetail` to `#deferredIncome`. It duplicated the Account Details tab's reference in the same template.

## Related issues and discussion

# WEB-1120


## Screenshots:
# Before:
<img width="1497" height="757" alt="image" src="https://github.com/user-attachments/assets/1e9b7d77-c4fc-46be-bd50-2bd3455cec79" />

# After:
<img width="1843" height="912" alt="image" src="https://github.com/user-attachments/assets/68e84c75-1121-452e-a2fc-7bacc5175ef8" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Deferred Income tab’s active-state highlighting.
  * Updated the tab label capitalization to “Deferred income.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->