### PR TITLE
WEB-1143: Call /branding only when production mode is enabled

### DIFF
--- a/src/app/shared/theme-picker/branding.service.spec.ts
+++ b/src/app/shared/theme-picker/branding.service.spec.ts
@@ -12,6 +12,7 @@ import { TestBed } from '@angular/core/testing';
 import { firstValueFrom } from 'rxjs';
 
 import { SettingsService } from 'app/settings/settings.service';
+import { environment } from 'environments/environment';
 import { BrandingService } from './branding.service';
 import { BRANDING_API_PATH } from './theme.model';
 
@@ -22,9 +23,12 @@ describe('BrandingService', () => {
   const serverUrl = 'https://core.example.org/fineract-provider/api/v1';
   const brandingUrl = `${serverUrl}${BRANDING_API_PATH}`;
   let tenantIdentifier: string;
+  const productionMode = environment.productionMode;
 
   beforeEach(() => {
     tenantIdentifier = 'acme';
+    // Branding is a production-mode feature; these cases cover it switched on.
+    environment.productionMode = true;
 
     TestBed.configureTestingModule({
       providers: [
@@ -51,6 +55,7 @@ describe('BrandingService', () => {
 
   afterEach(() => {
     httpMock.verify();
+    environment.productionMode = productionMode;
   });
 
   it('reads branding without credentials', async () => {
@@ -109,5 +114,27 @@ describe('BrandingService', () => {
     httpMock.expectOne(brandingUrl).flush('Unauthorized', { status: 401, statusText: 'Unauthorized' });
 
     await expect(result).rejects.toMatchObject({ status: 401 });
+  });
+
+  describe('when production mode is disabled', () => {
+    beforeEach(() => {
+      environment.productionMode = false;
+    });
+
+    it('does not read the branding endpoint', async () => {
+      // Branding is a production-mode feature: with it off the endpoint must
+      // never be contacted. `httpMock.verify()` in afterEach asserts no request
+      // was issued; the read fails so callers take the same fallback they do on
+      // a deployment without the plugin.
+      await expect(firstValueFrom(service.getTenantBranding())).rejects.toThrow(/production mode is off/);
+
+      httpMock.expectNone(brandingUrl);
+    });
+
+    it('does not write to the branding endpoint', async () => {
+      await expect(firstValueFrom(service.updateTenantBranding('purple'))).rejects.toThrow(/production mode is off/);
+
+      httpMock.expectNone((req) => req.url === BRANDING_API_PATH);
+    });
   });
 });

--- a/src/app/shared/theme-picker/branding.service.ts
+++ b/src/app/shared/theme-picker/branding.service.ts
@@ -11,13 +11,16 @@ import { Injectable, inject } from '@angular/core';
 import { HttpBackend, HttpClient, HttpHeaders } from '@angular/common/http';
 
 /** rxjs Imports */
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 
 /** Custom Services */
 import { SettingsService } from 'app/settings/settings.service';
 
 /** Custom Models */
 import { BRANDING_API_PATH } from './theme.model';
+
+/** Environment Configuration */
+import { environment } from 'environments/environment';
 
 /** Branding configured for the current tenant. */
 export interface TenantBranding {
@@ -30,6 +33,11 @@ export interface TenantBranding {
  * Backed by the Mifos self-service plugin, which owns the `/branding` endpoint and the table behind
  * it. The endpoint is therefore absent on deployments without that plugin, which callers must treat
  * as "no branding configured" rather than an error.
+ *
+ * Tenant branding is a production-mode feature, so the endpoint is only ever contacted when
+ * `productionMode` is enabled. With it off the deployment is treated exactly like one without the
+ * plugin - no request is issued at all, and callers take their existing "no branding configured"
+ * fallback.
  */
 @Injectable({
   providedIn: 'root'
@@ -38,6 +46,18 @@ export class BrandingService {
   private http = inject(HttpClient);
   private httpBackend = inject(HttpBackend);
   private settingsService = inject(SettingsService);
+
+  /** Whether the deployment runs in production mode, which is what enables tenant branding. */
+  private get enabled(): boolean {
+    return environment.productionMode === true;
+  }
+
+  /**
+   * @returns A failed read, so callers fall back the same way they do when the plugin is absent.
+   */
+  private disabled<T>(): Observable<T> {
+    return throwError(() => new Error('Tenant branding is disabled: production mode is off.'));
+  }
 
   /**
    * Reads without credentials, bypassing the interceptor chain.
@@ -52,6 +72,9 @@ export class BrandingService {
    * @returns {Observable<TenantBranding>} Branding of the current tenant.
    */
   getTenantBranding(): Observable<TenantBranding> {
+    if (!this.enabled) {
+      return this.disabled<TenantBranding>();
+    }
     const anonymousHttp = new HttpClient(this.httpBackend);
     return anonymousHttp.get<TenantBranding>(`${this.settingsService.serverUrl}${BRANDING_API_PATH}`, {
       headers: new HttpHeaders({ 'Fineract-Platform-TenantId': this.settingsService.tenantIdentifier || 'default' })
@@ -63,6 +86,9 @@ export class BrandingService {
    * @returns {Observable<TenantBranding>} Branding as stored.
    */
   updateTenantBranding(primaryColor: string): Observable<TenantBranding> {
+    if (!this.enabled) {
+      return this.disabled<TenantBranding>();
+    }
     return this.http.put<TenantBranding>(BRANDING_API_PATH, { primaryColor });
   }
 }


### PR DESCRIPTION
## Description

/branding has been updated to be called only when 'productionMode' is set to true.

## Related issues and discussion

# WEB-1143

## Screenshots, if any
# After video:

https://github.com/user-attachments/assets/ae914f2e-5da3-4d52-a84e-b63e183ae57c

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant branding is now available only in production mode.
  * Branding reads and updates are blocked when production mode is disabled, preventing unnecessary network requests.
* **Tests**
  * Added coverage to verify branding operations are rejected correctly outside production mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->