### PR TITLE
WEB-1154: Add issuance and expiry dates to Documents

### DIFF
--- a/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.html
+++ b/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.html
@@ -83,29 +83,37 @@
       </mat-form-field>
     }
 
-    @if (!editIdentifier) {
-      <mat-form-field class="flex-fill">
-        <mat-label>{{ 'labels.inputs.File Name' | translate }}</mat-label>
-        <input formControlName="fileName" required matInput />
-        @if (uploadDocumentForm.controls.fileName.hasError('required')) {
-          <mat-error>
-            {{ 'labels.inputs.File Name' | translate }} {{ 'labels.commons.is' | translate }}
-            <strong>{{ 'labels.commons.required' | translate }}</strong>
-          </mat-error>
-        }
-      </mat-form-field>
-    }
+    <mat-form-field class="flex-fill">
+      <mat-label>{{ 'labels.inputs.File Name' | translate }}</mat-label>
+      <input formControlName="fileName" [required]="fileNameRequired" matInput />
+      @if (uploadDocumentForm.controls.fileName.hasError('required')) {
+        <mat-error>
+          {{ 'labels.inputs.File Name' | translate }} {{ 'labels.commons.is' | translate }}
+          <strong>{{ 'labels.commons.required' | translate }}</strong>
+        </mat-error>
+      }
+    </mat-form-field>
 
     @if (!documentIdentifier) {
       <mat-form-field class="flex-fill">
         <mat-label>{{ 'labels.inputs.Description' | translate }}</mat-label>
         <input formControlName="description" matInput />
       </mat-form-field>
+      <mat-form-field class="flex-fill">
+        <mat-label>{{ 'labels.inputs.Issuance Date' | translate }}</mat-label>
+        <input matInput [matDatepicker]="documentIssuanceDatePicker" formControlName="issuanceDate" />
+        <mat-datepicker-toggle matSuffix [for]="documentIssuanceDatePicker"></mat-datepicker-toggle>
+        <mat-datepicker #documentIssuanceDatePicker></mat-datepicker>
+      </mat-form-field>
+      <mat-form-field class="flex-fill">
+        <mat-label>{{ 'labels.inputs.Expiry Date' | translate }}</mat-label>
+        <input matInput [matDatepicker]="documentExpiryDatePicker" formControlName="expiryDate" />
+        <mat-datepicker-toggle matSuffix [for]="documentExpiryDatePicker"></mat-datepicker-toggle>
+        <mat-datepicker #documentExpiryDatePicker></mat-datepicker>
+      </mat-form-field>
     }
 
-    @if (!editIdentifier) {
-      <mifosx-file-upload flex="60%" (change)="onFileSelect($event)"></mifosx-file-upload>
-    }
+    <mifosx-file-upload flex="60%" (change)="onFileSelect($event)"></mifosx-file-upload>
 
     <mat-dialog-actions align="end">
       <button mat-raised-button mat-dialog-close>{{ 'labels.buttons.Cancel' | translate }}</button>

--- a/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.spec.ts
+++ b/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DatePipe } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faFolderOpen } from '@fortawesome/free-solid-svg-icons';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { UploadDocumentDialogComponent } from './upload-document-dialog.component';
+
+describe('UploadDocumentDialogComponent', () => {
+  let component: UploadDocumentDialogComponent;
+  let fixture: ComponentFixture<UploadDocumentDialogComponent>;
+  let dialogData: any;
+
+  const createComponent = async (data: any) => {
+    dialogData = data;
+    await TestBed.configureTestingModule({
+      imports: [
+        UploadDocumentDialogComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        DatePipe,
+        provideNativeDateAdapter(),
+        { provide: MatDialogRef, useValue: {} },
+        { provide: MAT_DIALOG_DATA, useFactory: () => dialogData }
+      ]
+    }).compileComponents();
+
+    TestBed.inject(FaIconLibrary).addIcons(faFolderOpen);
+
+    fixture = TestBed.createComponent(UploadDocumentDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('shows prefilled file and date controls for standard document edit', async () => {
+    await createComponent({
+      documentIdentifier: false,
+      editIdentifier: true,
+      entityType: 'clients',
+      document: {
+        fileName: 'passport.pdf',
+        description: 'Passport',
+        issuanceDate: '2024-01-02',
+        expiryDate: '2030-06-30'
+      }
+    });
+
+    expect(component.uploadDocumentForm.get('fileName').value).toBe('passport.pdf');
+    expect(component.uploadDocumentForm.get('description').value).toBe('Passport');
+    expect(component.uploadDocumentForm.get('file').value).toBe('');
+    expect(component.uploadDocumentForm.valid).toBe(true);
+    expect(fixture.debugElement.query(By.css('input[formControlName="fileName"]'))).toBeTruthy();
+    expect(fixture.debugElement.query(By.css('mifosx-file-upload'))).toBeTruthy();
+    expect(component.uploadDocumentForm.get('issuanceDate').value).toEqual(new Date(2024, 0, 2));
+    expect(component.uploadDocumentForm.get('expiryDate').value).toEqual(new Date(2030, 5, 30));
+  });
+
+  it('keeps replacement file optional but updates file controls when selected during standard document edit', async () => {
+    await createComponent({
+      documentIdentifier: false,
+      editIdentifier: true,
+      document: {
+        fileName: 'original.pdf'
+      }
+    });
+    const replacement = new File(['replacement'], 'replacement.pdf', { type: 'application/pdf' });
+
+    component.onFileSelect({ target: { files: [replacement] } });
+
+    expect(component.uploadDocumentForm.get('fileName').value).toBe('replacement.pdf');
+    expect(component.uploadDocumentForm.get('file').value).toBe(replacement);
+    expect(component.uploadDocumentForm.valid).toBe(true);
+  });
+
+  it('shows optional prefilled file controls for client identifier edit', async () => {
+    await createComponent({
+      documentIdentifier: true,
+      editIdentifier: true,
+      identifier: {
+        documentType: { id: 1 },
+        status: 'clientIdentifierStatusType.active',
+        documentKey: 'ABC123',
+        documents: [{ fileName: 'passport.pdf' }]
+      },
+      allowedDocumentTypes: [{ id: 1, name: 'Passport' }],
+      statusOptions: [{ label: 'Active', value: 'Active' }]
+    });
+
+    expect(component.uploadDocumentForm.get('fileName').value).toBe('passport.pdf');
+    expect(component.uploadDocumentForm.get('file').value).toBe('');
+    expect(component.uploadDocumentForm.valid).toBe(true);
+    expect(fixture.debugElement.query(By.css('input[formControlName="fileName"]')).nativeElement.required).toBe(false);
+    expect(fixture.debugElement.query(By.css('mifosx-file-upload'))).toBeTruthy();
+  });
+});

--- a/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.ts
+++ b/src/app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component.ts
@@ -72,6 +72,10 @@ export class UploadDocumentDialogComponent implements OnInit {
     this.createUploadDocumentForm();
   }
 
+  get fileNameRequired(): boolean {
+    return !this.documentIdentifier || !this.editIdentifier;
+  }
+
   /**
    * Creates the upload Document form.
    */
@@ -95,19 +99,22 @@ export class UploadDocumentDialogComponent implements OnInit {
         issuanceDate: [this.parseIdentifierDate(this.data.identifier?.issuanceDate)],
         expiryDate: [this.parseIdentifierDate(this.data.identifier?.expiryDate)],
         fileName: [
-          '',
-          this.editIdentifier ? [] : Validators.required
+          this.data.identifier?.documents?.[0]?.fileName || this.data.identifier?.documents?.[0]?.name || '',
+          this.fileNameRequired ? Validators.required : []
         ],
         file: ['']
       });
     } else {
       // Standard document upload form
+      const document = this.data.document || {};
       this.uploadDocumentForm = this.formBuilder.group({
         fileName: [
-          '',
+          document.fileName || document.name || '',
           Validators.required
         ],
-        description: [''],
+        description: [document.description || ''],
+        issuanceDate: [this.parseDate(document.issuanceDate)],
+        expiryDate: [this.parseDate(document.expiryDate)],
         file: ['']
       });
     }
@@ -127,6 +134,10 @@ export class UploadDocumentDialogComponent implements OnInit {
   }
 
   private parseIdentifierDate(value: any): Date | string {
+    return this.parseDate(value);
+  }
+
+  private parseDate(value: any): Date | string {
     return value ? this.dateUtils.parseDate(value) : '';
   }
 }

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.spec.ts
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.spec.ts
@@ -10,10 +10,11 @@ import { TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { TranslateModule } from '@ngx-translate/core';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 
 import { ClientsService } from '../../clients.service';
+import { AlertService } from 'app/core/alert/alert.service';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
 import { DocumentPreviewService } from 'app/shared/services/document-preview.service';
 import { IdentitiesTabComponent } from './identities-tab.component';
@@ -27,11 +28,13 @@ describe('IdentitiesTabComponent', () => {
   let markForCheck: jest.Mock;
   let dialog: { open: jest.Mock };
   let dateUtils: { formatDate: jest.Mock; parseDate: jest.Mock };
+  let alertService: { alert: jest.Mock };
 
   beforeEach(async () => {
     clientsService = {
       addClientIdentifier: jest.fn(() => of({ resourceId: 'identifier-3' })),
       editClientIdentifier: jest.fn(() => of({})),
+      uploadClientIdentifierDocument: jest.fn(() => of({ resourceId: 'doc-3' })),
       downloadClientIdentificationDocument: jest.fn(() => of(new Blob(['image'], { type: 'image/png' })))
     } as any;
     documentPreviewService = {
@@ -43,6 +46,7 @@ describe('IdentitiesTabComponent', () => {
       release: jest.fn()
     } as any;
     dialog = { open: jest.fn() };
+    alertService = { alert: jest.fn() };
     dateUtils = {
       formatDate: jest.fn(
         (value: Date) =>
@@ -66,6 +70,7 @@ describe('IdentitiesTabComponent', () => {
         },
         { provide: DocumentPreviewService, useValue: documentPreviewService },
         { provide: MatDialog, useValue: dialog },
+        { provide: AlertService, useValue: alertService },
         { provide: Dates, useValue: dateUtils },
         { provide: SettingsService, useValue: { dateFormat: 'dd MMMM yyyy', language: { code: 'en' } } },
         {
@@ -208,6 +213,45 @@ describe('IdentitiesTabComponent', () => {
       issuanceDate: null,
       expiryDate: null,
       status: 'clientIdentifierStatusType.active'
+    });
+  });
+
+  it('keeps identifier edits and reports an error when replacement document upload fails', () => {
+    const identity: any = {
+      id: 'identifier-5',
+      documentType: { id: 5, name: 'Passport' },
+      documentKey: 'OLD',
+      description: 'Old value',
+      status: 'clientIdentifierStatusType.active',
+      documents: []
+    };
+    const replacement = new File(['replacement'], 'replacement.pdf', { type: 'application/pdf' });
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    clientsService.uploadClientIdentifierDocument.mockReturnValue(throwError(() => new Error('upload failed')) as any);
+    dialog.open.mockReturnValue({
+      afterClosed: () =>
+        of({
+          documentTypeId: 5,
+          documentKey: 'NEW',
+          description: 'New value',
+          issuanceDate: '',
+          expiryDate: '',
+          fileName: 'replacement.pdf',
+          file: replacement
+        })
+    });
+
+    component.editIdentifier(identity);
+
+    expect(clientsService.editClientIdentifier).toHaveBeenCalled();
+    expect(clientsService.uploadClientIdentifierDocument).toHaveBeenCalledWith('identifier-5', expect.any(FormData));
+    expect(identity).toMatchObject({
+      description: 'New value',
+      documentKey: 'NEW'
+    });
+    expect(alertService.alert).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'Failed to upload document'
     });
   });
 });

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
@@ -55,6 +55,7 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
+import { AlertService } from 'app/core/alert/alert.service';
 
 interface ClientIdentifierDocumentType {
   id: number | string;
@@ -128,6 +129,7 @@ export class IdentitiesTabComponent implements OnDestroy {
   private changeDetectorRef = inject(ChangeDetectorRef);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
+  private alertService = inject(AlertService);
 
   private destroyRef = inject(DestroyRef);
 
@@ -328,6 +330,33 @@ export class IdentitiesTabComponent implements OnDestroy {
             identity.documentKey = response.documentKey;
             identity.issuanceDate = response.issuanceDate || null;
             identity.expiryDate = response.expiryDate || null;
+            if (response.file) {
+              const formData: FormData = new FormData();
+              formData.append('name', response.fileName);
+              formData.append('file', response.file);
+              this.clientService.uploadClientIdentifierDocument(identity.id, formData).subscribe({
+                next: (docRes: any) => {
+                  const newDoc = {
+                    id: docRes.resourceId,
+                    parentEntityType: 'client_identifiers',
+                    parentEntityId: identity.id,
+                    name: response.fileName,
+                    fileName: response.file.name
+                  };
+                  identity.documents = identity.documents || [];
+                  identity.documents.push(newDoc);
+                  this.setThumbnail(newDoc, identity);
+                  this.changeDetectorRef.markForCheck();
+                },
+                error: (err: any) => {
+                  console.error('Failed to upload document', err);
+                  this.alertService.alert({
+                    type: 'error',
+                    message: 'Failed to upload document'
+                  });
+                }
+              });
+            }
             this.identifiersTable.renderRows();
             this.changeDetectorRef.markForCheck();
           },

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.html
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.html
@@ -59,6 +59,18 @@
               @if (document.description) {
                 <div class="description">{{ document.description }}</div>
               }
+              @if (document.issuanceDate || document.expiryDate) {
+                <div class="meta">
+                  @if (document.issuanceDate) {
+                    <span
+                      >{{ 'labels.inputs.Issuance Date' | translate }}: {{ document.issuanceDate | dateFormat }}</span
+                    >
+                  }
+                  @if (document.expiryDate) {
+                    <span>{{ 'labels.inputs.Expiry Date' | translate }}: {{ document.expiryDate | dateFormat }}</span>
+                  }
+                </div>
+              }
               <div class="actions">
                 <button
                   mat-icon-button

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.scss
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.scss
@@ -122,6 +122,10 @@
 .meta {
   font-size: 12px;
   color: $asbestos;
+
+  span {
+    display: block;
+  }
 }
 
 .description {

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.spec.ts
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.spec.ts
@@ -7,6 +7,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DatePipe } from '@angular/common';
 import { MatDialog } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
@@ -19,6 +20,7 @@ import { ClientsService } from 'app/clients/clients.service';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
 import { LoansService } from 'app/loans/loans.service';
 import { SavingsService } from 'app/savings/savings.service';
+import { SettingsService } from 'app/settings/settings.service';
 import { DocumentPreviewService } from 'app/shared/services/document-preview.service';
 import { EntityDocumentsTabComponent } from './entity-documents-tab.component';
 
@@ -27,10 +29,14 @@ describe('EntityDocumentsTabComponent', () => {
   let component: EntityDocumentsTabComponent;
   let clientsService: jest.Mocked<ClientsService>;
   let documentPreviewService: jest.Mocked<DocumentPreviewService>;
+  let dialog: jest.Mocked<MatDialog>;
 
   beforeEach(async () => {
     clientsService = {
       downloadClientDocument: jest.fn()
+    } as any;
+    dialog = {
+      open: jest.fn(() => ({ afterClosed: () => of(null) }))
     } as any;
     documentPreviewService = {
       isPreviewable: jest.fn(() => true),
@@ -51,9 +57,11 @@ describe('EntityDocumentsTabComponent', () => {
         { provide: ClientsService, useValue: clientsService },
         { provide: LoansService, useValue: {} },
         { provide: SavingsService, useValue: {} },
+        { provide: SettingsService, useValue: { dateFormat: 'dd MMMM yyyy', language: { code: 'en' } } },
+        DatePipe,
         { provide: DocumentPreviewService, useValue: documentPreviewService },
         { provide: AuthenticationService, useValue: { getCredentials: () => ({ permissions: ['ALL_FUNCTIONS'] }) } },
-        { provide: MatDialog, useValue: { open: jest.fn(() => ({ afterClosed: () => of(null) })) } }
+        { provide: MatDialog, useValue: dialog }
       ]
     }).compileComponents();
 
@@ -96,5 +104,81 @@ describe('EntityDocumentsTabComponent', () => {
     expect(component.isPreviewable(component.entityDocuments[0])).toBe(true);
     expect(documentPreviewService.resolvePreviewUrl).toHaveBeenCalled();
     expect(clientsService.downloadClientDocument).toHaveBeenCalledWith('3616', 45);
+  });
+
+  it('uploads a document with issuance and expiry dates', () => {
+    const file = new File(['content'], 'statement.pdf', { type: 'application/pdf' });
+    component.entityDocuments = [];
+    component.callbackUpload = jest.fn(() => of({ resourceId: 99 }));
+    dialog.open.mockReturnValue({
+      afterClosed: () =>
+        of({
+          fileName: 'statement.pdf',
+          description: 'Monthly statement',
+          issuanceDate: new Date(2024, 0, 2),
+          expiryDate: new Date(2030, 5, 30),
+          file
+        })
+    } as any);
+
+    component.uploadDocument();
+
+    const formData = (component.callbackUpload as jest.Mock).mock.calls[0][0] as FormData;
+    expect(formData.get('name')).toBe('statement.pdf');
+    expect(formData.get('description')).toBe('Monthly statement');
+    expect(formData.get('file')).toBe(file);
+    expect(formData.get('dateFormat')).toBe('yyyy-MM-dd');
+    expect(formData.get('locale')).toBe('en');
+    expect(formData.get('issuanceDate')).toBe('2024-01-02');
+    expect(formData.get('expiryDate')).toBe('2030-06-30');
+    expect(component.entityDocuments[0]).toEqual(
+      expect.objectContaining({
+        id: 99,
+        issuanceDate: '2024-01-02',
+        expiryDate: '2030-06-30'
+      })
+    );
+  });
+
+  it('uploads a document without optional dates', () => {
+    const file = new File(['content'], 'receipt.pdf', { type: 'application/pdf' });
+    component.entityDocuments = [];
+    component.callbackUpload = jest.fn(() => of({ resourceId: 100 }));
+    dialog.open.mockReturnValue({
+      afterClosed: () =>
+        of({
+          fileName: 'receipt.pdf',
+          description: '',
+          issuanceDate: '',
+          expiryDate: '',
+          file
+        })
+    } as any);
+
+    component.uploadDocument();
+
+    const formData = (component.callbackUpload as jest.Mock).mock.calls[0][0] as FormData;
+    expect(formData.has('issuanceDate')).toBe(false);
+    expect(formData.has('expiryDate')).toBe(false);
+    expect(formData.get('file')).toBe(file);
+  });
+
+  it('displays issuance and expiry dates with the date format pipe', () => {
+    component.entityDocuments = [
+      {
+        id: 101,
+        name: 'license.pdf',
+        fileName: 'license.pdf',
+        issuanceDate: '2024-01-02',
+        expiryDate: '2030-06-30'
+      }
+    ];
+    documentPreviewService.isPreviewable.mockReturnValue(false);
+
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Issuance Date: 02 January 2024');
+    expect(text).toContain('Expiry Date: 30 June 2030');
   });
 });

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.ts
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.ts
@@ -26,8 +26,10 @@ import type { LightGallery } from 'lightgallery/lightgallery';
 import type { GalleryItem } from 'lightgallery/lg-utils';
 import { UploadDocumentDialogComponent } from 'app/clients/clients-view/custom-dialogs/upload-document-dialog/upload-document-dialog.component';
 import { ClientsService } from 'app/clients/clients.service';
+import { Dates } from 'app/core/utils/dates';
 import { LoansService } from 'app/loans/loans.service';
 import { SavingsService } from 'app/savings/savings.service';
+import { SettingsService } from 'app/settings/settings.service';
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
 import { DocumentPreviewService } from 'app/shared/services/document-preview.service';
 import { Observable, throwError } from 'rxjs';
@@ -51,6 +53,7 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
   private savingsService = inject(SavingsService);
   private loansService = inject(LoansService);
   private clientsService = inject(ClientsService);
+  private settingsService = inject(SettingsService);
   private documentPreviewService = inject(DocumentPreviewService);
 
   @ViewChild('lightboxRoot', { static: true }) lightboxRoot: ElementRef<HTMLElement>;
@@ -97,6 +100,10 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
         formData.append('name', dialogResponse.fileName);
         formData.append('file', dialogResponse.file);
         formData.append('description', dialogResponse.description);
+        formData.append('dateFormat', Dates.DEFAULT_DATEFORMAT);
+        formData.append('locale', this.settingsService.language.code);
+        this.appendOptionalDate(formData, 'issuanceDate', dialogResponse.issuanceDate);
+        this.appendOptionalDate(formData, 'expiryDate', dialogResponse.expiryDate);
         this.callbackUpload(formData).subscribe((res: any) => {
           const newDocument = {
             id: res.resourceId,
@@ -104,6 +111,8 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
             parentEntityId: this.entityId,
             name: dialogResponse.fileName,
             description: dialogResponse.description,
+            issuanceDate: this.formatDocumentDate(dialogResponse.issuanceDate),
+            expiryDate: this.formatDocumentDate(dialogResponse.expiryDate),
             fileName: dialogResponse.file.name
           };
           this.entityDocuments.push(newDocument);
@@ -225,6 +234,25 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
     return value
       ? value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
       : '';
+  }
+
+  private appendOptionalDate(formData: FormData, key: string, value: Date | string | null | undefined): void {
+    const formattedDate = this.formatDocumentDate(value);
+    if (formattedDate) {
+      formData.append(key, formattedDate);
+    }
+  }
+
+  private formatDocumentDate(value: Date | string | null | undefined): string {
+    if (!value) {
+      return '';
+    }
+    if (value instanceof Date) {
+      const month = `${value.getMonth() + 1}`.padStart(2, '0');
+      const day = `${value.getDate()}`.padStart(2, '0');
+      return `${value.getFullYear()}-${month}-${day}`;
+    }
+    return value;
   }
 
   private setThumbnail(document: any): void {


### PR DESCRIPTION
## Description

Adds `issuanceDate` and `expiryDate` support to Documents.

This change:
- adds Issuance Date and Expiry Date to document create/edit flows
- displays both dates in document views
- preserves existing upload, download, preview, and delete behavior
- keeps file replacement optional during edit
- preserves Client Identifier behavior from WEB-1153

## Related issues and discussion

WEB-1154

## Screenshots, if any

https://github.com/user-attachments/assets/07c78979-41c2-4fcb-8a8d-15a4bcbe1ed2




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Upload and edit standard documents with prefilled file names, descriptions, issuance dates, and expiry dates.
  - Add an additional document while editing an identity.
  - View issuance and expiry dates on document cards when available.
- **Bug Fixes**
  - File replacement remains available during document edits.
  - Identifier document file names are optional when editing existing records.
  - Document uploads retain entered date information and formatting.
  - Display an error alert when an identity document upload fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->