### PR TITLE
WEB-1166: Fix chargeId race condition in charge forms

### DIFF
--- a/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.spec.ts
+++ b/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.spec.ts
@@ -8,7 +8,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { delay, of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { AddClientChargeComponent } from './add-client-charge.component';
 import { ClientsService } from 'app/clients/clients.service';
 import { SettingsService } from 'app/settings/settings.service';
@@ -112,23 +112,50 @@ describe('AddClientChargeComponent', () => {
     expect(notifier.notifyAndNavigate).not.toHaveBeenCalled();
   });
 
-  it('should apply only the latest charge template when chargeId changes rapidly', (done) => {
+  it('should apply only the latest charge template when chargeId changes rapidly', () => {
+    const firstResponse$ = new Subject<any>();
+    const secondResponse$ = new Subject<any>();
     clientsService.getChargeAndTemplate.mockReset();
     clientsService.getChargeAndTemplate.mockImplementation((chargeId: number) =>
-      of({
-        chargeTimeType: { id: chargeId, value: chargeId === 1 ? 'Specified due date' : 'Annual Fee' },
-        chargeCalculationType: { id: 1 },
-        amount: chargeId * 100,
-        feeInterval: null
-      }).pipe(delay(chargeId === 1 ? 50 : 0))
+      chargeId === 1 ? firstResponse$ : secondResponse$
     );
 
     component.clientChargeForm.controls.chargeId.setValue(1);
     component.clientChargeForm.controls.chargeId.setValue(2);
 
-    setTimeout(() => {
-      expect(component.clientChargeForm.value.amount).toBe(200);
-      done();
-    }, 100);
+    secondResponse$.next({
+      chargeTimeType: { id: 2, value: 'Annual Fee' },
+      chargeCalculationType: { id: 1 },
+      amount: 200,
+      feeInterval: null
+    });
+    firstResponse$.next({
+      chargeTimeType: { id: 1, value: 'Specified due date' },
+      chargeCalculationType: { id: 1 },
+      amount: 100,
+      feeInterval: null
+    });
+
+    expect(component.clientChargeForm.value.amount).toBe(200);
+  });
+
+  it('should load template after a failed request when chargeId changes again', () => {
+    clientsService.getChargeAndTemplate.mockReset();
+    clientsService.getChargeAndTemplate.mockImplementation((chargeId: number) => {
+      if (chargeId === 1) {
+        return throwError(() => new Error('API error'));
+      }
+      return of({
+        chargeTimeType: { id: 2, value: 'Annual Fee' },
+        chargeCalculationType: { id: 1 },
+        amount: 200,
+        feeInterval: null
+      });
+    });
+
+    component.clientChargeForm.controls.chargeId.setValue(1);
+    component.clientChargeForm.controls.chargeId.setValue(2);
+
+    expect(component.clientChargeForm.value.amount).toBe(200);
   });
 });

--- a/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.spec.ts
+++ b/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.spec.ts
@@ -8,7 +8,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { of, throwError } from 'rxjs';
+import { delay, of, throwError } from 'rxjs';
 import { AddClientChargeComponent } from './add-client-charge.component';
 import { ClientsService } from 'app/clients/clients.service';
 import { SettingsService } from 'app/settings/settings.service';
@@ -54,7 +54,7 @@ describe('AddClientChargeComponent', () => {
       formatDate: jest.fn(() => '20 March 2026')
     } as any;
 
-    notifier = { notifyAndNavigate: jest.fn() } as any;
+    notifier = { notifyAndNavigate: jest.fn(), notify: jest.fn() } as any;
 
     await TestBed.configureTestingModule({
       imports: [
@@ -110,5 +110,25 @@ describe('AddClientChargeComponent', () => {
     component.submit();
 
     expect(notifier.notifyAndNavigate).not.toHaveBeenCalled();
+  });
+
+  it('should apply only the latest charge template when chargeId changes rapidly', (done) => {
+    clientsService.getChargeAndTemplate.mockReset();
+    clientsService.getChargeAndTemplate.mockImplementation((chargeId: number) =>
+      of({
+        chargeTimeType: { id: chargeId, value: chargeId === 1 ? 'Specified due date' : 'Annual Fee' },
+        chargeCalculationType: { id: 1 },
+        amount: chargeId * 100,
+        feeInterval: null
+      }).pipe(delay(chargeId === 1 ? 50 : 0))
+    );
+
+    component.clientChargeForm.controls.chargeId.setValue(1);
+    component.clientChargeForm.controls.chargeId.setValue(2);
+
+    setTimeout(() => {
+      expect(component.clientChargeForm.value.amount).toBe(200);
+      done();
+    }, 100);
   });
 });

--- a/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.ts
+++ b/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.ts
@@ -18,7 +18,8 @@ import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
 import { ClientActionNotifierService } from '../client-action-notifier.service';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
-import { switchMap } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
 
 /**
  * Add Clients Charge component.
@@ -76,7 +77,7 @@ export class AddClientChargeComponent implements OnInit {
   buildDependencies() {
     this.clientChargeForm.controls.chargeId.valueChanges
       .pipe(
-        switchMap((chargeId) => this.clientsService.getChargeAndTemplate(chargeId)),
+        switchMap((chargeId) => this.clientsService.getChargeAndTemplate(chargeId).pipe(catchError(() => EMPTY))),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((data: any) => {

--- a/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.ts
+++ b/src/app/clients/clients-view/client-actions/add-client-charge/add-client-charge.component.ts
@@ -18,6 +18,7 @@ import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
 import { ClientActionNotifierService } from '../client-action-notifier.service';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { switchMap } from 'rxjs/operators';
 
 /**
  * Add Clients Charge component.
@@ -74,40 +75,38 @@ export class AddClientChargeComponent implements OnInit {
    */
   buildDependencies() {
     this.clientChargeForm.controls.chargeId.valueChanges
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((chargeId) => {
-        this.clientsService.getChargeAndTemplate(chargeId).subscribe((data: any) => {
-          this.chargeDetails = data;
-          const chargeTimeType = data.chargeTimeType.id;
-          if (
-            data.chargeTimeType.value === 'Withdrawal Fee' ||
-            data.chargeTimeType.value === 'Saving No Activity Fee'
-          ) {
-            this.chargeDetails.dueDateNotRequired = true;
-          }
-          if (data.chargeTimeType.value === 'Annual Fee' || data.chargeTimeType.value === 'Monthly Fee') {
-            this.chargeDetails.chargeTimeTypeAnnualOrMonth = true;
-          }
-          if (!this.chargeDetails.dueDateNotRequired && !this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
-            this.clientChargeForm.addControl('dueDate', new FormControl('', Validators.required));
-          } else {
-            this.clientChargeForm.removeControl('dueDate');
-          }
-          if (!this.chargeDetails.dueDateNotRequired && this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
-            this.clientChargeForm.addControl('feeOnMonthDay', new FormControl('', Validators.required));
-          } else {
-            this.clientChargeForm.removeControl('feeOnMonthDay');
-          }
-          if (chargeTimeType.value === 'Monthly Fee') {
-            this.clientChargeForm.addControl('feeInterval', new FormControl(data.feeInterval, Validators.required));
-          } else {
-            this.clientChargeForm.removeControl('feeInterval');
-          }
-          this.clientChargeForm.patchValue({
-            amount: data.amount,
-            chargeCalculationType: data.chargeCalculationType.id,
-            chargeTimeType: data.chargeTimeType.id
-          });
+      .pipe(
+        switchMap((chargeId) => this.clientsService.getChargeAndTemplate(chargeId)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((data: any) => {
+        this.chargeDetails = data;
+        const chargeTimeType = data.chargeTimeType.id;
+        if (data.chargeTimeType.value === 'Withdrawal Fee' || data.chargeTimeType.value === 'Saving No Activity Fee') {
+          this.chargeDetails.dueDateNotRequired = true;
+        }
+        if (data.chargeTimeType.value === 'Annual Fee' || data.chargeTimeType.value === 'Monthly Fee') {
+          this.chargeDetails.chargeTimeTypeAnnualOrMonth = true;
+        }
+        if (!this.chargeDetails.dueDateNotRequired && !this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
+          this.clientChargeForm.addControl('dueDate', new FormControl('', Validators.required));
+        } else {
+          this.clientChargeForm.removeControl('dueDate');
+        }
+        if (!this.chargeDetails.dueDateNotRequired && this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
+          this.clientChargeForm.addControl('feeOnMonthDay', new FormControl('', Validators.required));
+        } else {
+          this.clientChargeForm.removeControl('feeOnMonthDay');
+        }
+        if (chargeTimeType.value === 'Monthly Fee') {
+          this.clientChargeForm.addControl('feeInterval', new FormControl(data.feeInterval, Validators.required));
+        } else {
+          this.clientChargeForm.removeControl('feeInterval');
+        }
+        this.clientChargeForm.patchValue({
+          amount: data.amount,
+          chargeCalculationType: data.chargeCalculationType.id,
+          chargeTimeType: data.chargeTimeType.id
         });
       });
   }

--- a/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/add-charge-fixed-deposits-account/add-charge-fixed-deposits-account.component.ts
+++ b/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/add-charge-fixed-deposits-account/add-charge-fixed-deposits-account.component.ts
@@ -23,7 +23,8 @@ import { Dates } from 'app/core/utils/dates';
 import { SavingsService } from 'app/savings/savings.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
-import { switchMap } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
 
 /**
  * Add Fixed Deposits Charge component.
@@ -90,7 +91,7 @@ export class AddChargeFixedDepositsAccountComponent implements OnInit {
   buildDependencies() {
     this.fixedDepositsChargeForm.controls.chargeId.valueChanges
       .pipe(
-        switchMap((chargeId) => this.savingsService.getChargeTemplate(chargeId)),
+        switchMap((chargeId) => this.savingsService.getChargeTemplate(chargeId).pipe(catchError(() => EMPTY))),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((data: any) => {

--- a/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/add-charge-fixed-deposits-account/add-charge-fixed-deposits-account.component.ts
+++ b/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/add-charge-fixed-deposits-account/add-charge-fixed-deposits-account.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
@@ -22,6 +23,7 @@ import { Dates } from 'app/core/utils/dates';
 import { SavingsService } from 'app/savings/savings.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { switchMap } from 'rxjs/operators';
 
 /**
  * Add Fixed Deposits Charge component.
@@ -43,6 +45,7 @@ export class AddChargeFixedDepositsAccountComponent implements OnInit {
   private dateUtils = inject(Dates);
   private savingsService = inject(SavingsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum Due Date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -67,9 +70,11 @@ export class AddChargeFixedDepositsAccountComponent implements OnInit {
    * @param {SettingsService} settingsService Settings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { fixedDepositsAccountActionData: any }) => {
-      this.savingsChargeOptions = data.fixedDepositsAccountActionData.chargeOptions;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { fixedDepositsAccountActionData: any }) => {
+        this.savingsChargeOptions = data.fixedDepositsAccountActionData.chargeOptions;
+      });
     this.fixedDepositAccountId = this.route.parent.snapshot.params['fixedDepositAccountId'];
   }
 
@@ -83,8 +88,12 @@ export class AddChargeFixedDepositsAccountComponent implements OnInit {
   }
 
   buildDependencies() {
-    this.fixedDepositsChargeForm.controls.chargeId.valueChanges.subscribe((chargeId) => {
-      this.savingsService.getChargeTemplate(chargeId).subscribe((data: any) => {
+    this.fixedDepositsChargeForm.controls.chargeId.valueChanges
+      .pipe(
+        switchMap((chargeId) => this.savingsService.getChargeTemplate(chargeId)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((data: any) => {
         this.chargeDetails = data;
         const chargeTimeType = data.chargeTimeType.id;
         if (data.chargeTimeType.value === 'Withdrawal Fee' || data.chargeTimeType.value === 'Saving No Activity Fee') {
@@ -117,7 +126,6 @@ export class AddChargeFixedDepositsAccountComponent implements OnInit {
           chargeTimeType: data.chargeTimeType.id
         });
       });
-    });
   }
 
   /**

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/add-charge-recurring-deposits-account/add-charge-recurring-deposits-account.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/add-charge-recurring-deposits-account/add-charge-recurring-deposits-account.component.ts
@@ -23,7 +23,8 @@ import { Dates } from 'app/core/utils/dates';
 import { SavingsService } from 'app/savings/savings.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
-import { switchMap } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
 
 /**
  * Add Recurring Deposits Charge component.
@@ -89,7 +90,7 @@ export class AddChargeRecurringDepositsAccountComponent implements OnInit {
   buildDependencies() {
     this.recurringDepositsChargeForm.controls.chargeId.valueChanges
       .pipe(
-        switchMap((chargeId) => this.savingsService.getChargeTemplate(chargeId)),
+        switchMap((chargeId) => this.savingsService.getChargeTemplate(chargeId).pipe(catchError(() => EMPTY))),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((data: any) => {

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/add-charge-recurring-deposits-account/add-charge-recurring-deposits-account.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/add-charge-recurring-deposits-account/add-charge-recurring-deposits-account.component.ts
@@ -7,7 +7,8 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   UntypedFormGroup,
   UntypedFormBuilder,
@@ -22,6 +23,7 @@ import { Dates } from 'app/core/utils/dates';
 import { SavingsService } from 'app/savings/savings.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { switchMap } from 'rxjs/operators';
 
 /**
  * Add Recurring Deposits Charge component.
@@ -43,6 +45,7 @@ export class AddChargeRecurringDepositsAccountComponent implements OnInit {
   private dateUtils = inject(Dates);
   private savingsService = inject(SavingsService);
   private settingsService = inject(SettingsService);
+  private destroyRef = inject(DestroyRef);
 
   /** Minimum Due Date allowed. */
   minDate = new Date(2000, 0, 1);
@@ -66,9 +69,11 @@ export class AddChargeRecurringDepositsAccountComponent implements OnInit {
    * @param {SavingsService} savingsService Savings Service
    */
   constructor() {
-    this.route.data.subscribe((data: { recurringDepositsAccountActionData: any }) => {
-      this.savingsChargeOptions = data.recurringDepositsAccountActionData.chargeOptions;
-    });
+    this.route.data
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((data: { recurringDepositsAccountActionData: any }) => {
+        this.savingsChargeOptions = data.recurringDepositsAccountActionData.chargeOptions;
+      });
     this.recurringDepositAccountId = this.route.parent.snapshot.params['recurringDepositAccountId'];
   }
 
@@ -82,8 +87,12 @@ export class AddChargeRecurringDepositsAccountComponent implements OnInit {
   }
 
   buildDependencies() {
-    this.recurringDepositsChargeForm.controls.chargeId.valueChanges.subscribe((chargeId) => {
-      this.savingsService.getChargeTemplate(chargeId).subscribe((data: any) => {
+    this.recurringDepositsChargeForm.controls.chargeId.valueChanges
+      .pipe(
+        switchMap((chargeId) => this.savingsService.getChargeTemplate(chargeId)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((data: any) => {
         this.chargeDetails = data;
         const chargeTimeType = data.chargeTimeType.id;
         if (data.chargeTimeType.value === 'Withdrawal Fee' || data.chargeTimeType.value === 'Saving No Activity Fee') {
@@ -116,7 +125,6 @@ export class AddChargeRecurringDepositsAccountComponent implements OnInit {
           chargeTimeType: data.chargeTimeType.id
         });
       });
-    });
   }
 
   /**

--- a/src/app/savings/saving-account-actions/add-charge-savings-account/add-charge-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/add-charge-savings-account/add-charge-savings-account.component.ts
@@ -17,7 +17,8 @@ import { SavingsService } from '../../savings.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { Dates } from 'app/core/utils/dates';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
-import { switchMap } from 'rxjs/operators';
+import { EMPTY } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
 
 /**
  * Add Savings Charge component.
@@ -81,7 +82,7 @@ export class AddChargeSavingsAccountComponent implements OnInit {
   buildDependencies() {
     this.savingsChargeForm.controls.chargeId.valueChanges
       .pipe(
-        switchMap((chargeId) => this.savingsService.getChargeTemplate(chargeId)),
+        switchMap((chargeId) => this.savingsService.getChargeTemplate(chargeId).pipe(catchError(() => EMPTY))),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((data: any) => {

--- a/src/app/savings/saving-account-actions/add-charge-savings-account/add-charge-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/add-charge-savings-account/add-charge-savings-account.component.ts
@@ -17,6 +17,7 @@ import { SavingsService } from '../../savings.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { Dates } from 'app/core/utils/dates';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { switchMap } from 'rxjs/operators';
 
 /**
  * Add Savings Charge component.
@@ -79,40 +80,38 @@ export class AddChargeSavingsAccountComponent implements OnInit {
 
   buildDependencies() {
     this.savingsChargeForm.controls.chargeId.valueChanges
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((chargeId) => {
-        this.savingsService.getChargeTemplate(chargeId).subscribe((data: any) => {
-          this.chargeDetails = data;
-          const chargeTimeType = data.chargeTimeType.id;
-          if (
-            data.chargeTimeType.value === 'Withdrawal Fee' ||
-            data.chargeTimeType.value === 'Saving No Activity Fee'
-          ) {
-            this.chargeDetails.dueDateNotRequired = true;
-          }
-          if (data.chargeTimeType.value === 'Annual Fee' || data.chargeTimeType.value === 'Monthly Fee') {
-            this.chargeDetails.chargeTimeTypeAnnualOrMonth = true;
-          }
-          if (!this.chargeDetails.dueDateNotRequired && !this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
-            this.savingsChargeForm.addControl('dueDate', new FormControl('', Validators.required));
-          } else {
-            this.savingsChargeForm.removeControl('dueDate');
-          }
-          if (!this.chargeDetails.dueDateNotRequired && this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
-            this.savingsChargeForm.addControl('feeOnMonthDay', new FormControl('', Validators.required));
-          } else {
-            this.savingsChargeForm.removeControl('feeOnMonthDay');
-          }
-          if (chargeTimeType.value === 'Monthly Fee') {
-            this.savingsChargeForm.addControl('feeInterval', new FormControl(data.feeInterval, Validators.required));
-          } else {
-            this.savingsChargeForm.removeControl('feeInterval');
-          }
-          this.savingsChargeForm.patchValue({
-            amount: data.amount,
-            chargeCalculationType: data.chargeCalculationType.id,
-            chargeTimeType: data.chargeTimeType.id
-          });
+      .pipe(
+        switchMap((chargeId) => this.savingsService.getChargeTemplate(chargeId)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((data: any) => {
+        this.chargeDetails = data;
+        const chargeTimeType = data.chargeTimeType.id;
+        if (data.chargeTimeType.value === 'Withdrawal Fee' || data.chargeTimeType.value === 'Saving No Activity Fee') {
+          this.chargeDetails.dueDateNotRequired = true;
+        }
+        if (data.chargeTimeType.value === 'Annual Fee' || data.chargeTimeType.value === 'Monthly Fee') {
+          this.chargeDetails.chargeTimeTypeAnnualOrMonth = true;
+        }
+        if (!this.chargeDetails.dueDateNotRequired && !this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
+          this.savingsChargeForm.addControl('dueDate', new FormControl('', Validators.required));
+        } else {
+          this.savingsChargeForm.removeControl('dueDate');
+        }
+        if (!this.chargeDetails.dueDateNotRequired && this.chargeDetails.chargeTimeTypeAnnualOrMonth) {
+          this.savingsChargeForm.addControl('feeOnMonthDay', new FormControl('', Validators.required));
+        } else {
+          this.savingsChargeForm.removeControl('feeOnMonthDay');
+        }
+        if (chargeTimeType.value === 'Monthly Fee') {
+          this.savingsChargeForm.addControl('feeInterval', new FormControl(data.feeInterval, Validators.required));
+        } else {
+          this.savingsChargeForm.removeControl('feeInterval');
+        }
+        this.savingsChargeForm.patchValue({
+          amount: data.amount,
+          chargeCalculationType: data.chargeCalculationType.id,
+          chargeTimeType: data.chargeTimeType.id
         });
       });
   }


### PR DESCRIPTION
## Description

The `chargeId.valueChanges` handler in the Add Charge forms (client, savings, fixed deposit, and recurring deposit accounts) used a nested `.subscribe()` call to fetch charge templates with no cancellation of in-flight requests. Rapidly switching the selected charge type could let a slower, stale response arrive after a newer selection and overwrite the form with incorrect data (wrong amount, due date, or fee interval).

Replaced the nested subscription with `switchMap` combined with `takeUntilDestroyed(this.destroyRef)` in all four affected components, so only the response for the most recently selected chargeId is applied to the form. Added a regression test that simulates rapid chargeId changes with staggered response delays and asserts only the latest selection's data is reflected in the form.

No new dependencies required.

## Related issues and discussion

WEB-1166

## Screenshots, if any

Not applicable — this is a non-UI logic fix (no template/layout changes). Verified via automated regression test simulating the race condition, plus `ng lint` and full local test suite passing.

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Charge details now consistently reflect the most recently selected charge template.
  - Prevented outdated responses from overwriting current selections when users change templates quickly.
  - Improved charge-template loading across client, fixed-deposit, recurring-deposit, and savings account workflows.
  - Failed template lookups no longer disrupt charge-entry workflows.
  - Improved cleanup when leaving charge-entry screens, reducing stale updates and unnecessary processing.

- **Tests**
  - Added coverage for rapid template changes and recovery after failed template requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->