### PR TITLE
WEB-1139: Allow editing multi-row Data Table records

### DIFF
--- a/src/app/shared/form-dialog/form-dialog.component.html
+++ b/src/app/shared/form-dialog/form-dialog.component.html
@@ -29,13 +29,13 @@
 </div>
 
 <mat-dialog-actions class="layout-row layout-xs-column layout-align-center gap-2percent" align="end">
-  <button mat-raised-button mat-dialog-close>{{ 'labels.buttons.' + layout.cancelButtonText | translate }}</button>
+  <button mat-raised-button mat-dialog-close>{{ getButtonTranslationKey(layout.cancelButtonText) | translate }}</button>
   <button
     mat-raised-button
     color="primary"
     [mat-dialog-close]="{ data: form }"
     [disabled]="!form.valid || form.pristine"
   >
-    {{ 'labels.buttons.' + layout.addButtonText | translate }}
+    {{ getButtonTranslationKey(layout.addButtonText) | translate }}
   </button>
 </mat-dialog-actions>

--- a/src/app/shared/form-dialog/form-dialog.component.ts
+++ b/src/app/shared/form-dialog/form-dialog.component.ts
@@ -88,4 +88,8 @@ export class FormDialogComponent implements OnInit {
       this.form.markAsDirty();
     }
   }
+
+  getButtonTranslationKey(buttonText: string = ''): string {
+    return buttonText?.startsWith('labels.') ? buttonText : `labels.buttons.${buttonText}`;
+  }
 }

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.html
@@ -62,7 +62,25 @@
                   </mat-checkbox>
                 </td>
               }
-              @if (i > 0) {
+              @if (datatableColumn === ACTIONS_NAME_FIELD) {
+                <th mat-header-cell *matHeaderCellDef class="actions-column"></th>
+                <td mat-cell *matCellDef="let data" class="actions-cell">
+                  <span *mifosxHasPermission="'UPDATE_' + datatableName">
+                    <span class="mobile-cell-label">{{ 'labels.buttons.Edit' | translate }}</span>
+                    <button
+                      mat-icon-button
+                      color="primary"
+                      type="button"
+                      [attr.aria-label]="'labels.buttons.Edit' | translate"
+                      [matTooltip]="'labels.buttons.Edit' | translate"
+                      (click)="edit(data); $event.stopPropagation()"
+                    >
+                      <fa-icon icon="edit"></fa-icon>
+                    </button>
+                  </span>
+                </td>
+              }
+              @if (i > 0 && datatableColumn !== ACTIONS_NAME_FIELD) {
                 <th mat-header-cell class="right" *matHeaderCellDef mat-sort-header>
                   {{ getInputName(datatableColumn) }}
                 </th>

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
@@ -100,6 +100,18 @@
       min-width: 60px;
       max-width: 60px;
     }
+
+    .actions-column,
+    .mat-column-actions {
+      width: 72px;
+      min-width: 72px;
+      max-width: 72px;
+      text-align: center;
+    }
+
+    .actions-cell {
+      text-align: center;
+    }
   }
 }
 
@@ -168,6 +180,18 @@
         background-color: rgb(0 0 0 / 3%);
       }
 
+      .actions-cell,
+      .mat-column-actions {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        max-width: none;
+        min-width: 0;
+        padding: 8px 16px;
+        background-color: rgb(0 0 0 / 3%);
+      }
+
       .responsive-data-cell {
         display: grid;
         grid-template-columns: minmax(7rem, 38%) minmax(0, 1fr); /* stylelint-disable-line unit-allowed-list */
@@ -204,7 +228,9 @@
         }
 
         .selection-cell,
-        .mat-column-select {
+        .mat-column-select,
+        .actions-cell,
+        .mat-column-actions {
           background-color: rgb(255 255 255 / 8%);
         }
 

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
@@ -16,8 +16,8 @@ import { ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
-import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { of } from 'rxjs';
+import { faEdit, faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { of, throwError } from 'rxjs';
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
@@ -32,6 +32,13 @@ describe('DatatableMultiRowComponent', () => {
   let fixture: ComponentFixture<DatatableMultiRowComponent>;
   let component: DatatableMultiRowComponent;
   let matDialog: { open: jest.Mock };
+  let systemService: {
+    getEntityDatatable: jest.Mock;
+    addEntityDatatableEntry: jest.Mock;
+    editEntityDatatableEntryOneToMany: jest.Mock;
+    deleteDatatableContent: jest.Mock;
+    deleteDatatableEntry: jest.Mock;
+  };
 
   const row = (id: number, firstName: string, lastName: string, amount: number | null = id) => ({
     row: [
@@ -42,6 +49,8 @@ describe('DatatableMultiRowComponent', () => {
       amount,
       true,
       false,
+      '2025-01-15',
+      12,
       null
     ]
   });
@@ -55,6 +64,15 @@ describe('DatatableMultiRowComponent', () => {
       { columnName: 'amount', columnDisplayType: 'DECIMAL' },
       { columnName: 'is_active', columnDisplayType: 'BOOLEAN' },
       { columnName: 'is_verified', columnDisplayType: 'BOOLEAN' },
+      { columnName: 'date_of_birth', columnDisplayType: 'DATE' },
+      {
+        columnName: 'Relationship_cd_Relationship Type',
+        columnDisplayType: 'CODELOOKUP',
+        columnValues: [
+          { id: 11, value: 'Parent' },
+          { id: 12, value: 'Sibling' }
+        ]
+      },
       { columnName: 'empty_value', columnDisplayType: 'STRING' }
     ],
     data
@@ -76,8 +94,11 @@ describe('DatatableMultiRowComponent', () => {
   };
 
   beforeEach(async () => {
+    localStorage.setItem('mifosXLanguage', JSON.stringify({ code: 'en' }));
     const translations: Record<string, string> = {
       'labels.buttons.Add': 'Agregar',
+      'labels.buttons.Edit': 'Editar',
+      'labels.buttons.Save': 'Guardar',
       'labels.text.Client': 'Cliente',
       'labels.text.for': 'para',
       'labels.buttons.Yes': 'Sí',
@@ -92,6 +113,13 @@ describe('DatatableMultiRowComponent', () => {
     };
 
     matDialog = { open: jest.fn(() => ({ afterClosed: () => of({}) })) };
+    systemService = {
+      getEntityDatatable: jest.fn(() => of(createDataObject())),
+      addEntityDatatableEntry: jest.fn(() => of({})),
+      editEntityDatatableEntryOneToMany: jest.fn(() => of({})),
+      deleteDatatableContent: jest.fn(() => of({})),
+      deleteDatatableEntry: jest.fn(() => of({}))
+    };
 
     await TestBed.configureTestingModule({
       imports: [
@@ -115,7 +143,7 @@ describe('DatatableMultiRowComponent', () => {
         DecimalPipe,
         DateFormatPipe,
         DatetimeFormatPipe,
-        { provide: SystemService, useValue: { getEntityDatatable: jest.fn() } },
+        { provide: SystemService, useValue: systemService },
         {
           provide: SettingsService,
           useValue: {
@@ -128,7 +156,7 @@ describe('DatatableMultiRowComponent', () => {
       ]
     }).compileComponents();
 
-    TestBed.inject(FaIconLibrary).addIcons(faPlus, faTrash);
+    TestBed.inject(FaIconLibrary).addIcons(faEdit, faPlus, faTrash);
 
     fixture = TestBed.createComponent(DatatableMultiRowComponent);
     component = fixture.componentInstance;
@@ -152,6 +180,8 @@ describe('DatatableMultiRowComponent', () => {
       'Amount',
       'Is active',
       'Is verified',
+      'Date of birth',
+      'Relationship',
       'Empty value'
     ]);
     expect(mobileLabels).toEqual(labels);
@@ -168,7 +198,7 @@ describe('DatatableMultiRowComponent', () => {
 
   it('keeps dynamic sortable headers aligned with their data cells', () => {
     const headerCells = Array.from(
-      fixture.nativeElement.querySelectorAll('th[mat-header-cell]:not(.checkbox-column)')
+      fixture.nativeElement.querySelectorAll('th[mat-header-cell]:not(.checkbox-column):not(.actions-column)')
     ) as HTMLElement[];
     const dataCells = Array.from(fixture.nativeElement.querySelectorAll('td.responsive-data-cell')) as HTMLElement[];
     const stylesheet = readFileSync(join(__dirname, 'datatable-multi-row.component.scss'), 'utf8');
@@ -195,12 +225,15 @@ describe('DatatableMultiRowComponent', () => {
     expect(tableScrollWrapper.contains(paginator)).toBe(false);
     expect(component.datatableColumns).toEqual([
       'select',
+      'actions',
       'id',
       'first_name',
       'last_name',
       'amount',
       'is_active',
       'is_verified',
+      'date_of_birth',
+      'Relationship_cd_Relationship Type',
       'empty_value'
     ]);
     expect(component.datatableColumns).not.toContain('client_id');
@@ -271,6 +304,150 @@ describe('DatatableMultiRowComponent', () => {
 
     expect(paginator).toBeTruthy();
     expect(component.datatableData.paginator).toBe(component.paginator);
+  });
+
+  it('shows an edit action for each existing multi-row record', () => {
+    setDataObject(
+      createDataObject([
+        row(7, 'Ada', 'Lovelace'),
+        row(8, 'Grace', 'Hopper')
+      ])
+    );
+
+    const editButtons = fixture.nativeElement.querySelectorAll('td.actions-cell button[mat-icon-button]');
+
+    expect(component.datatableColumns).toContain('actions');
+    expect(editButtons.length).toBe(2);
+    expect(editButtons[0].getAttribute('aria-label')).toBe('Editar');
+  });
+
+  it('opens the selected multi-row record for editing with existing values prefilled', () => {
+    const selectedRow = {
+      row: [
+        7,
+        99,
+        'Ada',
+        'Lovelace',
+        0,
+        true,
+        false,
+        '2025-01-15',
+        12,
+        null
+      ]
+    };
+    setDataObject(createDataObject([selectedRow]));
+
+    component.edit(selectedRow);
+
+    const dialogData = (matDialog.open.mock.calls[0][1] as any).data;
+    const formfieldValues = Object.fromEntries(
+      dialogData.formfields.map((formfield: any) => [
+        formfield.controlName,
+        formfield.value
+      ])
+    );
+
+    expect(dialogData.title).toBe('Editar Client extra data para Cliente');
+    expect(dialogData.layout.addButtonText).toBe('labels.buttons.Save');
+    expect(formfieldValues.first_name).toBe('Ada');
+    expect(formfieldValues.is_active).toBe(true);
+    expect(formfieldValues.is_verified).toBe(false);
+    expect(formfieldValues.amount).toBe(0);
+    expect(formfieldValues.date_of_birth).toEqual(new Date(2025, 0, 15));
+    expect(formfieldValues['Relationship_cd_Relationship Type']).toBe(12);
+    expect(formfieldValues.empty_value).toBeNull();
+  });
+
+  it('updates the selected multi-row record without creating a duplicate row', () => {
+    const selectedRow = row(7, 'Ada', 'Lovelace', 0);
+    const updatedDataObject = createDataObject([row(7, 'Ada Jane', 'Lovelace', 0)]);
+    const afterClosed = jest.fn(() =>
+      of({
+        data: {
+          value: {
+            first_name: 'Ada Jane',
+            last_name: 'Lovelace',
+            amount: 0,
+            is_active: true,
+            is_verified: false,
+            date_of_birth: new Date(2025, 0, 16),
+            'Relationship_cd_Relationship Type': 11,
+            empty_value: ''
+          }
+        }
+      })
+    );
+    matDialog.open.mockReturnValueOnce({
+      afterClosed
+    });
+    const formatDateSpy = jest.spyOn((component as any).dateUtils, 'formatDate').mockReturnValue('2025-01-16');
+    systemService.getEntityDatatable.mockReturnValueOnce(of(updatedDataObject));
+
+    expect(matDialog.open).not.toHaveBeenCalled();
+    component.edit(selectedRow);
+
+    expect(matDialog.open).toHaveBeenCalled();
+    expect(afterClosed).toHaveBeenCalled();
+    expect(formatDateSpy).toHaveBeenCalledWith(new Date(2025, 0, 16), 'yyyy-MM-dd');
+    expect(systemService.editEntityDatatableEntryOneToMany).toHaveBeenCalledWith('99', 7, 'client_extra_data', {
+      first_name: 'Ada Jane',
+      last_name: 'Lovelace',
+      amount: 0,
+      is_active: true,
+      is_verified: false,
+      date_of_birth: '2025-01-16',
+      'Relationship_cd_Relationship Type': 11,
+      empty_value: '',
+      locale: 'en',
+      dateFormat: 'yyyy-MM-dd'
+    });
+    expect(systemService.addEntityDatatableEntry).not.toHaveBeenCalled();
+    expect(systemService.getEntityDatatable).toHaveBeenCalledWith('99', 'client_extra_data');
+    expect(component.datatableData.data).toEqual(updatedDataObject.data);
+    expect(component.datatableData.data).toHaveLength(1);
+  });
+
+  it('does not update when editing is cancelled', () => {
+    matDialog.open.mockReturnValueOnce({ afterClosed: () => of({}) });
+
+    component.edit(row(7, 'Ada', 'Lovelace'));
+
+    expect(systemService.editEntityDatatableEntryOneToMany).not.toHaveBeenCalled();
+    expect(systemService.addEntityDatatableEntry).not.toHaveBeenCalled();
+  });
+
+  it('restores loading state and preserves existing rows when update fails', () => {
+    const selectedRow = row(7, 'Ada', 'Lovelace');
+    const originalRows = component.datatableData.data;
+    matDialog.open.mockReturnValueOnce({
+      afterClosed: () =>
+        of({
+          data: {
+            value: {
+              first_name: 'Ada Jane'
+            }
+          }
+        })
+    });
+    systemService.editEntityDatatableEntryOneToMany.mockReturnValueOnce(throwError(() => new Error('Update failed')));
+
+    expect(() => component.edit(selectedRow)).not.toThrow();
+    expect(systemService.editEntityDatatableEntryOneToMany).toHaveBeenCalled();
+    expect(systemService.getEntityDatatable).not.toHaveBeenCalled();
+    expect(component.isLoading).toBe(false);
+    expect(component.datatableData.data).toBe(originalRows);
+  });
+
+  it('restores loading state and preserves existing rows when reload fails', () => {
+    const originalRows = component.datatableData.data;
+    systemService.getEntityDatatable.mockReturnValueOnce(throwError(() => new Error('Reload failed')));
+
+    component.getData();
+
+    expect(systemService.getEntityDatatable).toHaveBeenCalledWith('99', 'client_extra_data');
+    expect(component.isLoading).toBe(false);
+    expect(component.datatableData.data).toBe(originalRows);
   });
 
   it('displays the correct rows when changing pages', () => {

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
@@ -22,9 +22,11 @@ import {
   inject
 } from '@angular/core';
 import { MatCheckboxChange as MatCheckboxChange, MatCheckbox } from '@angular/material/checkbox';
+import { MatIconButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort, MatSortHeader } from '@angular/material/sort';
+import { MatTooltip } from '@angular/material/tooltip';
 import { formatDatatableDisplayLabel } from '@pipes/datatable-display-label.pipe';
 import {
   MatTable,
@@ -73,9 +75,11 @@ import { PageLoaderComponent } from 'app/shared/page-loader/page-loader.componen
     MatCellDef,
     MatCell,
     MatCheckbox,
+    MatIconButton,
     MatPaginator,
     MatSort,
     MatSortHeader,
+    MatTooltip,
     NgClass,
     MatHeaderRowDef,
     MatHeaderRow,
@@ -101,6 +105,7 @@ export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDest
   private translateService = inject(TranslateService);
 
   SELECT_NAME_FIELD = 'select';
+  ACTIONS_NAME_FIELD = 'actions';
   /** Data Object */
   @Input() dataObject: any;
   @Input() entityId: string;
@@ -162,7 +167,10 @@ export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDest
     if (!this.dataObject) {
       return;
     }
-    this.datatableColumns = [this.SELECT_NAME_FIELD];
+    this.datatableColumns = [
+      this.SELECT_NAME_FIELD,
+      this.ACTIONS_NAME_FIELD
+    ];
     this.dataObject.columnHeaders.filter((columnHeader: any) => {
       if (!this.datatables.isEntityId(columnHeader.columnName)) {
         this.datatableColumns.push(columnHeader.columnName);
@@ -186,16 +194,29 @@ export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDest
   }
 
   getData() {
+    const pageIndex = this.paginator?.pageIndex;
+    const pageSize = this.paginator?.pageSize;
     this.isLoading = true;
-    this.systemService.getEntityDatatable(this.entityId, this.datatableName).subscribe((dataObject: any) => {
-      this.dataObject.data = dataObject.data;
-      this.showDeleteBotton = false;
-      if (this.dataTableRef) {
-        this.setData();
+    this.systemService.getEntityDatatable(this.entityId, this.datatableName).subscribe({
+      next: (dataObject: any) => {
+        this.dataObject.data = dataObject.data;
+        this.showDeleteBotton = false;
+        if (this.dataTableRef) {
+          this.setData();
+        }
+        if (this.paginator && pageIndex !== undefined && pageSize !== undefined) {
+          this.paginator.pageSize = pageSize;
+          const lastPageIndex = Math.max(Math.ceil(this.datatableData.data.length / pageSize) - 1, 0);
+          this.paginator.pageIndex = Math.min(pageIndex, lastPageIndex);
+        }
+        this.isSelected = false;
+        this.isLoading = false;
+        this.changeDetectorRef.markForCheck();
+      },
+      error: () => {
+        this.isLoading = false;
+        this.changeDetectorRef.markForCheck();
       }
-      this.isSelected = false;
-      this.isLoading = false;
-      this.changeDetectorRef.markForCheck();
     });
   }
 
@@ -238,6 +259,74 @@ export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDest
 
   getAddDialogTitle(): string {
     return `${this.translateService.instant('labels.buttons.Add')} ${formatDatatableDisplayLabel(
+      this.datatableName
+    )} ${this.translateService.instant('labels.text.for')} ${this.getTranslatedEntityType()}`;
+  }
+
+  /**
+   * Updates the selected row in the given multi row data table.
+   */
+  edit(row: any) {
+    let dataTableEntryObject: any = { locale: this.settingsService.language.code };
+    const dateTransformColumns: string[] = [];
+    const columns = this.datatables.filterSystemColumns(this.dataObject.columnHeaders);
+    const formfields: FormfieldBase[] = this.datatables
+      .getFormfields(columns, dateTransformColumns, dataTableEntryObject)
+      .map((formfield: FormfieldBase, index: number) => {
+        const column = columns[index];
+        const value = row.row[column.idx];
+        if (value === null || value === undefined) {
+          formfield.value = value;
+        } else if (formfield.controlType === 'datepicker') {
+          formfield.value = this.dateUtils.parseDate(value);
+        } else if (formfield.controlType === 'datetimepicker') {
+          formfield.value = this.dateUtils.parseDatetime(value);
+        } else {
+          formfield.value = value;
+        }
+        return formfield;
+      });
+    const data = {
+      title: this.getEditDialogTitle(),
+      formfields: formfields,
+      layout: { addButtonText: 'labels.buttons.Save' },
+      pristine: false
+    };
+    const editDialogRef = this.dialog.open(FormDialogComponent, { data, width: '50rem' });
+    editDialogRef.afterClosed().subscribe((response: any) => {
+      if (response?.data) {
+        dateTransformColumns.forEach((column) => {
+          if (
+            response.data.value[column] !== null &&
+            response.data.value[column] !== undefined &&
+            response.data.value[column] !== ''
+          ) {
+            response.data.value[column] = this.dateUtils.formatDate(
+              response.data.value[column],
+              dataTableEntryObject.dateFormat
+            );
+          }
+        });
+        dataTableEntryObject = { ...response.data.value, ...dataTableEntryObject };
+        this.isLoading = true;
+        this.changeDetectorRef.markForCheck();
+        this.systemService
+          .editEntityDatatableEntryOneToMany(this.entityId, row.row[0], this.datatableName, dataTableEntryObject)
+          .subscribe({
+            next: () => {
+              this.getData();
+            },
+            error: () => {
+              this.isLoading = false;
+              this.changeDetectorRef.markForCheck();
+            }
+          });
+      }
+    });
+  }
+
+  getEditDialogTitle(): string {
+    return `${this.translateService.instant('labels.buttons.Edit')} ${formatDatatableDisplayLabel(
       this.datatableName
     )} ${this.translateService.instant('labels.text.for')} ${this.getTranslatedEntityType()}`;
   }
@@ -339,7 +428,11 @@ export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDest
   }
 
   getSortValue(data: any, columnName: string): string | number {
-    if (columnName === this.SELECT_NAME_FIELD || !this.dataObject?.columnHeaders) {
+    if (
+      columnName === this.SELECT_NAME_FIELD ||
+      columnName === this.ACTIONS_NAME_FIELD ||
+      !this.dataObject?.columnHeaders
+    ) {
       return '';
     }
     const columnIndex = this.dataObject.columnHeaders.findIndex(

--- a/src/app/system/system.service.spec.ts
+++ b/src/app/system/system.service.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+
+import { SystemService } from './system.service';
+
+describe('SystemService datatable entries', () => {
+  let service: SystemService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SystemService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    service = TestBed.inject(SystemService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('updates a one-to-many datatable row with the selected row id', async () => {
+    const payload = {
+      first_name: 'Ada Jane',
+      active: false,
+      percentage: 0,
+      locale: 'en',
+      dateFormat: 'yyyy-MM-dd'
+    };
+    const resultPromise = firstValueFrom(
+      service.editEntityDatatableEntryOneToMany('99', '7', 'client_extra_data', payload)
+    );
+
+    const req = httpMock.expectOne(
+      (request) => request.url === '/datatables/client_extra_data/99/7' && request.method === 'PUT'
+    );
+    expect(req.request.params.get('genericResultSet')).toBe('true');
+    expect(req.request.body).toEqual(payload);
+    req.flush({ resourceId: 7 });
+
+    await expect(resultPromise).resolves.toEqual({ resourceId: 7 });
+  });
+});

--- a/src/app/system/system.service.ts
+++ b/src/app/system/system.service.ts
@@ -745,6 +745,11 @@ export class SystemService {
     return this.http.put(`/datatables/${datatableName}/${entityId}`, data, { params: httpParams });
   }
 
+  editEntityDatatableEntryOneToMany(entityId: string, rowId: string, datatableName: string, data: any) {
+    const httpParams = new HttpParams().set('genericResultSet', 'true');
+    return this.http.put(`/datatables/${datatableName}/${entityId}/${rowId}`, data, { params: httpParams });
+  }
+
   deleteDatatableContent(entityId: string, datatableName: string) {
     const httpParams = new HttpParams().set('genericResultSet', 'true');
     return this.http.delete(`/datatables/${datatableName}/${entityId}`, { params: httpParams });


### PR DESCRIPTION
## Description

Adds support for editing existing records in multi-row Data Tables.

Users can now edit a selected row using a prefilled form, update its values through the existing Data Table API, and refresh the table without creating duplicate records.

The change preserves existing add, delete, sorting, pagination, permissions, translations, and responsive behavior.

## Related issues and discussion

WEB-1139

## Screenshots, if any



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added edit actions to datatable rows for users with update permission.
  * Added edit dialogs with prefilled values, including date fields.
  * Added save handling with table refresh while preserving pagination.
  * Added recovery handling when updates or data reloads fail.

* **Bug Fixes**
  * Prevented action controls from triggering row selection.
  * Excluded action columns from sorting and standard field rendering.
  * Improved cancel and add button translation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->