### PR TITLE
WEB-1125: Add missing fields for an Address

### DIFF
--- a/src/app/clients/client-stepper/client-address-step/client-address-step.component.html
+++ b/src/app/clients/client-stepper/client-address-step/client-address-step.component.html
@@ -62,6 +62,9 @@
                 {{ getSelectedValue('stateProvinceIdOptions', address.stateProvinceId)?.name }}<br
               /></span>
             }
+            @if (isFieldEnabled('countyDistrict')) {
+              <span>{{ 'labels.inputs.County / District' | translate }} : {{ address.countyDistrict }}<br /></span>
+            }
             @if (isFieldEnabled('countryId')) {
               <span
                 >{{ 'labels.inputs.Country' | translate }} :

--- a/src/app/clients/client-stepper/client-address-step/client-address-step.component.spec.ts
+++ b/src/app/clients/client-stepper/client-address-step/client-address-step.component.spec.ts
@@ -96,10 +96,33 @@ describe('ClientAddressStepComponent', () => {
     expect(formFields.some((field) => field.controlName === 'longitude')).toBe(true);
   });
 
-  it('should use the countyDistrict backend field name in the address form', () => {
+  it('should include WEB-1125 address fields with backend field names', () => {
     const formFields = component.getAddressFormFields();
 
+    expect(formFields.some((field) => field.controlName === 'street')).toBe(true);
+    expect(formFields.some((field) => field.controlName === 'townVillage')).toBe(true);
     expect(formFields.some((field) => field.controlName === 'countyDistrict')).toBe(true);
+  });
+
+  it('should populate WEB-1125 address fields when editing', () => {
+    const formFields = component.getAddressFormFields({
+      addressTypeId: 1,
+      street: 'MG Road',
+      townVillage: 'Indiranagar',
+      countyDistrict: 'Bangalore Urban'
+    });
+
+    expect(formFields.find((field) => field.controlName === 'street')?.value).toBe('MG Road');
+    expect(formFields.find((field) => field.controlName === 'townVillage')?.value).toBe('Indiranagar');
+    expect(formFields.find((field) => field.controlName === 'countyDistrict')?.value).toBe('Bangalore Urban');
+  });
+
+  it('should not conflict with another address field order when countyDistrict uses order 9', () => {
+    const formFields = component.getAddressFormFields();
+    const fieldsWithOrderNine = formFields.filter((field) => field.order === 9);
+
+    expect(fieldsWithOrderNine).toHaveLength(1);
+    expect(fieldsWithOrderNine[0].controlName).toBe('countyDistrict');
   });
 
   it('should hide latitude and longitude fields when disabled', () => {
@@ -131,13 +154,16 @@ describe('ClientAddressStepComponent', () => {
     expect(form.get('longitude')?.hasError('max')).toBe(true);
   });
 
-  it('should include latitude and longitude in the address array', () => {
+  it('should include WEB-1125 address fields in the address array', () => {
     dialog.open.mockReturnValue({
       afterClosed: () =>
         of({
           data: {
             value: {
               addressTypeId: 1,
+              street: 'Church Street',
+              townVillage: 'MG Layout',
+              countyDistrict: 'Central District',
               latitude: '12.9716',
               longitude: '77.5946'
             }
@@ -150,6 +176,9 @@ describe('ClientAddressStepComponent', () => {
     expect(component.address.address).toEqual([
       expect.objectContaining({
         addressTypeId: 1,
+        street: 'Church Street',
+        townVillage: 'MG Layout',
+        countyDistrict: 'Central District',
         latitude: '12.9716',
         longitude: '77.5946'
       })
@@ -234,6 +263,9 @@ describe('ClientAddressStepComponent', () => {
     component.clientAddressData = [
       {
         addressTypeId: 1,
+        street: 'MG Road',
+        townVillage: 'Indiranagar',
+        countyDistrict: 'Bangalore Urban',
         latitude: '12.9716',
         longitude: '77.5946'
       }
@@ -243,5 +275,8 @@ describe('ClientAddressStepComponent', () => {
 
     expect(fixture.nativeElement.textContent).toContain('12.9716');
     expect(fixture.nativeElement.textContent).toContain('77.5946');
+    expect(fixture.nativeElement.textContent).toContain('MG Road');
+    expect(fixture.nativeElement.textContent).toContain('Indiranagar');
+    expect(fixture.nativeElement.textContent).toContain('Bangalore Urban');
   });
 });

--- a/src/app/clients/client-stepper/client-address-step/client-address-step.component.ts
+++ b/src/app/clients/client-stepper/client-address-step/client-address-step.component.ts
@@ -310,10 +310,10 @@ export class ClientAddressStepComponent {
       this.isFieldEnabled('countyDistrict')
         ? new InputBase({
             controlName: 'countyDistrict',
-            label: this.translateService.instant('labels.inputs.Country District'),
+            label: this.translateService.instant('labels.inputs.County / District'),
             value: address ? address.countyDistrict : '',
             type: 'text',
-            order: 11
+            order: 9
           })
         : null
     );

--- a/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.html
+++ b/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.html
@@ -251,6 +251,9 @@
                   {{ getSelectedValue('stateProvinceIdOptions', address.stateProvinceId)?.name }}<br
                 /></span>
               }
+              @if (isFieldEnabled('countyDistrict')) {
+                <span>{{ 'labels.inputs.County / District' | translate }} : {{ address.countyDistrict }}<br /></span>
+              }
               @if (isFieldEnabled('countryId')) {
                 <span
                   >{{ 'labels.inputs.Country' | translate }} :

--- a/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.spec.ts
+++ b/src/app/clients/client-stepper/client-preview-step/client-preview-step.component.spec.ts
@@ -53,6 +53,9 @@ describe('ClientPreviewStepComponent', () => {
     component = fixture.componentInstance;
     component.clientAddressFieldConfig = [
       { field: 'addressType', isEnabled: true },
+      { field: 'street', isEnabled: true },
+      { field: 'townVillage', isEnabled: true },
+      { field: 'countyDistrict', isEnabled: true },
       { field: 'latitude', isEnabled: true },
       { field: 'longitude', isEnabled: true }
     ];
@@ -73,6 +76,9 @@ describe('ClientPreviewStepComponent', () => {
       address: [
         {
           addressTypeId: 1,
+          street: 'MG Road',
+          townVillage: 'Indiranagar',
+          countyDistrict: 'Bangalore Urban',
           latitude: '12.9716',
           longitude: '77.5946'
         }
@@ -85,6 +91,14 @@ describe('ClientPreviewStepComponent', () => {
 
     expect(fixture.nativeElement.textContent).toContain('12.9716');
     expect(fixture.nativeElement.textContent).toContain('77.5946');
+  });
+
+  it('should display WEB-1125 address fields when present', () => {
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('MG Road');
+    expect(fixture.nativeElement.textContent).toContain('Indiranagar');
+    expect(fixture.nativeElement.textContent).toContain('Bangalore Urban');
   });
 
   it('should preserve zero coordinates as displayable values', () => {

--- a/src/app/clients/clients-view/address-tab/address-tab.component.html
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.html
@@ -65,6 +65,9 @@
               {{ getSelectedValue('stateProvinceIdOptions', address.stateProvinceId)?.name }}<br
             /></span>
           }
+          @if (isFieldEnabled('countyDistrict')) {
+            <span>{{ 'labels.inputs.County / District' | translate }} : {{ address.countyDistrict }}<br /></span>
+          }
           @if (isFieldEnabled('countryId')) {
             <span
               >{{ 'labels.inputs.Country' | translate }} :

--- a/src/app/clients/clients-view/address-tab/address-tab.component.spec.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.spec.ts
@@ -100,6 +100,15 @@ describe('AddressTabComponent', () => {
           addressTypeId: 1,
           addressType: 'Home',
           street: 'MG Road',
+          addressLine1: 'Line 1',
+          addressLine2: 'Line 2',
+          addressLine3: 'Line 3',
+          townVillage: 'Indiranagar',
+          city: 'Bengaluru',
+          stateProvinceId: 2,
+          countyDistrict: 'Bangalore Urban',
+          countryId: 3,
+          postalCode: '560038',
           latitude: '12.9716',
           longitude: '77.5946',
           isActive: true
@@ -174,10 +183,20 @@ describe('AddressTabComponent', () => {
     expect(formFields.some((field) => field.controlName === 'longitude')).toBe(true);
   });
 
-  it('should use the countyDistrict backend field name in the address form', () => {
+  it('should include the missing address form controls with backend field names', () => {
     const formFields = component.getAddressFormFields('add');
 
+    expect(formFields.some((field) => field.controlName === 'street')).toBe(true);
+    expect(formFields.some((field) => field.controlName === 'townVillage')).toBe(true);
     expect(formFields.some((field) => field.controlName === 'countyDistrict')).toBe(true);
+  });
+
+  it('should populate missing address fields when editing', () => {
+    const formFields = component.getAddressFormFields('edit', component.clientAddressData[0]);
+
+    expect(formFields.find((field) => field.controlName === 'street')?.value).toBe('MG Road');
+    expect(formFields.find((field) => field.controlName === 'townVillage')?.value).toBe('Indiranagar');
+    expect(formFields.find((field) => field.controlName === 'countyDistrict')?.value).toBe('Bangalore Urban');
   });
 
   it('should hide latitude and longitude fields when disabled', () => {
@@ -198,13 +217,21 @@ describe('AddressTabComponent', () => {
     expect(formFields.some((field) => field.controlName === 'longitude')).toBe(false);
   });
 
-  it('should include latitude and longitude in the add payload', () => {
+  it('should include address fields in the add payload', () => {
     dialog.open.mockReturnValue({
       afterClosed: () =>
         of({
           data: {
             value: {
               addressType: 1,
+              street: 'Church Street',
+              addressLine1: 'Apartment 4',
+              addressLine2: 'Near Metro',
+              addressLine3: 'Block A',
+              townVillage: 'MG Layout',
+              countyDistrict: 'Central District',
+              city: 'Bengaluru',
+              postalCode: '560001',
               latitude: '12.9716',
               longitude: '77.5946'
             }
@@ -218,12 +245,23 @@ describe('AddressTabComponent', () => {
       '7',
       1,
       expect.objectContaining({
+        street: 'Church Street',
+        addressLine1: 'Apartment 4',
+        addressLine2: 'Near Metro',
+        addressLine3: 'Block A',
+        townVillage: 'MG Layout',
+        countyDistrict: 'Central District',
+        city: 'Bengaluru',
+        postalCode: '560001',
         latitude: '12.9716',
         longitude: '77.5946'
       })
     );
     expect(component.clientAddressData[component.clientAddressData.length - 1]).toEqual(
       expect.objectContaining({
+        street: 'Church Street',
+        townVillage: 'MG Layout',
+        countyDistrict: 'Central District',
         latitude: '12.9716',
         longitude: '77.5946'
       })
@@ -242,12 +280,20 @@ describe('AddressTabComponent', () => {
     expect(dialogConfig.data.contentTemplate).toBe(component.addressLocationMapDialogTemplate);
   });
 
-  it('should include latitude and longitude in the edit payload', () => {
+  it('should include address fields in the edit payload', () => {
     dialog.open.mockReturnValue({
       afterClosed: () =>
         of({
           data: {
             value: {
+              street: 'Updated Street',
+              addressLine1: 'Updated Line 1',
+              addressLine2: 'Updated Line 2',
+              addressLine3: 'Updated Line 3',
+              townVillage: 'Updated Village',
+              countyDistrict: 'Updated District',
+              city: 'Mysuru',
+              postalCode: '570001',
               latitude: '13',
               longitude: '78'
             }
@@ -262,12 +308,23 @@ describe('AddressTabComponent', () => {
       1,
       expect.objectContaining({
         addressId: 11,
+        street: 'Updated Street',
+        addressLine1: 'Updated Line 1',
+        addressLine2: 'Updated Line 2',
+        addressLine3: 'Updated Line 3',
+        townVillage: 'Updated Village',
+        countyDistrict: 'Updated District',
+        city: 'Mysuru',
+        postalCode: '570001',
         latitude: '13',
         longitude: '78'
       })
     );
     expect(component.clientAddressData[0]).toEqual(
       expect.objectContaining({
+        street: 'Updated Street',
+        townVillage: 'Updated Village',
+        countyDistrict: 'Updated District',
         latitude: '13',
         longitude: '78'
       })
@@ -352,6 +409,14 @@ describe('AddressTabComponent', () => {
 
     expect(form.get('latitude')?.hasError('max')).toBe(true);
     expect(form.get('longitude')?.hasError('min')).toBe(true);
+  });
+
+  it('should display returned missing address fields', () => {
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('MG Road');
+    expect(fixture.nativeElement.textContent).toContain('Indiranagar');
+    expect(fixture.nativeElement.textContent).toContain('Bangalore Urban');
   });
 
   it('should display saved coordinates and render the map for valid coordinates', () => {

--- a/src/app/clients/clients-view/address-tab/address-tab.component.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.ts
@@ -482,10 +482,10 @@ export class AddressTabComponent {
       this.isFieldEnabled('countyDistrict')
         ? new InputBase({
             controlName: 'countyDistrict',
-            label: this.translateService.instant('labels.inputs.State / Province'),
+            label: this.translateService.instant('labels.inputs.County / District'),
             value: address ? address.countyDistrict : '',
             type: 'text',
-            order: 11
+            order: 9
           })
         : null
     );

--- a/src/app/clients/create-client/create-client.component.spec.ts
+++ b/src/app/clients/create-client/create-client.component.spec.ts
@@ -379,9 +379,15 @@ describe('CreateClientComponent - Integration Tests', () => {
         Object.defineProperty(component.clientAddressStep, 'address', {
           get: jest.fn(() => ({
             address: [
-              { addressTypeId: 1, street: '123 Main St', city: 'New York' },
-              { addressTypeId: 1, street: '123 Main St', city: 'New York' },
-              { addressTypeId: 1, street: '123 Main St', city: 'New York', latitude: '12.9716', longitude: '77.5946' }
+              {
+                addressTypeId: 1,
+                street: '123 Main St',
+                townVillage: 'Greenwich Village',
+                countyDistrict: 'New York County',
+                city: 'New York',
+                latitude: '12.9716',
+                longitude: '77.5946'
+              }
             ]
           })),
           configurable: true
@@ -392,13 +398,17 @@ describe('CreateClientComponent - Integration Tests', () => {
 
       expect(mockClientsService.createClient).toHaveBeenCalledWith(
         expect.objectContaining({
-          address: expect.arrayContaining([
-            expect.objectContaining({
+          address: [
+            {
+              addressTypeId: 1,
               street: '123 Main St',
+              townVillage: 'Greenwich Village',
+              countyDistrict: 'New York County',
+              city: 'New York',
               latitude: '12.9716',
               longitude: '77.5946'
-            })
-          ])
+            }
+          ]
         })
       );
     });

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -2030,6 +2030,7 @@
       "Country": "Země",
       "Country Code": "Kód země",
       "Country District": "Okres",
+      "County / District": "Okres",
       "Cover Image": "Titulní obrázek",
       "Create Fixed Deposit Product": "Vytvořte produkt s pevným vkladem",
       "Create Journal Entries": "Vytvářejte záznamy deníku",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -2032,6 +2032,7 @@
       "Country": "Land",
       "Country Code": "Landesvorwahl",
       "Country District": "Landbezirk",
+      "County / District": "Landbezirk",
       "Cover Image": "Titelbild",
       "Create Fixed Deposit Product": "Erstellen Sie ein Festgeldprodukt",
       "Create Journal Entries": "Erstellen Sie Journaleinträge",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2053,6 +2053,7 @@
       "Country": "Country",
       "Country Code": "Country Code",
       "Country District": "Country District",
+      "County / District": "County / District",
       "Cover Image": "Cover Image",
       "Create Fixed Deposit Product": "Create Fixed Deposit Product",
       "Create Journal Entries": "Create Journal Entries",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -2030,6 +2030,7 @@
       "Country": "País",
       "Country Code": "Código de país",
       "Country District": "Distrito rural",
+      "County / District": "Distrito rural",
       "Cover Image": "Imagen principal",
       "Create Fixed Deposit Product": "Crear producto de Depósito Fijo",
       "Create Journal Entries": "Crear entradas de diario",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -2037,6 +2037,7 @@
       "Country": "País",
       "Country Code": "Código de país",
       "Country District": "Distrito rural",
+      "County / District": "Distrito rural",
       "Cover Image": "Imagen de Portada",
       "Create Fixed Deposit Product": "Crear producto de Depósito Fijo",
       "Create Journal Entries": "Crear entradas de diario",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -2033,6 +2033,7 @@
       "Country": "Pays",
       "Country Code": "Code postal",
       "Country District": "Pays District",
+      "County / District": "Pays District",
       "Cover Image": "Image de couverture",
       "Create Fixed Deposit Product": "Créer un produit de dépôt fixe",
       "Create Journal Entries": "Créer des entrées de journal",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -2030,6 +2030,7 @@
       "Country": "Paese",
       "Country Code": "Prefisso internazionale",
       "Country District": "Distretto di campagna",
+      "County / District": "Distretto di campagna",
       "Cover Image": "Immagine di copertina",
       "Create Fixed Deposit Product": "Creare un prodotto a deposito fisso",
       "Create Journal Entries": "Crea voci di diario",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -2031,6 +2031,7 @@
       "Country": "국가",
       "Country Code": "국가 코드",
       "Country District": "국가 지구",
+      "County / District": "국가 지구",
       "Cover Image": "표지 이미지",
       "Create Fixed Deposit Product": "정기예금 상품 생성",
       "Create Journal Entries": "분개 항목 만들기",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -2029,6 +2029,7 @@
       "Country": "Šalis",
       "Country Code": "Šalies kodas",
       "Country District": "Šalies rajonas",
+      "County / District": "Šalies rajonas",
       "Cover Image": "Viršelio vaizdas",
       "Create Fixed Deposit Product": "Sukurkite fiksuoto indėlio produktą",
       "Create Journal Entries": "Kurti žurnalo įrašus",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -2030,6 +2030,7 @@
       "Country": "Valsts",
       "Country Code": "Valsts kods",
       "Country District": "Lauku rajons",
+      "County / District": "Lauku rajons",
       "Cover Image": "Vāka attēls",
       "Create Fixed Deposit Product": "Izveidojiet fiksētā depozīta produktu",
       "Create Journal Entries": "Izveidojiet žurnāla ierakstus",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -2029,6 +2029,7 @@
       "Country": "देश",
       "Country Code": "देश कोड",
       "Country District": "देश जिल्ला",
+      "County / District": "देश जिल्ला",
       "Cover Image": "आवरण छवि",
       "Create Fixed Deposit Product": "फिक्स्ड डिपोजिट उत्पादन सिर्जना गर्नुहोस्",
       "Create Journal Entries": "जर्नल प्रविष्टिहरू सिर्जना गर्नुहोस्",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -2029,6 +2029,7 @@
       "Country": "País",
       "Country Code": "Código do país",
       "Country District": "Distrito rural",
+      "County / District": "Distrito rural",
       "Cover Image": "Imagem de capa",
       "Create Fixed Deposit Product": "Criar produto de depósito fixo",
       "Create Journal Entries": "Criar lançamentos contábeis manuais",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -2027,6 +2027,7 @@
       "Country": "Nchi",
       "Country Code": "Msimbo wa Nchi",
       "Country District": "Wilaya ya Nchi",
+      "County / District": "Wilaya ya Nchi",
       "Cover Image": "Picha ya Jalada",
       "Create Fixed Deposit Product": "Unda Bidhaa ya Amana isiyobadilika",
       "Create Journal Entries": "Unda Maingizo ya Jarida",


### PR DESCRIPTION
## Description

Adds the missing Address fields to the Client Address UI:

- Street
- Town / Village
- County / District

The fields are supported in add, edit, preview, and client address display flows using the backend field names `street`, `townVillage`, and `countyDistrict`.

Also adds focused test coverage for the updated address flows.

## Related issues and discussion

WEB-1125



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional County / District address fields to client creation, editing, previews, and address displays.
  * Preserved street, town/village, and County / District values when saving and updating client addresses.
  * Added localized County / District labels across supported languages.

* **Bug Fixes**
  * Corrected the County / District label and field placement.
  * Improved display of configured address details in client previews and address views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->