### PR TITLE
WEB-1130: Support XML report output format

### DIFF
--- a/src/app/reports/reports.service.spec.ts
+++ b/src/app/reports/reports.service.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ReportsService } from './reports.service';
+
+describe('ReportsService report output formats', () => {
+  let service: ReportsService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ReportsService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(ReportsService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('sends XML as the selected Pentaho output type', () => {
+    service
+      .getPentahoRunReportData('Client Details', { 'output-type': 'XML' }, 'default', 'en', 'dd MMMM yyyy')
+      .subscribe();
+
+    const req = httpMock.expectOne((request) => request.url === '/runreports/Client Details');
+    expect(req.request.params.get('output-type')).toBe('XML');
+    expect(req.request.responseType).toBe('arraybuffer');
+    req.flush(new ArrayBuffer(0));
+  });
+
+  it('sends XML as the selected BIRT output type', () => {
+    service
+      .getBirtRunReportData('Client Details', { 'output-type': 'XML' }, 'default', 'en', 'dd MMMM yyyy')
+      .subscribe();
+
+    const req = httpMock.expectOne((request) => request.url === '/runreports/Client Details');
+    expect(req.request.params.get('output-type')).toBe('XML');
+    expect(req.request.responseType).toBe('arraybuffer');
+    req.flush(new ArrayBuffer(0));
+  });
+});

--- a/src/app/reports/run-report/run-report.component.spec.ts
+++ b/src/app/reports/run-report/run-report.component.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DatePipe } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
+import { AlertService } from 'app/core/alert/alert.service';
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+import { ReportsService } from '../reports.service';
+import { RunReportComponent } from './run-report.component';
+
+jest.mock('exceljs', () => ({
+  Workbook: jest.fn()
+}));
+
+describe('RunReportComponent report output formats', () => {
+  let component: RunReportComponent;
+  let fixture: ComponentFixture<RunReportComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        RunReportComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { params: { name: 'Client Details' } },
+            queryParams: of({ type: 'Pentaho', id: 1 }),
+            data: of({ reportParameters: [], configurations: { globalConfiguration: [] } })
+          }
+        },
+        {
+          provide: ReportsService,
+          useValue: {
+            getPentahoParams: jest.fn(() => of([])),
+            getBirtParams: jest.fn(() => of([])),
+            getSelectOptions: jest.fn(() => of([]))
+          }
+        },
+        {
+          provide: SettingsService,
+          useValue: {
+            language: { code: 'en' },
+            dateFormat: 'dd MMMM yyyy',
+            maxAllowedDate: new Date(2026, 0, 1)
+          }
+        },
+        { provide: AlertService, useValue: { alert: jest.fn() } },
+        { provide: TranslateService, useValue: { instant: jest.fn((key: string) => key) } },
+        DatePipe,
+        Dates
+      ]
+    })
+      .overrideComponent(RunReportComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(RunReportComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('includes XML with the existing BIRT and Pentaho output formats', () => {
+    expect(component.outputTypeOptions.map((option) => option.value)).toEqual([
+      'PDF',
+      'HTML',
+      'XLS',
+      'XLSX',
+      'CSV',
+      'XML'
+    ]);
+  });
+
+  it('serializes XML selection as output-type=XML', () => {
+    component.setOutputType('XML');
+
+    expect(component.reportForm.get('outputType')?.value).toBe('XML');
+    expect(component.formatUserResponse(component.reportForm.value)).toEqual({ 'output-type': 'XML' });
+  });
+});

--- a/src/app/reports/run-report/run-report.component.ts
+++ b/src/app/reports/run-report/run-report.component.ts
@@ -218,7 +218,8 @@ export class RunReportComponent implements OnInit {
       { name: 'Normal format', value: 'HTML', i18nKey: 'labels.inputs.Normal format' },
       { name: 'Excel format', value: 'XLS', i18nKey: 'labels.inputs.Excel format' },
       { name: 'Excel 2007 format', value: 'XLSX', i18nKey: 'labels.inputs.Excel 2007 format' },
-      { name: 'CSV format', value: 'CSV', i18nKey: 'labels.inputs.CSV format' }
+      { name: 'CSV format', value: 'CSV', i18nKey: 'labels.inputs.CSV format' },
+      { name: 'XML format', value: 'XML', i18nKey: 'labels.inputs.XML format' }
     ];
   }
 

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1928,6 +1928,7 @@
       "Compounding on day of week": "Připisování v den v týdnu",
       "Compounding on nth day": "Připisování v n-tý den",
       "CSV format": "CSV formát",
+      "XML format": "XML format",
       "CURRENCY": "MĚNA",
       "Calculate interest for exact days in partial period": "Vypočítejte úrok za přesné dny v dílčím období",
       "Calculation": "Výpočet",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1930,6 +1930,7 @@
       "Compounding on day of week": "Zinseszins am Wochentag",
       "Compounding on nth day": "Zinseszins am n-ten Tag",
       "CSV format": "CSV-Format",
+      "XML format": "XML format",
       "CURRENCY": "WÄHRUNG",
       "Calculate interest for exact days in partial period": "Berechnen Sie die Zinsen für genaue Tage im Teilzeitraum",
       "Calculation": "Berechnung",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1950,6 +1950,7 @@
       "Compounding on day of week": "Compounding on day of week",
       "Compounding on nth day": "Compounding on nth day",
       "CSV format": "CSV format",
+      "XML format": "XML format",
       "CURRENCY": "CURRENCY",
       "Calculate interest for exact days in partial period": "Calculate interest for exact days in partial period",
       "Calculation": "Calculation",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1928,6 +1928,7 @@
       "Compounding on day of week": "Capitalización en día de la semana",
       "Compounding on nth day": "Capitalización en el día n",
       "CSV format": "formato CSV",
+      "XML format": "XML format",
       "CURRENCY": "MONEDA",
       "Calculate interest for exact days in partial period": "Calcular intereses por días exactos en periodo parcial",
       "Calculation": "Cálculo",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1935,6 +1935,7 @@
       "Compounding on day of week": "Capitalización en día de la semana",
       "Compounding on nth day": "Capitalización en el día n",
       "CSV format": "formato CSV",
+      "XML format": "XML format",
       "CURRENCY": "MONEDA",
       "Calculate interest for exact days in partial period": "Calcular intereses por días exactos en periodo parcial",
       "Calculation": "Cálculo",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1931,6 +1931,7 @@
       "Compounding on day of week": "Capitalisation le jour de la semaine",
       "Compounding on nth day": "Capitalisation le n-ième jour",
       "CSV format": "Format CSV",
+      "XML format": "XML format",
       "CURRENCY": "DEVISE",
       "Calculate interest for exact days in partial period": "Calculer les intérêts pour les jours exacts d'une période partielle",
       "Calculation": "Calcul",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1928,6 +1928,7 @@
       "Compounding on day of week": "Capitalizzazione nel giorno della settimana",
       "Compounding on nth day": "Capitalizzazione all'n-esimo giorno",
       "CSV format": "Formato CSV",
+      "XML format": "XML format",
       "CURRENCY": "VALUTA",
       "Calculate interest for exact days in partial period": "Calcola l'interesse per i giorni esatti nel periodo parziale",
       "Calculation": "Calcolo",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1929,6 +1929,7 @@
       "Compounding on day of week": "복리 적용 요일",
       "Compounding on nth day": "복리 적용 n번째 날",
       "CSV format": "CSV 형식",
+      "XML format": "XML format",
       "CURRENCY": "통화",
       "Calculate interest for exact days in partial period": "부분 기간의 정확한 날짜에 대한 이자를 계산합니다.",
       "Calculation": "계산",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1927,6 +1927,7 @@
       "Compounding on day of week": "Kapitalizacija savaitės dieną",
       "Compounding on nth day": "Kapitalizacija n-tąją dieną",
       "CSV format": "CSV formatu",
+      "XML format": "XML format",
       "CURRENCY": "VALIUTA",
       "Calculate interest for exact days in partial period": "Apskaičiuokite palūkanas už tikslias dienas daliniu laikotarpiu",
       "Calculation": "Skaičiavimas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1928,6 +1928,7 @@
       "Compounding on day of week": "Kapitalizācija nedēļas dienā",
       "Compounding on nth day": "Kapitalizācija n-tajā dienā",
       "CSV format": "CSV formātā",
+      "XML format": "XML format",
       "CURRENCY": "VALŪTA",
       "Calculate interest for exact days in partial period": "Aprēķiniet procentus par precīzām dienām daļējā periodā",
       "Calculation": "Aprēķins",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1927,6 +1927,7 @@
       "Compounding on day of week": "हप्ताको दिनमा चक्रीय ब्याज",
       "Compounding on nth day": "n औं दिनमा चक्रीय ब्याज",
       "CSV format": "CSV ढाँचा",
+      "XML format": "XML format",
       "CURRENCY": "मुद्रा",
       "Calculate interest for exact days in partial period": "आंशिक अवधिमा सही दिनहरूको लागि ब्याज गणना गर्नुहोस्",
       "Calculation": "हिसाब",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1927,6 +1927,7 @@
       "Compounding on day of week": "Capitalização no dia da semana",
       "Compounding on nth day": "Capitalização no n.º dia",
       "CSV format": "Formato CSV",
+      "XML format": "XML format",
       "CURRENCY": "MOEDA",
       "Calculate interest for exact days in partial period": "Calcular juros para dias exatos em período parcial",
       "Calculation": "Cálculo",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1925,6 +1925,7 @@
       "Compounding on day of week": "Riba ya mlundikano siku ya wiki",
       "Compounding on nth day": "Riba ya mlundikano siku ya n",
       "CSV format": "Umbizo la CSV",
+      "XML format": "XML format",
       "CURRENCY": "SARAFU",
       "Calculate interest for exact days in partial period": "Kukokotoa riba kwa siku kamili katika kipindi cha sehemu",
       "Calculation": "Hesabu",


### PR DESCRIPTION
## Description

Adds XML as a supported output format for Eclipse BIRT and Pentaho reports in the Mifos Web App.

The selected XML format is passed through the existing report flow as `output-type=XML`, while preserving the existing PDF, HTML, XLS, XLSX, and CSV formats.

## Related issues and discussion

WEB-1130

## Screenshots, if any


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added XML as an available output format for Pentaho and BIRT reports.
  * Added localized XML format labels across supported languages.

* **Tests**
  * Added coverage for report requests, XML output selection, form serialization, response handling, and request configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->