### PR TITLE
WEB-1136: Display Yes or No for Address boolean values

### DIFF
--- a/src/app/clients/clients-view/address-tab/address-tab.component.html
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.html
@@ -92,7 +92,9 @@
             <span>{{ 'labels.inputs.Longitude' | translate }} : {{ address.longitude }}<br /></span>
           }
           @if (isFieldEnabled('isActive')) {
-            <span>{{ 'labels.inputs.Active Status' | translate }} : {{ address.isActive }}<br /></span>
+            <span data-testid="client-address-active-status"
+              >{{ 'labels.inputs.Active Status' | translate }} : {{ address.isActive | yesNo }}<br
+            /></span>
           }
         </p>
         @if (

--- a/src/app/clients/clients-view/address-tab/address-tab.component.spec.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.spec.ts
@@ -57,6 +57,7 @@ describe('AddressTabComponent', () => {
   let clientsService: jest.Mocked<ClientsService>;
   let dialog: jest.Mocked<MatDialog>;
   let formGroupService: FormGroupService;
+  let translateService: TranslateService;
 
   const addressTemplate = {
     addressTypeIdOptions: [
@@ -162,9 +163,13 @@ describe('AddressTabComponent', () => {
     fixture = TestBed.createComponent(AddressTabComponent);
     component = fixture.componentInstance;
     formGroupService = TestBed.inject(FormGroupService);
-    const translateService = TestBed.inject(TranslateService);
+    translateService = TestBed.inject(TranslateService);
     translateService.setTranslation('en', {
       labels: {
+        buttons: {
+          Yes: 'Yes',
+          No: 'No'
+        },
         inputs: {
           'Address Line': 'Shared Address Line',
           'Address Line 1': 'Address Line One Label',
@@ -173,6 +178,7 @@ describe('AddressTabComponent', () => {
         }
       }
     });
+    translateService.setDefaultLang('en');
     translateService.use('en');
   });
 
@@ -186,6 +192,14 @@ describe('AddressTabComponent', () => {
     const panel = fixture.debugElement.query(By.directive(MatExpansionPanel)).componentInstance as MatExpansionPanel;
     panel.afterCollapse.emit();
     fixture.detectChanges();
+  }
+
+  function getActiveStatusElement(): HTMLElement {
+    const element = fixture.nativeElement.querySelector('[data-testid="client-address-active-status"]') as HTMLElement;
+
+    expect(element).not.toBeNull();
+
+    return element;
   }
 
   it('should show latitude and longitude fields when enabled', () => {
@@ -443,6 +457,45 @@ describe('AddressTabComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('MG Road');
     expect(fixture.nativeElement.textContent).toContain('Indiranagar');
     expect(fixture.nativeElement.textContent).toContain('Bangalore Urban');
+  });
+
+  it('should display active address status as translated Yes', () => {
+    component.clientAddressData[0].isActive = true;
+
+    fixture.detectChanges();
+
+    const activeStatusElement = getActiveStatusElement();
+    expect(activeStatusElement.textContent).toContain('Yes');
+    expect(activeStatusElement.textContent).not.toContain('true');
+  });
+
+  it('should display inactive address status as translated No', () => {
+    component.clientAddressData[0].isActive = false;
+
+    fixture.detectChanges();
+
+    const activeStatusElement = getActiveStatusElement();
+    expect(activeStatusElement.textContent).toContain('No');
+    expect(activeStatusElement.textContent).not.toContain('false');
+  });
+
+  it('should display address active status using non-English translations', () => {
+    translateService.setTranslation('fr', {
+      labels: {
+        buttons: {
+          Yes: 'Oui',
+          No: 'Non'
+        }
+      }
+    });
+    translateService.use('fr');
+    component.clientAddressData[0].isActive = false;
+
+    fixture.detectChanges();
+
+    const activeStatusElement = getActiveStatusElement();
+    expect(activeStatusElement.textContent).toContain('Non');
+    expect(activeStatusElement.textContent).not.toContain('false');
   });
 
   it('should display saved coordinates and render the map for valid coordinates', () => {

--- a/src/app/clients/clients-view/address-tab/address-tab.component.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.ts
@@ -46,6 +46,7 @@ import {
   normalizeAddressCoordinates
 } from 'app/clients/utils/address-coordinate.util';
 import { environment } from 'environments/environment';
+import { YesnoPipe } from 'app/pipes/yesno.pipe';
 
 /**
  * Clients Address Tab Component
@@ -64,7 +65,8 @@ import { environment } from 'environments/environment';
     MatExpansionPanelDescription,
     MatDivider,
     MatSlideToggle,
-    AddressLocationMapComponent
+    AddressLocationMapComponent,
+    YesnoPipe
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })


### PR DESCRIPTION
## Description

Fixes the remaining Address boolean display for WEB-1136.

Client Address Active Status now displays translated `Yes` and `No` instead of raw `true` and `false`.

The related Data Table boolean behavior for WEB-1137 was already implemented in the earlier change, so this PR completes the remaining Address-specific behavior.

## Related issues and discussion

WEB-1136  
WEB-1137

## Screenshots, if any


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Address active status is now displayed as localized “Yes” or “No” text instead of raw boolean values.
  * Status labels correctly adapt to the selected language, including French translations.
  * Address Line 1, 2, and 3 labels now display their correct translated descriptions independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->