### PR TITLE
WEB-1158: WC - created and submitted date of all features supported in WCP should follow business date or system date based on configuration

### DIFF
--- a/src/app/loans/custom-dialog/loan-delinquency-action-dialog/loan-delinquency-action-dialog.component.ts
+++ b/src/app/loans/custom-dialog/loan-delinquency-action-dialog/loan-delinquency-action-dialog.component.ts
@@ -18,6 +18,7 @@ import {
 } from '@angular/material/dialog';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { SettingsService } from 'app/settings/settings.service';
 
 @Component({
   selector: 'mifosx-loan-delinquency-action-dialog',
@@ -37,6 +38,7 @@ export class LoanDelinquencyActionDialogComponent {
   dialogRef = inject<MatDialogRef<LoanDelinquencyActionDialogComponent>>(MatDialogRef);
   data = inject(MAT_DIALOG_DATA);
   private formBuilder = inject(UntypedFormBuilder);
+  private settingsService = inject(SettingsService);
 
   delinquencyActionForm: UntypedFormGroup;
   /** Minimum date allowed. */
@@ -51,7 +53,7 @@ export class LoanDelinquencyActionDialogComponent {
   createDelinquencyActionForm() {
     this.delinquencyActionForm = this.formBuilder.group({
       startDate: [
-        new Date(),
+        new Date(this.settingsService.businessDate),
         Validators.required
       ],
       endDate: [

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.html
@@ -383,9 +383,9 @@
               {{ item.frequency | formatNumber: '' : 0 }} {{ item.frequencyType | translateKey: 'catalogs' }}
             </td>
           </ng-container>
-          <ng-container matColumnDef="createdDate">
-            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Created On' | translate }}</th>
-            <td mat-cell *matCellDef="let item">{{ item.createdDate | datetimeFormat }}</td>
+          <ng-container matColumnDef="submittedOnDate">
+            <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Submitted On' | translate }}</th>
+            <td mat-cell *matCellDef="let item">{{ item.submittedOnDate | dateFormat }}</td>
           </ng-container>
           <tr mat-header-row *matHeaderRowDef="nearBreachActionsColumns"></tr>
           <tr mat-row *matRowDef="let row; columns: nearBreachActionsColumns"></tr>

--- a/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-breach-actions-tab/loan-breach-actions-tab.component.ts
@@ -155,7 +155,7 @@ export class LoanBreachActionsTabComponent extends LoanProductBaseComponent impl
     'action',
     'threshold',
     'frequency',
-    'createdDate'
+    'submittedOnDate'
   ];
 
   rows = computed<BreachActionRow[]>(() => {

--- a/src/app/loans/loans-view/working-capital/loan-period-payment-rates/loan-period-payment-rates.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-period-payment-rates/loan-period-payment-rates.component.html
@@ -49,10 +49,10 @@
         {{ item.newRate | formatNumber }} %
       </td>
     </ng-container>
-    <ng-container matColumnDef="createdDate">
-      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Created On' | translate }}</th>
+    <ng-container matColumnDef="submittedOnDate">
+      <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Submitted On' | translate }}</th>
       <td mat-cell *matCellDef="let item" [ngClass]="periodPaymentRateStyle(item.reversed)">
-        {{ item.createdDate | dateFormat }}
+        {{ item.submittedOnDate | dateFormat }}
       </td>
     </ng-container>
     <tr mat-header-row *matHeaderRowDef="loanPaymentRatesColumns"></tr>

--- a/src/app/loans/loans-view/working-capital/loan-period-payment-rates/loan-period-payment-rates.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-period-payment-rates/loan-period-payment-rates.component.ts
@@ -75,7 +75,7 @@ export class LoanPeriodPaymentRatesComponent implements OnInit {
     'effectiveDate',
     'previousRate',
     'newRate',
-    'createdDate'
+    'submittedOnDate'
   ];
 
   constructor() {}

--- a/src/app/loans/models/working-capital-loan-account.model.ts
+++ b/src/app/loans/models/working-capital-loan-account.model.ts
@@ -13,7 +13,7 @@ export interface PeriodPaymentRateChange {
   previousRate: number;
   newRate: number;
   reversed: boolean;
-  createdDate: number[];
+  submittedOnDate: number[];
 }
 
 export interface BreachSchedule {

--- a/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
+++ b/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
@@ -176,7 +176,7 @@ export interface WorkingCapitalNearBreachActions {
   threshold: number;
   frequency: number;
   frequencyType: string;
-  createdDate: Date;
+  submittedOnDate: number[];
 }
 
 export interface WorkingCapitalWriteOffRequest {


### PR DESCRIPTION
## Description

Describe the changes made and why they were made instead of how they were made. List any dependencies that are required for this change.

## Related issues and discussion

#{https://mifosforge.jira.com/browse/WEB-1158}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delinquency action forms now default the start date to the configured business date.
  * Working capital action and payment-rate tables now display a clearly labeled submission date instead of the creation date.

* **Bug Fixes**
  * Corrected submission-date formatting and data representation for working capital records, improving consistency across displayed dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->