### PR TITLE
WEB-1140: Wrap long Data Table text

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
@@ -36,7 +36,6 @@
     min-width: 100%;
     width: max-content;
     border-radius: 4px;
-    overflow: hidden;
     table-layout: auto;
 
     th {
@@ -50,6 +49,7 @@
       max-width: 24rem;
       white-space: normal;
       overflow-wrap: anywhere;
+      vertical-align: top;
     }
 
     td {
@@ -60,6 +60,7 @@
       max-width: 24rem;
       white-space: normal;
       overflow-wrap: anywhere;
+      vertical-align: top;
     }
 
     ::ng-deep .mat-mdc-header-cell.right .mat-sort-header-container {
@@ -71,7 +72,9 @@
     }
 
     .cell-value {
+      display: block;
       min-width: 0;
+      max-width: 24rem;
       overflow-wrap: anywhere;
       white-space: normal;
     }
@@ -141,7 +144,6 @@
         display: block;
         width: 100%;
         margin-bottom: 16px;
-        overflow: hidden;
         border: 1px solid rgb(0 0 0 / 12%);
         border-radius: 8px;
         background: var(--mat-card-background-color, var(--card-background, #fff));
@@ -185,6 +187,7 @@
 
       .cell-value {
         min-width: 0;
+        max-width: none;
         line-height: 1.45;
       }
     }

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
@@ -217,8 +217,9 @@ describe('DatatableMultiRowComponent', () => {
   });
 
   it('renders long field labels and values in wrapping multi-row cell containers', () => {
-    const longColumnName = 'custom_field_name_with_a_very_long_unbroken_label_for_wrapping';
-    const longValue = 'averylongunbrokenfieldvaluethatshouldwrapandremainfullyvisible';
+    const longColumnName = 'very_long_customer_information_field_name_that_should_wrap_completely';
+    const longValue =
+      'This is a very long customer information value that should wrap across multiple lines instead of being truncated or hidden.';
     setDataObject({
       columnHeaders: [
         { columnName: 'id', columnDisplayType: 'INTEGER' },
@@ -236,17 +237,21 @@ describe('DatatableMultiRowComponent', () => {
       ]
     });
 
-    const expectedLabel = 'Custom field name with a very long unbroken label for wrapping';
+    const expectedLabel = 'Very long customer information field name that should wrap completely';
     const headerCells = Array.from(fixture.nativeElement.querySelectorAll('th[mat-header-cell]')) as HTMLElement[];
     const longValueCell = fixture.nativeElement.querySelector(`td[data-label="${expectedLabel}"]`) as HTMLElement;
     const mobileLabel = longValueCell.querySelector('.mobile-cell-label') as HTMLElement;
     const cellValue = longValueCell.querySelector('.cell-value') as HTMLElement;
+    const stylesheet = readFileSync(join(__dirname, 'datatable-multi-row.component.scss'), 'utf8');
 
     expect(headerCells.some((headerCell) => headerCell.textContent.replace(/\s+/g, ' ').trim() === expectedLabel)).toBe(
       true
     );
     expect(mobileLabel.textContent.trim()).toBe(expectedLabel);
     expect(cellValue.textContent.trim()).toBe(longValue);
+    expect(stylesheet).toContain('display: block;');
+    expect(stylesheet).toContain('max-width: 24rem;');
+    expect(stylesheet).toContain('vertical-align: top;');
   });
 
   it('renders boolean values as translated Yes and No labels', () => {

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.scss
@@ -29,11 +29,13 @@
   padding: 12px 0;
   grid-auto-flow: column;
   grid-auto-columns: minmax(220px, 220px);
+  align-items: stretch;
 }
 
 .data-item {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   padding: 16px;
   background-color: rgb(0 0 0 / 2%);
   border-radius: 8px;
@@ -67,19 +69,20 @@
   min-height: 28px;
   min-width: 0;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   font-weight: 400;
   line-height: 1.5;
 
   span,
   div {
+    min-width: 0;
     width: 100%;
   }
 }
 
 .default-value {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   width: 100%;
   min-width: 0;
   overflow-wrap: anywhere;

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.spec.ts
@@ -8,6 +8,8 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DatePipe, DecimalPipe } from '@angular/common';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
@@ -156,8 +158,9 @@ describe('DatatableSingleRowComponent', () => {
   });
 
   it('renders long field labels and text values in wrapping containers', () => {
-    const longFieldName = 'custom_field_name_with_a_very_long_unbroken_label_for_wrapping';
-    const longValue = 'averylongunbrokenfieldvaluethatshouldwrapandremainfullyvisible';
+    const longFieldName = 'very_long_customer_information_field_name_that_should_wrap_completely';
+    const longValue =
+      'This is a very long customer information value that should wrap across multiple lines instead of being truncated or hidden.';
     setDataObject({
       columnHeaders: [{ columnName: longFieldName, columnDisplayType: 'TEXT' }],
       data: [{ row: [longValue] }]
@@ -167,12 +170,17 @@ describe('DatatableSingleRowComponent', () => {
     const label = dataItem.querySelector('.data-label') as HTMLElement;
     const value = dataItem.querySelector('.data-value') as HTMLElement;
     const longText = dataItem.querySelector('.long-text') as HTMLElement;
+    const stylesheet = readFileSync(join(__dirname, 'datatable-single-row.component.scss'), 'utf8');
 
     expect(label.textContent.replace(/\s+/g, ' ').trim()).toBe(
-      'Custom Field Name With A Very Long Unbroken Label For Wrapping'
+      'Very Long Customer Information Field Name That Should Wrap Completely'
     );
     expect(value.textContent.trim()).toBe(longValue);
     expect(longText.textContent.trim()).toBe(longValue);
+    expect(dataItem.classList).toContain('data-item');
+    expect(stylesheet).toContain('align-items: stretch;');
+    expect(stylesheet).toContain('align-items: flex-start;');
+    expect(stylesheet).toContain('min-width: 0;');
   });
 
   it('translates single-row system timestamp labels', () => {

--- a/src/app/system/manage-data-tables/create-data-table/create-data-table.component.scss
+++ b/src/app/system/manage-data-tables/create-data-table/create-data-table.component.scss
@@ -64,9 +64,8 @@
 th.mat-mdc-header-cell:first-child,
 td.mat-mdc-cell:first-child {
   max-width: 300px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 th.mat-mdc-header-cell:not(.actions-column, :first-child),

--- a/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.scss
+++ b/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.scss
@@ -51,9 +51,8 @@
 th.mat-mdc-header-cell:first-child,
 td.mat-mdc-cell:first-child {
   max-width: 300px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 th.mat-mdc-header-cell:not(.actions-column, :first-child),

--- a/src/app/system/manage-data-tables/view-data-table/view-data-table.component.scss
+++ b/src/app/system/manage-data-tables/view-data-table/view-data-table.component.scss
@@ -10,6 +10,14 @@ table {
   width: 100%;
 }
 
+th.mat-mdc-header-cell:first-child,
+td.mat-mdc-cell:first-child {
+  max-width: 300px;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  vertical-align: top;
+}
+
 .code-name {
   opacity: 0.6;
   font-size: 0.9em;

--- a/src/app/system/manage-data-tables/view-data-table/view-data-table.component.spec.ts
+++ b/src/app/system/manage-data-tables/view-data-table/view-data-table.component.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DatePipe } from '@angular/common';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faCheckCircle, faEdit, faTimesCircle, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { of } from 'rxjs';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+import { SystemService } from 'app/system/system.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { ViewDataTableComponent } from './view-data-table.component';
+
+describe('ViewDataTableComponent', () => {
+  let fixture: ComponentFixture<ViewDataTableComponent>;
+
+  const longFieldName = 'This is a very long customer information field name that should wrap completely';
+  const columnHeaderData = [
+    { columnName: 'id', columnDisplayType: 'INTEGER' },
+    {
+      columnName: longFieldName,
+      columnDisplayType: 'TEXT',
+      columnLength: 500,
+      columnCode: '',
+      isColumnNullable: true,
+      isColumnUnique: false,
+      isColumnIndexed: false
+    }
+  ];
+
+  beforeEach(async () => {
+    const translations: Record<string, string> = {
+      'labels.buttons.Edit': 'Edit',
+      'labels.buttons.Delete': 'Delete',
+      'labels.inputs.Associated With': 'Associated With',
+      'labels.inputs.Field Name': 'Field Name',
+      'labels.inputs.Type': 'Type',
+      'labels.inputs.Length': 'Length',
+      'labels.inputs.Code': 'Code',
+      'labels.text.Mandatory': 'Mandatory',
+      'labels.inputs.Unique': 'Unique',
+      'labels.inputs.Indexed': 'Indexed'
+    };
+    const translateService = {
+      instant: jest.fn((key: string) => translations[key] || key),
+      get: jest.fn((key: string) => of(translations[key] || key)),
+      onLangChange: of({ lang: 'en' }),
+      onTranslationChange: of({}),
+      onDefaultLangChange: of({ lang: 'en' })
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ViewDataTableComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({
+              dataTable: {
+                applicationTableName: 'm_client',
+                registeredTableName: 'client_information',
+                columnHeaderData: columnHeaderData.map((column) => ({ ...column }))
+              }
+            })
+          }
+        },
+        { provide: MatDialog, useValue: { open: jest.fn() } },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+        {
+          provide: AuthenticationService,
+          useValue: { getCredentials: jest.fn(() => ({ permissions: ['ALL_FUNCTIONS'] })) }
+        },
+        { provide: SystemService, useValue: { deleteDataTable: jest.fn(() => of({})) } },
+        DatePipe,
+        {
+          provide: SettingsService,
+          useValue: {
+            language: { code: 'en' },
+            dateFormat: 'dd MMMM yyyy',
+            datetimeFormat: 'dd MMMM yyyy HH:mm'
+          }
+        },
+        { provide: TranslateService, useValue: translateService }
+      ]
+    }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIcons(faCheckCircle, faEdit, faTimesCircle, faTrash);
+
+    fixture = TestBed.createComponent(ViewDataTableComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders long Field Name values in wrapping table cells', () => {
+    const fieldNameCell = fixture.nativeElement.querySelector('td.mat-column-columnName') as HTMLElement;
+    const stylesheet = readFileSync(join(__dirname, 'view-data-table.component.scss'), 'utf8');
+
+    expect(fieldNameCell.textContent.replace(/\s+/g, ' ').trim()).toBe(longFieldName);
+    expect(stylesheet).toContain('td.mat-mdc-cell:first-child');
+    expect(stylesheet).toContain('overflow-wrap: anywhere;');
+    expect(stylesheet).toContain('white-space: normal;');
+    expect(stylesheet).not.toContain('text-overflow: ellipsis;');
+    expect(stylesheet).not.toContain('white-space: nowrap;');
+    expect(stylesheet).not.toContain('overflow: hidden;');
+  });
+});


### PR DESCRIPTION
## Description

Fixes WEB-1140 by ensuring long Data Table field names and values wrap correctly instead of being clipped or truncated.

The update covers Data Table record views as well as the Manage Data Tables create, edit, and details screens, allowing long text to remain fully visible while preserving existing responsive and table behavior.

## Related issues and discussion

WEB-1140

## Screenshots, if any

<img width="1377" height="646" alt="Screenshot 2026-08-19 at 11 01 47 PM" src="https://github.com/user-attachments/assets/35108bad-7d01-4543-a601-6e856fc694c4" />

<img width="1371" height="687" alt="Screenshot 2026-08-19 at 11 12 48 PM" src="https://github.com/user-attachments/assets/6a0a8960-f075-4975-a957-e3b950b73752" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table layouts so long field names and values wrap across multiple lines instead of being clipped or replaced with ellipses.
  * Updated cell alignment and sizing to keep content readable, especially on mobile devices.
  * Preserved full visibility of long labels in data table views.

* **Tests**
  * Added and updated coverage verifying long-content wrapping, alignment, sizing, and visibility across data table screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->