### PR TITLE
WEB-1141: Fix document preview upload bug

### DIFF
--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.ts
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.ts
@@ -14,7 +14,8 @@ import {
   OnDestroy,
   OnInit,
   ViewChild,
-  inject
+  inject,
+  ChangeDetectorRef
 } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import lightGallery from 'lightgallery';
@@ -46,6 +47,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 })
 export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
   dialog = inject(MatDialog);
+  private cdr = inject(ChangeDetectorRef);
   private savingsService = inject(SavingsService);
   private loansService = inject(LoansService);
   private clientsService = inject(ClientsService);
@@ -106,6 +108,7 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
           };
           this.entityDocuments.push(newDocument);
           this.setThumbnail(newDocument);
+          this.cdr.markForCheck();
         });
       }
     });
@@ -126,7 +129,9 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
           this.entityDocuments.splice(index, 1);
         }
         this.documentPreviewService.release(documentId);
+        this.previewThumbnails = { ...this.previewThumbnails };
         delete this.previewThumbnails[documentId];
+        this.cdr.markForCheck();
       }
     });
   }
@@ -149,7 +154,8 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
             this.getDownloadObservable(descriptor.id)
           );
           if (preview.type === 'image') {
-            this.previewThumbnails[item.id] = preview.url;
+            this.previewThumbnails = { ...this.previewThumbnails, [item.id]: preview.url };
+            this.cdr.markForCheck();
           }
           galleryItems.push({
             src: preview.url,
@@ -229,7 +235,8 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
       .resolvePreviewUrl(document, () => this.getDownloadObservable(document.id))
       .then((preview) => {
         if (preview.type === 'image') {
-          this.previewThumbnails[document.id] = preview.url;
+          this.previewThumbnails = { ...this.previewThumbnails, [document.id]: preview.url };
+          this.cdr.markForCheck();
         }
       })
       .catch((): void => undefined);


### PR DESCRIPTION
## Description

Fixed a UI bug where uploaded documents and thumbnails didn't appear until page reload. Added `ChangeDetectorRef.markForCheck()` to update the view after async background tasks complete in this `OnPush` component.
## Related issues and discussion

[WEB-1141](https://mifosforge.jira.com/browse/WEB-1141)

## Screenshots, if any

https://github.com/user-attachments/assets/8ce4d12d-3d25-419f-84c9-c172550076b0


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1141]: https://mifosforge.jira.com/browse/WEB-1141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document list updates after uploading, deleting, or changing document thumbnails.
  * Ensured updated thumbnails refresh reliably in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->