### PR TITLE
WEB-1128: Fix multirow datatable column alignment

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
@@ -62,6 +62,10 @@
       overflow-wrap: anywhere;
     }
 
+    ::ng-deep .mat-mdc-header-cell.right .mat-sort-header-container {
+      justify-content: flex-end;
+    }
+
     .mobile-cell-label {
       display: none;
     }

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
@@ -8,6 +8,8 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatePipe, DecimalPipe } from '@angular/common';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
@@ -162,6 +164,23 @@ describe('DatatableMultiRowComponent', () => {
     expect(selectionCell.getAttribute('data-label')).toBeNull();
     expect(selectionCell.querySelector('.mobile-cell-label')).toBeNull();
     expect(selectionCell.querySelector('mat-checkbox')).toBeTruthy();
+  });
+
+  it('keeps dynamic sortable headers aligned with their data cells', () => {
+    const headerCells = Array.from(
+      fixture.nativeElement.querySelectorAll('th[mat-header-cell]:not(.checkbox-column)')
+    ) as HTMLElement[];
+    const dataCells = Array.from(fixture.nativeElement.querySelectorAll('td.responsive-data-cell')) as HTMLElement[];
+    const stylesheet = readFileSync(join(__dirname, 'datatable-multi-row.component.scss'), 'utf8');
+
+    expect(headerCells.length).toBe(dataCells.length);
+    expect(stylesheet).toContain('::ng-deep .mat-mdc-header-cell.right .mat-sort-header-container');
+    expect(stylesheet).toContain('justify-content: flex-end;');
+    headerCells.forEach((headerCell, index) => {
+      expect(headerCell.classList).toContain('right');
+      expect(headerCell.querySelector('.mat-sort-header-container')).toBeTruthy();
+      expect(dataCells[index].classList).toContain('right');
+    });
   });
 
   it('preserves the existing displayed columns and desktop table structure', () => {


### PR DESCRIPTION
## Description

Fixes inconsistent column alignment in multi-row Data Tables so headers and row values use consistent alignment.

The change preserves existing table widths, responsive behavior, sorting, pagination, and other Data Table functionality.

## Related issues and discussion

WEB-1128

## Screenshots, if any



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment for right-aligned sortable table headers to match their corresponding data cells.

* **Tests**
  * Added coverage to verify sortable headers have the correct alignment and structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->