### PR TITLE
WEB-1151: Fix lint issue introduced by PR 3879

### DIFF
--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
@@ -49,9 +49,8 @@ describe('DatatableMultiRowComponent', () => {
       amount,
       true,
       false,
-      null,
       `2025-01-${String(id).padStart(2, '0')}T12:30:00`,
-      `2025-02-${String(id).padStart(2, '0')}T13:45:00`
+      `2025-02-${String(id).padStart(2, '0')}T13:45:00`,
       '2025-01-15',
       12,
       null
@@ -67,9 +66,8 @@ describe('DatatableMultiRowComponent', () => {
       { columnName: 'amount', columnDisplayType: 'DECIMAL' },
       { columnName: 'is_active', columnDisplayType: 'BOOLEAN' },
       { columnName: 'is_verified', columnDisplayType: 'BOOLEAN' },
-      { columnName: 'empty_value', columnDisplayType: 'STRING' },
       { columnName: 'created_at', columnDisplayType: 'DATETIME' },
-      { columnName: 'updated_at', columnDisplayType: 'DATETIME' }
+      { columnName: 'updated_at', columnDisplayType: 'DATETIME' },
       { columnName: 'date_of_birth', columnDisplayType: 'DATE' },
       {
         columnName: 'Relationship_cd_Relationship Type',
@@ -188,9 +186,8 @@ describe('DatatableMultiRowComponent', () => {
       'Amount',
       'Is active',
       'Is verified',
-      'Empty value',
       'Creado en',
-      'Actualizado en'
+      'Actualizado en',
       'Date of birth',
       'Relationship',
       'Empty value'
@@ -243,9 +240,8 @@ describe('DatatableMultiRowComponent', () => {
       'amount',
       'is_active',
       'is_verified',
-      'empty_value',
       'created_at',
-      'updated_at'
+      'updated_at',
       'date_of_birth',
       'Relationship_cd_Relationship Type',
       'empty_value'
@@ -371,6 +367,8 @@ describe('DatatableMultiRowComponent', () => {
         0,
         true,
         false,
+        '2025-03-07T12:30:00',
+        '2025-04-07T13:45:00',
         '2025-01-15',
         12,
         null


### PR DESCRIPTION
## Description

PR #3879 (WEB-1151) introduced 4 missing commas, a duplicate empty_value column, and a stale row literal in _datatable-multi-row.component.spec.ts_, breaking the ESLint CI step and all 27 tests in the suite.

## Related issues and discussion

[WEB-1151](WEB-1151)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1151]: https://mifosforge.jira.com/browse/WEB-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated data table test fixtures and assertions to reflect the revised column order.
  * Adjusted responsive labels and edit-prefill expectations for date-time fields.
  * Removed obsolete empty-value field expectations from test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->