### PR TITLE
WEB-1124: translate the Theme page and add custom brand colours

### DIFF
--- a/src/app/shared/theme-picker/theme-picker.component.html
+++ b/src/app/shared/theme-picker/theme-picker.component.html
@@ -16,7 +16,7 @@
       [style.background]="theme.primary"
       [attr.aria-checked]="currentTheme.id === theme.id"
       [attr.aria-label]="'labels.inputs.' + theme.name | translate"
-      [tabindex]="currentTheme.id === theme.id ? 0 : -1"
+      [tabindex]="isTabbable(i) ? 0 : -1"
       [matTooltip]="'labels.inputs.' + theme.name | translate"
       (click)="installTheme(theme)"
       (keydown)="onKeydown($event, i)"
@@ -27,3 +27,42 @@
     </button>
   }
 </div>
+
+<div class="mifosx-theme-picker-custom">
+  <span
+    class="mifosx-theme-picker-swatch mifosx-theme-picker-custom-swatch"
+    [class.is-selected]="currentTheme.isCustom"
+    [style.background]="currentTheme.isCustom ? currentTheme.primary : null"
+    [matTooltip]="'labels.inputs.Custom Color' | translate"
+  >
+    <input
+      type="color"
+      class="mifosx-theme-picker-custom-well"
+      [value]="customColor"
+      [attr.aria-label]="'labels.inputs.Custom Color' | translate"
+      (input)="onCustomColorPicked($event)"
+    />
+    @if (currentTheme.isCustom) {
+      <fa-icon class="mifosx-theme-chosen-icon" icon="check" aria-hidden="true"></fa-icon>
+    }
+  </span>
+
+  <mat-form-field class="mifosx-theme-picker-custom-field">
+    <mat-label>{{ 'labels.inputs.Custom Color' | translate }}</mat-label>
+    <input
+      matInput
+      type="text"
+      maxlength="7"
+      spellcheck="false"
+      autocomplete="off"
+      [value]="customColor"
+      (change)="onCustomHexEntered($event)"
+    />
+  </mat-form-field>
+</div>
+
+@if (contrastAdjusted) {
+  <p class="mifosx-theme-picker-note">
+    {{ 'labels.text.Custom color darkened for legibility' | translate }}
+  </p>
+}

--- a/src/app/shared/theme-picker/theme-picker.component.scss
+++ b/src/app/shared/theme-picker/theme-picker.component.scss
@@ -17,6 +17,10 @@ $theme-picker-swatch-size: 36px;
 
 .mifosx-theme-picker-swatch {
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
   width: $theme-picker-swatch-size;
   height: $theme-picker-swatch-size;
   padding: 0;
@@ -52,4 +56,51 @@ $theme-picker-swatch-size: 36px;
 
 .dark-theme .mifosx-theme-picker-swatch {
   border-color: rgb(255 255 255 / 30%);
+}
+
+/* Free colour choice, alongside the presets rather than inside the radio
+   group: the colour well is its own control and does not answer to the
+   group's arrow-key navigation. */
+.mifosx-theme-picker-custom {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+
+.mifosx-theme-picker-custom-swatch {
+  /* The spectrum reads as "any colour" until one has actually been picked. */
+  background: conic-gradient(#f44336, #ffeb3b, #4caf50, #00bcd4, #3f51b5, #9c27b0, #f44336);
+  cursor: pointer;
+  overflow: hidden;
+
+  &:focus-within {
+    outline: 2px solid var(--md-sys-color-primary, #1074b9);
+    outline-offset: 3px;
+  }
+}
+
+/* The native well is the whole swatch, so the circle itself opens the picker;
+   it is invisible because the swatch already shows the chosen colour. */
+.mifosx-theme-picker-custom-well {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.mifosx-theme-picker-custom-field {
+  width: 130px;
+}
+
+.mifosx-theme-picker-note {
+  margin: 0 0 12px;
+  font-size: 12px;
+  opacity: 0.75;
 }

--- a/src/app/shared/theme-picker/theme-picker.component.ts
+++ b/src/app/shared/theme-picker/theme-picker.component.ts
@@ -19,7 +19,13 @@ import {
 } from '@angular/core';
 
 /** Custom Model */
-import { PRIMARY_COLOR_THEMES, Theme } from './theme.model';
+import {
+  createCustomTheme,
+  DEFAULT_PRIMARY_COLOR_THEME,
+  normalizeHexColor,
+  PRIMARY_COLOR_THEMES,
+  Theme
+} from './theme.model';
 
 /** Custom Services */
 import { ThemeStorageService } from './theme-storage.service';
@@ -54,6 +60,7 @@ export class ThemePickerComponent implements OnInit {
   @Input() set selected(theme: Theme) {
     if (theme) {
       this.currentTheme = theme;
+      this.syncCustomColor();
     }
   }
 
@@ -64,12 +71,17 @@ export class ThemePickerComponent implements OnInit {
   currentTheme: Theme;
   /** Available themes for the application. */
   themes = PRIMARY_COLOR_THEMES;
+  /** Hue shown in the free colour controls, always the one actually applied. */
+  customColor: string = DEFAULT_PRIMARY_COLOR_THEME.primary;
+  /** True when the last picked hue had to be darkened to stay legible. */
+  contrastAdjusted = false;
 
   /**
    * Falls back to the cached colour until the host supplies a selection.
    */
   ngOnInit() {
     this.currentTheme ??= this.themeStorageService.getCachedTheme();
+    this.syncCustomColor();
   }
 
   /**
@@ -79,8 +91,67 @@ export class ThemePickerComponent implements OnInit {
    */
   installTheme(theme: Theme) {
     this.currentTheme = theme;
+    if (!theme.isCustom) {
+      this.contrastAdjusted = false;
+    }
     this.themeStorageService.previewTheme(theme);
     this.themeSelected.emit(theme);
+  }
+
+  /**
+   * Keeps one swatch reachable by Tab. The selected preset owns the tab stop,
+   * as a radio group requires; with a custom colour selected no preset is, so
+   * the first one takes it rather than leaving the group unreachable.
+   * @param {number} index Index of the swatch.
+   * @returns {boolean} True when the swatch is the group's tab stop.
+   */
+  isTabbable(index: number): boolean {
+    const selectedIndex = this.themes.findIndex((theme) => theme.id === this.currentTheme.id);
+    return index === (selectedIndex === -1 ? 0 : selectedIndex);
+  }
+
+  /**
+   * Applies the hue chosen in the colour well, which reports every drag step.
+   * @param {Event} event
+   */
+  onCustomColorPicked(event: Event) {
+    this.applyCustomColor((event.target as HTMLInputElement).value);
+  }
+
+  /**
+   * Applies a typed hex, restoring the field when it is not a colour so the
+   * text never disagrees with what is applied.
+   * @param {Event} event
+   */
+  onCustomHexEntered(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (!this.applyCustomColor(input.value)) {
+      input.value = this.customColor;
+    }
+  }
+
+  /**
+   * @param {string} value Colour as typed or picked.
+   * @returns {boolean} True when it was a colour and has been applied.
+   */
+  private applyCustomColor(value: string): boolean {
+    const theme = createCustomTheme(value);
+    if (!theme) {
+      return false;
+    }
+    // Reported rather than silently corrected: the administrator gets the
+    // nearest legible hue, and is told the one they picked was not.
+    this.contrastAdjusted = theme.primary !== normalizeHexColor(value);
+    this.customColor = theme.primary;
+    this.installTheme(theme);
+    return true;
+  }
+
+  /** Points the free colour controls at the selection when it is a custom one. */
+  private syncCustomColor() {
+    if (this.currentTheme?.isCustom) {
+      this.customColor = this.currentTheme.primary;
+    }
   }
 
   /**

--- a/src/app/shared/theme-picker/theme.model.spec.ts
+++ b/src/app/shared/theme-picker/theme.model.spec.ts
@@ -6,7 +6,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { DEFAULT_PRIMARY_COLOR_THEME, PRIMARY_COLOR_THEMES, resolvePrimaryColorTheme } from './theme.model';
+import {
+  createCustomTheme,
+  DEFAULT_PRIMARY_COLOR_THEME,
+  MIN_PRIMARY_CONTRAST_WITH_WHITE,
+  normalizeHexColor,
+  PRIMARY_COLOR_THEMES,
+  resolvePrimaryColorTheme
+} from './theme.model';
 
 /** Relative luminance per WCAG 2.1. */
 function luminance(hex: string): number {
@@ -30,10 +37,13 @@ describe('primary colour themes', () => {
     expect(PRIMARY_COLOR_THEMES.map((theme) => theme.id)).toEqual([
       'blue',
       'green',
+      'light-green',
       'purple',
+      'pink',
       'orange',
       'red',
-      'yellow'
+      'yellow',
+      'black'
     ]);
   });
 
@@ -63,9 +73,78 @@ describe('primary colour themes', () => {
       '',
       '   ',
       'chartreuse',
-      '#ff0000'
+      '#12345',
+      '#gggggg'
     ])('falls back to blue for %p', (value) => {
       expect(resolvePrimaryColorTheme(value).id).toBe('blue');
+    });
+
+    it('rebuilds a stored hex as a custom theme', () => {
+      const theme = resolvePrimaryColorTheme('#6a1b9a');
+      expect(theme.isCustom).toBe(true);
+      expect(theme.primary).toBe('#6a1b9a');
+    });
+
+    it('resolves a stored custom colour back to itself', () => {
+      // The id is what gets stored, so re-resolving it has to be a no-op or the
+      // tenant's colour would drift a shade darker on every page load.
+      const picked = createCustomTheme('#ff0000');
+      expect(resolvePrimaryColorTheme(picked.id)).toEqual(picked);
+    });
+  });
+
+  describe('normalizeHexColor', () => {
+    it('expands the short form and lowercases it', () => {
+      expect(normalizeHexColor('  #AbC ')).toBe('#aabbcc');
+    });
+
+    it.each([
+      null,
+      undefined,
+      '',
+      'red',
+      '123456',
+      '#12345'
+    ])('rejects %p', (value) => {
+      expect(normalizeHexColor(value)).toBeNull();
+    });
+  });
+
+  describe('createCustomTheme', () => {
+    it('keeps a hue that already carries white text', () => {
+      expect(createCustomTheme('#6a1b9a').primary).toBe('#6a1b9a');
+    });
+
+    it('darkens a hue that cannot carry white text', () => {
+      // Pure red is only 4:1 against white.
+      const theme = createCustomTheme('#ff0000');
+      expect(theme.primary).not.toBe('#ff0000');
+      expect(contrastWithWhite(theme.primary)).toBeGreaterThanOrEqual(MIN_PRIMARY_CONTRAST_WITH_WHITE);
+    });
+
+    it('keeps white label text legible on any picked hue', () => {
+      for (const picked of [
+        '#ffffff',
+        '#ffff00',
+        '#00ff00',
+        '#ff00ff',
+        '#000000',
+        '#7fffd4'
+      ]) {
+        const theme = createCustomTheme(picked);
+        expect(contrastWithWhite(theme.primary)).toBeGreaterThanOrEqual(MIN_PRIMARY_CONTRAST_WITH_WHITE);
+        expect(contrastWithWhite(theme.dark)).toBeGreaterThanOrEqual(MIN_PRIMARY_CONTRAST_WITH_WHITE);
+      }
+    });
+
+    it('derives a light hue that carries dark text', () => {
+      // Hue 100 is paired with near-black text by the palette.
+      const theme = createCustomTheme('#1074b9');
+      expect(luminance(theme.light)).toBeGreaterThan(luminance(theme.primary));
+    });
+
+    it('returns null for a value that is not a colour', () => {
+      expect(createCustomTheme('chartreuse')).toBeNull();
     });
   });
 });

--- a/src/app/shared/theme-picker/theme.model.ts
+++ b/src/app/shared/theme-picker/theme.model.ts
@@ -20,6 +20,12 @@ export interface Theme {
   light: string;
   dark: string;
   isDefault?: boolean;
+  /**
+   * True when the theme was derived from a hue the administrator picked rather
+   * than chosen from the presets. Such a theme has no translated name, so the
+   * UI labels it with `labels.inputs.Custom` and the hex itself.
+   */
+  isCustom?: boolean;
 }
 
 /**
@@ -41,24 +47,162 @@ export const BRANDING_API_PATH = '/branding';
 export const PRIMARY_COLOR_THEMES: Theme[] = [
   { id: 'blue', name: 'Blue', primary: '#1074b9', light: '#5ba2ec', dark: '#004989', isDefault: true },
   { id: 'green', name: 'Green', primary: '#2e7d32', light: '#7cc47f', dark: '#1b5e20' },
+  { id: 'light-green', name: 'Light Green', primary: '#5a7d0c', light: '#c5e1a5', dark: '#3d5600' },
   { id: 'purple', name: 'Purple', primary: '#6a1b9a', light: '#c3a0ea', dark: '#4a148c' },
+  { id: 'pink', name: 'Pink', primary: '#ad1457', light: '#f48fb1', dark: '#78002e' },
   { id: 'orange', name: 'Orange', primary: '#bf5000', light: '#ffb74d', dark: '#8f3b00' },
   { id: 'red', name: 'Red', primary: '#c62828', light: '#ef8c8c', dark: '#8e0000' },
-  { id: 'yellow', name: 'Yellow', primary: '#8f6a00', light: '#ffd54f', dark: '#6b5000' }
+  { id: 'yellow', name: 'Yellow', primary: '#8f6a00', light: '#ffd54f', dark: '#6b5000' },
+  { id: 'black', name: 'Black', primary: '#212121', light: '#9e9e9e', dark: '#000000' }
 ];
 
 /** Applied when the tenant has no valid configured colour. */
 export const DEFAULT_PRIMARY_COLOR_THEME: Theme = PRIMARY_COLOR_THEMES[0];
 
 /**
+ * Smallest contrast a primary hue may have against white.
+ *
+ * The Sass palette pairs hue 500 with a white contrast colour, so a primary the
+ * administrator picks freely still has to carry white label text. WCAG AA for
+ * normal text is 4.5:1.
+ */
+export const MIN_PRIMARY_CONTRAST_WITH_WHITE = 4.5;
+
+/** `#rgb` or `#rrggbb`, the two forms `<input type="color">` and users produce. */
+const HEX_COLOR_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+/**
+ * Normalises a hex colour to lowercase `#rrggbb`.
+ * @param {string} value Colour as typed or picked.
+ * @returns {string} Normalised colour, or null when it is not a hex colour.
+ */
+export function normalizeHexColor(value?: string | null): string | null {
+  const trimmed = value?.trim().toLowerCase();
+  if (!trimmed || !HEX_COLOR_PATTERN.test(trimmed)) {
+    return null;
+  }
+  const digits = trimmed.slice(1);
+  return digits.length === 3
+    ? `#${digits
+        .split('')
+        .map((digit) => digit + digit)
+        .join('')}`
+    : trimmed;
+}
+
+/** @returns {number[]} Red, green and blue of a `#rrggbb` colour, 0-255. */
+function toChannels(hex: string): number[] {
+  return [
+    1,
+    3,
+    5
+  ].map((offset) => parseInt(hex.slice(offset, offset + 2), 16));
+}
+
+/** @returns {string} `#rrggbb` for channels, clamped and rounded. */
+function toHex(channels: number[]): string {
+  return `#${channels
+    .map((channel) =>
+      Math.max(0, Math.min(255, Math.round(channel)))
+        .toString(16)
+        .padStart(2, '0')
+    )
+    .join('')}`;
+}
+
+/** @returns {number} Relative luminance per WCAG 2.1. */
+function relativeLuminance(channels: number[]): number {
+  const [
+    red,
+    green,
+    blue
+  ] = channels.map((channel) => {
+    const ratio = channel / 255;
+    return ratio <= 0.04045 ? ratio / 12.92 : Math.pow((ratio + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+/** @returns {number} Contrast ratio of the colour against white. */
+function contrastWithWhite(channels: number[]): number {
+  return 1.05 / (relativeLuminance(channels) + 0.05);
+}
+
+/** @returns {number[]} Channels rounded to whole 0-255 values. */
+function roundChannels(channels: number[]): number[] {
+  return channels.map((channel) => Math.round(channel));
+}
+
+/** @returns {number[]} Channels scaled towards black by `factor`. */
+function scaleChannels(channels: number[], factor: number): number[] {
+  return channels.map((channel) => channel * factor);
+}
+
+/** @returns {number[]} Channels mixed with white, `amount` being the share of white. */
+function mixWithWhite(channels: number[], amount: number): number[] {
+  return channels.map((channel) => channel + (255 - channel) * amount);
+}
+
+/**
+ * Darkens a hue just far enough to carry white text.
+ *
+ * A freely picked colour is often too light for the white label text the
+ * palette pairs with hue 500 - a pure red is only 4:1 - so it is stepped
+ * towards black until it passes. Stepping by a fixed factor reaches black well
+ * inside the iteration cap, so this always terminates, and it is idempotent:
+ * a hue that already passes is returned untouched, which is what lets a stored
+ * custom colour resolve back to itself on the next page load.
+ * @param {number[]} channels Picked hue.
+ * @returns {number[]} Hue that meets the contrast floor.
+ */
+function darkenUntilLegible(channels: number[]): number[] {
+  // Rounded on every step, so the contrast measured is the one the emitted
+  // `#rrggbb` actually has rather than the one a fractional channel would have.
+  let current = roundChannels(channels);
+  for (let step = 0; step < 200 && contrastWithWhite(current) < MIN_PRIMARY_CONTRAST_WITH_WHITE; step++) {
+    current = roundChannels(scaleChannels(current, 0.97));
+  }
+  return current;
+}
+
+/**
+ * Builds a theme from a colour the administrator picked.
+ *
+ * The picked hue becomes the primary, darkened if it could not carry white
+ * text, and the 100 / 700 hues are derived from it so the whole palette moves
+ * together. The theme's id is its own primary, which is what gets stored for
+ * the tenant.
+ * @param {string} value Colour as typed or picked, `#rgb` or `#rrggbb`.
+ * @returns {Theme} Custom theme, or null when the value is not a hex colour.
+ */
+export function createCustomTheme(value?: string | null): Theme | null {
+  const hex = normalizeHexColor(value);
+  if (!hex) {
+    return null;
+  }
+  const primary = darkenUntilLegible(toChannels(hex));
+  return {
+    id: toHex(primary),
+    name: 'Custom',
+    primary: toHex(primary),
+    light: toHex(mixWithWhite(primary, 0.6)),
+    dark: toHex(scaleChannels(primary, 0.7)),
+    isCustom: true
+  };
+}
+
+/**
  * Resolves a configured theme id to a theme.
  *
- * Falls back to the default for a missing, blank or unrecognised value, which
- * is also what keeps an unexpected server value from reaching the stylesheet.
+ * A preset id wins; otherwise a hex colour is rebuilt as a custom theme, since
+ * that is how a freely picked colour is stored. Falls back to the default for a
+ * missing, blank or unrecognised value, which is also what keeps an unexpected
+ * server value from reaching the stylesheet.
  * @param {string} themeId Configured theme id.
  * @returns {Theme} Matching theme, or the default.
  */
 export function resolvePrimaryColorTheme(themeId?: string | null): Theme {
   const normalized = themeId?.trim().toLowerCase();
-  return PRIMARY_COLOR_THEMES.find((theme) => theme.id === normalized) ?? DEFAULT_PRIMARY_COLOR_THEME;
+  const preset = PRIMARY_COLOR_THEMES.find((theme) => theme.id === normalized);
+  return preset ?? createCustomTheme(normalized) ?? DEFAULT_PRIMARY_COLOR_THEME;
 }

--- a/src/app/system/theme/theme.component.html
+++ b/src/app/system/theme/theme.component.html
@@ -23,7 +23,11 @@
 
         <p class="theme-selection">
           {{ 'labels.inputs.Theme' | translate }}:
-          <strong>{{ 'labels.inputs.' + selectedTheme.name | translate }}</strong>
+          @if (selectedTheme.isCustom) {
+            <strong>{{ 'labels.inputs.Custom' | translate }} ({{ selectedTheme.primary }})</strong>
+          } @else {
+            <strong>{{ 'labels.inputs.' + selectedTheme.name | translate }}</strong>
+          }
         </p>
       }
     </mat-card-content>

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1643,7 +1643,8 @@
       "View Exchange Rate": "Zobrazit směnný kurz",
       "Edit Exchange Rate": "Upravit směnný kurz",
       "Disable Breach Evaluation": "Zakázat hodnocení porušení",
-      "Enable Breach Evaluation": "Povolit hodnocení porušení"
+      "Enable Breach Evaluation": "Povolit hodnocení porušení",
+      "Theme": "Motiv"
     },
     "inputs": {
       "Annual interest rate": "Roční úroková sazba",
@@ -3284,7 +3285,19 @@
       "Link": "Propojení",
       "Audit Trail": "Auditní stopa",
       "Restart Period from Reset Date": "Restartovat období od data resetu",
-      "Breach evaluation disabled since": "Hodnocení porušení zakázáno od {{date}}"
+      "Breach evaluation disabled since": "Hodnocení porušení zakázáno od {{date}}",
+      "Blue": "Modrá",
+      "Green": "Zelená",
+      "Light Green": "Světle zelená",
+      "Purple": "Fialová",
+      "Pink": "Růžová",
+      "Orange": "Oranžová",
+      "Red": "Červená",
+      "Yellow": "Žlutá",
+      "Black": "Černá",
+      "Primary Color": "Hlavní barva",
+      "Custom": "Vlastní",
+      "Custom Color": "Vlastní barva"
     },
     "links": {
       "Community": "Společenství",
@@ -4352,7 +4365,13 @@
       "Payment system delink OTP sent": "Bylo vyžádáno nové OTP pro odebrání propojení s platebním systémem.",
       "Payment system delink OTP request failed": "Nepodařilo se vyžádat nové OTP pro odpojení.",
       "Payment system delink successful": "Propojení s platebním systémem bylo úspěšně odebráno.",
-      "Payment system delink failed": "Propojení s platebním systémem se nepodařilo odebrat."
+      "Payment system delink failed": "Propojení s platebním systémem se nepodařilo odebrat.",
+      "Theme": "Motiv",
+      "Set the primary color used across this tenant": "Nastavte hlavní barvu používanou v celém tomto nájemci",
+      "Tenant theme explanation": "Hlavní barva se použije pro všechny uživatele tohoto nájemce. Jednotliví uživatelé ji nemohou změnit.",
+      "Tenant theme unavailable": "Nastavení motivu není na tomto serveru k dispozici. Používá se výchozí barva.",
+      "Tenant theme updated successfully": "Motiv nájemce byl úspěšně aktualizován",
+      "Custom color darkened for legibility": "Vybraná barva byla ztmavena, aby na ní zůstal bílý text čitelný."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1645,7 +1645,8 @@
       "View Exchange Rate": "Wechselkurs anzeigen",
       "Edit Exchange Rate": "Wechselkurs bearbeiten",
       "Disable Breach Evaluation": "Verstoßbewertung deaktivieren",
-      "Enable Breach Evaluation": "Verstoßbewertung aktivieren"
+      "Enable Breach Evaluation": "Verstoßbewertung aktivieren",
+      "Theme": "Thema"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3286,7 +3287,19 @@
       "Link": "Verknüpfung",
       "Audit Trail": "Prüfpfad",
       "Restart Period from Reset Date": "Periode ab Reset-Datum neu starten",
-      "Breach evaluation disabled since": "Verstoßbewertung deaktiviert seit {{date}}"
+      "Breach evaluation disabled since": "Verstoßbewertung deaktiviert seit {{date}}",
+      "Blue": "Blau",
+      "Green": "Grün",
+      "Light Green": "Hellgrün",
+      "Purple": "Lila",
+      "Pink": "Rosa",
+      "Orange": "Orange",
+      "Red": "Rot",
+      "Yellow": "Gelb",
+      "Black": "Schwarz",
+      "Primary Color": "Primärfarbe",
+      "Custom": "Benutzerdefiniert",
+      "Custom Color": "Benutzerdefinierte Farbe"
     },
     "links": {
       "Community": "Gemeinschaft",
@@ -4353,7 +4366,13 @@
       "Payment system delink OTP sent": "Ein neues OTP zum Entfernen der Zahlungssystem-Verknüpfung wurde angefordert.",
       "Payment system delink OTP request failed": "Ein neues OTP zum Entfernen der Verknüpfung konnte nicht angefordert werden.",
       "Payment system delink successful": "Die Zahlungssystem-Verknüpfung wurde erfolgreich entfernt.",
-      "Payment system delink failed": "Die Zahlungssystem-Verknüpfung konnte nicht entfernt werden."
+      "Payment system delink failed": "Die Zahlungssystem-Verknüpfung konnte nicht entfernt werden.",
+      "Theme": "Thema",
+      "Set the primary color used across this tenant": "Legen Sie die Primärfarbe fest, die in diesem Mandanten verwendet wird",
+      "Tenant theme explanation": "Die Primärfarbe gilt für alle Benutzer dieses Mandanten. Einzelne Benutzer können sie nicht überschreiben.",
+      "Tenant theme unavailable": "Die Themenkonfiguration ist auf diesem Server nicht verfügbar. Es wird die Standardfarbe verwendet.",
+      "Tenant theme updated successfully": "Thema des Mandanten erfolgreich aktualisiert",
+      "Custom color darkened for legibility": "Die ausgewählte Farbe wurde abgedunkelt, damit weißer Text darauf lesbar bleibt."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3324,7 +3324,12 @@
       "Yellow": "Yellow",
       "Primary Color": "Primary Color",
       "Audit Trail": "Audit Trail",
-      "Breach evaluation disabled since": "Breach evaluation disabled since {{date}}"
+      "Breach evaluation disabled since": "Breach evaluation disabled since {{date}}",
+      "Light Green": "Light Green",
+      "Pink": "Pink",
+      "Black": "Black",
+      "Custom": "Custom",
+      "Custom Color": "Custom Color"
     },
     "links": {
       "Community": "Community",
@@ -4514,7 +4519,8 @@
       "Tenant theme explanation": "The primary color is applied to every user of this tenant. Individual users cannot override it.",
       "Tenant theme unavailable": "The theme configuration is not available on this server. The default color is being used.",
       "Tenant theme updated successfully": "Tenant theme updated successfully",
-      "Theme": "Theme"
+      "Theme": "Theme",
+      "Custom color darkened for legibility": "The selected color was darkened so that white text stays legible on it."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1643,7 +1643,8 @@
       "View Exchange Rate": "Ver tipo de cambio",
       "Edit Exchange Rate": "Editar tipo de cambio",
       "Disable Breach Evaluation": "Deshabilitar Evaluación de Incumplimiento",
-      "Enable Breach Evaluation": "Habilitar Evaluación de Incumplimiento"
+      "Enable Breach Evaluation": "Habilitar Evaluación de Incumplimiento",
+      "Theme": "Tema"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3285,7 +3286,19 @@
       "Dispute Management": "Gestión de disputas",
       "Audit Trail": "Registro de auditoría",
       "Restart Period from Reset Date": "Reiniciar el período desde la fecha de reinicio",
-      "Breach evaluation disabled since": "Evaluación de incumplimiento deshabilitada desde el {{date}}"
+      "Breach evaluation disabled since": "Evaluación de incumplimiento deshabilitada desde el {{date}}",
+      "Blue": "Azul",
+      "Green": "Verde",
+      "Light Green": "Verde claro",
+      "Purple": "Morado",
+      "Pink": "Rosa",
+      "Orange": "Naranja",
+      "Red": "Rojo",
+      "Yellow": "Amarillo",
+      "Black": "Negro",
+      "Primary Color": "Color principal",
+      "Custom": "Personalizado",
+      "Custom Color": "Color personalizado"
     },
     "links": {
       "Community": "Comunidad",
@@ -4353,7 +4366,13 @@
       "View Exchange Rate": "Ver tipo de cambio",
       "Edit Exchange Rate": "Editar tipo de cambio",
       "Currency Conversion": "Conversión de moneda",
-      "Currency conversion failed. Please try again.": "La conversión de moneda falló. Inténtelo de nuevo."
+      "Currency conversion failed. Please try again.": "La conversión de moneda falló. Inténtelo de nuevo.",
+      "Theme": "Tema",
+      "Set the primary color used across this tenant": "Defina el color principal usado en toda esta instancia",
+      "Tenant theme explanation": "El color principal se aplica a todos los usuarios de esta instancia. Los usuarios individuales no pueden cambiarlo.",
+      "Tenant theme unavailable": "La configuración del tema no está disponible en este servidor. Se está usando el color predeterminado.",
+      "Tenant theme updated successfully": "Tema de la instancia actualizado correctamente",
+      "Custom color darkened for legibility": "El color seleccionado se oscureció para que el texto blanco siga siendo legible."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1648,7 +1648,8 @@
       "View Exchange Rate": "Ver tipo de cambio",
       "Edit Exchange Rate": "Editar tipo de cambio",
       "Disable Breach Evaluation": "Deshabilitar Evaluación de Incumplimiento",
-      "Enable Breach Evaluation": "Habilitar Evaluación de Incumplimiento"
+      "Enable Breach Evaluation": "Habilitar Evaluación de Incumplimiento",
+      "Theme": "Tema"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3290,7 +3291,19 @@
       "Dispute Management": "Gestión de disputas",
       "Audit Trail": "Registro de auditoría",
       "Restart Period from Reset Date": "Reiniciar el período desde la fecha de reinicio",
-      "Breach evaluation disabled since": "Evaluación de incumplimiento deshabilitada desde el {{date}}"
+      "Breach evaluation disabled since": "Evaluación de incumplimiento deshabilitada desde el {{date}}",
+      "Blue": "Azul",
+      "Green": "Verde",
+      "Light Green": "Verde claro",
+      "Purple": "Morado",
+      "Pink": "Rosa",
+      "Orange": "Naranja",
+      "Red": "Rojo",
+      "Yellow": "Amarillo",
+      "Black": "Negro",
+      "Primary Color": "Color principal",
+      "Custom": "Personalizado",
+      "Custom Color": "Color personalizado"
     },
     "links": {
       "Community": "Comunidad",
@@ -4377,7 +4390,13 @@
       "View Exchange Rate": "Ver tipo de cambio",
       "Edit Exchange Rate": "Editar tipo de cambio",
       "Currency Conversion": "Conversión de moneda",
-      "Currency conversion failed. Please try again.": "La conversión de moneda falló. Inténtelo de nuevo."
+      "Currency conversion failed. Please try again.": "La conversión de moneda falló. Inténtelo de nuevo.",
+      "Theme": "Tema",
+      "Set the primary color used across this tenant": "Defina el color principal usado en toda esta instancia",
+      "Tenant theme explanation": "El color principal se aplica a todos los usuarios de esta instancia. Los usuarios individuales no pueden cambiarlo.",
+      "Tenant theme unavailable": "La configuración del tema no está disponible en este servidor. Se está usando el color predeterminado.",
+      "Tenant theme updated successfully": "Tema de la instancia actualizado correctamente",
+      "Custom color darkened for legibility": "El color seleccionado se oscureció para que el texto blanco siga siendo legible."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1646,7 +1646,8 @@
       "View Exchange Rate": "Afficher le taux de change",
       "Edit Exchange Rate": "Modifier le taux de change",
       "Disable Breach Evaluation": "Désactiver l'évaluation des manquements",
-      "Enable Breach Evaluation": "Activer l'évaluation des manquements"
+      "Enable Breach Evaluation": "Activer l'évaluation des manquements",
+      "Theme": "Thème"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3287,7 +3288,19 @@
       "Link": "Lien",
       "Audit Trail": "Piste d'audit",
       "Restart Period from Reset Date": "Redémarrer la période à partir de la date de réinitialisation",
-      "Breach evaluation disabled since": "Évaluation des manquements désactivée depuis le {{date}}"
+      "Breach evaluation disabled since": "Évaluation des manquements désactivée depuis le {{date}}",
+      "Blue": "Bleu",
+      "Green": "Vert",
+      "Light Green": "Vert clair",
+      "Purple": "Violet",
+      "Pink": "Rose",
+      "Orange": "Orange",
+      "Red": "Rouge",
+      "Yellow": "Jaune",
+      "Black": "Noir",
+      "Primary Color": "Couleur principale",
+      "Custom": "Personnalisé",
+      "Custom Color": "Couleur personnalisée"
     },
     "links": {
       "Community": "Communauté",
@@ -4354,7 +4367,13 @@
       "Payment system delink OTP sent": "Un nouvel OTP a été demandé pour supprimer le lien avec le système de paiement.",
       "Payment system delink OTP request failed": "Impossible de demander un nouvel OTP pour la suppression du lien.",
       "Payment system delink successful": "Le lien avec le système de paiement a été supprimé avec succès.",
-      "Payment system delink failed": "Impossible de supprimer le lien avec le système de paiement."
+      "Payment system delink failed": "Impossible de supprimer le lien avec le système de paiement.",
+      "Theme": "Thème",
+      "Set the primary color used across this tenant": "Définissez la couleur principale utilisée dans ce locataire",
+      "Tenant theme explanation": "La couleur principale s'applique à tous les utilisateurs de ce locataire. Les utilisateurs ne peuvent pas la remplacer.",
+      "Tenant theme unavailable": "La configuration du thème n'est pas disponible sur ce serveur. La couleur par défaut est utilisée.",
+      "Tenant theme updated successfully": "Thème du locataire mis à jour avec succès",
+      "Custom color darkened for legibility": "La couleur choisie a été assombrie afin que le texte blanc reste lisible."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1643,7 +1643,8 @@
       "View Exchange Rate": "Visualizza tasso di cambio",
       "Edit Exchange Rate": "Modifica tasso di cambio",
       "Disable Breach Evaluation": "Disabilita Valutazione delle Violazioni",
-      "Enable Breach Evaluation": "Abilita Valutazione delle Violazioni"
+      "Enable Breach Evaluation": "Abilita Valutazione delle Violazioni",
+      "Theme": "Tema"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3284,7 +3285,19 @@
       "Link": "Collegamento",
       "Audit Trail": "Traccia di controllo",
       "Restart Period from Reset Date": "Riavvia periodo dalla data di ripristino",
-      "Breach evaluation disabled since": "Valutazione delle violazioni disabilitata dal {{date}}"
+      "Breach evaluation disabled since": "Valutazione delle violazioni disabilitata dal {{date}}",
+      "Blue": "Blu",
+      "Green": "Verde",
+      "Light Green": "Verde chiaro",
+      "Purple": "Viola",
+      "Pink": "Rosa",
+      "Orange": "Arancione",
+      "Red": "Rosso",
+      "Yellow": "Giallo",
+      "Black": "Nero",
+      "Primary Color": "Colore principale",
+      "Custom": "Personalizzato",
+      "Custom Color": "Colore personalizzato"
     },
     "links": {
       "Community": "Comunità",
@@ -4352,7 +4365,13 @@
       "Payment system delink OTP sent": "È stato richiesto un nuovo OTP per rimuovere il collegamento al sistema di pagamento.",
       "Payment system delink OTP request failed": "Impossibile richiedere un nuovo OTP per lo scollegamento.",
       "Payment system delink successful": "Collegamento al sistema di pagamento rimosso correttamente.",
-      "Payment system delink failed": "Impossibile rimuovere il collegamento al sistema di pagamento."
+      "Payment system delink failed": "Impossibile rimuovere il collegamento al sistema di pagamento.",
+      "Theme": "Tema",
+      "Set the primary color used across this tenant": "Imposta il colore principale usato in questo inquilino",
+      "Tenant theme explanation": "Il colore principale viene applicato a tutti gli utenti di questo inquilino. I singoli utenti non possono modificarlo.",
+      "Tenant theme unavailable": "La configurazione del tema non è disponibile su questo server. Viene usato il colore predefinito.",
+      "Tenant theme updated successfully": "Tema dell'inquilino aggiornato correttamente",
+      "Custom color darkened for legibility": "Il colore scelto è stato scurito affinché il testo bianco resti leggibile."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1644,7 +1644,8 @@
       "View Exchange Rate": "환율 보기",
       "Edit Exchange Rate": "환율 편집",
       "Disable Breach Evaluation": "위반 평가 비활성화",
-      "Enable Breach Evaluation": "위반 평가 활성화"
+      "Enable Breach Evaluation": "위반 평가 활성화",
+      "Theme": "테마"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3284,7 +3285,19 @@
       "Link": "연결",
       "Audit Trail": "감사 추적",
       "Restart Period from Reset Date": "리셋 날짜부터 기간 다시 시작",
-      "Breach evaluation disabled since": "{{date}}부터 위반 평가 비활성화됨"
+      "Breach evaluation disabled since": "{{date}}부터 위반 평가 비활성화됨",
+      "Blue": "파랑",
+      "Green": "초록",
+      "Light Green": "연두",
+      "Purple": "보라",
+      "Pink": "분홍",
+      "Orange": "주황",
+      "Red": "빨강",
+      "Yellow": "노랑",
+      "Black": "검정",
+      "Primary Color": "기본 색상",
+      "Custom": "사용자 지정",
+      "Custom Color": "사용자 지정 색상"
     },
     "links": {
       "Community": "지역 사회",
@@ -4351,7 +4364,13 @@
       "Payment system delink OTP sent": "결제 시스템 연결을 제거하기 위한 새 OTP가 요청되었습니다.",
       "Payment system delink OTP request failed": "연결 해제를 위한 새 OTP를 요청할 수 없습니다.",
       "Payment system delink successful": "결제 시스템 연결이 성공적으로 제거되었습니다.",
-      "Payment system delink failed": "결제 시스템 연결을 제거할 수 없습니다."
+      "Payment system delink failed": "결제 시스템 연결을 제거할 수 없습니다.",
+      "Theme": "테마",
+      "Set the primary color used across this tenant": "이 테넌트 전체에 사용되는 기본 색상을 설정합니다",
+      "Tenant theme explanation": "기본 색상은 이 테넌트의 모든 사용자에게 적용됩니다. 개별 사용자는 이를 변경할 수 없습니다.",
+      "Tenant theme unavailable": "이 서버에서는 테마 설정을 사용할 수 없습니다. 기본 색상이 사용됩니다.",
+      "Tenant theme updated successfully": "테넌트 테마가 성공적으로 업데이트되었습니다",
+      "Custom color darkened for legibility": "선택한 색상은 흰색 글자가 잘 보이도록 어둡게 조정되었습니다."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1642,7 +1642,8 @@
       "View Exchange Rate": "Peržiūrėti valiutos kursą",
       "Edit Exchange Rate": "Redaguoti valiutos kursą",
       "Disable Breach Evaluation": "Išjungti pažeidimų vertinimą",
-      "Enable Breach Evaluation": "Įjungti pažeidimų vertinimą"
+      "Enable Breach Evaluation": "Įjungti pažeidimų vertinimą",
+      "Theme": "Tema"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3283,7 +3284,19 @@
       "Link": "Susiejimas",
       "Audit Trail": "Audito takas",
       "Restart Period from Reset Date": "Iš naujo paleisti laikotarpį nuo atstatymo datos",
-      "Breach evaluation disabled since": "Pažeidimų vertinimas išjungtas nuo {{date}}"
+      "Breach evaluation disabled since": "Pažeidimų vertinimas išjungtas nuo {{date}}",
+      "Blue": "Mėlyna",
+      "Green": "Žalia",
+      "Light Green": "Šviesiai žalia",
+      "Purple": "Violetinė",
+      "Pink": "Rožinė",
+      "Orange": "Oranžinė",
+      "Red": "Raudona",
+      "Yellow": "Geltona",
+      "Black": "Juoda",
+      "Primary Color": "Pagrindinė spalva",
+      "Custom": "Pasirinktinė",
+      "Custom Color": "Pasirinktinė spalva"
     },
     "links": {
       "Community": "bendruomenė",
@@ -4352,7 +4365,13 @@
       "Payment system delink OTP sent": "Paprašyta naujo OTP mokėjimo sistemos susiejimui pašalinti.",
       "Payment system delink OTP request failed": "Nepavyko paprašyti naujo OTP atsiejimui.",
       "Payment system delink successful": "Mokėjimo sistemos susiejimas sėkmingai pašalintas.",
-      "Payment system delink failed": "Nepavyko pašalinti mokėjimo sistemos susiejimo."
+      "Payment system delink failed": "Nepavyko pašalinti mokėjimo sistemos susiejimo.",
+      "Theme": "Tema",
+      "Set the primary color used across this tenant": "Nustatykite pagrindinę spalvą, naudojamą visame šiame nuomininke",
+      "Tenant theme explanation": "Pagrindinė spalva taikoma visiems šio nuomininko naudotojams. Atskiri naudotojai jos pakeisti negali.",
+      "Tenant theme unavailable": "Temos konfigūracija šiame serveryje neprieinama. Naudojama numatytoji spalva.",
+      "Tenant theme updated successfully": "Nuomininko tema sėkmingai atnaujinta",
+      "Custom color darkened for legibility": "Pasirinkta spalva buvo patamsinta, kad baltas tekstas liktų įskaitomas."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1643,7 +1643,8 @@
       "View Exchange Rate": "Skatīt valūtas kursu",
       "Edit Exchange Rate": "Rediģēt valūtas kursu",
       "Disable Breach Evaluation": "Atspējot pārkāpumu novērtēšanu",
-      "Enable Breach Evaluation": "Iespējot pārkāpumu novērtēšanu"
+      "Enable Breach Evaluation": "Iespējot pārkāpumu novērtēšanu",
+      "Theme": "Tēma"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3284,7 +3285,19 @@
       "Link": "Saite",
       "Audit Trail": "Revīzijas taka",
       "Restart Period from Reset Date": "Restartēt periodu no atiestatīšanas datuma",
-      "Breach evaluation disabled since": "Pārkāpumu novērtēšana atspējota kopš {{date}}"
+      "Breach evaluation disabled since": "Pārkāpumu novērtēšana atspējota kopš {{date}}",
+      "Blue": "Zila",
+      "Green": "Zaļa",
+      "Light Green": "Gaiši zaļa",
+      "Purple": "Violeta",
+      "Pink": "Rozā",
+      "Orange": "Oranža",
+      "Red": "Sarkana",
+      "Yellow": "Dzeltena",
+      "Black": "Melna",
+      "Primary Color": "Primārā krāsa",
+      "Custom": "Pielāgota",
+      "Custom Color": "Pielāgota krāsa"
     },
     "links": {
       "Community": "kopiena",
@@ -4351,7 +4364,13 @@
       "Payment system delink OTP sent": "Tika pieprasīts jauns OTP maksājumu sistēmas saites noņemšanai.",
       "Payment system delink OTP request failed": "Neizdevās pieprasīt jaunu OTP atsaistīšanai.",
       "Payment system delink successful": "Maksājumu sistēmas saite veiksmīgi noņemta.",
-      "Payment system delink failed": "Neizdevās noņemt maksājumu sistēmas saiti."
+      "Payment system delink failed": "Neizdevās noņemt maksājumu sistēmas saiti.",
+      "Theme": "Tēma",
+      "Set the primary color used across this tenant": "Iestatiet primāro krāsu, ko izmanto visā šajā īrnieka vidē",
+      "Tenant theme explanation": "Primārā krāsa tiek lietota visiem šī īrnieka lietotājiem. Atsevišķi lietotāji to nevar mainīt.",
+      "Tenant theme unavailable": "Tēmas konfigurācija šajā serverī nav pieejama. Tiek izmantota noklusējuma krāsa.",
+      "Tenant theme updated successfully": "Īrnieka tēma veiksmīgi atjaunināta",
+      "Custom color darkened for legibility": "Izvēlētā krāsa tika padarīta tumšāka, lai baltais teksts paliktu salasāms."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1642,7 +1642,8 @@
       "View Exchange Rate": "विनिमय दर हेर्नुहोस्",
       "Edit Exchange Rate": "विनिमय दर सम्पादन गर्नुहोस्",
       "Disable Breach Evaluation": "उल्लंघन मूल्यांकन असक्षम गर्नुहोस्",
-      "Enable Breach Evaluation": "उल्लंघन मूल्यांकन सक्षम गर्नुहोस्"
+      "Enable Breach Evaluation": "उल्लंघन मूल्यांकन सक्षम गर्नुहोस्",
+      "Theme": "विषयवस्तु"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3283,7 +3284,19 @@
       "Link": "लिंक",
       "Audit Trail": "अडिट ट्रेल",
       "Restart Period from Reset Date": "रिसेट मितिबाट अवधि पुनः सुरु गर्नुहोस्",
-      "Breach evaluation disabled since": "{{date}} देखि उल्लंघन मूल्यांकन असक्षम"
+      "Breach evaluation disabled since": "{{date}} देखि उल्लंघन मूल्यांकन असक्षम",
+      "Blue": "निलो",
+      "Green": "हरियो",
+      "Light Green": "हल्का हरियो",
+      "Purple": "बैजनी",
+      "Pink": "गुलाबी",
+      "Orange": "सुन्तला",
+      "Red": "रातो",
+      "Yellow": "पहेँलो",
+      "Black": "कालो",
+      "Primary Color": "प्राथमिक रङ",
+      "Custom": "अनुकूलित",
+      "Custom Color": "अनुकूलित रङ"
     },
     "links": {
       "Community": "समुदाय",
@@ -4351,7 +4364,13 @@
       "Payment system delink OTP sent": "भुक्तानी प्रणाली लिंक हटाउन नयाँ OTP अनुरोध गरियो।",
       "Payment system delink OTP request failed": "लिंक हटाउन नयाँ OTP अनुरोध गर्न सकिएन।",
       "Payment system delink successful": "भुक्तानी प्रणाली लिंक सफलतापूर्वक हटाइयो।",
-      "Payment system delink failed": "भुक्तानी प्रणाली लिंक हटाउन सकिएन।"
+      "Payment system delink failed": "भुक्तानी प्रणाली लिंक हटाउन सकिएन।",
+      "Theme": "विषयवस्तु",
+      "Set the primary color used across this tenant": "यो टेनेन्टभर प्रयोग हुने प्राथमिक रङ सेट गर्नुहोस्",
+      "Tenant theme explanation": "प्राथमिक रङ यो टेनेन्टका सबै प्रयोगकर्तामा लागू हुन्छ। व्यक्तिगत प्रयोगकर्ताले यसलाई परिवर्तन गर्न सक्दैनन्।",
+      "Tenant theme unavailable": "यो सर्भरमा विषयवस्तु कन्फिगरेसन उपलब्ध छैन। पूर्वनिर्धारित रङ प्रयोग भइरहेको छ।",
+      "Tenant theme updated successfully": "टेनेन्टको विषयवस्तु सफलतापूर्वक अद्यावधिक भयो",
+      "Custom color darkened for legibility": "छानिएको रङलाई सेतो पाठ पढ्न मिल्ने बनाउन गाढा बनाइयो।"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1642,7 +1642,8 @@
       "View Exchange Rate": "Ver taxa de câmbio",
       "Edit Exchange Rate": "Editar taxa de câmbio",
       "Disable Breach Evaluation": "Desativar Avaliação de Violações",
-      "Enable Breach Evaluation": "Ativar Avaliação de Violações"
+      "Enable Breach Evaluation": "Ativar Avaliação de Violações",
+      "Theme": "Tema"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3283,7 +3284,19 @@
       "Link": "Ligação",
       "Audit Trail": "Trilha de auditoria",
       "Restart Period from Reset Date": "Reiniciar período a partir da data de reinício",
-      "Breach evaluation disabled since": "Avaliação de violações desativada desde {{date}}"
+      "Breach evaluation disabled since": "Avaliação de violações desativada desde {{date}}",
+      "Blue": "Azul",
+      "Green": "Verde",
+      "Light Green": "Verde claro",
+      "Purple": "Roxo",
+      "Pink": "Rosa",
+      "Orange": "Laranja",
+      "Red": "Vermelho",
+      "Yellow": "Amarelo",
+      "Black": "Preto",
+      "Primary Color": "Cor principal",
+      "Custom": "Personalizado",
+      "Custom Color": "Cor personalizada"
     },
     "links": {
       "Community": "Comunidade",
@@ -4351,7 +4364,13 @@
       "Payment system delink OTP sent": "Foi solicitado um novo OTP para remover a ligação ao sistema de pagamentos.",
       "Payment system delink OTP request failed": "Não foi possível solicitar um novo OTP para desligar.",
       "Payment system delink successful": "Ligação ao sistema de pagamentos removida com sucesso.",
-      "Payment system delink failed": "Não foi possível remover a ligação ao sistema de pagamentos."
+      "Payment system delink failed": "Não foi possível remover a ligação ao sistema de pagamentos.",
+      "Theme": "Tema",
+      "Set the primary color used across this tenant": "Defina a cor principal utilizada em todo este inquilino",
+      "Tenant theme explanation": "A cor principal é aplicada a todos os utilizadores deste inquilino. Os utilizadores individuais não a podem alterar.",
+      "Tenant theme unavailable": "A configuração do tema não está disponível neste servidor. Está a ser utilizada a cor predefinida.",
+      "Tenant theme updated successfully": "Tema do inquilino atualizado com sucesso",
+      "Custom color darkened for legibility": "A cor escolhida foi escurecida para que o texto branco continue legível."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1640,7 +1640,8 @@
       "View Exchange Rate": "Tazama kiwango cha ubadilishaji",
       "Edit Exchange Rate": "Hariri kiwango cha ubadilishaji",
       "Disable Breach Evaluation": "Zima Tathmini ya Ukiukaji",
-      "Enable Breach Evaluation": "Washa Tathmini ya Ukiukaji"
+      "Enable Breach Evaluation": "Washa Tathmini ya Ukiukaji",
+      "Theme": "Mandhari"
     },
     "inputs": {
       "Annual interest rate": "Annual interest rate",
@@ -3281,7 +3282,19 @@
       "Link": "Kiungo",
       "Audit Trail": "Njia ya Ukaguzi",
       "Restart Period from Reset Date": "Anza upya kipindi kutoka tarehe ya uwekaji upya",
-      "Breach evaluation disabled since": "Tathmini ya ukiukaji imezimwa tangu {{date}}"
+      "Breach evaluation disabled since": "Tathmini ya ukiukaji imezimwa tangu {{date}}",
+      "Blue": "Bluu",
+      "Green": "Kijani",
+      "Light Green": "Kijani hafifu",
+      "Purple": "Zambarau",
+      "Pink": "Waridi",
+      "Orange": "Chungwa",
+      "Red": "Nyekundu",
+      "Yellow": "Njano",
+      "Black": "Nyeusi",
+      "Primary Color": "Rangi Kuu",
+      "Custom": "Maalum",
+      "Custom Color": "Rangi Maalum"
     },
     "links": {
       "Community": "Jumuiya",
@@ -4348,7 +4361,13 @@
       "Payment system delink OTP sent": "OTP mpya imeombwa ili kuondoa kiungo cha mfumo wa malipo.",
       "Payment system delink OTP request failed": "Imeshindikana kuomba OTP mpya ya kutenganisha.",
       "Payment system delink successful": "Kiungo cha mfumo wa malipo kimeondolewa kwa mafanikio.",
-      "Payment system delink failed": "Imeshindikana kuondoa kiungo cha mfumo wa malipo."
+      "Payment system delink failed": "Imeshindikana kuondoa kiungo cha mfumo wa malipo.",
+      "Theme": "Mandhari",
+      "Set the primary color used across this tenant": "Weka rangi kuu inayotumika katika mpangaji huyu",
+      "Tenant theme explanation": "Rangi kuu hutumika kwa watumiaji wote wa mpangaji huyu. Watumiaji binafsi hawawezi kuibadilisha.",
+      "Tenant theme unavailable": "Mipangilio ya mandhari haipatikani kwenye seva hii. Rangi chaguo-msingi inatumika.",
+      "Tenant theme updated successfully": "Mandhari ya mpangaji yamesasishwa kwa mafanikio",
+      "Custom color darkened for legibility": "Rangi uliyochagua imefanywa nyeusi zaidi ili maandishi meupe yaendelee kusomeka."
     },
     "permissions": {
       "actions": {


### PR DESCRIPTION
## Description

The Theme page rendered raw translation keys (`labels.heading.Theme`, `labels.text.Tenant theme explanation`, `labels.inputs.Primary Color`, `labels.inputs.Blue`) in every non-English locale, and asked for more colours plus a colour selector.

**Translations.** The theme keys existed only in `en-US.json`, so ngx-translate echoed the key itself. Adds 19 keys to each of the 12 non-English locales and 6 new keys to `en-US`. This also covers two keys that were failing less obviously:

- `labels.text.Theme` — the breadcrumb resolves the page title through `labels.text.<label>`, which is why the heading read "Theme" inside an otherwise Spanish page.
- `labels.text.Set the primary color used across this tenant` — the System menu sub-caption.

Verified as pure additions: no existing key in any locale file was removed or altered, and every file round-trips byte-identically to its original formatting.

**New colours.** Adds Pink, Light Green and Black, ordered next to their neighbours so the existing colour ids keep their relative positions. Yellow already existed.

**Custom colour.** Adds a colour well and a hex field beside the presets. It sits outside the `radiogroup` so the presets' arrow-key navigation is unchanged, and `isTabbable()` keeps a tab stop inside the group when a custom colour is selected —
the previous `currentTheme.id === theme.id` check would have left the group unreachable by keyboard in that state.

### Dependencies

Requires **openMF/selfservice-plugin#188** (MX-395), which widens the `primaryColor` contract to accept `pink`, `light-green`, `black` and six-digit hex values. Until that ships, selecting one of the new colours previews correctly but the save is rejected
with a 400 and the page resets to the stored colour. The six original colours are unaffected.

## Related issues and discussion

# WEB-1124

Backend counterpart is openMF/selfservice-plugin#188.

## Screenshots, if any
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/22c140dd-181b-437b-8a75-74b943d5c685" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/48a65462-f3f7-4fd1-8af5-5462c7956086" />
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/0e00b89a-24d3-435a-806e-5a502b9eb688" />
<img width="292" height="315" alt="image" src="https://github.com/user-attachments/assets/cc09df41-f2a9-4bd5-9a8e-05dc04cb0c08" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added custom theme colors with color picker and hexadecimal input.
  * Added Light Green, Pink, and Black preset themes.
  * Custom colors are automatically adjusted when needed to maintain readable white text.
  * Added clear custom-theme labels, selection styling, tooltips, and guidance messages.
* **Accessibility**
  * Improved keyboard navigation for theme swatches.
* **Localization**
  * Added and updated theme-related translations across supported languages.
* **Tests**
  * Expanded coverage for custom colors, contrast handling, presets, and invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->