### PR TITLE
WEB-1118 [Clients] Allow deselecting optional dropdown fields (Gender, Staff, Client Type/Classification)

### DIFF
--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.html
@@ -200,6 +200,17 @@
             </mat-option>
           }
         </mat-select>
+        @if (createClientForm.value.genderId) {
+          <button
+            matSuffix
+            mat-icon-button
+            type="button"
+            aria-label="{{ 'labels.buttons.Clear' | translate }}"
+            (click)="clearProperty($event, 'genderId')"
+          >
+            <fa-icon icon="close" size="md"></fa-icon>
+          </button>
+        }
       </mat-form-field>
     }
 
@@ -212,6 +223,17 @@
           </mat-option>
         }
       </mat-select>
+      @if (createClientForm.value.staffId) {
+        <button
+          matSuffix
+          mat-icon-button
+          type="button"
+          aria-label="{{ 'labels.buttons.Clear' | translate }}"
+          (click)="clearProperty($event, 'staffId')"
+        >
+          <fa-icon icon="close" size="md"></fa-icon>
+        </button>
+      }
     </mat-form-field>
 
     @if (createClientForm.value.legalFormId === LegalFormId.PERSON) {
@@ -246,6 +268,17 @@
           </mat-option>
         }
       </mat-select>
+      @if (createClientForm.value.clientTypeId) {
+        <button
+          matSuffix
+          mat-icon-button
+          type="button"
+          aria-label="{{ 'labels.buttons.Clear' | translate }}"
+          (click)="clearProperty($event, 'clientTypeId')"
+        >
+          <fa-icon icon="close" size="md"></fa-icon>
+        </button>
+      }
     </mat-form-field>
 
     <mat-form-field class="flex-48">
@@ -257,6 +290,17 @@
           </mat-option>
         }
       </mat-select>
+      @if (createClientForm.value.clientClassificationId) {
+        <button
+          matSuffix
+          mat-icon-button
+          type="button"
+          aria-label="{{ 'labels.buttons.Clear' | translate }}"
+          (click)="clearProperty($event, 'clientClassificationId')"
+        >
+          <fa-icon icon="close" size="md"></fa-icon>
+        </button>
+      }
     </mat-form-field>
 
     <mat-form-field class="flex-48" (click)="submittedOnDatePicker.open()">

--- a/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
+++ b/src/app/clients/client-stepper/client-general-step/client-general-step.component.ts
@@ -31,6 +31,7 @@ import { MatDivider } from '@angular/material/divider';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
+import { MatIconButton } from '@angular/material/button';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
@@ -49,7 +50,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatCheckbox,
     MatStepperPrevious,
     FaIconComponent,
-    MatStepperNext
+    MatStepperNext,
+    MatIconButton
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -250,6 +252,12 @@ export class ClientGeneralStepComponent implements OnInit {
 
   getDateLabel(legalFormId: number, values: string[]): string {
     return legalFormId === LegalFormId.PERSON ? values[0] : values[1];
+  }
+
+  clearProperty($event: Event, propertyName: string): void {
+    this.createClientForm.get(propertyName)?.patchValue('');
+    this.createClientForm.markAsDirty();
+    $event.stopPropagation();
   }
 
   /**


### PR DESCRIPTION
## Description

Gender, Staff, Client Type and Client Classification on the client creation form are optional, but once you picked a value there was no way to clear it back to empty - `mat-select` doesn't have a built-in clear option. Added an × button next to each of these four fields that only shows up once a value is selected, same pattern already used for the delinquency bucket fields in the loan product settings step.

No new dependencies.

## Related issues and discussion

#[WEB-1118](https://mifosforge.jira.com/browse/WEB-1118?atlOrigin=eyJpIjoiZmU0M2E5ZTVmMTRjNDk4OGFlZDRiYmIyMGRkNmFhNmUiLCJwIjoiaiJ9)

## Before
<img width="1245" height="488" alt="image" src="https://github.com/user-attachments/assets/2eb00fb6-70f3-4a44-a673-59500f43fc28" />

## After 
<img width="1247" height="496" alt="image" src="https://github.com/user-attachments/assets/cfe56bee-d00e-44e5-b017-e927a6bff381" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clear buttons to the Gender, Staff, Client Type, and Client Classification fields.
  - Buttons appear only when a value is selected, allowing individual fields to be reset quickly without affecting other selections.

- **Bug Fixes**
  - Clearing a field now correctly updates the form state and marks it as modified.
  - Removed outdated name-validation notes; no name-validation changes are included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[WEB-1118]: https://mifosforge.jira.com/browse/WEB-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ