### PR TITLE
WEB-1127: Fix datatable column translations

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
@@ -40,7 +40,11 @@
             @for (columnHeader of dataObject.columnHeaders; track columnHeader; let i = $index) {
               <div class="data-item" [ngClass]="setAttributeClass(columnHeader.columnName)">
                 <div class="data-label mat-body-strong">
-                  {{ formatDisplayLabel(columnHeader.columnName) }}
+                  @if (getSystemColumnTranslationKey(columnHeader.columnName); as translationKey) {
+                    {{ translationKey | translate }}
+                  } @else {
+                    {{ formatDisplayLabel(columnHeader.columnName) }}
+                  }
                 </div>
                 <div class="data-value">
                   @switch (getColumnType(columnHeader.columnDisplayType, columnHeader.columnType)) {

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.spec.ts
@@ -39,14 +39,18 @@ describe('DatatableSingleRowComponent', () => {
           { id: 12, value: 'Married' }
         ]
       },
-      { columnName: 'first_name', columnDisplayType: 'STRING' }
+      { columnName: 'first_name', columnDisplayType: 'STRING' },
+      { columnName: 'created_at', columnDisplayType: 'DATETIME', columnType: 'created_at' },
+      { columnName: 'updated_at', columnDisplayType: 'DATETIME', columnType: 'updated_at' }
     ],
     data: [
       {
         row: [
           7,
           12,
-          'Ada'
+          'Ada',
+          '2025-01-15T12:30:00Z',
+          '2025-01-16T13:45:00Z'
         ]
       }
     ]
@@ -58,9 +62,13 @@ describe('DatatableSingleRowComponent', () => {
     getDataItems()[index].querySelector(selector).textContent.replace(/\s+/g, ' ').trim();
 
   beforeEach(async () => {
+    const translations: Record<string, string> = {
+      'labels.inputs.Created At': 'Creado en',
+      'labels.inputs.Updated At': 'Actualizado en'
+    };
     const translateService = {
-      instant: jest.fn((key: string) => key),
-      get: jest.fn((key: string) => of(key)),
+      instant: jest.fn((key: string) => translations[key] || key),
+      get: jest.fn((key: string) => of(translations[key] || key)),
       onLangChange: of({ lang: 'en' }),
       onTranslationChange: of({}),
       onDefaultLangChange: of({ lang: 'en' })
@@ -122,5 +130,10 @@ describe('DatatableSingleRowComponent', () => {
   it('leaves normal single-row field labels unchanged', () => {
     expect(getDataItemText(2, '.data-label')).toBe('First Name');
     expect(getDataItemText(2, '.data-value')).toBe('Ada');
+  });
+
+  it('translates single-row system timestamp labels', () => {
+    expect(getDataItemText(3, '.data-label')).toBe('Creado en');
+    expect(getDataItemText(4, '.data-label')).toBe('Actualizado en');
   });
 });

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
@@ -85,6 +85,17 @@ export class DatatableSingleRowComponent implements OnInit, OnChanges {
     return this.datatables.toDisplayLabel(label);
   }
 
+  getSystemColumnTranslationKey(columnName: string): string | null {
+    switch (columnName) {
+      case 'created_at':
+        return 'labels.inputs.Created At';
+      case 'updated_at':
+        return 'labels.inputs.Updated At';
+      default:
+        return null;
+    }
+  }
+
   ngOnInit() {
     this.route.params.subscribe((routeParams: any) => {
       this.datatableName = routeParams.datatableName;

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3253,6 +3253,7 @@
       "Unit Type": "Typ jednotky",
       "Unrealized Income": "Nerealizovaný výnos",
       "Unrecognized Amount": "Nerozpoznaná částka",
+      "Updated At": "Aktualizováno dne",
       "Updated By": "Aktualizováno uživatelem",
       "Updated on": "Aktualizováno dne",
       "Url": "URL",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3255,6 +3255,7 @@
       "Unit Type": "Gerätetyp",
       "Unrealized Income": "Nicht realisierter Ertrag",
       "Unrecognized Amount": "Nicht erfasster Betrag",
+      "Updated At": "Aktualisiert am",
       "Updated By": "Aktualisiert von",
       "Updated on": "Aktualisiert am",
       "Url": "URL",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3309,6 +3309,7 @@
       "Unit Type": "Unit Type",
       "Unrealized Income": "Unrealized Income",
       "Unrecognized Amount": "Unrecognized Amount",
+      "Updated At": "Updated At",
       "Updated By": "Updated By",
       "Updated on": "Updated on",
       "Url": "Url",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3257,6 +3257,7 @@
       "Unit Type": "Tipo de unidad",
       "Unrealized Income": "Ingreso No Realizado",
       "Unrecognized Amount": "Monto no reconocido",
+      "Updated At": "Actualizado en",
       "Updated By": "Actualizado por",
       "Updated on": "Actualizado en",
       "Url": "URL",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3262,6 +3262,7 @@
       "Unit Type": "Tipo de unidad",
       "Unrealized Income": "Ingreso No Realizado",
       "Unrecognized Amount": "Monto no reconocido",
+      "Updated At": "Actualizado en",
       "Updated By": "Actualizado por",
       "Updated on": "Actualizado en",
       "Url": "URL",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3256,6 +3256,7 @@
       "Unit Type": "Type d'unité",
       "Unrealized Income": "Revenu non réalisé",
       "Unrecognized Amount": "Montant non reconnu",
+      "Updated At": "Mis à jour le",
       "Updated By": "Mis à jour par",
       "Updated on": "Mis à jour le",
       "Url": "URL",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3253,6 +3253,7 @@
       "Unit Type": "Tipo di unità",
       "Unrealized Income": "Reddito non realizzato",
       "Unrecognized Amount": "Importo non riconosciuto",
+      "Updated At": "Aggiornato il",
       "Updated By": "Aggiornato da",
       "Updated on": "Aggiornato il",
       "Url": "URL",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3253,6 +3253,7 @@
       "Unit Type": "단위 유형",
       "Unrealized Income": "미실현 수익",
       "Unrecognized Amount": "인식되지 않은 금액",
+      "Updated At": "업데이트 날짜",
       "Updated By": "업데이트한 사람",
       "Updated on": "업데이트 날짜",
       "Url": "URL",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3252,6 +3252,7 @@
       "Unit Type": "Vieneto tipas",
       "Unrealized Income": "Nerealizuotos pajamos",
       "Unrecognized Amount": "Neatpažinta suma",
+      "Updated At": "Atnaujinta",
       "Updated By": "Atnaujino",
       "Updated on": "Atnaujinta",
       "Url": "URL",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3253,6 +3253,7 @@
       "Unit Type": "Vienības veids",
       "Unrealized Income": "Nerealizētie ienākumi",
       "Unrecognized Amount": "Neatpazīta summa",
+      "Updated At": "Atjaunināts",
       "Updated By": "Atjaunināja",
       "Updated on": "Atjaunināts",
       "Url": "URL",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3252,6 +3252,7 @@
       "Unit Type": "एकाइ प्रकार",
       "Unrealized Income": "अप्राप्त आम्दानी",
       "Unrecognized Amount": "अपरिचित रकम",
+      "Updated At": "मा अद्यावधिक गरियो",
       "Updated By": "द्वारा अपडेट गरिएको",
       "Updated on": "मा अद्यावधिक गरियो",
       "Url": "Url",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3252,6 +3252,7 @@
       "Unit Type": "Tipo de unidade",
       "Unrealized Income": "Rendimento Não Realizado",
       "Unrecognized Amount": "Valor não reconhecido",
+      "Updated At": "Atualizado em",
       "Updated By": "Atualizado por",
       "Updated on": "Atualizado em",
       "Url": "URL",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3250,6 +3250,7 @@
       "Unit Type": "Aina ya kitengo",
       "Unrealized Income": "Mapato Yasiyopatikana",
       "Unrecognized Amount": "Kiasi Kisichotambulika",
+      "Updated At": "Ilisasishwa",
       "Updated By": "Imesasishwa Na",
       "Updated on": "Ilisasishwa",
       "Url": "Url",


### PR DESCRIPTION
## Description

Fixes translation of the `Created at` and `Updated at` labels in single-row Data Tables by using the existing Mifos translation system.

Existing date values, formatting, and multi-row Data Table behavior remain unchanged.

## Related issues and discussion

WEB-1127



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Datatable column labels now use localized system translations when available.
  * “Created At” and “Updated At” labels display consistently across supported languages.
  * Unrecognized column names continue to use their formatted names as a fallback.

* **Localization**
  * Added or updated “Updated At” translations for Czech, German, English, Spanish, French, Italian, Korean, Lithuanian, Latvian, Nepali, Portuguese, and Swahili.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->