### PR TITLE
fix(WEB-1132): render note changes without a manual page refresh

### DIFF
--- a/src/app/centers/centers-view/notes-tab/notes-tab.component.ts
+++ b/src/app/centers/centers-view/notes-tab/notes-tab.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { AuthenticationService } from '../../../core/authentication/authentication.service';
@@ -28,6 +28,7 @@ export class NotesTabComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private authenticationService = inject(AuthenticationService);
   private centersService = inject(CentersService);
+  private cdr = inject(ChangeDetectorRef);
 
   entityId: string;
   username: string;
@@ -50,24 +51,32 @@ export class NotesTabComponent implements OnInit {
 
   addNote(noteContent: any) {
     this.centersService.createCenterNote(this.entityId, noteContent).subscribe((response: any) => {
-      this.entityNotes.push({
-        id: response.resourceId,
-        createdByUsername: this.username,
-        createdOn: new Date(),
-        note: noteContent.note
-      });
+      this.entityNotes = [
+        ...this.entityNotes,
+        {
+          id: response.resourceId,
+          createdByUsername: this.username,
+          createdOn: new Date(),
+          note: noteContent.note
+        }
+      ];
+      this.cdr.markForCheck();
     });
   }
 
-  editNote(noteId: string, noteContent: any, index: number) {
-    this.centersService.editCenterNote(this.entityId, noteId, noteContent).subscribe(() => {
-      this.entityNotes[index].note = noteContent.note;
+  editNote(noteId: number, noteContent: any, index: number) {
+    this.centersService.editCenterNote(this.entityId, String(noteId), noteContent).subscribe(() => {
+      this.entityNotes = this.entityNotes.map((entityNote: any) =>
+        entityNote.id === noteId ? { ...entityNote, note: noteContent.note } : entityNote
+      );
+      this.cdr.markForCheck();
     });
   }
 
-  deleteNote(noteId: string, index: number) {
-    this.centersService.deleteCenterNote(this.entityId, noteId).subscribe(() => {
-      this.entityNotes.splice(index, 1);
+  deleteNote(noteId: number, index: number) {
+    this.centersService.deleteCenterNote(this.entityId, String(noteId)).subscribe(() => {
+      this.entityNotes = this.entityNotes.filter((entityNote: any) => entityNote.id !== noteId);
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/clients/clients-view/notes-tab/notes-tab.component.ts
+++ b/src/app/clients/clients-view/notes-tab/notes-tab.component.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 
@@ -37,6 +37,7 @@ export class NotesTabComponent implements OnInit {
   private clientsService = inject(ClientsService);
   private authenticationService = inject(AuthenticationService);
   private destroyRef = inject(DestroyRef);
+  private cdr = inject(ChangeDetectorRef);
 
   /** Client ID */
   entityId: string;
@@ -72,9 +73,15 @@ export class NotesTabComponent implements OnInit {
    * @param {number} index Index
    */
   editNote(noteId: string, noteContent: any, index: number) {
-    this.clientsService.editClientNote(this.entityId, noteId, noteContent).subscribe(() => {
-      this.entityNotes[index].note = noteContent.note;
-    });
+    this.clientsService
+      .editClientNote(this.entityId, noteId, noteContent)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.entityNotes = this.entityNotes.map((entityNote: any) =>
+          entityNote.id === noteId ? { ...entityNote, note: noteContent.note } : entityNote
+        );
+        this.cdr.markForCheck();
+      });
   }
 
   /**
@@ -83,22 +90,33 @@ export class NotesTabComponent implements OnInit {
    * @param {number} index Index
    */
   deleteNote(noteId: string, index: number) {
-    this.clientsService.deleteClientNote(this.entityId, noteId).subscribe(() => {
-      this.entityNotes.splice(index, 1);
-    });
+    this.clientsService
+      .deleteClientNote(this.entityId, noteId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.entityNotes = this.entityNotes.filter((entityNote: any) => entityNote.id !== noteId);
+        this.cdr.markForCheck();
+      });
   }
 
   /**
    * Creates a client note.
    */
   addNote(noteContent: any) {
-    this.clientsService.createClientNote(this.entityId, noteContent).subscribe((response: any) => {
-      this.entityNotes.push({
-        id: response.resourceId,
-        createdByUsername: this.username,
-        createdOn: new Date(),
-        note: noteContent.note
+    this.clientsService
+      .createClientNote(this.entityId, noteContent)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((response: any) => {
+        this.entityNotes = [
+          ...this.entityNotes,
+          {
+            id: response.resourceId,
+            createdByUsername: this.username,
+            createdOn: new Date(),
+            note: noteContent.note
+          }
+        ];
+        this.cdr.markForCheck();
       });
-    });
   }
 }

--- a/src/app/groups/groups-view/notes-tab/notes-tab.component.ts
+++ b/src/app/groups/groups-view/notes-tab/notes-tab.component.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 /** Custom Services */
@@ -35,6 +35,7 @@ export class NotesTabComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private authenticationService = inject(AuthenticationService);
   private groupsService = inject(GroupsService);
+  private cdr = inject(ChangeDetectorRef);
 
   /** Group ID */
   entityId: string;
@@ -52,6 +53,8 @@ export class NotesTabComponent implements OnInit {
   constructor() {
     this.entityId = this.route.parent.snapshot.params['groupId'];
     this.addNote = this.addNote.bind(this);
+    this.editNote = this.editNote.bind(this);
+    this.deleteNote = this.deleteNote.bind(this);
   }
 
   ngOnInit() {
@@ -67,12 +70,16 @@ export class NotesTabComponent implements OnInit {
    */
   addNote(noteContent: any) {
     this.groupsService.createGroupNote(this.entityId, noteContent).subscribe((response: any) => {
-      this.entityNotes.push({
-        id: response.resourceId,
-        createdByUsername: this.username,
-        createdOn: new Date(),
-        note: noteContent.note
-      });
+      this.entityNotes = [
+        ...this.entityNotes,
+        {
+          id: response.resourceId,
+          createdByUsername: this.username,
+          createdOn: new Date(),
+          note: noteContent.note
+        }
+      ];
+      this.cdr.markForCheck();
     });
   }
 
@@ -83,7 +90,10 @@ export class NotesTabComponent implements OnInit {
    */
   editNote(noteId: string, noteContent: any, index: number) {
     this.groupsService.editGroupNote(this.entityId, noteId, noteContent).subscribe(() => {
-      this.entityNotes[index].note = noteContent.note;
+      this.entityNotes = this.entityNotes.map((entityNote: any) =>
+        entityNote.id === noteId ? { ...entityNote, note: noteContent.note } : entityNote
+      );
+      this.cdr.markForCheck();
     });
   }
 
@@ -93,7 +103,8 @@ export class NotesTabComponent implements OnInit {
    */
   deleteNote(noteId: string, index: number) {
     this.groupsService.deleteGroupNote(this.entityId, noteId).subscribe(() => {
-      this.entityNotes.splice(index, 1);
+      this.entityNotes = this.entityNotes.filter((entityNote: any) => entityNote.id !== noteId);
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/loans/loans-view/notes-tab/notes-tab.component.ts
+++ b/src/app/loans/loans-view/notes-tab/notes-tab.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 
@@ -33,6 +33,7 @@ export class NotesTabComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private loansService = inject(LoansService);
   private authenticationService = inject(AuthenticationService);
+  private cdr = inject(ChangeDetectorRef);
 
   entityId: string;
   username: string;
@@ -42,6 +43,9 @@ export class NotesTabComponent implements OnInit {
     const savedCredentials = this.authenticationService.getCredentials();
     this.username = savedCredentials.username;
     this.entityId = this.route.parent.snapshot.params['loanId'];
+    this.addNote = this.addNote.bind(this);
+    this.editNote = this.editNote.bind(this);
+    this.deleteNote = this.deleteNote.bind(this);
     this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanNotes: any }) => {
       this.entityNotes = data.loanNotes;
     });
@@ -55,24 +59,32 @@ export class NotesTabComponent implements OnInit {
 
   addNote(noteContent: any) {
     this.loansService.createLoanNote(this.entityId, noteContent).subscribe((response: any) => {
-      this.entityNotes.push({
-        id: response.resourceId,
-        createdByUsername: this.username,
-        createdOn: new Date(),
-        note: noteContent.note
-      });
+      this.entityNotes = [
+        ...this.entityNotes,
+        {
+          id: response.resourceId,
+          createdByUsername: this.username,
+          createdOn: new Date(),
+          note: noteContent.note
+        }
+      ];
+      this.cdr.markForCheck();
     });
   }
 
   editNote(noteId: string, noteContent: any, index: number) {
     this.loansService.editLoanNote(this.entityId, noteId, noteContent).subscribe(() => {
-      this.entityNotes[index].note = noteContent.note;
+      this.entityNotes = this.entityNotes.map((entityNote: any) =>
+        entityNote.id === noteId ? { ...entityNote, note: noteContent.note } : entityNote
+      );
+      this.cdr.markForCheck();
     });
   }
 
   deleteNote(noteId: string, index: number) {
     this.loansService.deleteLoanNote(this.entityId, noteId).subscribe(() => {
-      this.entityNotes.splice(index, 1);
+      this.entityNotes = this.entityNotes.filter((entityNote: any) => entityNote.id !== noteId);
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/savings/savings-account-view/notes-tab/notes-tab.component.ts
+++ b/src/app/savings/savings-account-view/notes-tab/notes-tab.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
@@ -29,6 +29,7 @@ export class NotesTabComponent {
   private savingsService = inject(SavingsService);
   private authenticationService = inject(AuthenticationService);
   private destroyRef = inject(DestroyRef);
+  private cdr = inject(ChangeDetectorRef);
 
   entityId: string;
   username: string;
@@ -38,6 +39,9 @@ export class NotesTabComponent {
     const savedCredentials = this.authenticationService.getCredentials();
     this.username = savedCredentials.username;
     this.entityId = this.route.parent.snapshot.params['savingAccountId'];
+    this.addNote = this.addNote.bind(this);
+    this.editNote = this.editNote.bind(this);
+    this.deleteNote = this.deleteNote.bind(this);
     this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { savingAccountNotes: any }) => {
       this.entityNotes = data.savingAccountNotes;
     });
@@ -45,24 +49,32 @@ export class NotesTabComponent {
 
   addNote(noteContent: any) {
     this.savingsService.createSavingsNote(this.entityId, noteContent).subscribe((response: any) => {
-      this.entityNotes.push({
-        id: response.resourceId,
-        createdByUsername: this.username,
-        createdOn: new Date(),
-        note: noteContent.note
-      });
+      this.entityNotes = [
+        ...this.entityNotes,
+        {
+          id: response.resourceId,
+          createdByUsername: this.username,
+          createdOn: new Date(),
+          note: noteContent.note
+        }
+      ];
+      this.cdr.markForCheck();
     });
   }
 
   editNote(noteId: string, noteContent: any, index: number) {
     this.savingsService.editSavingsNote(this.entityId, noteId, noteContent).subscribe(() => {
-      this.entityNotes[index].note = noteContent.note;
+      this.entityNotes = this.entityNotes.map((entityNote: any) =>
+        entityNote.id === noteId ? { ...entityNote, note: noteContent.note } : entityNote
+      );
+      this.cdr.markForCheck();
     });
   }
 
   deleteNote(noteId: string, index: number) {
     this.savingsService.deleteSavingsNote(this.entityId, noteId).subscribe(() => {
-      this.entityNotes.splice(index, 1);
+      this.entityNotes = this.entityNotes.filter((entityNote: any) => entityNote.id !== noteId);
+      this.cdr.markForCheck();
     });
   }
 }

--- a/src/app/shared/tabs/entity-notes-tab/entity-notes-tab.component.html
+++ b/src/app/shared/tabs/entity-notes-tab/entity-notes-tab.component.html
@@ -55,6 +55,7 @@
                   mat-raised-button
                   color="primary"
                   (click)="editNote(entityNote.id, entityNote.note, i)"
+                  data-testid="note-edit-action"
                   [title]="'labels.heading.Edit Note' | translate"
                 >
                   <fa-icon icon="edit" class="m-r-10" aria-hidden="true"></fa-icon
@@ -65,6 +66,7 @@
                   mat-raised-button
                   color="warn"
                   (click)="deleteNote(entityNote.id, i)"
+                  data-testid="note-delete-action"
                   [title]="('labels.inputs.Note' | translate) + ': ' + ('labels.buttons.Delete' | translate)"
                 >
                   <fa-icon icon="trash" class="m-r-10" aria-hidden="true"></fa-icon

--- a/src/app/shared/tabs/entity-notes-tab/notes-tab-change-detection.spec.ts
+++ b/src/app/shared/tabs/entity-notes-tab/notes-tab-change-detection.spec.ts
@@ -1,0 +1,387 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ApplicationRef, Type } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { TranslateModule } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faEdit, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { Observable, Subject, of } from 'rxjs';
+
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+import { CentersService } from 'app/centers/centers.service';
+import { ClientsService } from 'app/clients/clients.service';
+import { GroupsService } from 'app/groups/groups.service';
+import { LoansService } from 'app/loans/loans.service';
+import { SavingsService } from 'app/savings/savings.service';
+
+import { NotesTabComponent as CenterNotesTabComponent } from 'app/centers/centers-view/notes-tab/notes-tab.component';
+import { NotesTabComponent as ClientNotesTabComponent } from 'app/clients/clients-view/notes-tab/notes-tab.component';
+import { NotesTabComponent as GroupNotesTabComponent } from 'app/groups/groups-view/notes-tab/notes-tab.component';
+import { NotesTabComponent as LoanNotesTabComponent } from 'app/loans/loans-view/notes-tab/notes-tab.component';
+import { NotesTabComponent as SavingsNotesTabComponent } from 'app/savings/savings-account-view/notes-tab/notes-tab.component';
+
+/**
+ * The notes tabs render their notes through the OnPush EntityNotesTabComponent, and the note
+ * service responses arrive outside Angular's event handling. These specs drive each tab through
+ * the DOM and only run change detection the way the framework does at runtime
+ * (ApplicationRef.tick()), so a note list that is updated in place stays on screen unchanged -
+ * which is the "the note is invisible until the page is reloaded" defect.
+ *
+ * They also hold two requests open at once and complete them out of order, which is where a
+ * callback that trusts the render index it was called with resolves against the wrong note.
+ */
+
+/** Note as the tabs hold it: resolver rows and locally appended rows share this shape. */
+interface NoteRecord {
+  id: number;
+  note: string;
+  createdByUsername: string;
+  createdOn: Date;
+}
+
+interface NoteContent {
+  note: string;
+}
+
+/** Only `resourceId` is read, and only from the create response. */
+interface NoteRequestResponse {
+  resourceId?: number;
+}
+
+/**
+ * The surface of a notes tab that these specs rely on. `noteId` is `string | number` because the
+ * tabs declare it differently - centers types it as the numeric id the template actually passes,
+ * the others still declare `string` - while every one of them receives `entityNote.id` at runtime.
+ */
+interface NotesTab {
+  entityId: string;
+  entityNotes: NoteRecord[];
+  addNote(noteContent: NoteContent): void;
+  editNote(noteId: string | number, noteContent: NoteContent, index: number): void;
+  deleteNote(noteId: string | number, index: number): void;
+}
+
+/** Entity service double: only the three note methods of the tab under test are stubbed. */
+type NoteServiceDouble = Record<string, () => Observable<NoteRequestResponse>>;
+
+/** What the shared component reads back from its edit and delete dialogs. */
+interface NoteDialogResponse {
+  data?: { value: NoteContent };
+  delete?: boolean;
+}
+
+type RouteParams = Record<string, string>;
+
+interface ParentRouteDouble {
+  snapshot: { params: RouteParams };
+  params: Observable<RouteParams>;
+  parent?: ParentRouteDouble;
+}
+
+interface ActivatedRouteDouble extends ParentRouteDouble {
+  data: Observable<Record<string, NoteRecord[]>>;
+  parent: ParentRouteDouble;
+}
+
+interface NotesTabScenario {
+  name: string;
+  component: Type<NotesTab>;
+  serviceToken: Type<unknown>;
+  routeParams: RouteParams;
+  dataKey: string;
+  createMethod: string;
+  editMethod: string;
+  deleteMethod: string;
+}
+
+const SCENARIOS: NotesTabScenario[] = [
+  {
+    name: 'Client Notes',
+    component: ClientNotesTabComponent,
+    serviceToken: ClientsService,
+    routeParams: { clientId: '94' },
+    dataKey: 'clientNotes',
+    createMethod: 'createClientNote',
+    editMethod: 'editClientNote',
+    deleteMethod: 'deleteClientNote'
+  },
+  {
+    name: 'Group Notes',
+    component: GroupNotesTabComponent,
+    serviceToken: GroupsService,
+    routeParams: { groupId: '12' },
+    dataKey: 'groupNotes',
+    createMethod: 'createGroupNote',
+    editMethod: 'editGroupNote',
+    deleteMethod: 'deleteGroupNote'
+  },
+  {
+    name: 'Center Notes',
+    component: CenterNotesTabComponent,
+    serviceToken: CentersService,
+    routeParams: { centerId: '5' },
+    dataKey: 'centerNotes',
+    createMethod: 'createCenterNote',
+    editMethod: 'editCenterNote',
+    deleteMethod: 'deleteCenterNote'
+  },
+  {
+    name: 'Loan Notes',
+    component: LoanNotesTabComponent,
+    serviceToken: LoansService,
+    routeParams: { loanId: '77' },
+    dataKey: 'loanNotes',
+    createMethod: 'createLoanNote',
+    editMethod: 'editLoanNote',
+    deleteMethod: 'deleteLoanNote'
+  },
+  {
+    name: 'Savings Account Notes',
+    component: SavingsNotesTabComponent,
+    serviceToken: SavingsService,
+    routeParams: { savingAccountId: '33' },
+    dataKey: 'savingAccountNotes',
+    createMethod: 'createSavingsNote',
+    editMethod: 'editSavingsNote',
+    deleteMethod: 'deleteSavingsNote'
+  }
+];
+
+/**
+ * Note actions carry their own test id in the shared component, so looking one up inside its own
+ * card keeps the lookup independent of button order, button count and translated labels.
+ */
+const ACTION_TESTID: Record<'edit' | 'delete', string> = {
+  edit: 'note-edit-action',
+  delete: 'note-delete-action'
+};
+
+const noteRecord = (id: number, note: string): NoteRecord => ({
+  id,
+  note,
+  createdByUsername: 'mifos',
+  createdOn: new Date()
+});
+
+describe('Notes tabs render note changes without a page reload', () => {
+  let fixture: ComponentFixture<NotesTab>;
+  let appRef: ApplicationRef;
+  let dialogResponse: NoteDialogResponse;
+
+  /** Every note request opened so far, in call order, each still awaiting its response. */
+  let openRequests: Subject<NoteRequestResponse>[];
+
+  /** Opens a request that stays pending until the spec completes it explicitly. */
+  const openRequest = (): Observable<NoteRequestResponse> => {
+    const response = new Subject<NoteRequestResponse>();
+    openRequests.push(response);
+    return response.asObservable();
+  };
+
+  /** Completes the request opened `order`-th, outside any event handler. */
+  const completeRequest = (order: number, response: NoteRequestResponse = {}) => {
+    openRequests[order].next(response);
+  };
+
+  /** Completes anything a test left pending, so no subscription outlives its spec. */
+  afterEach(() => {
+    (openRequests ?? []).forEach((request) => request.complete());
+    openRequests = [];
+  });
+
+  const noteServiceDouble = (scenario: NotesTabScenario): NoteServiceDouble => ({
+    [scenario.createMethod]: jest.fn(openRequest),
+    [scenario.editMethod]: jest.fn(openRequest),
+    [scenario.deleteMethod]: jest.fn(openRequest)
+  });
+
+  const setup = async (scenario: NotesTabScenario, notes: NoteRecord[] = [noteRecord(1, 'first note')]) => {
+    openRequests = [];
+    dialogResponse = {};
+
+    const parentRoute: ParentRouteDouble = {
+      snapshot: { params: scenario.routeParams },
+      params: of(scenario.routeParams)
+    };
+    parentRoute.parent = parentRoute;
+
+    const route: ActivatedRouteDouble = {
+      data: of({ [scenario.dataKey]: notes }),
+      snapshot: { params: scenario.routeParams },
+      params: of(scenario.routeParams),
+      parent: parentRoute
+    };
+
+    const entityServices = [
+      ClientsService,
+      GroupsService,
+      CentersService,
+      LoansService,
+      SavingsService
+    ].map((token) => ({
+      provide: token,
+      useValue: token === scenario.serviceToken ? noteServiceDouble(scenario) : {}
+    }));
+
+    await TestBed.configureTestingModule({
+      imports: [
+        scenario.component,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: ActivatedRoute, useValue: route },
+        { provide: AuthenticationService, useValue: { getCredentials: () => ({ username: 'mifos' }) } },
+        { provide: MatDialog, useValue: { open: () => ({ afterClosed: () => of(dialogResponse) }) } },
+        { provide: SettingsService, useValue: { dateFormat: 'dd MMMM yyyy', language: { code: 'en' } } },
+        {
+          provide: Dates,
+          useValue: { angularToMomentFormat: () => 'DD MMMM YYYY', getMomentLocale: () => 'en' }
+        },
+        ...entityServices,
+        provideAnimationsAsync()
+      ]
+    }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIcons(faPlus, faEdit, faTrash);
+    appRef = TestBed.inject(ApplicationRef);
+    fixture = TestBed.createComponent(scenario.component);
+    appRef.attachView(fixture.componentRef.hostView);
+    fixture.detectChanges();
+  };
+
+  const host = (): HTMLElement => fixture.nativeElement as HTMLElement;
+
+  const noteCards = (): HTMLElement[] => Array.from(host().querySelectorAll<HTMLElement>('.note-card'));
+
+  const renderedNotes = (): string[] =>
+    noteCards().map((card) => card.querySelector('.note-content')?.textContent?.trim() ?? '');
+
+  const cardFor = (noteText: string): HTMLElement => {
+    const card = noteCards().find(
+      (candidate) => candidate.querySelector('.note-content')?.textContent?.trim() === noteText
+    );
+    if (!card) {
+      throw new Error(`No rendered note card for "${noteText}". Rendered: ${JSON.stringify(renderedNotes())}`);
+    }
+    return card;
+  };
+
+  const submitNewNote = (text: string) => {
+    const textarea = host().querySelector('textarea') as HTMLTextAreaElement;
+    textarea.value = text;
+    textarea.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    (host().querySelector('form') as HTMLFormElement).dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+  };
+
+  /** Clicks an action on the card showing `noteText`, identified by the action's own test id. */
+  const clickNoteAction = (noteText: string, action: 'edit' | 'delete') => {
+    const selector = `button[data-testid="${ACTION_TESTID[action]}"]`;
+    const button = cardFor(noteText).querySelector<HTMLButtonElement>(selector);
+    if (!button) {
+      throw new Error(`No "${action}" action on the note card for "${noteText}"`);
+    }
+    button.click();
+    fixture.detectChanges();
+  };
+
+  const startEdit = (noteText: string, updatedText: string) => {
+    dialogResponse = { data: { value: { note: updatedText } } };
+    clickNoteAction(noteText, 'edit');
+  };
+
+  const startDelete = (noteText: string) => {
+    dialogResponse = { delete: true };
+    clickNoteAction(noteText, 'delete');
+  };
+
+  SCENARIOS.forEach((scenario) => {
+    describe(scenario.name, () => {
+      it('shows an added note as soon as the request completes', async () => {
+        await setup(scenario);
+        expect(renderedNotes()).toEqual(['first note']);
+
+        submitNewNote('second note');
+        completeRequest(0, { resourceId: 2 });
+        appRef.tick();
+
+        expect(renderedNotes()).toEqual([
+          'first note',
+          'second note'
+        ]);
+      });
+
+      it('shows an edited note as soon as the request completes', async () => {
+        await setup(scenario);
+
+        startEdit('first note', 'updated note');
+        completeRequest(0);
+        appRef.tick();
+
+        expect(renderedNotes()).toEqual(['updated note']);
+      });
+
+      it('removes a deleted note as soon as the request completes', async () => {
+        await setup(scenario);
+
+        startDelete('first note');
+        completeRequest(0);
+        appRef.tick();
+
+        expect(renderedNotes()).toEqual([]);
+      });
+
+      it('edits the note it was asked to edit when an earlier request completes first', async () => {
+        await setup(scenario, [
+          noteRecord(1, 'note A'),
+          noteRecord(2, 'note B'),
+          noteRecord(3, 'note C')
+        ]);
+
+        startEdit('note C', 'note C updated');
+        startDelete('note A');
+
+        completeRequest(1);
+        appRef.tick();
+        completeRequest(0);
+        appRef.tick();
+
+        expect(renderedNotes()).toEqual([
+          'note B',
+          'note C updated'
+        ]);
+      });
+
+      it('deletes the note it was asked to delete when an earlier request completes first', async () => {
+        await setup(scenario, [
+          noteRecord(1, 'note A'),
+          noteRecord(2, 'note B'),
+          noteRecord(3, 'note C')
+        ]);
+
+        startDelete('note C');
+        startDelete('note A');
+
+        completeRequest(1);
+        appRef.tick();
+        completeRequest(0);
+        appRef.tick();
+
+        expect(renderedNotes()).toEqual(['note B']);
+      });
+    });
+  });
+});


### PR DESCRIPTION

## Description

Notes added, edited or deleted from a notes tab were not reflected in the list until the browser was refreshed manually. From the user's point of view there was no confirmation that the note had been saved, which invites capturing the same note twice. Reported against Client Notes (`/#/clients/94/notes` on the demo instance); the same defect is present on four other tabs.

**Root cause**

The notes tab components and the shared `EntityNotesTabComponent` that renders the list are both `ChangeDetectionStrategy.OnPush`, and the tabs updated `entityNotes` in place (`push()` / `splice()` / `entityNotes[index].note = …`).

1. The form submit is handled in the shared component's template, so the click marks the views dirty — the POST itself always worked.
2. The response arrives later. `ApplicationRef.tick()` skips OnPush views that are neither dirty nor have changed inputs. The parent is not dirty at that point, so it is skipped, `[entityNotes]` is never re-evaluated, and the child's `@for` never re-runs.
3. Reloading the page re-runs the route resolver, which is why a refresh appeared to fix it.

**Impacted features**

- Client Notes
- Loan Notes
- Savings Account Notes
- Center Notes
- Group Notes

Center Notes and Group Notes have no Jira ticket. They were found to carry the identical defect while fixing the reported three, so they are fixed here rather than left behind.

**Fix**

- `entityNotes` is updated immutably — spread on add, `filter()` on delete, `map()` with a new object on edit — so the child's input reference actually changes.
- `ChangeDetectorRef.markForCheck()` is called after each successful response so the parent view is checked and the new reference reaches the binding.

Both halves are required. A new array reference alone never reaches the binding, because the OnPush parent is never checked after an HTTP response. `markForCheck()` alone leaves the child clean, because its input reference did not change.

- **Edit and delete match on `id`, not on the render index.** The index is captured when the button is clicked, so a second request that completes first leaves it pointing at the wrong note, or past the end of the list.

- **Latent `bind(this)` defect.** Loans and savings passed no bound callbacks to the shared component, and groups bound only `addNote`. Since the shared component invokes them as `this.callbackAdd(...)`, those methods executed with `this` bound to `EntityNotesTabComponent` — which happens to inject the same entity services and hold `entityNotes` as an `@Input`, so the old mutating code limped along by accident while silently recording `createdByUsername: undefined` on new notes. With this change those callbacks use an injected `ChangeDetectorRef`, so leaving them unbound would throw. They are now bound the way clients and centers already did it.

No signals, no change to the shared component's public API, no change to service behaviour, no new dependencies.

**Regression coverage**

`notes-tab-change-detection.spec.ts` drives all five tabs through the DOM — form submit to add, note actions located by their own title inside their own card to edit and delete — and asserts the rendered `.note-card` list.

Three details make these real regression tests rather than ones that pass either way:

- Change detection runs through `ApplicationRef.tick()` with the fixture's host view attached, which is the runtime path that skips clean OnPush views. `fixture.detectChanges()` force-refreshes the root view and hides the defect.
- The service doubles return a pending `Subject`, not `of(...)`. A synchronous double resolves inside the event handler while the view is still dirty, and passes against the buggy code.
- Two requests are held open at once and completed out of order, which is what exposes an index-based update.

Reverting the component changes and keeping the spec turns all 25 tests red. Restoring index-based matching alone turns exactly the 10 out-of-order tests red.

## Related issues and discussion

Jira: [WEB-1132](https://mifosforge.jira.com/browse/WEB-1132), [WEB-1133](https://mifosforge.jira.com/browse/WEB-1133), [WEB-1134](https://mifosforge.jira.com/browse/WEB-1134) — the reported Client Notes, Loan Notes and Savings Account Notes defects. They share one root cause and one fix in a shared render path, so they are addressed in a single PR rather than split into three conflicting ones.

Slack: discussion pending in `#web-app`. Flagging this openly rather than omitting it — happy to close this PR and re-open after the thread if maintainers prefer.

## Screenshots, if any
Before:
https://github.com/user-attachments/assets/dd943999-1aae-4d11-a287-cee8f644b01a

After:
https://github.com/user-attachments/assets/6b84424a-efd2-49d3-ba8d-b1836f5212c3



This recording is evidence for **Client Notes only**. Loan, Savings Account, Center and Group Notes are covered by the automated regression tests, not by this recording. No visual/layout changes are included in this PR — the change is behavioural, so there is no styling diff to show.

## Verification

| Check | Result |
|---|---|
| `npx jest --runInBand` (full suite, with the fix) | 928 passed / 930 |
| `npx jest --runInBand` (baseline, changes stashed) | 903 passed / 905 |
| New spec with the fix | 25 / 25 pass |
| New spec with the component changes reverted | 25 / 25 fail |
| New spec with index-based matching restored | 10 / 25 fail — the out-of-order cases |
| `npx eslint .` | 0 errors |
| `npx stylelint "src/**/*.scss"` | clean |
| `npx prettier . --check` | clean |
| `npx htmlhint "src"` | 769 files, 0 errors |
| `node scripts/check-file-headers.js` | all headers valid |
| `npm run build:prod` | success |

The two failures in both jest runs are the same pre-existing ones in `clients.component.spec.ts` (IME composition, post-destroy debounce). They are present on an unmodified `dev` and are untouched by this change. Exactly the 25 new tests separate the two totals.

**Manual verification against a live Fineract instance was not performed** — no instance was available. The evidence here is the automated suite, the production build, and the Client Notes recording above.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1132]: https://mifosforge.jira.com/browse/WEB-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Notes added, edited, or deleted in client, group, center, loan, and savings views now appear immediately.
  * Improved reliability when multiple note updates complete in a different order.
  * Note changes remain accurate when concurrent operations affect the same list.

* **Tests**
  * Added coverage for note changes after asynchronous requests, including concurrent edits and deletions.
  * Verified note updates across all supported entity views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->