### PR TITLE
fix(notes): render note changes without a manual page refresh

### DIFF
--- a/src/app/centers/centers-view/notes-tab/notes-tab.component.ts
+++ b/src/app/centers/centers-view/notes-tab/notes-tab.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { AuthenticationService } from '../../../core/authentication/authentication.service';
@@ -28,6 +28,7 @@ export class NotesTabComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private authenticationService = inject(AuthenticationService);
   private centersService = inject(CentersService);
+  private cdr = inject(ChangeDetectorRef);
 
   entityId: string;
   username: string;
@@ -50,24 +51,32 @@ export class NotesTabComponent implements OnInit {
 
   addNote(noteContent: any) {
     this.centersService.createCenterNote(this.entityId, noteContent).subscribe((response: any) => {
-      this.entityNotes.push({
-        id: response.resourceId,
-        createdByUsername: this.username,
-        createdOn: new Date(),
-        note: noteContent.note
-      });
+      this.entityNotes = [
+        ...this.entityNotes,
+        {
+          id: response.resourceId,
+          createdByUsername: this.username,
+          createdOn: new Date(),
+          note: noteContent.note
+        }
+      ];
+      this.cdr.markForCheck();
     });
   }
 
   editNote(noteId: string, noteContent: any, index: number) {
     this.centersService.editCenterNote(this.entityId, noteId, noteContent).subscribe(() => {
-      this.entityNotes[index].note = noteContent.note;
+      this.entityNotes = this.entityNotes.map((entityNote: any, i: number) =>
+        i === index ? { ...entityNote, note: noteContent.note } : entityNote
+      );
+      this.cdr.markForCheck();
     });
   }
 
   deleteNote(noteId: string, index: number) {
     this.centersService.deleteCenterNote(this.entityId, noteId).subscribe(() => {
-      this.entityNotes.splice(index, 1);
+      this.entityNotes = this.entityNotes.filter((_: any, i: number) => i !== index);
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/clients/clients-view/notes-tab/notes-tab.component.ts
+++ b/src/app/clients/clients-view/notes-tab/notes-tab.component.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 
@@ -37,6 +37,7 @@ export class NotesTabComponent implements OnInit {
   private clientsService = inject(ClientsService);
   private authenticationService = inject(AuthenticationService);
   private destroyRef = inject(DestroyRef);
+  private cdr = inject(ChangeDetectorRef);
 
   /** Client ID */
   entityId: string;
@@ -73,7 +74,10 @@ export class NotesTabComponent implements OnInit {
    */
   editNote(noteId: string, noteContent: any, index: number) {
     this.clientsService.editClientNote(this.entityId, noteId, noteContent).subscribe(() => {
-      this.entityNotes[index].note = noteContent.note;
+      this.entityNotes = this.entityNotes.map((entityNote: any, i: number) =>
+        i === index ? { ...entityNote, note: noteContent.note } : entityNote
+      );
+      this.cdr.markForCheck();
     });
   }
 
@@ -84,7 +88,8 @@ export class NotesTabComponent implements OnInit {
    */
   deleteNote(noteId: string, index: number) {
     this.clientsService.deleteClientNote(this.entityId, noteId).subscribe(() => {
-      this.entityNotes.splice(index, 1);
+      this.entityNotes = this.entityNotes.filter((_: any, i: number) => i !== index);
+      this.cdr.markForCheck();
     });
   }
 
@@ -93,12 +98,16 @@ export class NotesTabComponent implements OnInit {
    */
   addNote(noteContent: any) {
     this.clientsService.createClientNote(this.entityId, noteContent).subscribe((response: any) => {
-      this.entityNotes.push({
-        id: response.resourceId,
-        createdByUsername: this.username,
-        createdOn: new Date(),
-        note: noteContent.note
-      });
+      this.entityNotes = [
+        ...this.entityNotes,
+        {
+          id: response.resourceId,
+          createdByUsername: this.username,
+          createdOn: new Date(),
+          note: noteContent.note
+        }
+      ];
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/groups/groups-view/notes-tab/notes-tab.component.ts
+++ b/src/app/groups/groups-view/notes-tab/notes-tab.component.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -35,6 +35,7 @@ export class NotesTabComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private authenticationService = inject(AuthenticationService);
   private groupsService = inject(GroupsService);
+  private cdr = inject(ChangeDetectorRef);
 
   /** Group ID */
   entityId: string;
@@ -52,6 +53,8 @@ export class NotesTabComponent implements OnInit {
   constructor() {
     this.entityId = this.route.parent.snapshot.params['groupId'];
     this.addNote = this.addNote.bind(this);
+    this.editNote = this.editNote.bind(this);
+    this.deleteNote = this.deleteNote.bind(this);
   }
 
   ngOnInit() {
@@ -67,12 +70,16 @@ export class NotesTabComponent implements OnInit {
    */
   addNote(noteContent: any) {
     this.groupsService.createGroupNote(this.entityId, noteContent).subscribe((response: any) => {
-      this.entityNotes.push({
-        id: response.resourceId,
-        createdByUsername: this.username,
-        createdOn: new Date(),
-        note: noteContent.note
-      });
+      this.entityNotes = [
+        ...this.entityNotes,
+        {
+          id: response.resourceId,
+          createdByUsername: this.username,
+          createdOn: new Date(),
+          note: noteContent.note
+        }
+      ];
+      this.cdr.markForCheck();
     });
   }
 
@@ -83,7 +90,10 @@ export class NotesTabComponent implements OnInit {
    */
   editNote(noteId: string, noteContent: any, index: number) {
     this.groupsService.editGroupNote(this.entityId, noteId, noteContent).subscribe(() => {
-      this.entityNotes[index].note = noteContent.note;
+      this.entityNotes = this.entityNotes.map((entityNote: any, i: number) =>
+        i === index ? { ...entityNote, note: noteContent.note } : entityNote
+      );
+      this.cdr.markForCheck();
     });
   }
 
@@ -93,7 +103,8 @@ export class NotesTabComponent implements OnInit {
    */
   deleteNote(noteId: string, index: number) {
     this.groupsService.deleteGroupNote(this.entityId, noteId).subscribe(() => {
-      this.entityNotes.splice(index, 1);
+      this.entityNotes = this.entityNotes.filter((_: any, i: number) => i !== index);
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/loans/loans-view/notes-tab/notes-tab.component.ts
+++ b/src/app/loans/loans-view/notes-tab/notes-tab.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 
@@ -33,6 +33,7 @@ export class NotesTabComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private loansService = inject(LoansService);
   private authenticationService = inject(AuthenticationService);
+  private cdr = inject(ChangeDetectorRef);
 
   entityId: string;
   username: string;
@@ -42,6 +43,9 @@ export class NotesTabComponent implements OnInit {
     const savedCredentials = this.authenticationService.getCredentials();
     this.username = savedCredentials.username;
     this.entityId = this.route.parent.snapshot.params['loanId'];
+    this.addNote = this.addNote.bind(this);
+    this.editNote = this.editNote.bind(this);
+    this.deleteNote = this.deleteNote.bind(this);
     this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanNotes: any }) => {
       this.entityNotes = data.loanNotes;
     });
@@ -55,24 +59,32 @@ export class NotesTabComponent implements OnInit {
 
   addNote(noteContent: any) {
     this.loansService.createLoanNote(this.entityId, noteContent).subscribe((response: any) => {
-      this.entityNotes.push({
-        id: response.resourceId,
-        createdByUsername: this.username,
-        createdOn: new Date(),
-        note: noteContent.note
-      });
+      this.entityNotes = [
+        ...this.entityNotes,
+        {
+          id: response.resourceId,
+          createdByUsername: this.username,
+          createdOn: new Date(),
+          note: noteContent.note
+        }
+      ];
+      this.cdr.markForCheck();
     });
   }
 
   editNote(noteId: string, noteContent: any, index: number) {
     this.loansService.editLoanNote(this.entityId, noteId, noteContent).subscribe(() => {
-      this.entityNotes[index].note = noteContent.note;
+      this.entityNotes = this.entityNotes.map((entityNote: any, i: number) =>
+        i === index ? { ...entityNote, note: noteContent.note } : entityNote
+      );
+      this.cdr.markForCheck();
     });
   }
 
   deleteNote(noteId: string, index: number) {
     this.loansService.deleteLoanNote(this.entityId, noteId).subscribe(() => {
-      this.entityNotes.splice(index, 1);
+      this.entityNotes = this.entityNotes.filter((_: any, i: number) => i !== index);
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/savings/savings-account-view/notes-tab/notes-tab.component.ts
+++ b/src/app/savings/savings-account-view/notes-tab/notes-tab.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
@@ -29,6 +29,7 @@ export class NotesTabComponent {
   private savingsService = inject(SavingsService);
   private authenticationService = inject(AuthenticationService);
   private destroyRef = inject(DestroyRef);
+  private cdr = inject(ChangeDetectorRef);
 
   entityId: string;
   username: string;
@@ -38,6 +39,9 @@ export class NotesTabComponent {
     const savedCredentials = this.authenticationService.getCredentials();
     this.username = savedCredentials.username;
     this.entityId = this.route.parent.snapshot.params['savingAccountId'];
+    this.addNote = this.addNote.bind(this);
+    this.editNote = this.editNote.bind(this);
+    this.deleteNote = this.deleteNote.bind(this);
     this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingAccountNotes: any }) => {
       this.entityNotes = data.savingAccountNotes;
     });
@@ -45,24 +49,32 @@ export class NotesTabComponent {
 
   addNote(noteContent: any) {
     this.savingsService.createSavingsNote(this.entityId, noteContent).subscribe((response: any) => {
-      this.entityNotes.push({
-        id: response.resourceId,
-        createdByUsername: this.username,
-        createdOn: new Date(),
-        note: noteContent.note
-      });
+      this.entityNotes = [
+        ...this.entityNotes,
+        {
+          id: response.resourceId,
+          createdByUsername: this.username,
+          createdOn: new Date(),
+          note: noteContent.note
+        }
+      ];
+      this.cdr.markForCheck();
     });
   }
 
   editNote(noteId: string, noteContent: any, index: number) {
     this.savingsService.editSavingsNote(this.entityId, noteId, noteContent).subscribe(() => {
-      this.entityNotes[index].note = noteContent.note;
+      this.entityNotes = this.entityNotes.map((entityNote: any, i: number) =>
+        i === index ? { ...entityNote, note: noteContent.note } : entityNote
+      );
+      this.cdr.markForCheck();
     });
   }
 
   deleteNote(noteId: string, index: number) {
     this.savingsService.deleteSavingsNote(this.entityId, noteId).subscribe(() => {
-      this.entityNotes.splice(index, 1);
+      this.entityNotes = this.entityNotes.filter((_: any, i: number) => i !== index);
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/shared/tabs/entity-notes-tab/notes-tab-change-detection.spec.ts
+++ b/src/app/shared/tabs/entity-notes-tab/notes-tab-change-detection.spec.ts
@@ -1,0 +1,237 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ApplicationRef, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { TranslateModule } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faEdit, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { describe, expect, it, jest } from '@jest/globals';
+import { Subject, of } from 'rxjs';
+
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+import { CentersService } from 'app/centers/centers.service';
+import { ClientsService } from 'app/clients/clients.service';
+import { GroupsService } from 'app/groups/groups.service';
+import { LoansService } from 'app/loans/loans.service';
+import { SavingsService } from 'app/savings/savings.service';
+
+import { NotesTabComponent as CenterNotesTabComponent } from 'app/centers/centers-view/notes-tab/notes-tab.component';
+import { NotesTabComponent as ClientNotesTabComponent } from 'app/clients/clients-view/notes-tab/notes-tab.component';
+import { NotesTabComponent as GroupNotesTabComponent } from 'app/groups/groups-view/notes-tab/notes-tab.component';
+import { NotesTabComponent as LoanNotesTabComponent } from 'app/loans/loans-view/notes-tab/notes-tab.component';
+import { NotesTabComponent as SavingsNotesTabComponent } from 'app/savings/savings-account-view/notes-tab/notes-tab.component';
+
+/**
+ * The notes tabs render their notes through the OnPush EntityNotesTabComponent, and the note
+ * service responses arrive outside Angular's event handling. These specs drive each tab through
+ * the DOM and only run change detection the way the framework does at runtime
+ * (ApplicationRef.tick()), so a note list that is updated in place stays on screen unchanged -
+ * which is the "the note is invisible until the page is reloaded" defect.
+ */
+
+interface NotesTabScenario {
+  name: string;
+  component: Type<any>;
+  serviceToken: Type<any>;
+  routeParams: { [key: string]: string };
+  dataKey: string;
+  createMethod: string;
+  editMethod: string;
+  deleteMethod: string;
+}
+
+const SCENARIOS: NotesTabScenario[] = [
+  {
+    name: 'Client Notes',
+    component: ClientNotesTabComponent,
+    serviceToken: ClientsService,
+    routeParams: { clientId: '94' },
+    dataKey: 'clientNotes',
+    createMethod: 'createClientNote',
+    editMethod: 'editClientNote',
+    deleteMethod: 'deleteClientNote'
+  },
+  {
+    name: 'Group Notes',
+    component: GroupNotesTabComponent,
+    serviceToken: GroupsService,
+    routeParams: { groupId: '12' },
+    dataKey: 'groupNotes',
+    createMethod: 'createGroupNote',
+    editMethod: 'editGroupNote',
+    deleteMethod: 'deleteGroupNote'
+  },
+  {
+    name: 'Center Notes',
+    component: CenterNotesTabComponent,
+    serviceToken: CentersService,
+    routeParams: { centerId: '5' },
+    dataKey: 'centerNotes',
+    createMethod: 'createCenterNote',
+    editMethod: 'editCenterNote',
+    deleteMethod: 'deleteCenterNote'
+  },
+  {
+    name: 'Loan Notes',
+    component: LoanNotesTabComponent,
+    serviceToken: LoansService,
+    routeParams: { loanId: '77' },
+    dataKey: 'loanNotes',
+    createMethod: 'createLoanNote',
+    editMethod: 'editLoanNote',
+    deleteMethod: 'deleteLoanNote'
+  },
+  {
+    name: 'Savings Account Notes',
+    component: SavingsNotesTabComponent,
+    serviceToken: SavingsService,
+    routeParams: { savingAccountId: '33' },
+    dataKey: 'savingAccountNotes',
+    createMethod: 'createSavingsNote',
+    editMethod: 'editSavingsNote',
+    deleteMethod: 'deleteSavingsNote'
+  }
+];
+
+describe('Notes tabs render note changes without a page reload', () => {
+  let fixture: ComponentFixture<any>;
+  let appRef: ApplicationRef;
+  let dialogResponse: any;
+
+  /** Response of the note request under test, held open so it resolves outside event handling. */
+  let pendingResponse: Subject<any>;
+
+  const noteServiceMock = (scenario: NotesTabScenario) => ({
+    [scenario.createMethod]: jest.fn(() => pendingResponse),
+    [scenario.editMethod]: jest.fn(() => pendingResponse),
+    [scenario.deleteMethod]: jest.fn(() => pendingResponse)
+  });
+
+  const setup = async (scenario: NotesTabScenario) => {
+    pendingResponse = new Subject<any>();
+    dialogResponse = {};
+
+    const parentRoute: any = {
+      snapshot: { params: scenario.routeParams },
+      params: of(scenario.routeParams)
+    };
+    parentRoute.parent = parentRoute;
+
+    const entityServices = [
+      ClientsService,
+      GroupsService,
+      CentersService,
+      LoansService,
+      SavingsService
+    ].map((token) => ({
+      provide: token,
+      useValue: token === scenario.serviceToken ? noteServiceMock(scenario) : {}
+    }));
+
+    await TestBed.configureTestingModule({
+      imports: [
+        scenario.component,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({
+              [scenario.dataKey]: [{ id: 1, note: 'first note', createdByUsername: 'mifos', createdOn: new Date() }]
+            }),
+            snapshot: { params: scenario.routeParams },
+            params: of(scenario.routeParams),
+            parent: parentRoute
+          }
+        },
+        { provide: AuthenticationService, useValue: { getCredentials: () => ({ username: 'mifos' }) } },
+        { provide: MatDialog, useValue: { open: () => ({ afterClosed: () => of(dialogResponse) }) } },
+        { provide: SettingsService, useValue: { dateFormat: 'dd MMMM yyyy', language: { code: 'en' } } },
+        {
+          provide: Dates,
+          useValue: { angularToMomentFormat: () => 'DD MMMM YYYY', getMomentLocale: () => 'en' }
+        },
+        ...entityServices,
+        provideAnimationsAsync()
+      ]
+    }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIcons(faPlus, faEdit, faTrash);
+    appRef = TestBed.inject(ApplicationRef);
+    fixture = TestBed.createComponent(scenario.component);
+    appRef.attachView(fixture.componentRef.hostView);
+    fixture.detectChanges();
+  };
+
+  const renderedNotes = (): string[] =>
+    Array.from(fixture.nativeElement.querySelectorAll('.note-card .note-content')).map((element: any) =>
+      element.textContent.trim()
+    );
+
+  const submitNewNote = (text: string) => {
+    const textarea: HTMLTextAreaElement = fixture.nativeElement.querySelector('textarea');
+    textarea.value = text;
+    textarea.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    fixture.nativeElement.querySelector('form').dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+  };
+
+  const clickNoteAction = (index: number, action: 'edit' | 'delete') => {
+    const buttons = fixture.nativeElement.querySelectorAll('.note-card .note-actions button');
+    buttons[index * 2 + (action === 'edit' ? 0 : 1)].click();
+    fixture.detectChanges();
+  };
+
+  SCENARIOS.forEach((scenario) => {
+    describe(scenario.name, () => {
+      it('shows an added note as soon as the request completes', async () => {
+        await setup(scenario);
+        expect(renderedNotes()).toEqual(['first note']);
+
+        submitNewNote('second note');
+        pendingResponse.next({ resourceId: 2 });
+        appRef.tick();
+
+        expect(renderedNotes()).toEqual([
+          'first note',
+          'second note'
+        ]);
+      });
+
+      it('shows an edited note as soon as the request completes', async () => {
+        await setup(scenario);
+
+        dialogResponse = { data: { value: { note: 'updated note' } } };
+        clickNoteAction(0, 'edit');
+        pendingResponse.next({});
+        appRef.tick();
+
+        expect(renderedNotes()).toEqual(['updated note']);
+      });
+
+      it('removes a deleted note as soon as the request completes', async () => {
+        await setup(scenario);
+
+        dialogResponse = { delete: true };
+        clickNoteAction(0, 'delete');
+        pendingResponse.next({});
+        appRef.tick();
+
+        expect(renderedNotes()).toEqual([]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

**Problem**

Notes added, edited or deleted from a notes tab were not reflected in the list until the browser was refreshed manually. From the user's point of view there was no confirmation that the note had been saved, which invites capturing the same note twice. Reported against Client Notes (`/#/clients/94/notes` on the demo instance); the same defect is present on four other tabs.

**Root cause**

The notes tab components and the shared `EntityNotesTabComponent` that renders the list are both `ChangeDetectionStrategy.OnPush`, and the tabs updated `entityNotes` in place (`push()` / `splice()` / `entityNotes[index].note = …`).

1. The form submit is handled in the shared component's template, so the click marks the views dirty — the POST itself always worked.
2. The response arrives later. `ApplicationRef.tick()` skips OnPush views that are neither dirty nor have changed inputs. The parent is not dirty at that point, so it is skipped, `[entityNotes]` is never re-evaluated, and the child's `@for` never re-runs.
3. Reloading the page re-runs the route resolver, which is why a refresh appeared to fix it.

**Impacted features**

- Client Notes
- Loan Notes
- Savings Account Notes
- Center Notes
- Group Notes

Jira covers Client, Loan and Savings Account Notes. **Center and Group Notes were not separately reported but carry the identical defect**, so they are fixed here rather than left behind.

**Fix**

- `entityNotes` is now updated immutably — spread on add, `filter()` on delete, `map()` with a new object on edit — so the child's input reference actually changes.
- `ChangeDetectorRef.markForCheck()` is called after each successful response so the parent view is checked and the new reference reaches the binding.

Both halves are required. A new array reference alone never reaches the binding, because the OnPush parent is never checked after an HTTP response. `markForCheck()` alone leaves the child clean, because its input reference did not change.

- **Latent `bind(this)` defect.** Loans and savings passed no bound callbacks to the shared component, and groups bound only `addNote`. Since the shared component invokes them as `this.callbackAdd(...)`, those methods executed with `this` bound to `EntityNotesTabComponent` — which happens to inject the same entity services and hold `entityNotes` as an `@Input`, so the old mutating code limped along by accident while silently recording `createdByUsername: undefined` on new notes. With this change those callbacks use an injected `ChangeDetectorRef`, so leaving them unbound would throw. They are now bound the way clients and centers already did it.

No signals, no change to the shared component's public API, no change to service behaviour, no new dependencies.

**Regression coverage**

`notes-tab-change-detection.spec.ts` drives all five tabs through the DOM — form submit to add, action buttons with a stubbed `MatDialog` to edit and delete — and asserts the rendered `.note-card` list.

Two details make it a real regression test rather than one that passes either way:

- Change detection runs through `ApplicationRef.tick()` with the fixture's host view attached, which is the runtime path that skips clean OnPush views. `fixture.detectChanges()` force-refreshes the root view and hides the defect.
- The service mocks return a pending `Subject`, not `of(...)`. A synchronous mock resolves inside the event handler while the view is still dirty, and passes against the buggy code.

Reverting the component changes and keeping the spec turns all 15 tests red.

## Related issues and discussion

Jira: Client Notes, Loan Notes and Savings Account Notes tickets (IDs to be added). Center Notes and Group Notes have no ticket — the same defect was found in them while fixing the reported three.

## Screenshots, if any

**Before / After**

Client Notes behavior before and after the change: `client_notes_fixed.mp4`

This video is evidence for **Client Notes only**. Loan, Savings Account, Center and Group Notes are covered by the automated regression tests, not by this recording.

## Verification

| Check | Result |
|---|---|
| `npx jest --runInBand` (full suite, with the fix) | 918 passed / 920 |
| `npx jest --runInBand` (baseline, changes stashed) | 903 passed / 905 |
| New spec with the fix | 15 / 15 pass |
| New spec with the component changes reverted | 15 / 15 fail |
| `npx eslint .` | 0 errors |
| `npx stylelint "src/**/*.scss"` | clean |
| `npx prettier . --check` | clean |
| `npx htmlhint "src"` | 769 files, 0 errors |
| `node scripts/check-file-headers.js` | all headers valid |
| `npm run build:prod` | success |

The two failures in both runs are the same pre-existing ones in `clients.component.spec.ts` (IME composition, post-destroy debounce). They are present on an unmodified `dev` and are untouched by this change. Exactly the 15 new tests separate the two totals.

**Manual verification against a live Fineract instance was not performed** — no instance was available. The evidence here is the automated suite, the production build, and the Client Notes recording above.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note creation, editing, and deletion across client, group, center, loan, and savings account views.
  * Note changes now appear immediately and reliably in the interface.

* **Tests**
  * Added regression coverage confirming note updates render correctly after asynchronous operations across all supported note tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->