### PR TITLE
WEB-1151: Fix Data Table lint errors

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
@@ -51,10 +51,9 @@ describe('DatatableMultiRowComponent', () => {
       false,
       null,
       `2025-01-${String(id).padStart(2, '0')}T12:30:00`,
-      `2025-02-${String(id).padStart(2, '0')}T13:45:00`
+      `2025-02-${String(id).padStart(2, '0')}T13:45:00`,
       '2025-01-15',
-      12,
-      null
+      12
     ]
   });
 
@@ -69,7 +68,7 @@ describe('DatatableMultiRowComponent', () => {
       { columnName: 'is_verified', columnDisplayType: 'BOOLEAN' },
       { columnName: 'empty_value', columnDisplayType: 'STRING' },
       { columnName: 'created_at', columnDisplayType: 'DATETIME' },
-      { columnName: 'updated_at', columnDisplayType: 'DATETIME' }
+      { columnName: 'updated_at', columnDisplayType: 'DATETIME' },
       { columnName: 'date_of_birth', columnDisplayType: 'DATE' },
       {
         columnName: 'Relationship_cd_Relationship Type',
@@ -78,8 +77,7 @@ describe('DatatableMultiRowComponent', () => {
           { id: 11, value: 'Parent' },
           { id: 12, value: 'Sibling' }
         ]
-      },
-      { columnName: 'empty_value', columnDisplayType: 'STRING' }
+      }
     ],
     data
   });
@@ -190,10 +188,9 @@ describe('DatatableMultiRowComponent', () => {
       'Is verified',
       'Empty value',
       'Creado en',
-      'Actualizado en'
+      'Actualizado en',
       'Date of birth',
-      'Relationship',
-      'Empty value'
+      'Relationship'
     ]);
     expect(mobileLabels).toEqual(labels);
   });
@@ -245,10 +242,9 @@ describe('DatatableMultiRowComponent', () => {
       'is_verified',
       'empty_value',
       'created_at',
-      'updated_at'
+      'updated_at',
       'date_of_birth',
-      'Relationship_cd_Relationship Type',
-      'empty_value'
+      'Relationship_cd_Relationship Type'
     ]);
     expect(component.datatableColumns).not.toContain('client_id');
     expect(headerCells.length).toBe(component.datatableColumns.length);
@@ -371,9 +367,11 @@ describe('DatatableMultiRowComponent', () => {
         0,
         true,
         false,
+        null,
+        '2025-01-07T12:30:00',
+        '2025-02-07T13:45:00',
         '2025-01-15',
-        12,
-        null
+        12
       ]
     };
     setDataObject(createDataObject([selectedRow]));


### PR DESCRIPTION
## Description

Fixes the lint/build errors introduced after the WEB-1151 merge.

The change corrects the multi-row Data Table test syntax and aligns the test fixtures with the `created_at` and `updated_at` timestamp columns while preserving the existing WEB-1151 and WEB-1139 behavior.

## Related issues and discussion

WEB-1151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated tests to reflect the current ordering of table values and dynamic columns.
  * Improved validation of responsive column labels and displayed data.
  * Aligned edit-dialog test scenarios with the latest table presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->