### PR TITLE
WEB-1142: WC - Add menu item options when loan is overpaid

### DIFF
--- a/src/app/loans/common-resolvers/loan-action-button.resolver.ts
+++ b/src/app/loans/common-resolvers/loan-action-button.resolver.ts
@@ -56,7 +56,9 @@ export class LoanActionButtonResolver {
     } else if (loanActionButton === 'Merchant Issued Refund') {
       return this.loansService.getLoanActionTemplate(loanId, 'merchantIssuedRefund');
     } else if (loanActionButton === 'Credit Balance Refund') {
-      return this.loansService.getLoanActionTemplate(loanId, 'creditBalanceRefund');
+      return this.loanProductService.isLoanProduct
+        ? this.loansService.getLoanActionTemplate(loanId, 'creditBalanceRefund')
+        : this.loansService.getWorkingCapitalLoanActionTemplate(loanId, 'creditBalanceRefund');
     } else if (loanActionButton === 'Waive Interest') {
       return this.loansService.getLoanActionTemplate(loanId, 'waiveinterest');
     } else if (loanActionButton === 'Write Off') {

--- a/src/app/loans/loans-view/loan-account-actions/add-loan-charge/add-loan-charge.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/add-loan-charge/add-loan-charge.component.html
@@ -80,7 +80,7 @@
             mat-raised-button
             color="primary"
             [disabled]="!loanChargeForm.valid || isSubmitting()"
-            *mifosxHasPermission="'CREATE_LOANCHARGE'"
+            *mifosxHasPermission="requiredPermission"
           >
             {{ 'labels.buttons.Submit' | translate }}
           </button>

--- a/src/app/loans/loans-view/loan-account-actions/add-loan-charge/add-loan-charge.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/add-loan-charge/add-loan-charge.component.ts
@@ -70,6 +70,10 @@ export class AddLoanChargeComponent extends LoanAccountActionsBaseComponent impl
     this.loanId = this.route.snapshot.params['loanId'];
   }
 
+  get requiredPermission(): string {
+    return this.isWorkingCapital ? 'CREATE_WORKINGCAPITALLOANCHARGE' : 'CREATE_LOANCHARGE';
+  }
+
   /**
    * Creates the Loan Charge form.
    */

--- a/src/app/loans/loans-view/loan-account-actions/loan-credit-balance-refund/loan-credit-balance-refund.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/loan-credit-balance-refund/loan-credit-balance-refund.component.html
@@ -58,7 +58,7 @@
             mat-raised-button
             color="primary"
             [disabled]="!creditBalanceLoanForm.valid"
-            *mifosxHasPermission="'REPAYMENT_LOAN'"
+            *mifosxHasPermission="requiredPermission"
           >
             {{ 'labels.buttons.Submit' | translate }}
           </button>

--- a/src/app/loans/loans-view/loan-account-actions/loan-credit-balance-refund/loan-credit-balance-refund.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/loan-credit-balance-refund/loan-credit-balance-refund.component.ts
@@ -55,13 +55,17 @@ export class LoanCreditBalanceRefundComponent extends LoanAccountActionsBaseComp
     }
   }
 
+  get requiredPermission(): string {
+    return this.isWorkingCapital ? 'CREDITBALANCEREFUND_WORKINGCAPITALLOAN' : 'CREDITBALANCEREFUND_LOAN';
+  }
+
   /**
    * Creates the create close form.
    */
   createCreditBalanceLoanForm() {
     this.creditBalanceLoanForm = this.formBuilder.group({
       transactionDate: [
-        new Date(),
+        this.isWorkingCapital ? this.settingsService.businessDate : new Date(),
         Validators.required
       ],
       transactionAmount: [
@@ -75,7 +79,7 @@ export class LoanCreditBalanceRefundComponent extends LoanAccountActionsBaseComp
 
   setCreditBalanceLoanDetails() {
     this.creditBalanceLoanForm.patchValue({
-      transactionAmount: this.dataObject.amount
+      transactionAmount: this.dataObject.amount ?? this.dataObject.expectedAmount
     });
   }
 
@@ -93,9 +97,11 @@ export class LoanCreditBalanceRefundComponent extends LoanAccountActionsBaseComp
       dateFormat,
       locale
     };
-    const command = this.dataObject.type.code.split('.')[1];
     data['transactionAmount'] = data['transactionAmount'] * 1;
-    this.loanService.submitLoanActionButton(this.loanId, data, command).subscribe((response: any) => {
+    const request = this.isWorkingCapital
+      ? this.loanService.applyWorkingCapitalLoanActionCommand(this.loanId, data, 'creditBalanceRefund')
+      : this.loanService.submitLoanActionButton(this.loanId, data, this.dataObject.type.code.split('.')[1]);
+    request.subscribe((_response: any) => {
       this.gotoLoanView('transactions');
     });
   }

--- a/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/make-repayment/make-repayment.component.ts
@@ -102,6 +102,9 @@ export class MakeRepaymentComponent extends LoanAccountActionsBaseComponent impl
     if (this.loanProductService.isWorkingCapital && this.command === 'payoutRefund') {
       return 'PAYOUTREFUND_WORKINGCAPITALLOAN';
     }
+    if (this.loanProductService.isWorkingCapital && this.command === 'repayment') {
+      return 'REPAYMENT_WORKINGCAPITALLOAN';
+    }
     const map: Record<string, string> = {
       repayment: 'REPAYMENT_LOAN',
       goodwillCredit: 'CREATE_GOODWILL_TRANSACTION',

--- a/src/app/loans/loans-view/loan-accounts-button-config.ts
+++ b/src/app/loans/loans-view/loan-accounts-button-config.ts
@@ -26,7 +26,10 @@ export class LoansAccountButtonConfiguration {
     taskPermissionName?: string;
   }[];
 
+  private readonly isWorkingCapital: boolean;
+
   constructor(isWorkingCapital: boolean, status: string, substatus: OptionData) {
+    this.isWorkingCapital = isWorkingCapital;
     if (!isWorkingCapital) {
       this.setOptions(status, substatus);
       this.setButtons(status);
@@ -111,7 +114,7 @@ export class LoansAccountButtonConfiguration {
           {
             name: 'Credit Balance Refund',
             icon: 'coins',
-            taskPermissionName: 'CREATE_CREDIT_BALANCE_REFUND'
+            taskPermissionName: 'CREDITBALANCEREFUND_LOAN'
           },
           {
             name: 'Make Repayment',
@@ -173,7 +176,7 @@ export class LoansAccountButtonConfiguration {
           {
             name: 'Add Loan Charge',
             icon: 'plus',
-            taskPermissionName: 'CREATE_LOANCHARGE'
+            taskPermissionName: 'CREATE_WORKINGCAPITALLOANCHARGE'
           },
           {
             name: 'Disburse',
@@ -192,12 +195,12 @@ export class LoansAccountButtonConfiguration {
           {
             name: 'Add Loan Charge',
             icon: 'plus',
-            taskPermissionName: 'CREATE_LOANCHARGE'
+            taskPermissionName: 'CREATE_WORKINGCAPITALLOANCHARGE'
           },
           {
             name: 'Make Repayment',
             icon: 'coins',
-            taskPermissionName: 'REPAYMENT_LOAN'
+            taskPermissionName: 'REPAYMENT_WORKINGCAPITALLOAN'
           },
           {
             name: 'Payout Refund',
@@ -227,6 +230,21 @@ export class LoansAccountButtonConfiguration {
         break;
       case 'Overpaid':
         this.buttonsArray = [
+          {
+            name: 'Credit Balance Refund',
+            icon: 'coins',
+            taskPermissionName: 'CREDITBALANCEREFUND_WORKINGCAPITALLOAN'
+          },
+          {
+            name: 'Make Repayment',
+            icon: 'coins',
+            taskPermissionName: 'REPAYMENT_WORKINGCAPITALLOAN'
+          },
+          {
+            name: 'Add Loan Charge',
+            icon: 'plus',
+            taskPermissionName: 'CREATE_WORKINGCAPITALLOANCHARGE'
+          },
           {
             name: 'Payout Refund',
             icon: 'coins',
@@ -435,7 +453,7 @@ export class LoansAccountButtonConfiguration {
           {
             name: 'Add Loan Charge',
             icon: 'plus',
-            taskPermissionName: 'CREATE_LOANCHARGE'
+            taskPermissionName: this.isWorkingCapital ? 'CREATE_WORKINGCAPITALLOANCHARGE' : 'CREATE_LOANCHARGE'
           },
           {
             name: 'Approve',

--- a/src/app/loans/loans-view/loans-view.component.ts
+++ b/src/app/loans/loans-view/loans-view.component.ts
@@ -454,8 +454,8 @@ export class LoansViewComponent extends LoanProductBaseComponent implements OnIn
         });
       }
     } else if (
-      (this.loanProductService.isLoanProduct && this.status === 'Closed (obligations met)') ||
-      this.status === 'Overpaid'
+      this.loanProductService.isLoanProduct &&
+      (this.status === 'Closed (obligations met)' || this.status === 'Overpaid')
     ) {
       if (this.loanDetailsData.multiDisburseLoan) {
         this.buttonConfig.addButton({


### PR DESCRIPTION
## Description

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{https://mifosforge.jira.com/browse/WEB-1142}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added working-capital-specific permissions for loan charges, repayments, and credit-balance refunds.
  * Added credit-balance refund, repayment, and loan-charge actions for overpaid working-capital loans.
  * Working-capital refunds now use the appropriate business date and transaction amount defaults.

* **Bug Fixes**
  * Corrected loan action availability based on product type and account status.
  * Ensured working-capital actions use the appropriate permissions and processing flows.
  * Prevented standard loan actions from appearing for incompatible overpaid loan products.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->