### PR TITLE
feat(copilot): name the account on confirmation cards, and settle on one product name

### DIFF
--- a/src/app/copilot/components/action-card/action-card.component.ts
+++ b/src/app/copilot/components/action-card/action-card.component.ts
@@ -6,10 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ActionCard, ActionCardType } from '../../core/models/action-card.model';
+import { translateCardLabel } from '../../core/card-label';
 
 /** Renders a single structured ActionCard (client / loan / savings / insight / confirmation). */
 @Component({
@@ -22,6 +23,8 @@ import { ActionCard, ActionCardType } from '../../core/models/action-card.model'
   styleUrls: ['./action-card.component.scss']
 })
 export class ActionCardComponent {
+  private readonly translate = inject(TranslateService);
+
   @Input() card!: ActionCard;
   @Output() action = new EventEmitter<string | undefined>();
   @Output() route = new EventEmitter<string | undefined>();
@@ -43,11 +46,25 @@ export class ActionCardComponent {
     }
   }
 
-  /** Ordered label/value pairs for the card body. */
+  /**
+   * Ordered label/value pairs, with the label put into the officer's language.
+   *
+   * Row labels are written by the gateway from its tool manifest, which is English. The
+   * shared vocabulary is translated here; anything a deployment added itself falls through
+   * to the gateway's own wording.
+   */
   objectEntries(data: Record<string, string>): [
     string,
     string
   ][] {
-    return Object.entries(data ?? {});
+    return Object.entries(data ?? {}).map(
+      ([
+        label,
+        value
+      ]) => [
+        translateCardLabel(label, (key) => this.translate.instant(key)),
+        value
+      ]
+    );
   }
 }

--- a/src/app/copilot/components/chat-area/chat-area.component.html
+++ b/src/app/copilot/components/chat-area/chat-area.component.html
@@ -70,6 +70,7 @@
     <div class="msg__content">
       <div class="cards">
         <mifosx-confirmation-card
+          #confirmCard
           [card]="pendingCard"
           (confirmed)="confirmPending.emit()"
           (cancelled)="cancelPending.emit()"

--- a/src/app/copilot/components/chat-area/chat-area.component.ts
+++ b/src/app/copilot/components/chat-area/chat-area.component.ts
@@ -20,15 +20,18 @@ import {
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import moment from 'moment';
 import { SettingsService } from 'app/settings/settings.service';
 import { Dates } from 'app/core/utils/dates';
+import { relativeTime } from '../../core/relative-time';
 import { ChatMessage } from '../../core/models/chat-message.model';
 import { ActionCard } from '../../core/models/action-card.model';
 import { MarkdownPipe } from '../../pipes/markdown.pipe';
 import { ActionCardComponent } from '../action-card/action-card.component';
 import { ConfirmationCardComponent } from '../confirmation-card/confirmation-card.component';
 import { QuickChipsComponent } from '../quick-chips/quick-chips.component';
+
+/** Breathing room left above a confirmation card once it is scrolled into view. */
+const CARD_TOP_GAP_PX = 12;
 
 /** Scrollable chat body: welcome state, message bubbles, cards, typing indicator. */
 @Component({
@@ -49,7 +52,7 @@ export class ChatAreaComponent implements OnChanges, AfterViewChecked {
   @Input() isStreaming = false;
   @Input() greetingTime = '';
   @Input() emptySuggestions: string[] = [];
-  /** Write action awaiting confirmation — rendered INSIDE the chat flow so it scrolls
+  /** Write action awaiting confirmation, rendered INSIDE the chat flow so it scrolls
    *  with the conversation and can never overlap other messages. */
   @Input() pendingCard: ActionCard | null = null;
 
@@ -60,6 +63,8 @@ export class ChatAreaComponent implements OnChanges, AfterViewChecked {
   @Output() cancelPending = new EventEmitter<void>();
 
   @ViewChild('messageContainer') private messageContainer?: ElementRef<HTMLElement>;
+  /** The confirmation card, so it can be shown from its top rather than from its buttons. */
+  @ViewChild('confirmCard', { read: ElementRef }) private confirmCard?: ElementRef<HTMLElement>;
 
   /** How close to the bottom (px) still counts as "following the conversation". */
   private static readonly STICK_THRESHOLD_PX = 160;
@@ -87,11 +92,21 @@ export class ChatAreaComponent implements OnChanges, AfterViewChecked {
   }
 
   ngAfterViewChecked(): void {
-    if (this.pendingScroll && this.messageContainer) {
-      const container = this.messageContainer.nativeElement;
-      container.scrollTop = container.scrollHeight;
-      this.pendingScroll = false;
+    if (!this.pendingScroll || !this.messageContainer) {
+      return;
     }
+    const container = this.messageContainer.nativeElement;
+    const card = this.confirmCard?.nativeElement;
+    if (card) {
+      // Show a confirmation card from its top edge. Scrolling to the bottom of the
+      // conversation puts Confirm on screen and pushes the client and the amount above
+      // the fold, which is the wrong half of a money decision to hide.
+      const offset = card.getBoundingClientRect().top - container.getBoundingClientRect().top;
+      container.scrollTop = Math.max(0, container.scrollTop + offset - CARD_TOP_GAP_PX);
+    } else {
+      container.scrollTop = container.scrollHeight;
+    }
+    this.pendingScroll = false;
   }
 
   trackByMessageId(_index: number, msg: ChatMessage): string {
@@ -101,13 +116,8 @@ export class ChatAreaComponent implements OnChanges, AfterViewChecked {
   private readonly settingsService = inject(SettingsService);
   private readonly dateUtils = inject(Dates);
 
-  /**
-   * Relative time localized to the USER'S CHOSEN app language — resolved per
-   * call (instance locale), never trusting moment's global locale, which other
-   * pipes mutate as a side effect and may point at a different language.
-   */
+  /** "3 minutes ago", in the language the officer chose. See core/relative-time.ts. */
   relativeTime(timestamp: number): string {
-    const locale = this.dateUtils.getMomentLocale(this.settingsService.language);
-    return moment(timestamp).locale(locale).fromNow();
+    return relativeTime(timestamp, this.dateUtils.getMomentLocale(this.settingsService.language));
   }
 }

--- a/src/app/copilot/components/confirmation-card/confirmation-card.component.ts
+++ b/src/app/copilot/components/confirmation-card/confirmation-card.component.ts
@@ -6,10 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ActionCard } from '../../core/models/action-card.model';
+import { translateCardLabel } from '../../core/card-label';
 
 /** Mandatory confirmation shown before any write action ("involves real money"). */
 @Component({
@@ -22,15 +23,31 @@ import { ActionCard } from '../../core/models/action-card.model';
   styleUrls: ['./confirmation-card.component.scss']
 })
 export class ConfirmationCardComponent {
+  private readonly translate = inject(TranslateService);
+
   @Input() card!: ActionCard;
   @Output() confirmed = new EventEmitter<void>();
   @Output() cancelled = new EventEmitter<void>();
 
-  /** Ordered label/value pairs for the confirmation summary. */
+  /**
+   * Ordered label/value pairs, with the label put into the officer's language.
+   *
+   * Row labels are written by the gateway from its tool manifest, which is English. The
+   * shared vocabulary is translated here; anything a deployment added itself falls through
+   * to the gateway's own wording.
+   */
   objectEntries(data: Record<string, string>): [
     string,
     string
   ][] {
-    return Object.entries(data ?? {});
+    return Object.entries(data ?? {}).map(
+      ([
+        label,
+        value
+      ]) => [
+        translateCardLabel(label, (key) => this.translate.instant(key)),
+        value
+      ]
+    );
   }
 }

--- a/src/app/copilot/components/copilot-panel/copilot-panel.component.ts
+++ b/src/app/copilot/components/copilot-panel/copilot-panel.component.ts
@@ -7,7 +7,7 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectorRef, Component, Input, OnInit, ViewEncapsulation, inject } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, ViewEncapsulation, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -56,7 +56,10 @@ export type CopilotTab = 'chat' | 'recent' | 'preferences' | 'help';
   styleUrls: ['./copilot-panel.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class CopilotPanelComponent implements OnInit {
+// Deliberately no ngOnInit. The shell creates this panel as soon as the feature is on,
+// which can be before the officer's credentials are written, and reading the transcript
+// then would list the previous officer's conversations. Recent Chats loads when it opens.
+export class CopilotPanelComponent {
   private readonly featureService = inject(CopilotFeatureService);
   private readonly translate = inject(TranslateService);
   private readonly chatService = inject(ChatService);
@@ -99,7 +102,7 @@ export class CopilotPanelComponent implements OnInit {
   ];
 
   // markForCheck() on every mirror update: this panel is created dynamically by the shell,
-  // and streaming callbacks arrive outside a template event — without it, an OnPush ancestor
+  // and streaming callbacks arrive outside a template event, and without it an OnPush ancestor
   // chain would never repaint the incoming tokens.
   constructor() {
     const cdr = inject(ChangeDetectorRef);
@@ -131,7 +134,12 @@ export class CopilotPanelComponent implements OnInit {
     });
   }
 
-  ngOnInit(): void {
+  /**
+   * Recent Chats is read at the moment it is shown rather than when the session starts.
+   * A login is announced before the new credentials are written, so anything loaded on
+   * that event would belong to whoever was signed in a moment earlier.
+   */
+  private refreshHistory(): void {
     this.chatService.loadHistory();
   }
 
@@ -153,6 +161,9 @@ export class CopilotPanelComponent implements OnInit {
 
   switchTab(tab: CopilotTab): void {
     this.activeTab = tab;
+    if (tab === 'recent') {
+      this.refreshHistory();
+    }
   }
 
   clearChat(): void {
@@ -183,12 +194,12 @@ export class CopilotPanelComponent implements OnInit {
     this.chatService.stopStreaming();
   }
 
-  /** Officer confirmed the pending write — the gateway executes it now. */
+  /** Officer confirmed the pending write, so the gateway executes it now. */
   confirmPendingAction(): void {
     this.chatService.decideAction('approve');
   }
 
-  /** Officer rejected the pending write — nothing executes. */
+  /** Officer rejected the pending write, so nothing executes. */
   cancelPendingAction(): void {
     this.chatService.decideAction('reject');
   }
@@ -222,22 +233,49 @@ export class CopilotPanelComponent implements OnInit {
     }
   }
 
-  /** Flatten the pending action into the confirmation card the officer reviews. */
+  /**
+   * Build the card the officer reads before money moves.
+   *
+   * The gateway sends ready-to-read rows: it looked the account up first, so the card can
+   * say "Client: Aisha Bello / Loan account: 000000012 / Approved amount: USD 28,000.00"
+   * rather than echoing back the arguments the model produced. Falling back to those raw
+   * arguments only matters against a gateway too old to send rows.
+   */
   private toConfirmationCard(pending: PendingAction): ActionCard {
     const data: Record<string, string> = {};
-    for (const [
-      key,
-      value
-    ] of Object.entries(pending.args ?? {})) {
-      data[key] = value != null && typeof value === 'object' ? JSON.stringify(value) : String(value ?? '');
+    for (const row of pending.display ?? []) {
+      data[row.label] = row.value;
+    }
+    if (Object.keys(data).length === 0) {
+      for (const [
+        key,
+        value
+      ] of Object.entries(pending.args ?? {})) {
+        if (value == null || String(value).trim().length === 0) {
+          continue;
+        }
+        data[this.humanizeKey(key)] = typeof value === 'object' ? JSON.stringify(value) : String(value);
+      }
     }
     if (pending.idempotencyKey) {
-      data[this.translate.instant('copilot.confirm.reference')] = pending.idempotencyKey;
+      // A short reference reads like the receipt number on a teller slip; the gateway keeps
+      // the full key for the audit trail.
+      data[this.translate.instant('copilot.confirm.reference')] = pending.idempotencyKey.slice(0, 8).toUpperCase();
     }
     return {
       type: 'confirmation',
-      title: pending.humanSummary || pending.tool,
+      title: pending.humanSummary || this.humanizeKey(pending.tool),
       data
     };
+  }
+
+  /** Last-resort label: "approvedLoanAmount" reads as "Approved loan amount". */
+  private humanizeKey(key: string): string {
+    const spaced = key
+      .replace(/^mifos_/, '')
+      .replace(/[_-]+/g, ' ')
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .trim();
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
   }
 }

--- a/src/app/copilot/components/recent-chats/recent-chats.component.ts
+++ b/src/app/copilot/components/recent-chats/recent-chats.component.ts
@@ -6,11 +6,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import moment from 'moment';
+import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
 import { Conversation } from '../../core/models/chat-message.model';
+import { relativeTime } from '../../core/relative-time';
 
 /** Recent Chats tab: list of saved conversations with preview, meta and delete. */
 @Component({
@@ -36,8 +38,11 @@ export class RecentChatsComponent {
     return conv.id;
   }
 
-  /** Relative time via moment (localizes with the active moment locale). */
+  private readonly settingsService = inject(SettingsService);
+  private readonly dateUtils = inject(Dates);
+
+  /** "3 minutes ago", in the language the officer chose rather than whichever one a date pipe set last. */
   relativeTime(timestamp: number): string {
-    return moment(timestamp).fromNow();
+    return relativeTime(timestamp, this.dateUtils.getMomentLocale(this.settingsService.language));
   }
 }

--- a/src/app/copilot/copilot.config.ts
+++ b/src/app/copilot/copilot.config.ts
@@ -20,7 +20,7 @@ export interface CopilotConfig {
   /**
    * Time allowed until the FIRST streamed chunk arrives. LLM turns with tool
    * calls routinely take tens of seconds before the first token, so this is
-   * deliberately long. Chat POSTs are never auto-retried — an LLM turn is not
+   * deliberately long. Chat POSTs are never auto-retried, because an LLM turn is not
    * idempotent; retry is a visible user action (ADR-001 §03).
    */
   firstTokenTimeoutMs: number;

--- a/src/app/copilot/core/card-label.spec.ts
+++ b/src/app/copilot/core/card-label.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { translateCardLabel } from './card-label';
+
+/**
+ * The gateway labels card rows from its tool manifest, which is written in English.
+ * These labels are what an officer reads before approving money, so they have to arrive
+ * in the officer's own language without the gateway needing to know thirteen of them.
+ */
+describe('translateCardLabel', () => {
+  const FRENCH: Record<string, string> = {
+    'copilot.cardLabels.client': 'Client',
+    'copilot.cardLabels.loanAccount': 'Compte de prêt',
+    'copilot.cardLabels.approvedAmount': 'Montant approuvé',
+    'copilot.cardLabels.appliedFor': 'Montant demandé'
+  };
+
+  /** Stands in for TranslateService.instant, which echoes the key when it has no entry. */
+  const translate = (key: string): string => FRENCH[key] ?? key;
+
+  it('turns a manifest label into the officer language', () => {
+    expect(translateCardLabel('Loan account', translate)).toBe('Compte de prêt');
+    expect(translateCardLabel('Approved amount', translate)).toBe('Montant approuvé');
+  });
+
+  it('matches labels of one word as readily as several', () => {
+    expect(translateCardLabel('Client', translate)).toBe('Client');
+  });
+
+  it('shows an unknown label exactly as the gateway sent it', () => {
+    // A deployment can add its own tools to the manifest. An English row reads better
+    // than the raw translation key leaking onto a confirmation card.
+    expect(translateCardLabel('Collateral value', translate)).toBe('Collateral value');
+  });
+
+  it('is not thrown by spacing or casing the manifest happens to use', () => {
+    expect(translateCardLabel('  loan   account  ', translate)).toBe('Compte de prêt');
+    expect(translateCardLabel('Applied For', translate)).toBe('Montant demandé');
+  });
+
+  it('leaves an empty label alone rather than looking up a key for nothing', () => {
+    expect(translateCardLabel('', translate)).toBe('');
+    expect(translateCardLabel('   ', translate)).toBe('   ');
+  });
+});

--- a/src/app/copilot/core/card-label.ts
+++ b/src/app/copilot/core/card-label.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Prefix for the shared card-row vocabulary in the translation files. */
+const LABEL_PREFIX = 'copilot.cardLabels.';
+
+/**
+ * "Loan account" becomes "loanAccount", matching the translation keys.
+ * Anything that is not a letter or digit is treated as a word break.
+ */
+function slug(label: string): string {
+  const words = label
+    .trim()
+    .split(/[^A-Za-z0-9]+/)
+    .filter((word) => word.length > 0);
+  if (words.length === 0) {
+    return '';
+  }
+  return words
+    .map((word, index) =>
+      index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+    )
+    .join('');
+}
+
+/**
+ * Translate a card row label into the officer's language.
+ *
+ * Rows arrive from the gateway already labelled, and those labels come from the tool
+ * manifest, which is written in English. Rather than teach the gateway thirteen languages,
+ * the shared vocabulary lives here: "Loan account", "Approved amount" and the rest resolve
+ * through `copilot.cardLabels.*`.
+ *
+ * A label with no entry is shown exactly as the gateway sent it. That matters, because a
+ * deployment can add its own tools to the manifest, and an English row reads better than a
+ * missing-translation placeholder.
+ */
+export function translateCardLabel(label: string, translate: (key: string) => string): string {
+  const key = slug(label);
+  if (!key) {
+    return label;
+  }
+  const translated = translate(LABEL_PREFIX + key);
+  return translated && translated !== LABEL_PREFIX + key ? translated : label;
+}

--- a/src/app/copilot/core/idempotency.ts
+++ b/src/app/copilot/core/idempotency.ts
@@ -11,7 +11,7 @@
  *
  * DISPLAY-ONLY (ADR-001 §04): the gateway mints the authoritative
  * Idempotency-Key server-side at action-card creation and ignores any
- * client-supplied key — a client-controllable dedup key would be a tampering
+ * client-supplied key, because a client-controllable dedup key would be a tampering
  * vector against Fineract's CommandSource dedup. This factory remains for
  * client-side labels and tracing only. Pure logic, see idempotency.spec.ts.
  */

--- a/src/app/copilot/core/mcp-client.spec.ts
+++ b/src/app/copilot/core/mcp-client.spec.ts
@@ -96,21 +96,54 @@ describe('McpClient', () => {
 
   it('maps a snake_case action_card payload to a PendingAction', async () => {
     const fetchFn = fetchWithChunks([
-      'event: action_card\ndata: {"card_id":"card-7","tool":"fineract_loan_approve",' +
-        '"args":{"loanId":4521},"human_summary":"Approve loan #4521","idempotency_key":"srv-1",' +
-        '"expires_at":"2026-08-09T12:00:00Z"}\n\n',
+      'event: action_card\ndata: {"card_id":"card-7","tool":"mifos_loan_approve",' +
+        '"args":{"loanId":4521},"human_summary":"Approve Agriculture Term Loan for Rajesh Kumar",' +
+        '"idempotency_key":"srv-1","expires_at":"2026-08-09T12:00:00Z"}\n\n',
       'event: done\ndata: {}\n\n'
     ]);
     const events = await collect(client(fetchFn).chat(REQUEST, {}));
 
     expect(events[0].pendingAction).toEqual({
       cardId: 'card-7',
-      tool: 'fineract_loan_approve',
+      tool: 'mifos_loan_approve',
       args: { loanId: 4521 },
-      humanSummary: 'Approve loan #4521',
+      display: [],
+      humanSummary: 'Approve Agriculture Term Loan for Rajesh Kumar',
       idempotencyKey: 'srv-1',
       expiresAt: '2026-08-09T12:00:00Z'
     });
+  });
+
+  it('keeps the gateway ordering of the rows the officer reads', async () => {
+    // The gateway decides what comes first (who and which account, then what changes);
+    // the transport must not reorder or drop those rows.
+    const fetchFn = fetchWithChunks([
+      'event: action_card\ndata: {"card_id":"card-8","tool":"mifos_loan_approve","args":{"loanId":12},' +
+        '"rows":{"Client":"Aisha Bello","Loan account":"000000012","Product":"Weekly Loan",' +
+        '"Approved amount":"USD 28,000.00","Approval date":"21 August 2026"},' +
+        '"human_summary":"Approve Weekly Loan for Aisha Bello"}\n\n',
+      'event: done\ndata: {}\n\n'
+    ]);
+    const events = await collect(client(fetchFn).chat(REQUEST, {}));
+
+    expect(events[0].pendingAction?.display).toEqual([
+      { label: 'Client', value: 'Aisha Bello' },
+      { label: 'Loan account', value: '000000012' },
+      { label: 'Product', value: 'Weekly Loan' },
+      { label: 'Approved amount', value: 'USD 28,000.00' },
+      { label: 'Approval date', value: '21 August 2026' }
+    ]);
+  });
+
+  it('drops blank rows rather than rendering an empty line on the card', async () => {
+    const fetchFn = fetchWithChunks([
+      'event: action_card\ndata: {"card_id":"card-9","tool":"mifos_loan_approve","args":{},' +
+        '"rows":{"Client":"Aisha Bello","Product":"","Approved amount":null}}\n\n',
+      'event: done\ndata: {}\n\n'
+    ]);
+    const events = await collect(client(fetchFn).chat(REQUEST, {}));
+
+    expect(events[0].pendingAction?.display).toEqual([{ label: 'Client', value: 'Aisha Bello' }]);
   });
 
   it('skips malformed frames without surfacing an error', async () => {

--- a/src/app/copilot/core/mcp-client.ts
+++ b/src/app/copilot/core/mcp-client.ts
@@ -12,7 +12,8 @@ import {
   McpErrorCode,
   McpStreamEvent,
   McpStreamEventType,
-  PendingAction
+  PendingAction,
+  CardRow
 } from './models/mcp-response.model';
 import { ActionCard } from './models/action-card.model';
 
@@ -45,13 +46,13 @@ const VALID_EVENT_TYPES: ReadonlyArray<McpStreamEventType> = [
 /**
  * Low-level, framework-agnostic transport for wire contract v1: POSTs a JSON
  * body and consumes the SSE response via fetch + ReadableStream. Native
- * EventSource is unusable here — it can neither POST a body nor set the
+ * EventSource is unusable here: it can neither POST a body nor set the
  * Authorization/tenant headers this contract requires.
  *
  * Retry policy (ADR-001): a chat turn is NOT idempotent, so this client never
  * retries automatically. Cancel/retry is a visible user action.
  *
- * No Angular dependency — see mcp-client.spec.ts. The DI wrapper lives in
+ * No Angular dependency, see mcp-client.spec.ts. The DI wrapper lives in
  * services/mcp-client.service.ts.
  */
 export class McpClient {
@@ -70,7 +71,7 @@ export class McpClient {
     signal?: AbortSignal
   ): AsyncIterable<McpStreamEvent> {
     if (!CARD_ID_PATTERN.test(cardId)) {
-      // Dot-segments etc. survive encodeURIComponent — refuse anything but plain ids.
+      // Dot-segments etc. survive encodeURIComponent, so refuse anything but plain ids.
       return this.singleErrorStream('INTERNAL', 'Invalid confirmation reference.', false);
     }
     const path = `/copilot/api/v1/actions/${encodeURIComponent(cardId)}/decision`;
@@ -89,7 +90,7 @@ export class McpClient {
    * POST `body` and yield parsed SSE events until 'done', end-of-stream, or
    * abort. Transport failures surface as a terminal 'error' event rather than
    * a thrown exception, so consumers have a single event-driven code path.
-   * A user-initiated abort ends the stream silently — stopping is not an error.
+   * A user-initiated abort ends the stream silently, since stopping is not an error.
    */
   private async *stream(
     path: string,
@@ -98,7 +99,7 @@ export class McpClient {
     signal?: AbortSignal
   ): AsyncGenerator<McpStreamEvent> {
     if (signal?.aborted) {
-      return; // Cancelled before the (lazy) generator ever ran — never send the POST.
+      return; // Cancelled before the (lazy) generator ever ran, so never send the POST.
     }
     const fetchFn = this.options.fetchFn ?? fetch.bind(globalThis);
     const controller = new AbortController();
@@ -164,7 +165,7 @@ export class McpClient {
       }
     } catch (error) {
       if (signal?.aborted) {
-        return; // User pressed stop — end silently.
+        return; // User pressed stop, so end silently.
       }
       if (timedOut) {
         yield this.errorEvent('LLM_UNAVAILABLE', 'Timed out waiting for the assistant to respond.', true);
@@ -248,6 +249,25 @@ export class McpClient {
     }
   }
 
+  /**
+   * Rows arrive as an ordered object so the gateway controls what the officer reads first
+   * (who and which account, then what changes). Blank values are dropped rather than shown
+   * as an empty line.
+   */
+  private toDisplayRows(raw: unknown): CardRow[] {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return [];
+    }
+    return Object.entries(raw as Record<string, unknown>)
+      .map(
+        ([
+          label,
+          value
+        ]) => ({ label, value: value == null ? '' : String(value) })
+      )
+      .filter((row) => row.label.trim().length > 0 && row.value.trim().length > 0);
+  }
+
   /** An action_card with a card_id awaits approval; without one it is display-only. */
   private normalizeActionCard(payload: Record<string, unknown>): McpStreamEvent {
     const cardId = payload['card_id'];
@@ -261,6 +281,7 @@ export class McpClient {
         cardId: String(cardId),
         tool: String(payload['tool'] ?? ''),
         args: this.toRecord(payload['args']),
+        display: this.toDisplayRows(payload['rows']),
         humanSummary: String(payload['human_summary'] ?? payload['summary'] ?? ''),
         idempotencyKey: payload['idempotency_key'] != null ? String(payload['idempotency_key']) : undefined,
         expiresAt: payload['expires_at'] != null ? String(payload['expires_at']) : undefined
@@ -310,7 +331,7 @@ export class McpClient {
         }
       }
     } catch {
-      // Non-JSON error body — keep the status-derived defaults.
+      // Non-JSON error body, so keep the status-derived defaults.
     }
     return this.errorEvent(code, message, retryable);
   }

--- a/src/app/copilot/core/models/copilot-context.model.ts
+++ b/src/app/copilot/core/models/copilot-context.model.ts
@@ -28,7 +28,7 @@ export interface CopilotContext {
   language: string;
   /**
    * Origin of the Fineract backend THIS UI is connected to. The gateway compares it
-   * against its own FINERACT_BASE_URL and refuses to run on a mismatch — the Copilot
+   * against its own FINERACT_BASE_URL and refuses to run on a mismatch, so the Copilot
    * must never write to a different bank than the one on the officer's screen.
    */
   backendOrigin?: string;

--- a/src/app/copilot/core/models/mcp-response.model.ts
+++ b/src/app/copilot/core/models/mcp-response.model.ts
@@ -12,7 +12,7 @@ import { CopilotContext } from './copilot-context.model';
 /**
  * Wire contract v1 (ADR-001) between the web-app and the Copilot gateway.
  * The gateway streams typed SSE events; the frontend never derives approval
- * state from model prose — action cards arrive as structured events.
+ * state from model prose. Action cards arrive as structured events.
  */
 
 /** Discriminator for events arriving over the SSE stream. */
@@ -23,16 +23,35 @@ export type McpErrorCode =
   'AUTH_EXPIRED' | 'PERMISSION_DENIED' | 'LLM_UNAVAILABLE' | 'TOOL_FAILED' | 'RATE_LIMITED' | 'CANCELLED' | 'INTERNAL';
 
 /**
+ * One labelled line on a confirmation card, as the gateway wrote it.
+ *
+ * The gateway resolves the account before the card is shown, so the label is already
+ * chosen and the value already formatted. The panel translates the label and renders
+ * the value as given; it does no formatting of its own, because the value on screen has
+ * to be the one the gateway will act on.
+ */
+export interface CardRow {
+  label: string;
+  value: string;
+}
+
+/**
  * A write action awaiting human confirmation. Constructed server-side from the
- * model's parsed function call — never authored by the model as prose.
+ * model's parsed function call, never authored by the model as prose.
  */
 export interface PendingAction {
   /** Server-issued id used to approve/reject via the decision endpoint. */
   cardId: string;
   /** MCP tool the gateway will execute on approval. */
   tool: string;
-  /** Parsed tool arguments, shown to the officer verbatim. */
+  /** Parsed tool arguments: the machine record of exactly what will execute. */
   args: Record<string, unknown>;
+  /**
+   * What the officer reads: labelled, formatted rows the gateway built by reading the
+   * account first, so the card names the client, account and product instead of echoing
+   * raw ids and unformatted numbers back.
+   */
+  display: CardRow[];
   /** One-sentence summary of what will happen, built by the gateway. */
   humanSummary: string;
   /** Display-only. The gateway's copy is authoritative (ADR-001 §04). */

--- a/src/app/copilot/core/relative-time.spec.ts
+++ b/src/app/copilot/core/relative-time.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { describe, it, expect, afterEach } from '@jest/globals';
+import moment from 'moment';
+import 'moment/locale/cs';
+import 'moment/locale/fr';
+import { relativeTime } from './relative-time';
+
+/**
+ * Timestamps in the Copilot were rendering in Czech for an officer working in English.
+ * The cause was not the Copilot: date-format.pipe and datetime-format.pipe both call
+ * moment.locale() as a side effect of rendering, which sets the language process-wide,
+ * and anything calling fromNow() afterwards inherits it.
+ */
+describe('relativeTime', () => {
+  const FIVE_MINUTES_AGO = Date.now() - 5 * 60_000;
+
+  afterEach(() => {
+    moment.locale('en');
+  });
+
+  it('answers in the language it was asked for', () => {
+    expect(relativeTime(FIVE_MINUTES_AGO, 'en')).toBe('5 minutes ago');
+    expect(relativeTime(FIVE_MINUTES_AGO, 'fr')).toContain('minutes');
+  });
+
+  it('ignores a global locale another part of the app has set', () => {
+    // This is the actual bug. A date pipe rendered somewhere else in the page, moment's
+    // global locale became Czech, and Recent Chats started saying "před 5 minutami".
+    moment.locale('cs');
+
+    expect(relativeTime(FIVE_MINUTES_AGO, 'en')).toBe('5 minutes ago');
+  });
+
+  it('leaves the global locale exactly as it found it', () => {
+    moment.locale('cs');
+
+    relativeTime(FIVE_MINUTES_AGO, 'en');
+
+    expect(moment.locale()).toBe('cs');
+  });
+
+  it('falls back to English rather than to whatever was set last', () => {
+    moment.locale('cs');
+
+    expect(relativeTime(FIVE_MINUTES_AGO, '')).toBe('5 minutes ago');
+  });
+});

--- a/src/app/copilot/core/relative-time.ts
+++ b/src/app/copilot/core/relative-time.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import moment from 'moment';
+
+/**
+ * "3 minutes ago", in the language the officer chose.
+ *
+ * Always pass the locale. `moment().fromNow()` reads a process-wide locale that
+ * `date-format.pipe` and `datetime-format.pipe` both assign to as a side effect of
+ * rendering, so whichever of them ran last decides the language. That is how the Copilot
+ * ended up showing "před 14 minutami" to an officer working in English.
+ *
+ * Calling `.locale()` on the instance leaves the global setting alone, so this cannot
+ * change what any other part of the app renders either.
+ */
+export function relativeTime(timestamp: number, momentLocale: string): string {
+  return moment(timestamp)
+    .locale(momentLocale || 'en')
+    .fromNow();
+}

--- a/src/app/copilot/core/response-parser.ts
+++ b/src/app/copilot/core/response-parser.ts
@@ -13,7 +13,7 @@ const SUGGEST_BLOCK = /```suggest\s*([\s\S]*?)```/gi;
  *
  * Deliberately narrow (ADR-001 §04): approvable action cards arrive ONLY as typed SSE
  * events constructed server-side from the parsed function call. Model prose that merely
- * looks like an action card renders as plain text — the fenced ```action_card``` parsing
+ * looks like an action card renders as plain text, since the fenced ```action_card``` parsing
  * path was removed so the LLM can never author the content a human approves against.
  */
 export class ResponseParser {

--- a/src/app/copilot/services/chat.service.spec.ts
+++ b/src/app/copilot/services/chat.service.spec.ts
@@ -29,10 +29,37 @@ const CONTEXT: CopilotContext = {
   language: 'en'
 };
 
+/**
+ * Give this suite a localStorage that actually stores.
+ *
+ * The repo-wide stub in setup-jest.ts is a bare jest.fn() for every method, so writes go
+ * nowhere and reads answer undefined. Assertions about what survives a logout would pass
+ * against any implementation at all, including one that leaks.
+ */
+function useRealLocalStorage(): Record<string, string> {
+  const backing: Record<string, string> = {};
+  const storage = window.localStorage as unknown as Record<string, jest.Mock>;
+  storage['getItem'].mockImplementation((key: string) => (key in backing ? backing[key] : null));
+  storage['setItem'].mockImplementation((key: string, value: string) => {
+    backing[key] = String(value);
+  });
+  storage['removeItem'].mockImplementation((key: string) => {
+    delete backing[key];
+  });
+  storage['clear'].mockImplementation(() => {
+    for (const key of Object.keys(backing)) {
+      delete backing[key];
+    }
+  });
+  return backing;
+}
+
 describe('ChatService', () => {
   let service: ChatService;
   let mcpMock: { chat: jest.Mock; decision: jest.Mock };
   let loggedIn$: BehaviorSubject<boolean>;
+  let currentUser: string | null;
+  let store: Record<string, string>;
 
   beforeEach(() => {
     mcpMock = {
@@ -40,6 +67,8 @@ describe('ChatService', () => {
       decision: jest.fn(() => from([{ type: 'done' }] as McpStreamEvent[]))
     };
     loggedIn$ = new BehaviorSubject<boolean>(true);
+    currentUser = 'priya';
+    store = useRealLocalStorage();
     TestBed.configureTestingModule({
       providers: [
         ChatService,
@@ -53,7 +82,7 @@ describe('ChatService', () => {
           provide: AuthenticationService,
           useValue: {
             isAuthenticated$: loggedIn$.asObservable(),
-            getCredentials: () => ({ username: 'priya' })
+            getCredentials: () => (currentUser ? { username: currentUser } : null)
           }
         },
         { provide: TranslateService, useValue: { instant: (key: string) => key } }
@@ -123,8 +152,9 @@ describe('ChatService', () => {
         type: 'action_card',
         pendingAction: {
           cardId: 'card-7',
-          tool: 'fineract_loan_approve',
+          tool: 'mifos_loan_approve',
           args: { loanId: 4521 },
+          display: [],
           humanSummary: 'Approve loan #4521'
         }
       })
@@ -148,11 +178,11 @@ describe('ChatService', () => {
   });
 
   it('never sends a locally minted archive id as the wire conversationId', () => {
-    // Turn 1 pauses at an action card — no 'done', so no gateway id was ever issued.
+    // Turn 1 pauses at an action card, so no 'done' and no gateway id was ever issued.
     mcpMock.chat.mockReturnValueOnce(
       of<McpStreamEvent>({
         type: 'action_card',
-        pendingAction: { cardId: 'card-1', tool: 't', args: {}, humanSummary: 's' }
+        pendingAction: { cardId: 'card-1', tool: 't', args: {}, display: [], humanSummary: 's' }
       })
     );
     service.sendMessage('Approve the loan');
@@ -169,7 +199,7 @@ describe('ChatService', () => {
     mcpMock.chat.mockReturnValue(
       of<McpStreamEvent>({
         type: 'action_card',
-        pendingAction: { cardId: 'card-9', tool: 't', args: {}, humanSummary: 's' }
+        pendingAction: { cardId: 'card-9', tool: 't', args: {}, display: [], humanSummary: 's' }
       })
     );
     service.sendMessage('Approve the loan');
@@ -181,7 +211,7 @@ describe('ChatService', () => {
     );
     service.decideAction('approve');
 
-    // The card came back — the officer can retry instead of losing the action.
+    // The card came back, so the officer can retry instead of losing the action.
     expect(service.pendingAction$.value?.cardId).toBe('card-9');
   });
 
@@ -189,12 +219,12 @@ describe('ChatService', () => {
     mcpMock.chat.mockReturnValue(
       of<McpStreamEvent>({
         type: 'action_card',
-        pendingAction: { cardId: 'card-9', tool: 't', args: {}, humanSummary: 's' }
+        pendingAction: { cardId: 'card-9', tool: 't', args: {}, display: [], humanSummary: 's' }
       })
     );
     service.sendMessage('Approve the loan');
 
-    // e.g. the LLM summarization failed AFTER the write executed — the gateway did not
+    // e.g. the LLM summarization failed AFTER the write executed, and the gateway did not
     // restore the card, so offering it back would be a dead card and manufactured doubt.
     mcpMock.decision.mockReturnValue(
       from([
@@ -272,7 +302,7 @@ describe('ChatService', () => {
     mcpMock.chat.mockReturnValueOnce(
       of<McpStreamEvent>({
         type: 'action_card',
-        pendingAction: { cardId: 'card-1', tool: 't', args: {}, humanSummary: 's' }
+        pendingAction: { cardId: 'card-1', tool: 't', args: {}, display: [], humanSummary: 's' }
       })
     );
     service.sendMessage('Approve the loan');
@@ -306,5 +336,115 @@ describe('ChatService', () => {
     mcpMock.chat.mockReturnValue(from([{ type: 'done' }] as McpStreamEvent[]));
     service.sendMessage('New session');
     expect(mcpMock.chat).toHaveBeenCalledWith(expect.objectContaining({ conversationId: undefined }));
+  });
+
+  describe('one officer per session', () => {
+    const keyFor = (user: string) => `mifosXCopilotChats:default:${user}`;
+
+    it('wipes the previous officer when another logs in directly over them', () => {
+      // isAuthenticated$ carries a bare boolean and emits true again on a direct switch,
+      // so a de-duplicated subscription would leave the first officer's chat on screen.
+      service.sendMessage('Show loans for Aisha');
+      expect(service.messages$.value.length).toBeGreaterThan(0);
+
+      currentUser = 'daniel';
+      loggedIn$.next(true);
+      service.sendMessage('Show loans for Kwame');
+
+      const authors = service.messages$.value.filter((message) => message.role === 'user');
+      expect(authors).toHaveLength(1);
+      expect(authors[0].content).toBe('Show loans for Kwame');
+    });
+
+    it('never lets a card raised by one officer be approved by the next', () => {
+      mcpMock.chat.mockReturnValueOnce(
+        from([
+          {
+            type: 'action_card',
+            pendingAction: { cardId: 'card-1', tool: 'mifos_loan_approve', args: {}, display: [], humanSummary: 's' }
+          }
+        ] as McpStreamEvent[])
+      );
+      service.sendMessage('Approve the loan');
+      expect(service.pendingAction$.value).not.toBeNull();
+
+      currentUser = 'daniel';
+      loggedIn$.next(true);
+      service.decideAction('approve');
+
+      expect(service.pendingAction$.value).toBeNull();
+      expect(mcpMock.decision).not.toHaveBeenCalled();
+    });
+
+    it('catches the switch even when the auth event arrives before the new credentials', () => {
+      // onLoginSuccess() announces the login and writes the credentials afterwards, so the
+      // new identity is not readable at the moment of the event. It must still be caught.
+      service.sendMessage('Show loans for Aisha');
+      loggedIn$.next(true); // Announced while getCredentials() still returns the old user.
+
+      // Cleared on the event itself, not merely by the time the next officer acts.
+      expect(service.messages$.value).toHaveLength(0);
+      expect(service.pendingAction$.value).toBeNull();
+      expect(service.conversations$.value).toHaveLength(0);
+
+      currentUser = 'daniel'; // Credentials land a moment later.
+      service.sendMessage('Show loans for Kwame');
+
+      const authors = service.messages$.value.filter((message) => message.role === 'user');
+      expect(authors).toHaveLength(1);
+      expect(authors[0].content).toBe('Show loans for Kwame');
+    });
+
+    it("does not put the previous officer's transcripts into Recent Chats", () => {
+      // The login event fires while getCredentials() still names the previous officer, so
+      // reading storage at that moment would list their conversations to the new one.
+      service.sendMessage('Aisha');
+      service.clearChat();
+      expect(service.conversations$.value).toHaveLength(1);
+
+      loggedIn$.next(true); // Announced; credentials have not been replaced yet.
+
+      // Observed before the incoming officer performs any chat operation.
+      expect(service.conversations$.value).toHaveLength(0);
+    });
+
+    it('gives an officer their own archive back when the panel asks for it', () => {
+      service.sendMessage('Aisha');
+      service.clearChat();
+      const mine = service.conversations$.value.length;
+      expect(mine).toBe(1);
+
+      loggedIn$.next(true);
+      expect(service.conversations$.value).toHaveLength(0);
+
+      service.loadHistory(); // What the panel does when it shows Recent Chats.
+
+      expect(service.conversations$.value).toHaveLength(mine);
+    });
+
+    it('clears the transcript of whoever was signed in, not of nobody', () => {
+      // logout() clears the credentials before it announces itself, so reading the username
+      // at that point yields the anonymous key and the real transcript would survive.
+      service.sendMessage('Show loans for Aisha');
+      service.clearChat(); // Archives the conversation under priya's key.
+      expect(localStorage.getItem(keyFor('priya'))).not.toBeNull();
+
+      currentUser = null;
+      loggedIn$.next(false);
+
+      expect(localStorage.getItem(keyFor('priya'))).toBeNull();
+      expect(Object.keys(store)).toHaveLength(0);
+    });
+
+    it("keeps each officer's archive separate", () => {
+      service.sendMessage('Aisha');
+      service.clearChat();
+
+      currentUser = 'daniel';
+      loggedIn$.next(true);
+
+      expect(service.conversations$.value).toHaveLength(0);
+      expect(localStorage.getItem(keyFor('priya'))).not.toBeNull();
+    });
   });
 });

--- a/src/app/copilot/services/chat.service.ts
+++ b/src/app/copilot/services/chat.service.ts
@@ -9,7 +9,6 @@
 /** Angular Imports */
 import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject, Observable, Subscription } from 'rxjs';
-import { distinctUntilChanged } from 'rxjs/operators';
 import { TranslateService } from '@ngx-translate/core';
 
 /** Custom Services */
@@ -54,13 +53,14 @@ function isConversation(value: unknown): value is Conversation {
  *
  * Security invariants (ADR-001):
  *  - every outgoing message passes the InputSanitizer first;
- *  - approvable actions come ONLY from typed action_card events — fenced
+ *  - approvable actions come ONLY from typed action_card events, and fenced
  *    ```action_card``` text in model prose is never parsed into a card;
  *  - stopping a stream aborts the underlying request (nothing keeps running);
- *  - all conversation state resets on auth changes so one user's chat can
- *    never leak into (or be archived under) another user's session;
- *  - the wire conversationId is gateway-assigned only — locally minted archive
- *    ids never leave the browser.
+ *  - conversation state belongs to exactly one tenant+user, and is wiped the
+ *    moment that changes, so one officer's chat can never leak into (or be
+ *    archived under) another's session;
+ *  - the wire conversationId only ever comes from the gateway, so locally minted
+ *    archive ids never leave the browser.
  */
 @Injectable({ providedIn: 'root' })
 export class ChatService {
@@ -84,32 +84,66 @@ export class ChatService {
   private readonly parser = new ResponseParser();
 
   private subscription: Subscription | null = null;
-  /** Gateway-assigned conversation id — set ONLY from 'done' events, sent on the wire. */
+  /**
+   * Gateway-assigned conversation id, sent on the wire. Only ever set from a 'done' event
+   * or restored from an archived conversation that carried one; a locally minted archive id
+   * never gets in here.
+   */
   private wireConversationId?: string;
-  /** Local id used for the Recent Chats archive — never sent to the gateway. */
+  /** Local id used for the Recent Chats archive, never sent to the gateway. */
   private archiveId?: string;
   /** Pending action backed up during a decision, restored if the decision fails retryably. */
   private decisionBackup: PendingAction | null = null;
+  /**
+   * Storage key of the officer the in-memory conversation belongs to, or null when nothing
+   * is loaded. This is the identity check; the auth service's boolean is only the trigger.
+   */
+  private stateOwner: string | null = null;
   private seq = 0;
 
   constructor() {
-    // Root-singleton services outlive logins: wipe all conversation state whenever the
-    // authenticated user changes, so user A's chat never leaks into user B's session.
-    this.authenticationService.isAuthenticated$.pipe(distinctUntilChanged()).subscribe((loggedIn) => {
-      const previousKey = this.storageKey();
+    // Root-singleton services outlive logins, so this service has to notice when the
+    // officer changes. isAuthenticated$ carries a bare boolean and emits true again when
+    // one officer logs in directly over another, so it cannot be de-duplicated: every
+    // emission wipes state, and storageKey() decides whose history may be read back.
+    this.authenticationService.isAuthenticated$.subscribe((loggedIn) => {
+      const previousOwner = this.stateOwner;
       this.reset();
       if (loggedIn) {
-        this.loadHistory();
-      } else {
-        // Transcripts hold client names and loan ids. Do not leave them on a shared
-        // branch machine after logout.
-        this.clearPersistedHistory(previousKey);
+        // Deliberately no load here. The credentials still name the previous officer at
+        // this point, so reading a transcript now would put theirs in front of the new
+        // one. State stays unowned until something asks for it, which is late enough.
+        return;
+      }
+      if (previousOwner) {
+        // Transcripts hold client names and loan amounts. Do not leave them on a shared
+        // branch machine after logout. The key comes from whoever the state belonged to,
+        // because logout clears the credentials before it announces itself.
+        this.clearPersistedHistory(previousOwner);
       }
     });
   }
 
+  /**
+   * Rebind to whoever is signed in now, wiping state that belongs to someone else.
+   *
+   * The auth service announces a login before it writes the new credentials, so the
+   * identity is not yet readable at the moment of the event. Every entry point that
+   * touches conversation state checks again here, by which point it is.
+   */
+  private ensureCurrentUser(): void {
+    const key = this.storageKey();
+    if (this.stateOwner !== null && this.stateOwner !== key) {
+      this.reset();
+    }
+    if (this.stateOwner === null) {
+      this.loadHistory();
+    }
+  }
+
   /** Send a user message and stream the assistant reply. */
   sendMessage(content: string): void {
+    this.ensureCurrentUser();
     if (this.isStreaming$.value) {
       return;
     }
@@ -151,6 +185,7 @@ export class ChatService {
 
   /** Approve or reject the pending write action; the reply continues streaming. */
   decideAction(decision: 'approve' | 'reject'): void {
+    this.ensureCurrentUser(); // A card must never be approved under a different login.
     const pending = this.pendingAction$.value;
     if (!pending || this.isStreaming$.value) {
       return;
@@ -174,6 +209,7 @@ export class ChatService {
 
   /** Start a fresh conversation, archiving the current one. */
   clearChat(): void {
+    this.ensureCurrentUser();
     this.stopStreaming();
     this.archiveCurrentConversation();
     this.messages$.next([]);
@@ -183,10 +219,12 @@ export class ChatService {
     this.archiveId = undefined;
   }
 
-  /** Load persisted conversations for the current user + tenant. */
+  /** Load persisted conversations for the current user + tenant, and bind state to them. */
   loadHistory(): void {
+    const key = this.storageKey();
+    this.stateOwner = key;
     try {
-      const raw = localStorage.getItem(this.storageKey());
+      const raw = localStorage.getItem(key);
       const parsed = raw ? JSON.parse(raw) : [];
       // localStorage is writable by any script on the origin and by older versions of
       // this feature, so validate each record instead of trusting the array.
@@ -198,6 +236,10 @@ export class ChatService {
 
   /** Reopen a saved conversation. */
   openConversation(conversation: Conversation): void {
+    this.ensureCurrentUser();
+    if (!this.conversations$.value.some((saved) => saved.id === conversation.id)) {
+      return; // Belonged to a previous session; ensureCurrentUser() has already wiped it.
+    }
     this.stopStreaming();
     this.archiveCurrentConversation();
     this.messages$.next(conversation.messages ?? []);
@@ -210,6 +252,7 @@ export class ChatService {
 
   /** Remove a saved conversation. */
   deleteConversation(id: string): void {
+    this.ensureCurrentUser();
     const remaining = this.conversations$.value.filter((conversation) => conversation.id !== id);
     this.conversations$.next(remaining);
     this.persistConversations(remaining);
@@ -276,7 +319,7 @@ export class ChatService {
         this.appendToDraft(
           `${this.draftContent() ? '\n\n' : ''}${event.message ?? this.translate.instant('copilot.errors.streamFailed')}`
         );
-        // Restore the card ONLY on AUTH_EXPIRED — the one code the gateway pairs with a
+        // Restore the card ONLY on AUTH_EXPIRED, the one code the gateway pairs with a
         // server-side card restore. Restoring on other retryable errors (e.g. the LLM
         // summarization failing AFTER a successful write) would offer the officer a dead
         // card and manufacture doubt about whether the action executed.
@@ -290,7 +333,7 @@ export class ChatService {
 
   /**
    * Close out the streaming draft: extract fenced ```suggest``` follow-ups
-   * (kept per ADR-001) — any fenced action_card text stays as plain prose and
+   * (kept per ADR-001), so any fenced action_card text stays as plain prose and
    * is deliberately NOT turned into an approvable card.
    */
   private finalizeDraft(): void {
@@ -317,7 +360,7 @@ export class ChatService {
 
   /**
    * A turn that paused at a confirmation card (or errored before any token) leaves an
-   * assistant message with nothing in it — remove it so no empty bubble ever renders.
+   * assistant message with nothing in it, so remove it and no empty bubble ever renders.
    */
   private dropEmptyDraft(): void {
     const messages = this.messages$.value;
@@ -332,7 +375,7 @@ export class ChatService {
     }
   }
 
-  /** Full wipe on auth changes — aborts any stream WITHOUT archiving (wrong user's key). */
+  /** Full wipe on auth changes, aborting any stream WITHOUT archiving (wrong user's key). */
   private reset(): void {
     this.subscription?.unsubscribe();
     this.subscription = null;
@@ -343,6 +386,7 @@ export class ChatService {
     this.decisionBackup = null;
     this.wireConversationId = undefined;
     this.archiveId = undefined;
+    this.stateOwner = null;
   }
 
   // ─── Message-list helpers (immutable updates for change detection) ────────
@@ -381,7 +425,7 @@ export class ChatService {
 
   // ─── History persistence (localStorage; gateway sync arrives later) ───────
 
-  /** The gateway issued the real id — migrate any local archive record onto it. */
+  /** The gateway issued the real id, so migrate any local archive record onto it. */
   private adoptServerConversationId(serverId: string): void {
     this.wireConversationId = serverId;
     if (this.archiveId && this.archiveId !== serverId && this.archiveId.startsWith('local-')) {

--- a/src/app/copilot/services/copilot-feature.service.ts
+++ b/src/app/copilot/services/copilot-feature.service.ts
@@ -25,7 +25,7 @@ const PANEL_STATE_KEY = 'copilot_panel_state';
  *   L1 deployment  -> environment.enableCopilot (master switch, zero bytes when off)
  *   L2 role        -> the logged-in user holds one of the allowed permissions
  *                     (ALL_FUNCTIONS / USE_MCP_TOOLS / READ_COPILOT). This is a
- *                     UX gate only — Fineract RBAC re-checks every tool call
+ *                     UX gate only, since Fineract RBAC re-checks every tool call
  *                     server-side with the officer's own credential.
  *   L3 user pref   -> expanded / collapsed / hidden in localStorage
  */

--- a/src/app/copilot/services/mcp-client.service.spec.ts
+++ b/src/app/copilot/services/mcp-client.service.spec.ts
@@ -7,6 +7,7 @@
  */
 
 import { TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
 import { lastValueFrom } from 'rxjs';
 import { toArray } from 'rxjs/operators';
 import { describe, it, expect, beforeEach } from '@jest/globals';
@@ -43,7 +44,13 @@ describe('McpClientService', () => {
         McpClientService,
         { provide: COPILOT_CONFIG, useValue: { ...DEFAULT_COPILOT_CONFIG, mcpBaseUrl: 'mock' } },
         { provide: AuthenticationService, useValue: { getCredentials: () => credentials } },
-        { provide: SettingsService, useValue: { tenantIdentifier: 'default' } }
+        { provide: SettingsService, useValue: { tenantIdentifier: 'default' } },
+        // Demo mode resolves its copy through the translation files, so the key comes
+        // back as-is here and the assertions stay about behaviour, not wording.
+        {
+          provide: TranslateService,
+          useValue: { instant: (key: string) => key, currentLang: 'en-US' }
+        }
       ]
     });
     service = TestBed.inject(McpClientService);
@@ -66,8 +73,8 @@ describe('McpClientService', () => {
     const events = await lastValueFrom(service.chat(request('Approve this loan')).pipe(toArray()));
 
     const pending = events.find((event) => event.pendingAction);
-    expect(pending?.pendingAction?.tool).toBe('fineract_loan_approve');
-    // The stream pauses for confirmation — no done event yet.
+    expect(pending?.pendingAction?.tool).toBe('mifos_loan_approve');
+    // The stream pauses for confirmation, so no done event yet.
     expect(events.map((event) => event.type)).not.toContain('done');
   });
 
@@ -93,4 +100,27 @@ describe('McpClientService', () => {
     expect(headers['Authorization']).toBeUndefined();
     expect(headers['Fineract-Platform-TenantId']).toBe('default');
   });
+
+  it('gives two demo approvals raised together distinguishable ids', async () => {
+    // The decision endpoint keys on this id, so two cards sharing one would make the
+    // actions indistinguishable. Date.now() alone is not enough inside one millisecond.
+    const now = jest.spyOn(Date, 'now').mockReturnValue(1_800_000_000_000);
+    try {
+      const first = await firstCard();
+      const second = await firstCard();
+
+      expect(first).not.toBe(second);
+      expect(first.startsWith('mock-card-')).toBe(true);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  /** Runs a demo write turn and returns the card id it paused with. */
+  async function firstCard(): Promise<string> {
+    const events = await lastValueFrom(service.chat(request('Approve this loan')).pipe(toArray()));
+    const card = events.find((event) => event.pendingAction)?.pendingAction;
+    expect(card).toBeDefined();
+    return card!.cardId;
+  }
 });

--- a/src/app/copilot/services/mcp-client.service.ts
+++ b/src/app/copilot/services/mcp-client.service.ts
@@ -8,6 +8,7 @@
 
 /** Angular Imports */
 import { Injectable, inject } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 
 /** Custom Services */
@@ -27,7 +28,7 @@ import { mockChatStream, mockDecisionStream } from './mcp-fixtures';
  * DI wrapper around the framework-agnostic core McpClient.
  *
  * Responsibilities:
- *  - build the per-request headers (Authorization, tenant, correlation id) —
+ *  - build the per-request headers (Authorization, tenant, correlation id),
  *    the app's AuthenticationInterceptor only covers the Fineract origin, so
  *    the Copilot transport must set them itself;
  *  - adapt the async event stream into an RxJS Observable whose unsubscribe
@@ -40,8 +41,16 @@ export class McpClientService {
   private readonly config = inject(COPILOT_CONFIG);
   private readonly authenticationService = inject(AuthenticationService);
   private readonly settingsService = inject(SettingsService);
+  private readonly translate = inject(TranslateService);
 
   private client?: McpClient;
+
+  /**
+   * Demo mode answers in the officer's language like the real gateway does, so the
+   * fixtures resolve their copy through the same translation files as the rest of the UI.
+   */
+  private readonly translator = (key: string, params?: Record<string, unknown>): string =>
+    this.translate.instant(key, params);
 
   /** True when no real gateway is configured and fixtures answer instead. */
   get isMockMode(): boolean {
@@ -52,7 +61,7 @@ export class McpClientService {
   /** Stream a chat turn as Observable events; unsubscribing cancels the request. */
   chat(request: McpChatRequest): Observable<McpStreamEvent> {
     if (this.isMockMode) {
-      return this.toObservable(() => mockChatStream(request));
+      return this.toObservable(() => mockChatStream(request, this.translator, this.translate.currentLang));
     }
     return this.toObservable((signal) => this.mcpClient().chat(request, this.buildHeaders(), signal));
   }
@@ -60,7 +69,7 @@ export class McpClientService {
   /** Approve/reject a pending action; the stream continues the paused turn. */
   decision(cardId: string, decision: 'approve' | 'reject', clientMsgId: string): Observable<McpStreamEvent> {
     if (this.isMockMode) {
-      return this.toObservable(() => mockDecisionStream(cardId, decision));
+      return this.toObservable(() => mockDecisionStream(cardId, decision, this.translator));
     }
     return this.toObservable((signal) =>
       this.mcpClient().decision(cardId, { decision, clientMsgId }, this.buildHeaders(), signal)
@@ -106,7 +115,7 @@ export class McpClientService {
       'Fineract-Platform-TenantId': this.settingsService.tenantIdentifier || environment.fineractPlatformTenantId,
       'X-Correlation-Id': this.correlationId()
     };
-    // Prefer the OAuth access token whenever one exists — environment flags may not reflect
+    // Prefer the OAuth access token whenever one exists, because environment flags may not reflect
     // the runtime auth mode (OIDC can be enabled via env.js), but an accessToken on the
     // credentials is definitive. Basic key is the fallback for Basic-auth deployments.
     const credentials = this.authenticationService.getCredentials();

--- a/src/app/copilot/services/mcp-fixtures.ts
+++ b/src/app/copilot/services/mcp-fixtures.ts
@@ -11,11 +11,33 @@ import { McpChatRequest, McpStreamEvent } from '../core/models/mcp-response.mode
 /**
  * Mock transport used while the Copilot gateway is not deployed
  * (copilotMcpBaseUrl = 'mock'). Streams contract-v1 events with realistic
- * pacing so the full UI — tokens, cards, approval flow — works end to end.
+ * pacing so the full UI (tokens, cards, approval flow) works end to end.
  * Swapping to the real gateway is a configuration change only.
+ *
+ * The wording here is held to the same bar as production: accounts are named,
+ * amounts carry their currency, no record id is shown to the officer, and
+ * every string an officer reads comes from the translation files. A demo that
+ * only speaks English would misrepresent a product that ships in thirteen
+ * languages.
  */
 
+/** Resolves a translation key, supplied by the caller so this module stays DI-free. */
+export type Translator = (key: string, params?: Record<string, unknown>) => string;
+
 const TOKEN_DELAY_MS = 18;
+
+/** Stand-ins used when no client is in focus, so the demo still reads like a branch. */
+const DEMO_CLIENT = 'Rajesh Kumar';
+const DEMO_LOAN_ACCOUNT = '000000004521';
+const DEMO_CLIENT_ACCOUNT = '000000000052';
+const DEMO_CURRENCY = 'INR';
+
+/**
+ * The one date the demo runs on. Both the value sent for execution and the value shown on
+ * the card derive from it, because a card that disagrees with what will execute is the
+ * exact failure this feature exists to prevent, and a demo should not model that.
+ */
+const DEMO_DATE = new Date(Date.UTC(2026, 7, 21));
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -35,27 +57,84 @@ function suggest(...items: string[]): McpStreamEvent {
   return { type: 'suggest', suggestions: items };
 }
 
+/** yyyy-MM-dd, the form a write tool takes. */
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** "21 August 2026", the form an officer reads. */
+function readableDate(date: Date, locale: string): string {
+  return new Intl.DateTimeFormat(locale || 'en', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC'
+  }).format(date);
+}
+
+/** Grouped thousands with the currency in front, matching what the gateway sends. */
+function money(amount: number, locale: string): string {
+  const formatted = new Intl.NumberFormat(locale || 'en', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  }).format(amount);
+  return `${DEMO_CURRENCY} ${formatted}`;
+}
+
+/**
+ * A card id that is unique even for two approvals raised in the same millisecond, and whose
+ * tail varies so the reference shown on the card is not the same string every time.
+ */
+let cardSequence = 0;
+function nextCardId(): string {
+  cardSequence += 1;
+  return `mock-card-${Date.now().toString(36)}-${cardSequence.toString(36).padStart(4, '0')}`;
+}
+
+/** A name is only a name once it has a non-blank value. */
+function clientName(request: McpChatRequest): string {
+  return request.context.clientName?.trim() || DEMO_CLIENT;
+}
+
 /** Streams a mock reply for a chat turn, selected by simple intent matching. */
-export async function* mockChatStream(request: McpChatRequest): AsyncGenerator<McpStreamEvent> {
+export async function* mockChatStream(
+  request: McpChatRequest,
+  t: Translator,
+  locale = 'en'
+): AsyncGenerator<McpStreamEvent> {
   const message = request.message.toLowerCase();
-  const clientLabel =
-    request.context.clientName ?? (request.context.clientId ? `client #${request.context.clientId}` : null);
+  const client = clientName(request);
+  const loanAccount = request.context.loanId ? String(request.context.loanId).padStart(12, '0') : DEMO_LOAN_ACCOUNT;
+  const clientAccount = request.context.clientId
+    ? String(request.context.clientId).padStart(12, '0')
+    : DEMO_CLIENT_ACCOUNT;
+  const product = t('copilot.demo.product');
 
   if (/(approve|disburse|repay|repayment|record|transfer|waive)/.test(message)) {
-    // Write intent -> the gateway pauses with an approval card; nothing executes yet.
-    yield* tokens('I can do that. Please review and confirm the action below before I execute it.\n');
+    // Write intent, so the gateway pauses with an approval card and nothing executes yet.
+    yield* tokens(t('copilot.demo.writeIntro'));
     await sleep(120);
     yield {
       type: 'action_card',
       pendingAction: {
-        cardId: `mock-card-${Date.now()}`,
-        tool: 'fineract_loan_approve',
+        cardId: nextCardId(),
+        tool: 'mifos_loan_approve',
         args: {
           loanId: request.context.loanId ?? 4521,
-          approvedAmount: 25000,
-          client: clientLabel ?? 'Rajesh Kumar'
+          approvedLoanAmount: 25000,
+          approvedOnDate: isoDate(DEMO_DATE)
         },
-        humanSummary: `Approve loan #${request.context.loanId ?? 4521} for ${clientLabel ?? 'Rajesh Kumar'} (₹25,000)`,
+        // What the officer reads: the gateway looked the account up first. Every value
+        // here is derived from the same source as the argument it stands for.
+        display: [
+          { label: 'Client', value: client },
+          { label: 'Loan account', value: loanAccount },
+          { label: 'Product', value: product },
+          { label: 'Applied for', value: money(30000, locale) },
+          { label: 'Approved amount', value: money(25000, locale) },
+          { label: 'Approval date', value: readableDate(DEMO_DATE, locale) }
+        ],
+        humanSummary: t('copilot.demo.approveSummary', { product, client }),
         idempotencyKey: 'srv-mock-0001',
         expiresAt: new Date(Date.now() + 5 * 60_000).toISOString()
       }
@@ -64,88 +143,103 @@ export async function* mockChatStream(request: McpChatRequest): AsyncGenerator<M
   }
 
   if (/loan/.test(message)) {
-    yield { type: 'tool_call', toolName: 'fineract_loan_details', toolPhase: 'started', readOnly: true };
+    yield { type: 'tool_call', toolName: 'mifos_loan_details', toolPhase: 'started', readOnly: true };
     await sleep(350);
-    yield { type: 'tool_call', toolName: 'fineract_loan_details', toolPhase: 'finished', readOnly: true };
-    yield* tokens(`Here is the active loan${clientLabel ? ` for **${clientLabel}**` : ''}:\n`);
+    yield { type: 'tool_call', toolName: 'mifos_loan_details', toolPhase: 'finished', readOnly: true };
+    yield* tokens(t('copilot.demo.loanIntro', { client }));
     yield {
       type: 'action_card',
       card: {
         type: 'loan',
-        title: `Loan #${request.context.loanId ?? 4521} — Active`,
+        title: t('copilot.demo.loanTitle', { product }),
         data: {
-          Product: 'Agriculture Term Loan',
-          Principal: '₹50,000',
-          Outstanding: '₹31,250',
-          'Next EMI': '₹5,000 due in 2 days',
-          Status: 'Active'
+          // Keys are the shared card vocabulary; the card components translate them.
+          'Loan account': loanAccount,
+          Principal: money(50000, locale),
+          Outstanding: money(31250, locale),
+          'Next instalment': t('copilot.demo.nextInstalment', { amount: money(5000, locale), days: 2 }),
+          Status: t('copilot.demo.statusActive')
         }
       }
     };
-    yield suggest('Show repayment schedule', 'Record a repayment', 'Show overdue loans');
+    yield suggest(
+      t('copilot.demo.suggest.schedule'),
+      t('copilot.demo.suggest.recordRepayment'),
+      t('copilot.demo.suggest.overdue')
+    );
     yield { type: 'done', conversationId: request.conversationId ?? 'mock-conv-1' };
     return;
   }
 
   if (/(client|search|who is)/.test(message)) {
-    yield { type: 'tool_call', toolName: 'fineract_client_search', toolPhase: 'started', readOnly: true };
+    yield { type: 'tool_call', toolName: 'mifos_client_search', toolPhase: 'started', readOnly: true };
     await sleep(300);
-    yield { type: 'tool_call', toolName: 'fineract_client_search', toolPhase: 'finished', readOnly: true };
-    yield* tokens('I found this client:\n');
+    yield { type: 'tool_call', toolName: 'mifos_client_search', toolPhase: 'finished', readOnly: true };
+    yield* tokens(t('copilot.demo.clientIntro'));
     yield {
       type: 'action_card',
       card: {
         type: 'client',
-        title: clientLabel ?? 'Rajesh Kumar',
+        title: client,
         data: {
-          'Client ID': String(request.context.clientId ?? 4521),
-          Office: 'Head Office',
-          Status: 'Active',
+          'Client account': clientAccount,
+          Office: t('copilot.demo.office'),
+          Status: t('copilot.demo.statusActive'),
           'Active loans': '1',
-          'Savings balance': '₹12,300'
+          'Savings balance': money(12300, locale)
         }
       }
     };
-    yield suggest('Show their loans', 'Show KYC documents', 'Check savings balance');
+    yield suggest(
+      t('copilot.demo.suggest.theirLoans'),
+      t('copilot.demo.suggest.kyc'),
+      t('copilot.demo.suggest.savings')
+    );
     yield { type: 'done', conversationId: request.conversationId ?? 'mock-conv-1' };
     return;
   }
 
-  yield* tokens(
-    'I am running in **mock mode** (no gateway connected yet), but the full pipeline you are ' +
-      'seeing — streaming, cards, confirmations — is the real one. Try “show loans for this client” ' +
-      'or “approve this loan”.'
+  yield* tokens(t('copilot.demo.modeNotice'));
+  yield suggest(
+    t('copilot.demo.suggest.clientLoans'),
+    t('copilot.demo.suggest.approve'),
+    t('copilot.demo.suggest.searchClient')
   );
-  yield suggest('Show loans for this client', 'Approve this loan', 'Search client Rajesh');
   yield { type: 'done', conversationId: request.conversationId ?? 'mock-conv-1' };
 }
 
 /** Streams the continuation of a paused turn after approve/reject. */
 export async function* mockDecisionStream(
   cardId: string,
-  decision: 'approve' | 'reject'
+  decision: 'approve' | 'reject',
+  t: Translator
 ): AsyncGenerator<McpStreamEvent> {
   await sleep(250);
   if (decision === 'approve') {
-    yield { type: 'tool_call', toolName: 'fineract_loan_approve', toolPhase: 'started', readOnly: false };
+    yield { type: 'tool_call', toolName: 'mifos_loan_approve', toolPhase: 'started', readOnly: false };
     await sleep(600);
-    yield { type: 'tool_call', toolName: 'fineract_loan_approve', toolPhase: 'finished', readOnly: false };
-    yield* tokens('Done — the loan has been approved and recorded in the audit trail.\n');
+    yield { type: 'tool_call', toolName: 'mifos_loan_approve', toolPhase: 'finished', readOnly: false };
+    yield* tokens(t('copilot.demo.approved'));
     yield {
       type: 'action_card',
       card: {
         type: 'insight',
-        title: 'Loan approved',
+        title: t('copilot.demo.approvedTitle'),
         data: {
-          Status: 'Approved',
-          'Audit reference': cardId,
-          'Executed as': 'your user (Fineract RBAC applied)'
+          Status: t('copilot.demo.statusApproved'),
+          // Take the varying tail: every demo card id starts "mock-card-".
+          Reference: cardId.slice(-8).toUpperCase(),
+          'Approved by': t('copilot.demo.approvedByYou')
         }
       }
     };
-    yield suggest('Disburse this loan', 'Show the repayment schedule', 'Back to client profile');
+    yield suggest(
+      t('copilot.demo.suggest.disburse'),
+      t('copilot.demo.suggest.schedule'),
+      t('copilot.demo.suggest.backToClient')
+    );
   } else {
-    yield* tokens('Understood — I cancelled the action. Nothing was executed.');
+    yield* tokens(t('copilot.demo.cancelled'));
   }
   yield { type: 'done', conversationId: 'mock-conv-1' };
 }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3727,7 +3727,7 @@
       "Auto Loan": "Úvěr na automobil",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financování nákupu nových i ojetých vozů s pevnými měsíčními splátkami po zvolenou dobu splatnosti.",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Financov\u00e1n\u00ed \u201ekup te\u010f, zapla\u0165 pozd\u011bji\u201c pro kr\u00e1tkodob\u00e9, \u010dasto bez\u00faro\u010dn\u00e9 n\u00e1kupy, spl\u00e1cen\u00e9 v pevn\u00fdch spl\u00e1tk\u00e1ch.",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Financování „kup teď, zaplať později“ pro krátkodobé, často bezúročné nákupy, splácené v pevných splátkách.",
       "Consumer Durable Loan": "Úvěr na spotřební zboží",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "Financování přímo v prodejně pro elektroniku, spotřebiče a další zboží dlouhodobé spotřeby, často s bezúročnými splátkami.",
       "Credit Card EMI": "Splátky kreditní kartou",
@@ -3739,17 +3739,17 @@
       "Quick secured loan against pledged gold ornaments or coins, with fast disbursal and minimal paperwork": "Rychlý zajištěný úvěr proti zastaveným zlatým šperkům nebo mincím, s rychlým vyplacením a minimem papírování.",
       "Home Loan": "Úvěr na bydlení",
       "Invoice Discounting": "Odkup faktur",
-      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "Kr\u00e1tkodob\u00e9 financov\u00e1n\u00ed oproti neuhrazen\u00fdm faktur\u00e1m pro zlep\u0161en\u00ed pen\u011b\u017en\u00edho toku podniku p\u0159ed splatnost\u00ed platby od z\u00e1kazn\u00edka.",
+      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "Krátkodobé financování oproti neuhrazeným fakturám pro zlepšení peněžního toku podniku před splatností platby od zákazníka.",
       "JLG Loan": "Úvěr JLG",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "Skupinou zajištěné mikroúvěry pro jednotlivce ve skupině se společnou odpovědností, obvykle na výdělečnou činnost.",
       "Line of Credit": "Úvěrová linka",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Revolvingov\u00fd \u00fav\u011brov\u00fd r\u00e1mec, kter\u00fd lze podle pot\u0159eby \u010derpat, spl\u00e1cet a znovu vyu\u017e\u00edvat, s \u00faroky \u00fa\u010dtovan\u00fdmi pouze z vyu\u017eit\u00e9 \u010d\u00e1stky.",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Revolvingový úvěrový rámec, který lze podle potřeby čerpat, splácet a znovu využívat, s úroky účtovanými pouze z využité částky.",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "Úvěr zajištěný stávající obytnou nebo komerční nemovitostí zastavenou jako zajištění.",
       "Loan vs Securities / FD": "Úvěr proti cenným papírům / termínovanému vkladu",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "Úvěr poskytnutý proti akciím, podílovým fondům nebo termínovaným vkladům bez nutnosti prodat samotnou investici.",
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Dlouhodobé financování na koupi, výstavbu nebo rekonstrukci nemovitosti určené k bydlení.",
       "Merchant Cash Advance": "Záloha pro obchodníky",
-      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Provozn\u00ed kapit\u00e1l poskytnut\u00fd oproti budouc\u00edm platb\u00e1m kartou nebo digit\u00e1ln\u00edm tr\u017eb\u00e1m, spl\u00e1cen\u00fd procentem z denn\u00edch transakc\u00ed.",
+      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Provozní kapitál poskytnutý oproti budoucím platbám kartou nebo digitálním tržbám, splácený procentem z denních transakcí.",
       "Mortgage Loan (LAP)": "Hypoteční úvěr (LAP)",
       "No resets have been recorded for this loan": "Pro tento úvěr nebyly zaznamenány žádné resety.",
       "No variations added yet": "Zatím nebyly přidány žádné varianty",
@@ -3757,7 +3757,7 @@
       "A row with the greater than condition must repeat the cycle number above it": "Řádek s podmínkou „větší než“ musí zopakovat číslo cyklu z řádku nad ním",
       "Fix the loan cycle variations before creating the product": "Před vytvořením produktu opravte varianty úvěrových cyklů",
       "Personal Loan": "Osobní úvěr",
-      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Nezaji\u0161t\u011bn\u00e9 financov\u00e1n\u00ed osobn\u00edch pot\u0159eb, jako je cestov\u00e1n\u00ed, l\u00e9\u010debn\u00e9 v\u00fddaje nebo svatby, s flexibiln\u00ed dobou splatnosti a minimem dokumentace.",
+      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Nezajištěné financování osobních potřeb, jako je cestování, léčebné výdaje nebo svatby, s flexibilní dobou splatnosti a minimem dokumentace.",
       "Custom / Advanced": "Vlastní / pokročilé",
       "Two Wheeler Loan": "Úvěr na motocykly a skútry",
       "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Financování nových i ojetých motocyklů a skútrů s rychlým schválením a flexibilní zálohou.",
@@ -5785,7 +5785,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "Aktuální relace",
     "newChat": "Nový chat",
     "close": "Zavřít",
@@ -5794,21 +5794,21 @@
       "afternoon": "Dobré odpoledne",
       "evening": "Dobrý večer"
     },
-    "welcomeHeading": "Jak vám dnes mohu pomoci s obsluhou vašich klientů?",
+    "welcomeHeading": "Co byste chtěli udělat?",
     "suggestions": {
-      "clientDetails": "Zobrazte mi údaje o klientovi John Doe",
-      "repaymentSchedule": "Jaký je splátkový kalendář úvěru č. 107?",
-      "savingsBalance": "Zobrazte zůstatek spořicího účtu klienta č. 52",
-      "overdueLoans": "Kolik úvěrů je tento týden po splatnosti?"
+      "clientDetails": "Zobrazte profil tohoto klienta",
+      "repaymentSchedule": "Jaký je splátkový kalendář tohoto úvěru?",
+      "savingsBalance": "Jaký je zůstatek spoření tohoto klienta?",
+      "overdueLoans": "Které úvěry jsou tento týden po splatnosti?"
     },
     "input": {
-      "placeholder": "Zeptejte se na klienty, úvěry nebo účty...",
+      "placeholder": "Zeptejte se na klienta, úvěr nebo účet",
       "attach": "Připojit soubor",
       "voice": "Hlasový vstup",
       "send": "Odeslat zprávu",
       "stop": "Zastavit generování"
     },
-    "disclaimer": "Mifos Intelligence AI je navržena tak, aby pomáhala, nikoli nahrazovala lidské rozhodování.",
+    "disclaimer": "Mifos X Copilot vám pomáhá najít odpovědi. Vše, co pohybuje penězi, stále vyžaduje vaše schválení.",
     "nav": {
       "recentChats": "Nedávné chaty",
       "chat": "Chat",
@@ -5823,20 +5823,20 @@
       "delete": "Smazat konverzaci"
     },
     "help": {
-      "capabilitiesTitle": "Co umí Mifos Intelligence AI?",
+      "capabilitiesTitle": "Co Mifos X Copilot umí",
       "capabilities": {
-        "lookup": "Vyhledávat informace a profily klientů",
-        "loans": "Zobrazit podrobnosti úvěrů a splátkové kalendáře",
-        "savings": "Kontrolovat zůstatky spořicích účtů",
-        "portfolio": "Získat přehled o portfoliích klientů",
-        "navigate": "Přejít na konkrétní stránky v Mifos X"
+        "lookup": "Najít klienta a zobrazit jeho profil",
+        "loans": "Zobrazit detaily úvěru a splátkový kalendář",
+        "savings": "Zkontrolovat zůstatek spoření",
+        "portfolio": "Shrnout portfolio klienta",
+        "navigate": "Přejít na správnou stránku"
       },
-      "examplesTitle": "Příklady dotazů",
-      "importantTitle": "Důležité",
+      "examplesTitle": "Co vyzkoušet",
+      "importantTitle": "Dobré vědět",
       "important": {
-        "assist": "Odpovědi AI slouží pouze jako pomoc, nikoli jako konečná rozhodnutí",
-        "verify": "Před provedením akce vždy ověřte kritická finanční data",
-        "noExecute": "AI neprovádí transakce sama"
+        "assist": "Odpovědi vám pomáhají rozhodnout. Nejsou rozhodnutím.",
+        "verify": "Než podle údajů jednáte, zkontrolujte je.",
+        "noExecute": "Nic nepohne penězi, dokud to nepotvrdíte."
       }
     },
     "cardType": {
@@ -5846,18 +5846,79 @@
       "insight": "Přehled",
       "confirmation": "Potvrzení"
     },
-    "confirmWarning": "Tato akce se týká skutečných peněz. Potvrďte prosím.",
-    "openAssistant": "Otevřít asistenta AI",
+    "confirmWarning": "Tato akce pohybuje skutečnými penězi. Zkontrolujte údaje a potvrďte.",
+    "openAssistant": "Otevřít Mifos X Copilot",
     "newChatTitle": "Nová konverzace",
     "errors": {
       "invalidLength": "Zpráva je prázdná nebo příliš dlouhá. Zkraťte ji prosím a zkuste to znovu.",
       "injectionBlocked": "Zpráva vypadá jako pokus o obejití pokynů, proto nebyla odeslána. Přeformulujte ji prosím.",
-      "streamFailed": "Při komunikaci s asistentem se něco pokazilo. Zkuste to prosím znovu."
+      "streamFailed": "Mifos X Copilot je nedostupný. Zkuste to prosím znovu."
     },
     "confirm": {
       "reference": "Reference",
-      "pendingAnnouncement": "Před provedením této akce je vyžadováno potvrzení."
+      "pendingAnnouncement": "Před provedením akce zkontrolujte údaje."
     },
-    "assistantAvatarAlt": "Asistent Mifos AI"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Datum aktivace",
+      "activeLoans": "Aktivní úvěry",
+      "amount": "Částka",
+      "appliedFor": "Požadovaná částka",
+      "approvalDate": "Datum schválení",
+      "approvedAmount": "Schválená částka",
+      "approvedBy": "Schválil",
+      "client": "Klient",
+      "clientAccount": "Klientský účet",
+      "disbursementDate": "Datum výplaty",
+      "expectedDisbursement": "Očekávaná výplata",
+      "firstName": "Jméno",
+      "lastName": "Příjmení",
+      "loanAccount": "Úvěrový účet",
+      "mobileNumber": "Mobilní číslo",
+      "nextInstalment": "Další splátka",
+      "office": "Kancelář",
+      "outstanding": "Nesplacený zůstatek",
+      "principal": "Jistina",
+      "product": "Produkt",
+      "reference": "Reference",
+      "repaymentAmount": "Výše splátky",
+      "repayments": "Splátky",
+      "savingsAccount": "Spořicí účet",
+      "savingsBalance": "Zůstatek spoření",
+      "search": "Vyhledávání",
+      "status": "Stav",
+      "submittedOn": "Odesláno dne",
+      "transactionDate": "Datum transakce"
+    },
+    "demo": {
+      "product": "Zemědělský termínovaný úvěr",
+      "office": "Hlavní kancelář",
+      "statusActive": "Aktivní",
+      "statusApproved": "Schválený",
+      "writeIntro": "Mohu to udělat. Než akci provedu, zkontrolujte prosím níže uvedené údaje a potvrďte ji.",
+      "approveSummary": "Schválit {{product}} pro klienta {{client}}",
+      "loanIntro": "Zde je aktivní úvěr klienta **{{client}}**:",
+      "loanTitle": "{{product}}, aktivní",
+      "nextInstalment": "{{amount}}, splatná za {{days}} dní",
+      "clientIntro": "Našel jsem tohoto klienta:",
+      "modeNotice": "Pracuji v **ukázkovém režimu**, zatím bez připojené brány, ale všechno, co zde vidíte (průběžně načítaná odpověď, karty i krok potvrzení), je skutečné.",
+      "approved": "Schváleno. Úvěr je nyní zaznamenán v auditní stopě pod vaším uživatelským účtem.",
+      "approvedTitle": "Úvěr schválen",
+      "approvedByYou": "Vy, pod vaším přihlášením a vašimi oprávněními",
+      "cancelled": "Zrušeno. Nic nebylo provedeno.",
+      "suggest": {
+        "schedule": "Zobrazte splátkový kalendář",
+        "recordRepayment": "Proveďte splátku",
+        "overdue": "Zobrazte úvěry po splatnosti",
+        "theirLoans": "Zobrazte úvěry klienta",
+        "kyc": "Zobrazte dokumenty KYC",
+        "savings": "Zkontrolujte zůstatek spoření",
+        "clientLoans": "Zobrazte úvěry tohoto klienta",
+        "approve": "Schvalte tento úvěr",
+        "searchClient": "Vyhledejte klienta",
+        "disburse": "Vyplaťte tento úvěr",
+        "backToClient": "Zpět na profil klienta"
+      }
+    }
   }
 }

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3729,7 +3729,7 @@
       "Auto Loan": "Autokredit",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finanzierung für den Kauf von Neu- oder Gebrauchtwagen mit festen monatlichen Raten über eine gewählte Laufzeit.",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Finanzierung kurzfristiger, h\u00e4ufig zinsfreier K\u00e4ufe nach dem Prinzip \u201eJetzt kaufen, sp\u00e4ter bezahlen\u201c, die in festen Raten beglichen werden.",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Finanzierung kurzfristiger, häufig zinsfreier Käufe nach dem Prinzip „Jetzt kaufen, später bezahlen“, die in festen Raten beglichen werden.",
       "Consumer Durable Loan": "Konsumgüterkredit",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "Finanzierung direkt am Verkaufsort für Elektronik, Haushaltsgeräte und andere langlebige Güter, oft mit zinsfreien Ratenoptionen.",
       "Credit Card EMI": "Kreditkarten-Ratenzahlung",
@@ -3741,17 +3741,17 @@
       "Quick secured loan against pledged gold ornaments or coins, with fast disbursal and minimal paperwork": "Schneller, durch verpfändeten Goldschmuck oder Goldmünzen besicherter Kredit mit zügiger Auszahlung und geringem bürokratischem Aufwand.",
       "Home Loan": "Wohnbaukredit",
       "Invoice Discounting": "Rechnungsvorfinanzierung",
-      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "Kurzfristige Finanzierung gegen unbezahlte Rechnungen, um den Gesch\u00e4ftscashflow vor F\u00e4lligkeit der Kundenzahlung zu verbessern.",
+      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "Kurzfristige Finanzierung gegen unbezahlte Rechnungen, um den Geschäftscashflow vor Fälligkeit der Kundenzahlung zu verbessern.",
       "JLG Loan": "JLG-Kredit",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "Gruppengestützte Kleinkredite für Mitglieder einer Solidarhaftungsgruppe, in der Regel für einkommensschaffende Tätigkeiten.",
       "Line of Credit": "Kreditlinie",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Ein revolvierender Kreditrahmen, der bei Bedarf in Anspruch genommen, zur\u00fcckgezahlt und erneut genutzt werden kann; Zinsen fallen nur auf den genutzten Betrag an.",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Ein revolvierender Kreditrahmen, der bei Bedarf in Anspruch genommen, zurückgezahlt und erneut genutzt werden kann; Zinsen fallen nur auf den genutzten Betrag an.",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "Darlehen, bei dem eine bestehende Wohn- oder Gewerbeimmobilie als Sicherheit dient.",
       "Loan vs Securities / FD": "Kredit gegen Wertpapiere / Festgeld",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "Kredit gegen Aktien, Investmentfonds oder Festgeld, ohne die zugrunde liegende Anlage aufzulösen.",
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Langfristige Finanzierung für den Kauf, den Bau oder die Renovierung einer Wohnimmobilie.",
       "Merchant Cash Advance": "Händlervorschuss",
-      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Betriebskapital, das gegen k\u00fcnftige Karten- oder Digitalums\u00e4tze vorgestreckt und als Prozentsatz der t\u00e4glichen Transaktionen zur\u00fcckgezahlt wird.",
+      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Betriebskapital, das gegen künftige Karten- oder Digitalumsätze vorgestreckt und als Prozentsatz der täglichen Transaktionen zurückgezahlt wird.",
       "Mortgage Loan (LAP)": "Hypothekendarlehen (LAP)",
       "No resets have been recorded for this loan": "Für dieses Darlehen wurden keine Zurücksetzungen erfasst.",
       "No variations added yet": "Noch keine Varianten hinzugefügt",
@@ -3759,7 +3759,7 @@
       "A row with the greater than condition must repeat the cycle number above it": "Eine Zeile mit der Bedingung „größer als“ muss die Zyklusnummer der Zeile darüber wiederholen",
       "Fix the loan cycle variations before creating the product": "Korrigieren Sie die Kreditzyklus-Varianten, bevor Sie das Produkt erstellen",
       "Personal Loan": "Privatkredit",
-      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Unbesicherte Finanzierung f\u00fcr pers\u00f6nliche Bed\u00fcrfnisse wie Reisen, medizinische Ausgaben oder Hochzeiten, mit flexibler Laufzeit und minimalem Dokumentationsaufwand.",
+      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Unbesicherte Finanzierung für persönliche Bedürfnisse wie Reisen, medizinische Ausgaben oder Hochzeiten, mit flexibler Laufzeit und minimalem Dokumentationsaufwand.",
       "Custom / Advanced": "Benutzerdefiniert / Erweitert",
       "Two Wheeler Loan": "Zweiradkredit",
       "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Finanzierung neuer oder gebrauchter Zweiräder mit schneller Zusage und flexibler Anzahlung.",
@@ -5785,7 +5785,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "Aktuelle Sitzung",
     "newChat": "Neuer Chat",
     "close": "Schließen",
@@ -5794,21 +5794,21 @@
       "afternoon": "Guten Tag",
       "evening": "Guten Abend"
     },
-    "welcomeHeading": "Wie kann ich Sie heute bei der Betreuung Ihrer Kunden unterstützen?",
+    "welcomeHeading": "Was möchten Sie tun?",
     "suggestions": {
-      "clientDetails": "Zeige mir die Details des Kunden John Doe",
-      "repaymentSchedule": "Wie lautet der Tilgungsplan für Kredit Nr. 107?",
-      "savingsBalance": "Zeige den Kontostand des Sparkontos von Kunde Nr. 52",
-      "overdueLoans": "Wie viele Kredite sind diese Woche überfällig?"
+      "clientDetails": "Zeigen Sie das Profil dieses Kunden",
+      "repaymentSchedule": "Wie lautet der Tilgungsplan dieses Kredits?",
+      "savingsBalance": "Wie hoch ist das Sparguthaben dieses Kunden?",
+      "overdueLoans": "Welche Kredite sind diese Woche überfällig?"
     },
     "input": {
-      "placeholder": "Fragen Sie zu Kunden, Krediten oder Konten...",
+      "placeholder": "Fragen Sie nach einem Kunden, einem Kredit oder einem Konto",
       "attach": "Datei anhängen",
       "voice": "Spracheingabe",
       "send": "Nachricht senden",
       "stop": "Generierung stoppen"
     },
-    "disclaimer": "Mifos Intelligence AI soll die menschliche Entscheidungsfindung unterstützen, nicht ersetzen.",
+    "disclaimer": "Mifos X Copilot hilft Ihnen, Antworten zu finden. Alles, was Geld bewegt, benötigt weiterhin Ihre Freigabe.",
     "nav": {
       "recentChats": "Letzte Chats",
       "chat": "Chat",
@@ -5823,20 +5823,20 @@
       "delete": "Unterhaltung löschen"
     },
     "help": {
-      "capabilitiesTitle": "Was kann Mifos Intelligence AI?",
+      "capabilitiesTitle": "Was Mifos X Copilot kann",
       "capabilities": {
-        "lookup": "Kundeninformationen und -profile nachschlagen",
+        "lookup": "Einen Kunden finden und sein Profil anzeigen",
         "loans": "Kreditdetails und Tilgungspläne anzeigen",
-        "savings": "Sparkontostände prüfen",
-        "portfolio": "Einblicke in Kundenportfolios erhalten",
-        "navigate": "Zu bestimmten Seiten in Mifos X navigieren"
+        "savings": "Ein Sparguthaben prüfen",
+        "portfolio": "Das Portfolio eines Kunden zusammenfassen",
+        "navigate": "Sie zur richtigen Seite bringen"
       },
-      "examplesTitle": "Beispielfragen",
-      "importantTitle": "Wichtig",
+      "examplesTitle": "Zum Ausprobieren",
+      "importantTitle": "Gut zu wissen",
       "important": {
-        "assist": "KI-Antworten dienen nur als Hilfe, nicht als endgültige Entscheidungen",
-        "verify": "Überprüfen Sie immer kritische Finanzdaten, bevor Sie handeln",
-        "noExecute": "Die KI führt keine Transaktionen selbstständig aus"
+        "assist": "Antworten helfen Ihnen bei der Entscheidung. Sie sind nicht die Entscheidung.",
+        "verify": "Prüfen Sie die Zahlen, bevor Sie danach handeln.",
+        "noExecute": "Es wird kein Geld bewegt, bevor Sie es bestätigen."
       }
     },
     "cardType": {
@@ -5846,18 +5846,79 @@
       "insight": "Einblick",
       "confirmation": "Bestätigung"
     },
-    "confirmWarning": "Diese Aktion betrifft echtes Geld. Bitte bestätigen Sie.",
-    "openAssistant": "KI-Assistenten öffnen",
+    "confirmWarning": "Hier wird echtes Geld bewegt. Prüfen Sie die Angaben und bestätigen Sie dann.",
+    "openAssistant": "Mifos X Copilot öffnen",
     "newChatTitle": "Neue Unterhaltung",
     "errors": {
       "invalidLength": "Die Nachricht ist leer oder zu lang. Bitte kürzen Sie sie und versuchen Sie es erneut.",
       "injectionBlocked": "Die Nachricht sieht wie ein Versuch aus, die Anweisungen zu umgehen, und wurde daher nicht gesendet. Bitte formulieren Sie sie um.",
-      "streamFailed": "Bei der Verbindung zum Assistenten ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+      "streamFailed": "Mifos X Copilot ist nicht erreichbar. Bitte versuchen Sie es erneut."
     },
     "confirm": {
       "reference": "Referenz",
-      "pendingAnnouncement": "Vor Ausführung dieser Aktion ist eine Bestätigung erforderlich."
+      "pendingAnnouncement": "Prüfen Sie die Angaben, bevor diese Aktion ausgeführt wird."
     },
-    "assistantAvatarAlt": "Mifos KI-Assistent"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Aktivierungsdatum",
+      "activeLoans": "Aktive Kredite",
+      "amount": "Betrag",
+      "appliedFor": "Beantragt",
+      "approvalDate": "Genehmigungsdatum",
+      "approvedAmount": "Genehmigter Betrag",
+      "approvedBy": "Genehmigt durch",
+      "client": "Kunde",
+      "clientAccount": "Kundenkonto",
+      "disbursementDate": "Auszahlungsdatum",
+      "expectedDisbursement": "Voraussichtliche Auszahlung",
+      "firstName": "Vorname",
+      "lastName": "Nachname",
+      "loanAccount": "Kreditkonto",
+      "mobileNumber": "Handynummer",
+      "nextInstalment": "Nächste Rate",
+      "office": "Büro",
+      "outstanding": "Ausstehender Betrag",
+      "principal": "Kapital",
+      "product": "Produkt",
+      "reference": "Referenz",
+      "repaymentAmount": "Rückzahlungsbetrag",
+      "repayments": "Rückzahlungen",
+      "savingsAccount": "Sparkonto",
+      "savingsBalance": "Sparguthaben",
+      "search": "Suche",
+      "status": "Status",
+      "submittedOn": "Eingereicht am",
+      "transactionDate": "Transaktionsdatum"
+    },
+    "demo": {
+      "product": "Agrar-Ratenkredit",
+      "office": "Hauptbüro",
+      "statusActive": "Aktiv",
+      "statusApproved": "Genehmigt",
+      "writeIntro": "Das kann ich für Sie erledigen. Bitte überprüfen Sie die Angaben unten und bestätigen Sie, bevor ich die Aktion ausführe.",
+      "approveSummary": "{{product}} für {{client}} genehmigen",
+      "loanIntro": "Hier ist der aktive Kredit von **{{client}}**:",
+      "loanTitle": "{{product}}, aktiv",
+      "nextInstalment": "{{amount}}, fällig in {{days}} Tagen",
+      "clientIntro": "Ich habe diesen Kunden gefunden:",
+      "modeNotice": "Ich befinde mich im **Demomodus**, es ist noch kein Gateway verbunden. Alles, was Sie hier sehen (die gestreamte Antwort, die Karten, der Bestätigungsschritt), ist jedoch echt.",
+      "approved": "Genehmigt. Der Kredit ist nun im Prüfpfad unter Ihrem Benutzer erfasst.",
+      "approvedTitle": "Kredit genehmigt",
+      "approvedByYou": "Sie, mit Ihrer Anmeldung und Ihren eigenen Berechtigungen",
+      "cancelled": "Abgebrochen. Es wurde nichts ausgeführt.",
+      "suggest": {
+        "schedule": "Zeigen Sie den Tilgungsplan",
+        "recordRepayment": "Erfassen Sie eine Rückzahlung",
+        "overdue": "Zeigen Sie überfällige Kredite",
+        "theirLoans": "Zeigen Sie die Kredite dieser Person",
+        "kyc": "Zeigen Sie die KYC-Dokumente",
+        "savings": "Prüfen Sie das Sparguthaben",
+        "clientLoans": "Zeigen Sie die Kredite dieses Kunden",
+        "approve": "Genehmigen Sie diesen Kredit",
+        "searchClient": "Suchen Sie nach einem Kunden",
+        "disburse": "Zahlen Sie diesen Kredit aus",
+        "backToClient": "Zurück zum Kundenprofil"
+      }
+    }
   }
 }

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -5649,35 +5649,35 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
-    "currentSession": "Current Session",
-    "newChat": "New Chat",
+    "brand": "Mifos X Copilot",
+    "currentSession": "Current session",
+    "newChat": "New chat",
     "close": "Close",
     "greeting": {
       "morning": "Good morning",
       "afternoon": "Good afternoon",
       "evening": "Good evening"
     },
-    "welcomeHeading": "How can I help you support your clients today?",
+    "welcomeHeading": "What would you like to do?",
     "suggestions": {
-      "clientDetails": "Show me details for client John Doe",
-      "repaymentSchedule": "What is the repayment schedule for loan #107?",
-      "savingsBalance": "Show savings account balance for client #52",
-      "overdueLoans": "How many loans are overdue this week?"
+      "clientDetails": "Show me this client's profile",
+      "repaymentSchedule": "What is the repayment schedule for this loan?",
+      "savingsBalance": "What is this client's savings balance?",
+      "overdueLoans": "Which loans are overdue this week?"
     },
     "input": {
-      "placeholder": "Ask about clients, loans, or accounts...",
+      "placeholder": "Ask about a client, a loan or an account",
       "attach": "Attach file",
       "voice": "Voice input",
       "send": "Send message",
       "stop": "Stop generating"
     },
-    "disclaimer": "Mifos Intelligence AI is designed to assist, not replace, human decision making.",
+    "disclaimer": "Mifos X Copilot helps you find answers. Anything that moves money still needs your approval.",
     "nav": {
-      "recentChats": "Recent Chats",
+      "recentChats": "Recent chats",
       "chat": "Chat",
       "preferences": "Preferences",
-      "helpCenter": "Help Center"
+      "helpCenter": "Help"
     },
     "preferencesHeading": "Preferences",
     "recent": {
@@ -5687,20 +5687,20 @@
       "delete": "Delete conversation"
     },
     "help": {
-      "capabilitiesTitle": "What can Mifos Intelligence AI do?",
+      "capabilitiesTitle": "What Mifos X Copilot can do",
       "capabilities": {
-        "lookup": "Look up client information and profiles",
-        "loans": "View loan details and repayment schedules",
-        "savings": "Check savings account balances",
-        "portfolio": "Get insights on client portfolios",
-        "navigate": "Navigate to specific pages in Mifos X"
+        "lookup": "Find a client and show their profile",
+        "loans": "Show loan details and repayment schedules",
+        "savings": "Check a savings balance",
+        "portfolio": "Summarize a client's portfolio",
+        "navigate": "Take you to the right page"
       },
-      "examplesTitle": "Example prompts",
-      "importantTitle": "Important",
+      "examplesTitle": "Things to try",
+      "importantTitle": "Worth knowing",
       "important": {
-        "assist": "AI responses are for assistance only, not final decisions",
-        "verify": "Always verify critical financial data before taking action",
-        "noExecute": "The AI does not execute transactions on its own"
+        "assist": "Answers help you decide. They are not the decision.",
+        "verify": "Check the figures before you act on them.",
+        "noExecute": "Nothing moves money until you confirm it."
       }
     },
     "cardType": {
@@ -5710,18 +5710,79 @@
       "insight": "Insight",
       "confirmation": "Confirmation"
     },
-    "confirmWarning": "This action involves real money. Please confirm.",
-    "openAssistant": "Open AI Assistant",
+    "confirmWarning": "This moves real money. Check the details, then confirm.",
+    "openAssistant": "Open Mifos X Copilot",
     "newChatTitle": "New conversation",
     "errors": {
       "invalidLength": "That message is empty or too long. Please shorten it and try again.",
       "injectionBlocked": "That message looks like an instruction-override attempt, so it was not sent. Please rephrase it.",
-      "streamFailed": "Something went wrong while contacting the assistant. Please try again."
+      "streamFailed": "Could not reach Mifos X Copilot. Please try again."
     },
     "confirm": {
       "reference": "Reference",
-      "pendingAnnouncement": "Confirmation required before this action runs."
+      "pendingAnnouncement": "Confirm the details before this action runs."
     },
-    "assistantAvatarAlt": "Mifos AI assistant"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Activation date",
+      "activeLoans": "Active loans",
+      "amount": "Amount",
+      "appliedFor": "Applied for",
+      "approvalDate": "Approval date",
+      "approvedAmount": "Approved amount",
+      "approvedBy": "Approved by",
+      "client": "Client",
+      "clientAccount": "Client account",
+      "disbursementDate": "Disbursement date",
+      "expectedDisbursement": "Expected disbursement",
+      "firstName": "First name",
+      "lastName": "Last name",
+      "loanAccount": "Loan account",
+      "mobileNumber": "Mobile number",
+      "nextInstalment": "Next installment",
+      "office": "Office",
+      "outstanding": "Outstanding",
+      "principal": "Principal",
+      "product": "Product",
+      "reference": "Reference",
+      "repaymentAmount": "Repayment amount",
+      "repayments": "Repayments",
+      "savingsAccount": "Savings account",
+      "savingsBalance": "Savings balance",
+      "search": "Search",
+      "status": "Status",
+      "submittedOn": "Submitted on",
+      "transactionDate": "Transaction date"
+    },
+    "demo": {
+      "product": "Agriculture Term Loan",
+      "office": "Head Office",
+      "statusActive": "Active",
+      "statusApproved": "Approved",
+      "writeIntro": "I can do that. Please review the details below and confirm before I run it.",
+      "approveSummary": "Approve {{product}} for {{client}}",
+      "loanIntro": "Here is the active loan for **{{client}}**:",
+      "loanTitle": "{{product}}, active",
+      "nextInstalment": "{{amount}}, due in {{days}} days",
+      "clientIntro": "I found this client:",
+      "modeNotice": "I am running in **demo mode**, with no gateway connected yet, but everything you see here (the streaming reply, the cards, the confirmation step) is the real thing.",
+      "approved": "Approved. The loan is now recorded against your user in the audit trail.",
+      "approvedTitle": "Loan approved",
+      "approvedByYou": "You, under your own permissions",
+      "cancelled": "Cancelled. Nothing was executed.",
+      "suggest": {
+        "schedule": "Show the repayment schedule",
+        "recordRepayment": "Record a repayment",
+        "overdue": "Show overdue loans",
+        "theirLoans": "Show their loans",
+        "kyc": "Show KYC documents",
+        "savings": "Check the savings balance",
+        "clientLoans": "Show loans for this client",
+        "approve": "Approve this loan",
+        "searchClient": "Search for a client",
+        "disburse": "Disburse this loan",
+        "backToClient": "Back to the client profile"
+      }
+    }
   }
 }

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3728,7 +3728,7 @@
       "Auto Loan": "Crédito Automotriz",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financiamiento para la compra de autos nuevos o usados con cuotas mensuales fijas durante el plazo elegido.",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Financiamiento de compra ahora y paga despu\u00e9s para compras de corto plazo, a menudo sin intereses, pagado en cuotas fijas.",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Financiamiento de compra ahora y paga después para compras de corto plazo, a menudo sin intereses, pagado en cuotas fijas.",
       "Consumer Durable Loan": "Crédito para Bienes Duraderos",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "Financiamiento en el punto de venta para electrónica, electrodomésticos y otros bienes duraderos, a menudo con cuotas sin interés.",
       "Credit Card EMI": "Mensualidades con Tarjeta de Crédito",
@@ -3744,7 +3744,7 @@
       "JLG Loan": "Crédito JLG",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "Microcréditos respaldados por el grupo para integrantes de un Grupo de Responsabilidad Solidaria, generalmente para actividades generadoras de ingresos.",
       "Line of Credit": "Línea de Crédito",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "L\u00edmite de cr\u00e9dito renovable que puede utilizarse, pagarse y reutilizarse seg\u00fan sea necesario, con intereses cobrados solo sobre el monto utilizado.",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Límite de crédito renovable que puede utilizarse, pagarse y reutilizarse según sea necesario, con intereses cobrados solo sobre el monto utilizado.",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "Préstamo garantizado con una propiedad residencial o comercial existente entregada en garantía.",
       "Loan vs Securities / FD": "Crédito contra Valores / Depósito a Plazo",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "Crédito otorgado contra acciones, fondos mutuos o depósitos a plazo sin liquidar la inversión subyacente.",
@@ -3758,7 +3758,7 @@
       "A row with the greater than condition must repeat the cycle number above it": "Una fila con la condición «mayor que» debe repetir el número de ciclo de la fila anterior",
       "Fix the loan cycle variations before creating the product": "Corrija las variaciones por ciclo de crédito antes de crear el producto",
       "Personal Loan": "Crédito Personal",
-      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Financiamiento sin garant\u00eda para necesidades personales como viajes, gastos m\u00e9dicos o matrimonios, con plazos flexibles y documentaci\u00f3n m\u00ednima.",
+      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Financiamiento sin garantía para necesidades personales como viajes, gastos médicos o matrimonios, con plazos flexibles y documentación mínima.",
       "Custom / Advanced": "Personalizado / Avanzado",
       "Two Wheeler Loan": "Crédito para Motos",
       "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Financiamiento de motos nuevas o usadas, con aprobación rápida y opciones flexibles de pago inicial.",
@@ -5497,7 +5497,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "Sesión actual",
     "newChat": "Nuevo chat",
     "close": "Cerrar",
@@ -5506,21 +5506,21 @@
       "afternoon": "Buenas tardes",
       "evening": "Buenas noches"
     },
-    "welcomeHeading": "¿Cómo puedo ayudarte a atender a tus clientes hoy?",
+    "welcomeHeading": "¿Qué quieres hacer?",
     "suggestions": {
-      "clientDetails": "Muéstrame los detalles del cliente John Doe",
-      "repaymentSchedule": "¿Cuál es el calendario de pagos del préstamo n.º 107?",
-      "savingsBalance": "Muestra el saldo de la cuenta de ahorros del cliente n.º 52",
-      "overdueLoans": "¿Cuántos préstamos están vencidos esta semana?"
+      "clientDetails": "Muéstrame el perfil de este cliente",
+      "repaymentSchedule": "¿Cuál es el calendario de pagos de este préstamo?",
+      "savingsBalance": "¿Cuál es el saldo de ahorros de este cliente?",
+      "overdueLoans": "¿Qué préstamos están vencidos esta semana?"
     },
     "input": {
-      "placeholder": "Pregunta sobre clientes, préstamos o cuentas...",
+      "placeholder": "Pregunta por un cliente, un préstamo o una cuenta",
       "attach": "Adjuntar archivo",
       "voice": "Entrada de voz",
       "send": "Enviar mensaje",
       "stop": "Detener generación"
     },
-    "disclaimer": "Mifos Intelligence AI está diseñada para ayudar, no para reemplazar, la toma de decisiones humana.",
+    "disclaimer": "Mifos X Copilot te ayuda a encontrar respuestas. Todo lo que mueve dinero sigue necesitando tu aprobación.",
     "nav": {
       "recentChats": "Chats recientes",
       "chat": "Chat",
@@ -5535,20 +5535,20 @@
       "delete": "Eliminar conversación"
     },
     "help": {
-      "capabilitiesTitle": "¿Qué puede hacer Mifos Intelligence AI?",
+      "capabilitiesTitle": "Lo que puede hacer Mifos X Copilot",
       "capabilities": {
-        "lookup": "Buscar información y perfiles de clientes",
-        "loans": "Ver detalles de préstamos y calendarios de pago",
-        "savings": "Consultar saldos de cuentas de ahorro",
-        "portfolio": "Obtener información sobre las carteras de clientes",
-        "navigate": "Navegar a páginas específicas en Mifos X"
+        "lookup": "Encontrar un cliente y mostrar su perfil",
+        "loans": "Mostrar detalles del préstamo y calendarios de pago",
+        "savings": "Consultar un saldo de ahorros",
+        "portfolio": "Resumir la cartera de un cliente",
+        "navigate": "Llevarte a la página correcta"
       },
-      "examplesTitle": "Ejemplos de preguntas",
-      "importantTitle": "Importante",
+      "examplesTitle": "Cosas para probar",
+      "importantTitle": "Conviene saber",
       "important": {
-        "assist": "Las respuestas de la IA son solo de ayuda, no decisiones finales",
-        "verify": "Verifica siempre los datos financieros críticos antes de actuar",
-        "noExecute": "La IA no ejecuta transacciones por sí sola"
+        "assist": "Las respuestas te ayudan a decidir. No son la decisión.",
+        "verify": "Revisa las cifras antes de actuar sobre ellas.",
+        "noExecute": "No se mueve dinero hasta que tú lo confirmes."
       }
     },
     "cardType": {
@@ -5558,18 +5558,79 @@
       "insight": "Información",
       "confirmation": "Confirmación"
     },
-    "confirmWarning": "Esta acción implica dinero real. Por favor, confirma.",
-    "openAssistant": "Abrir el asistente de IA",
+    "confirmWarning": "Esto mueve dinero real. Revisa los datos y luego confirma.",
+    "openAssistant": "Abrir Mifos X Copilot",
     "newChatTitle": "Nueva conversación",
     "errors": {
       "invalidLength": "El mensaje está vacío o es demasiado largo. Por favor acórtalo e inténtalo de nuevo.",
       "injectionBlocked": "El mensaje parece un intento de anular las instrucciones, por lo que no se envió. Por favor reformúlalo.",
-      "streamFailed": "Algo salió mal al contactar al asistente. Por favor inténtalo de nuevo."
+      "streamFailed": "No se pudo contactar con Mifos X Copilot. Inténtalo de nuevo."
     },
     "confirm": {
       "reference": "Referencia",
-      "pendingAnnouncement": "Se requiere confirmación antes de ejecutar esta acción."
+      "pendingAnnouncement": "Revisa los datos antes de que se ejecute esta acción."
     },
-    "assistantAvatarAlt": "Asistente Mifos AI"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Fecha de activación",
+      "activeLoans": "Préstamos activos",
+      "amount": "Monto",
+      "appliedFor": "Monto solicitado",
+      "approvalDate": "Fecha de aprobación",
+      "approvedAmount": "Monto aprobado",
+      "approvedBy": "Aprobado por",
+      "client": "Cliente",
+      "clientAccount": "Cuenta del cliente",
+      "disbursementDate": "Fecha de curso",
+      "expectedDisbursement": "Curso previsto",
+      "firstName": "Nombre",
+      "lastName": "Apellido",
+      "loanAccount": "Cuenta de préstamo",
+      "mobileNumber": "Teléfono móvil",
+      "nextInstalment": "Próxima cuota",
+      "office": "Oficina",
+      "outstanding": "Saldo pendiente",
+      "principal": "Capital",
+      "product": "Producto",
+      "reference": "Referencia",
+      "repaymentAmount": "Monto del pago",
+      "repayments": "Pagos",
+      "savingsAccount": "Cuenta de ahorros",
+      "savingsBalance": "Saldo de ahorros",
+      "search": "Buscar",
+      "status": "Estado",
+      "submittedOn": "Registrado el",
+      "transactionDate": "Fecha de transacción"
+    },
+    "demo": {
+      "product": "Crédito Agrícola a Plazo",
+      "office": "Casa Matriz",
+      "statusActive": "Activo",
+      "statusApproved": "Aprobado",
+      "writeIntro": "Puedo hacerlo. Revisa los datos a continuación y confirma antes de que lo ejecute.",
+      "approveSummary": "Aprobar {{product}} para {{client}}",
+      "loanIntro": "Este es el préstamo activo de **{{client}}**:",
+      "loanTitle": "{{product}}, activo",
+      "nextInstalment": "{{amount}}, vence en {{days}} días",
+      "clientIntro": "Encontré este cliente:",
+      "modeNotice": "Estoy funcionando en **modo demo**, todavía sin un gateway conectado, pero todo lo que ves aquí (la respuesta en streaming, las tarjetas, el paso de confirmación) es real.",
+      "approved": "Aprobado. El préstamo queda registrado a tu nombre de usuario en el registro de auditoría.",
+      "approvedTitle": "Préstamo aprobado",
+      "approvedByYou": "Tú, con tus propios permisos",
+      "cancelled": "Cancelado. No se ejecutó nada.",
+      "suggest": {
+        "schedule": "Muéstrame el calendario de pagos",
+        "recordRepayment": "Registrar un pago",
+        "overdue": "Muéstrame los préstamos vencidos",
+        "theirLoans": "Muéstrame sus préstamos",
+        "kyc": "Muéstrame los documentos KYC",
+        "savings": "Consultar el saldo de ahorros",
+        "clientLoans": "Muéstrame los préstamos de este cliente",
+        "approve": "Aprobar este préstamo",
+        "searchClient": "Buscar un cliente",
+        "disburse": "Desembolsar este préstamo",
+        "backToClient": "Volver al perfil del cliente"
+      }
+    }
   }
 }

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3732,7 +3732,7 @@
       "Auto Loan": "Crédito Automotriz",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financiamiento para la compra de autos nuevos o usados con cuotas mensuales fijas durante el plazo elegido.",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Financiamiento de compra ahora y paga despu\u00e9s para compras de corto plazo, a menudo sin intereses, liquidado en cuotas fijas.",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Financiamiento de compra ahora y paga después para compras de corto plazo, a menudo sin intereses, liquidado en cuotas fijas.",
       "Consumer Durable Loan": "Crédito para Bienes Duraderos",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "Financiamiento en el punto de venta para electrónica, electrodomésticos y otros bienes duraderos, a menudo con mensualidades sin intereses.",
       "Credit Card EMI": "Mensualidades con Tarjeta de Crédito",
@@ -3748,7 +3748,7 @@
       "JLG Loan": "Crédito JLG",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "Microcréditos respaldados por el grupo para integrantes de un Grupo de Responsabilidad Solidaria, generalmente para actividades generadoras de ingresos.",
       "Line of Credit": "Línea de Crédito",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "L\u00edmite de cr\u00e9dito revolvente que puede utilizarse, pagarse y reutilizarse seg\u00fan sea necesario, con intereses cobrados solo sobre el monto utilizado.",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Límite de crédito revolvente que puede utilizarse, pagarse y reutilizarse según sea necesario, con intereses cobrados solo sobre el monto utilizado.",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "Préstamo garantizado con una propiedad residencial o comercial existente entregada en garantía.",
       "Loan vs Securities / FD": "Crédito contra Valores / Depósito a Plazo",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "Crédito otorgado contra acciones, fondos de inversión o depósitos a plazo sin liquidar la inversión subyacente.",
@@ -3762,7 +3762,7 @@
       "A row with the greater than condition must repeat the cycle number above it": "Una fila con la condición «mayor que» debe repetir el número de ciclo de la fila anterior",
       "Fix the loan cycle variations before creating the product": "Corrija las variaciones por ciclo de crédito antes de crear el producto",
       "Personal Loan": "Crédito Personal",
-      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Financiamiento sin garant\u00eda para necesidades personales como viajes, gastos m\u00e9dicos o bodas, con plazos flexibles y documentaci\u00f3n m\u00ednima.",
+      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Financiamiento sin garantía para necesidades personales como viajes, gastos médicos o bodas, con plazos flexibles y documentación mínima.",
       "Custom / Advanced": "Personalizado / Avanzado",
       "Two Wheeler Loan": "Crédito para Motos",
       "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Financiamiento de motos nuevas o usadas, con aprobación rápida y opciones flexibles de pago inicial.",
@@ -5519,7 +5519,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "Sesión actual",
     "newChat": "Nuevo chat",
     "close": "Cerrar",
@@ -5528,21 +5528,21 @@
       "afternoon": "Buenas tardes",
       "evening": "Buenas noches"
     },
-    "welcomeHeading": "¿Cómo puedo ayudarte a atender a tus clientes hoy?",
+    "welcomeHeading": "¿Qué quieres hacer?",
     "suggestions": {
-      "clientDetails": "Muéstrame los detalles del cliente John Doe",
-      "repaymentSchedule": "¿Cuál es el calendario de pagos del préstamo n.º 107?",
-      "savingsBalance": "Muestra el saldo de la cuenta de ahorros del cliente n.º 52",
-      "overdueLoans": "¿Cuántos préstamos están vencidos esta semana?"
+      "clientDetails": "Muéstrame el perfil de este cliente",
+      "repaymentSchedule": "¿Cuál es el calendario de pagos de este préstamo?",
+      "savingsBalance": "¿Cuál es el saldo de ahorros de este cliente?",
+      "overdueLoans": "¿Qué préstamos están vencidos esta semana?"
     },
     "input": {
-      "placeholder": "Pregunta sobre clientes, préstamos o cuentas...",
+      "placeholder": "Pregunta por un cliente, un préstamo o una cuenta",
       "attach": "Adjuntar archivo",
       "voice": "Entrada de voz",
       "send": "Enviar mensaje",
       "stop": "Detener generación"
     },
-    "disclaimer": "Mifos Intelligence AI está diseñada para ayudar, no para reemplazar, la toma de decisiones humana.",
+    "disclaimer": "Mifos X Copilot te ayuda a encontrar respuestas. Todo lo que mueve dinero sigue necesitando tu aprobación.",
     "nav": {
       "recentChats": "Chats recientes",
       "chat": "Chat",
@@ -5557,20 +5557,20 @@
       "delete": "Eliminar conversación"
     },
     "help": {
-      "capabilitiesTitle": "¿Qué puede hacer Mifos Intelligence AI?",
+      "capabilitiesTitle": "Lo que puede hacer Mifos X Copilot",
       "capabilities": {
-        "lookup": "Buscar información y perfiles de clientes",
-        "loans": "Ver detalles de préstamos y calendarios de pago",
-        "savings": "Consultar saldos de cuentas de ahorro",
-        "portfolio": "Obtener información sobre las carteras de clientes",
-        "navigate": "Navegar a páginas específicas en Mifos X"
+        "lookup": "Encontrar un cliente y mostrar su perfil",
+        "loans": "Mostrar detalles del préstamo y calendarios de pago",
+        "savings": "Consultar un saldo de ahorros",
+        "portfolio": "Resumir la cartera de un cliente",
+        "navigate": "Llevarte a la página correcta"
       },
-      "examplesTitle": "Ejemplos de preguntas",
-      "importantTitle": "Importante",
+      "examplesTitle": "Cosas para probar",
+      "importantTitle": "Conviene saber",
       "important": {
-        "assist": "Las respuestas de la IA son solo de ayuda, no decisiones finales",
-        "verify": "Verifica siempre los datos financieros críticos antes de actuar",
-        "noExecute": "La IA no ejecuta transacciones por sí sola"
+        "assist": "Las respuestas te ayudan a decidir. No son la decisión.",
+        "verify": "Revisa las cifras antes de actuar sobre ellas.",
+        "noExecute": "No se mueve dinero hasta que tú lo confirmes."
       }
     },
     "cardType": {
@@ -5580,18 +5580,79 @@
       "insight": "Información",
       "confirmation": "Confirmación"
     },
-    "confirmWarning": "Esta acción implica dinero real. Por favor, confirma.",
-    "openAssistant": "Abrir el asistente de IA",
+    "confirmWarning": "Esto mueve dinero real. Revisa los datos y luego confirma.",
+    "openAssistant": "Abrir Mifos X Copilot",
     "newChatTitle": "Nueva conversación",
     "errors": {
       "invalidLength": "El mensaje está vacío o es demasiado largo. Por favor acórtalo e inténtalo de nuevo.",
       "injectionBlocked": "El mensaje parece un intento de anular las instrucciones, por lo que no se envió. Por favor reformúlalo.",
-      "streamFailed": "Algo salió mal al contactar al asistente. Por favor inténtalo de nuevo."
+      "streamFailed": "No se pudo contactar con Mifos X Copilot. Inténtalo de nuevo."
     },
     "confirm": {
       "reference": "Referencia",
-      "pendingAnnouncement": "Se requiere confirmación antes de ejecutar esta acción."
+      "pendingAnnouncement": "Revisa los datos antes de que se ejecute esta acción."
     },
-    "assistantAvatarAlt": "Asistente Mifos AI"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Fecha de activación",
+      "activeLoans": "Préstamos activos",
+      "amount": "Monto",
+      "appliedFor": "Monto solicitado",
+      "approvalDate": "Fecha de aprobación",
+      "approvedAmount": "Monto aprobado",
+      "approvedBy": "Aprobado por",
+      "client": "Cliente",
+      "clientAccount": "Cuenta del cliente",
+      "disbursementDate": "Fecha de desembolso",
+      "expectedDisbursement": "Desembolso esperado",
+      "firstName": "Nombre",
+      "lastName": "Apellido",
+      "loanAccount": "Cuenta de préstamo",
+      "mobileNumber": "Teléfono móvil",
+      "nextInstalment": "Próxima cuota",
+      "office": "Sucursal",
+      "outstanding": "Saldo pendiente",
+      "principal": "Capital",
+      "product": "Producto",
+      "reference": "Referencia",
+      "repaymentAmount": "Monto del pago",
+      "repayments": "Pagos",
+      "savingsAccount": "Cuenta de ahorros",
+      "savingsBalance": "Saldo de ahorros",
+      "search": "Búsqueda",
+      "status": "Estado",
+      "submittedOn": "Fecha de solicitud",
+      "transactionDate": "Fecha de transacción"
+    },
+    "demo": {
+      "product": "Préstamo Agrícola a Plazo",
+      "office": "Sucursal Matriz",
+      "statusActive": "Activo",
+      "statusApproved": "Aprobado",
+      "writeIntro": "Puedo hacerlo. Revisa los datos de abajo y confirma antes de que lo ejecute.",
+      "approveSummary": "Aprobar {{product}} para {{client}}",
+      "loanIntro": "Este es el préstamo activo de **{{client}}**:",
+      "loanTitle": "{{product}}, activo",
+      "nextInstalment": "{{amount}}, vence en {{days}} días",
+      "clientIntro": "Encontré a este cliente:",
+      "modeNotice": "Estoy funcionando en **modo demo**, todavía sin gateway conectado, pero todo lo que ves aquí (la respuesta que se escribe en vivo, las tarjetas, el paso de confirmación) es real.",
+      "approved": "Aprobado. El préstamo quedó registrado a nombre de tu usuario en el registro de auditoría.",
+      "approvedTitle": "Préstamo aprobado",
+      "approvedByYou": "Tú, con tu usuario y tus permisos",
+      "cancelled": "Cancelado. No se ejecutó nada.",
+      "suggest": {
+        "schedule": "Muéstrame el calendario de pagos",
+        "recordRepayment": "Registrar un pago",
+        "overdue": "Muéstrame los préstamos vencidos",
+        "theirLoans": "Muéstrame sus préstamos",
+        "kyc": "Muéstrame los documentos KYC",
+        "savings": "Consultar el saldo de ahorros",
+        "clientLoans": "Muéstrame los préstamos de este cliente",
+        "approve": "Aprobar este préstamo",
+        "searchClient": "Buscar un cliente",
+        "disburse": "Desembolsar este préstamo",
+        "backToClient": "Volver al perfil del cliente"
+      }
+    }
   }
 }

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3730,7 +3730,7 @@
       "Auto Loan": "Prêt automobile",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financement pour l'achat de voitures neuves ou d'occasion avec des mensualités fixes sur une durée choisie.",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Financement \u00ab achetez maintenant, payez plus tard \u00bb pour des achats \u00e0 court terme, souvent sans int\u00e9r\u00eat, r\u00e9gl\u00e9s en mensualit\u00e9s fixes.",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Financement « achetez maintenant, payez plus tard » pour des achats à court terme, souvent sans intérêt, réglés en mensualités fixes.",
       "Consumer Durable Loan": "Prêt biens de consommation durables",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "Financement sur le lieu de vente pour l'électronique, l'électroménager et d'autres biens de consommation durables, souvent avec des mensualités sans intérêts.",
       "Credit Card EMI": "Paiement échelonné par carte de crédit",
@@ -3742,17 +3742,17 @@
       "Quick secured loan against pledged gold ornaments or coins, with fast disbursal and minimal paperwork": "Prêt garanti rapide contre des bijoux ou des pièces en or mis en gage, avec un décaissement rapide et des formalités minimales.",
       "Home Loan": "Prêt immobilier",
       "Invoice Discounting": "Escompte de factures",
-      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "Financement \u00e0 court terme adoss\u00e9 aux factures impay\u00e9es pour am\u00e9liorer la tr\u00e9sorerie de l'entreprise avant l'\u00e9ch\u00e9ance du paiement client.",
+      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "Financement à court terme adossé aux factures impayées pour améliorer la trésorerie de l'entreprise avant l'échéance du paiement client.",
       "JLG Loan": "Prêt JLG",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "Microcrédits garantis par le groupe pour les membres d'un groupe à responsabilité solidaire, généralement destinés à des activités génératrices de revenus.",
       "Line of Credit": "Ligne de crédit",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Une ligne de cr\u00e9dit renouvelable pouvant \u00eatre utilis\u00e9e, rembours\u00e9e et r\u00e9utilis\u00e9e selon les besoins, avec des int\u00e9r\u00eats calcul\u00e9s uniquement sur le montant utilis\u00e9.",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Une ligne de crédit renouvelable pouvant être utilisée, remboursée et réutilisée selon les besoins, avec des intérêts calculés uniquement sur le montant utilisé.",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "Prêt garanti par un bien résidentiel ou commercial existant mis en gage.",
       "Loan vs Securities / FD": "Prêt sur titres / dépôt à terme",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "Crédit accordé sur des actions, des fonds communs de placement ou des dépôts à terme, sans liquider le placement sous-jacent.",
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Financement à long terme pour l'achat, la construction ou la rénovation d'un bien résidentiel.",
       "Merchant Cash Advance": "Avance de trésorerie commerçant",
-      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Fonds de roulement avanc\u00e9 sur les ventes futures par carte ou num\u00e9riques, rembours\u00e9 sous forme de pourcentage des transactions quotidiennes.",
+      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Fonds de roulement avancé sur les ventes futures par carte ou numériques, remboursé sous forme de pourcentage des transactions quotidiennes.",
       "Mortgage Loan (LAP)": "Prêt hypothécaire (LAP)",
       "No resets have been recorded for this loan": "Aucune réinitialisation n'a été enregistrée pour ce prêt.",
       "No variations added yet": "Aucune variation ajoutée pour le moment",
@@ -3760,7 +3760,7 @@
       "A row with the greater than condition must repeat the cycle number above it": "Une ligne avec la condition « supérieur à » doit reprendre le numéro de cycle de la ligne précédente",
       "Fix the loan cycle variations before creating the product": "Corrigez les variations par cycle de prêt avant de créer le produit",
       "Personal Loan": "Prêt personnel",
-      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Financement non garanti pour des besoins personnels tels que les voyages, les frais m\u00e9dicaux ou les mariages, avec une dur\u00e9e flexible et un minimum de formalit\u00e9s.",
+      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Financement non garanti pour des besoins personnels tels que les voyages, les frais médicaux ou les mariages, avec une durée flexible et un minimum de formalités.",
       "Custom / Advanced": "Personnalisé / Avancé",
       "Two Wheeler Loan": "Prêt deux-roues",
       "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Financement de deux-roues neufs ou d'occasion, avec accord rapide et acompte modulable.",
@@ -5499,7 +5499,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "Session actuelle",
     "newChat": "Nouvelle discussion",
     "close": "Fermer",
@@ -5508,21 +5508,21 @@
       "afternoon": "Bon après-midi",
       "evening": "Bonsoir"
     },
-    "welcomeHeading": "Comment puis-je vous aider à accompagner vos clients aujourd'hui ?",
+    "welcomeHeading": "Que souhaitez-vous faire ?",
     "suggestions": {
-      "clientDetails": "Affichez les détails du client John Doe",
-      "repaymentSchedule": "Quel est l'échéancier de remboursement du prêt n° 107 ?",
-      "savingsBalance": "Affichez le solde du compte d'épargne du client n° 52",
-      "overdueLoans": "Combien de prêts sont en retard cette semaine ?"
+      "clientDetails": "Affichez le profil de ce client",
+      "repaymentSchedule": "Quel est l'échéancier de remboursement de ce prêt ?",
+      "savingsBalance": "Quel est le solde d'épargne de ce client ?",
+      "overdueLoans": "Quels prêts sont en retard cette semaine ?"
     },
     "input": {
-      "placeholder": "Posez une question sur les clients, les prêts ou les comptes...",
+      "placeholder": "Posez une question sur un client, un prêt ou un compte",
       "attach": "Joindre un fichier",
       "voice": "Entrée vocale",
       "send": "Envoyer le message",
       "stop": "Arrêter la génération"
     },
-    "disclaimer": "Mifos Intelligence AI est conçue pour assister, et non remplacer, la prise de décision humaine.",
+    "disclaimer": "Mifos X Copilot vous aide à trouver des réponses. Toute opération qui déplace de l'argent requiert toujours votre validation.",
     "nav": {
       "recentChats": "Discussions récentes",
       "chat": "Discussion",
@@ -5537,20 +5537,20 @@
       "delete": "Supprimer la conversation"
     },
     "help": {
-      "capabilitiesTitle": "Que peut faire Mifos Intelligence AI ?",
+      "capabilitiesTitle": "Ce que Mifos X Copilot peut faire",
       "capabilities": {
-        "lookup": "Rechercher les informations et profils des clients",
-        "loans": "Consulter les détails des prêts et les échéanciers",
-        "savings": "Vérifier les soldes des comptes d'épargne",
-        "portfolio": "Obtenir des informations sur les portefeuilles clients",
-        "navigate": "Naviguer vers des pages spécifiques dans Mifos X"
+        "lookup": "Trouver un client et afficher son profil",
+        "loans": "Afficher les détails d'un prêt et son échéancier",
+        "savings": "Consulter un solde d'épargne",
+        "portfolio": "Résumer le portefeuille d'un client",
+        "navigate": "Vous amener à la bonne page"
       },
-      "examplesTitle": "Exemples de questions",
-      "importantTitle": "Important",
+      "examplesTitle": "À essayer",
+      "importantTitle": "Bon à savoir",
       "important": {
-        "assist": "Les réponses de l'IA sont fournies à titre indicatif, pas comme décisions finales",
-        "verify": "Vérifiez toujours les données financières critiques avant d'agir",
-        "noExecute": "L'IA n'exécute pas de transactions par elle-même"
+        "assist": "Les réponses vous aident à décider. Elles ne sont pas la décision.",
+        "verify": "Vérifiez les chiffres avant d'agir.",
+        "noExecute": "Aucun mouvement d'argent tant que vous ne confirmez pas."
       }
     },
     "cardType": {
@@ -5560,18 +5560,79 @@
       "insight": "Analyse",
       "confirmation": "Confirmation"
     },
-    "confirmWarning": "Cette action implique de l'argent réel. Veuillez confirmer.",
-    "openAssistant": "Ouvrir l'assistant IA",
+    "confirmWarning": "Cette opération déplace de l'argent réel. Vérifiez les détails, puis confirmez.",
+    "openAssistant": "Ouvrir Mifos X Copilot",
     "newChatTitle": "Nouvelle conversation",
     "errors": {
       "invalidLength": "Le message est vide ou trop long. Veuillez le raccourcir et réessayer.",
       "injectionBlocked": "Le message ressemble à une tentative de contournement des instructions, il n'a donc pas été envoyé. Veuillez le reformuler.",
-      "streamFailed": "Une erreur s'est produite lors de la connexion à l'assistant. Veuillez réessayer."
+      "streamFailed": "Mifos X Copilot est injoignable. Veuillez réessayer."
     },
     "confirm": {
       "reference": "Référence",
-      "pendingAnnouncement": "Une confirmation est requise avant l'exécution de cette action."
+      "pendingAnnouncement": "Vérifiez les détails avant l'exécution de cette action."
     },
-    "assistantAvatarAlt": "Assistant Mifos IA"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Date d'activation",
+      "activeLoans": "Prêts actifs",
+      "amount": "Montant",
+      "appliedFor": "Montant demandé",
+      "approvalDate": "Date d'approbation",
+      "approvedAmount": "Montant approuvé",
+      "approvedBy": "Approuvé par",
+      "client": "Client",
+      "clientAccount": "Compte client",
+      "disbursementDate": "Date de décaissement",
+      "expectedDisbursement": "Décaissement prévu",
+      "firstName": "Prénom",
+      "lastName": "Nom de famille",
+      "loanAccount": "Compte de prêt",
+      "mobileNumber": "Numéro de portable",
+      "nextInstalment": "Prochain versement",
+      "office": "Bureau",
+      "outstanding": "Encours",
+      "principal": "Principal",
+      "product": "Produit",
+      "reference": "Référence",
+      "repaymentAmount": "Montant du remboursement",
+      "repayments": "Remboursements",
+      "savingsAccount": "Compte d'épargne",
+      "savingsBalance": "Solde d'épargne",
+      "search": "Recherche",
+      "status": "Statut",
+      "submittedOn": "Soumis le",
+      "transactionDate": "Date de la transaction"
+    },
+    "demo": {
+      "product": "Prêt agricole à terme",
+      "office": "Siège",
+      "statusActive": "Actif",
+      "statusApproved": "Approuvé",
+      "writeIntro": "Je peux le faire. Veuillez vérifier les détails ci-dessous, puis confirmer avant que je l'exécute.",
+      "approveSummary": "Approuver {{product}} pour {{client}}",
+      "loanIntro": "Voici le prêt actif de **{{client}}** :",
+      "loanTitle": "{{product}}, actif",
+      "nextInstalment": "{{amount}}, exigible dans {{days}} jours",
+      "clientIntro": "J'ai trouvé ce client :",
+      "modeNotice": "Je fonctionne en **mode démo**, sans passerelle connectée pour l'instant, mais tout ce que vous voyez ici (la réponse en continu, les cartes, l'étape de confirmation) est bien réel.",
+      "approved": "Approuvé. Le prêt est désormais enregistré sous votre compte utilisateur dans la piste d'audit.",
+      "approvedTitle": "Prêt approuvé",
+      "approvedByYou": "Vous, avec votre propre compte et vos propres autorisations",
+      "cancelled": "Annulé. Aucune opération n'a été exécutée.",
+      "suggest": {
+        "schedule": "Affichez l'échéancier de remboursement",
+        "recordRepayment": "Effectuez un remboursement",
+        "overdue": "Affichez les prêts en retard",
+        "theirLoans": "Affichez ses prêts",
+        "kyc": "Affichez les documents KYC",
+        "savings": "Consultez le solde d'épargne",
+        "clientLoans": "Affichez les prêts de ce client",
+        "approve": "Approuvez ce prêt",
+        "searchClient": "Recherchez un client",
+        "disburse": "Décaissez ce prêt",
+        "backToClient": "Retour au profil du client"
+      }
+    }
   }
 }

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3726,7 +3726,7 @@
       "Auto Loan": "Prestito auto",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finanziamento per l'acquisto di auto nuove o usate con rate mensili fisse per la durata scelta.",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Finanziamento \u00abcompra ora, paga dopo\u00bb per acquisti a breve termine, spesso senza interessi, saldato in rate fisse.",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Finanziamento «compra ora, paga dopo» per acquisti a breve termine, spesso senza interessi, saldato in rate fisse.",
       "Consumer Durable Loan": "Prestito per beni durevoli",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "Finanziamento nel punto vendita per elettronica, elettrodomestici e altri beni durevoli, spesso con rate a interessi zero.",
       "Credit Card EMI": "Rateizzazione carta di credito",
@@ -3742,7 +3742,7 @@
       "JLG Loan": "Prestito JLG",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "Microcrediti garantiti dal gruppo per i membri di un gruppo a responsabilità solidale, in genere per attività generatrici di reddito.",
       "Line of Credit": "Linea di credito",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Un fido rotativo che pu\u00f2 essere utilizzato, rimborsato e riutilizzato secondo necessit\u00e0, con interessi addebitati solo sull'importo utilizzato.",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Un fido rotativo che può essere utilizzato, rimborsato e riutilizzato secondo necessità, con interessi addebitati solo sull'importo utilizzato.",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "Prestito garantito da un immobile residenziale o commerciale esistente dato in pegno.",
       "Loan vs Securities / FD": "Prestito su titoli / deposito vincolato",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "Credito concesso su azioni, fondi comuni o depositi vincolati senza liquidare l'investimento sottostante.",
@@ -5496,7 +5496,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "Sessione corrente",
     "newChat": "Nuova chat",
     "close": "Chiudi",
@@ -5505,21 +5505,21 @@
       "afternoon": "Buon pomeriggio",
       "evening": "Buonasera"
     },
-    "welcomeHeading": "Come posso aiutarti ad assistere i tuoi clienti oggi?",
+    "welcomeHeading": "Cosa vuoi fare?",
     "suggestions": {
-      "clientDetails": "Mostrami i dettagli del cliente John Doe",
-      "repaymentSchedule": "Qual è il piano di rimborso del prestito n. 107?",
-      "savingsBalance": "Mostra il saldo del conto di risparmio del cliente n. 52",
-      "overdueLoans": "Quanti prestiti sono scaduti questa settimana?"
+      "clientDetails": "Mostrami il profilo di questo cliente",
+      "repaymentSchedule": "Qual è il piano di rimborso di questo prestito?",
+      "savingsBalance": "Qual è il saldo di risparmio di questo cliente?",
+      "overdueLoans": "Quali prestiti sono scaduti questa settimana?"
     },
     "input": {
-      "placeholder": "Chiedi informazioni su clienti, prestiti o conti...",
+      "placeholder": "Chiedi di un cliente, un prestito o un conto",
       "attach": "Allega file",
       "voice": "Input vocale",
       "send": "Invia messaggio",
       "stop": "Interrompi generazione"
     },
-    "disclaimer": "Mifos Intelligence AI è progettata per assistere, non sostituire, le decisioni umane.",
+    "disclaimer": "Mifos X Copilot ti aiuta a trovare risposte. Tutto ciò che muove denaro richiede comunque la tua approvazione.",
     "nav": {
       "recentChats": "Chat recenti",
       "chat": "Chat",
@@ -5534,20 +5534,20 @@
       "delete": "Elimina conversazione"
     },
     "help": {
-      "capabilitiesTitle": "Cosa può fare Mifos Intelligence AI?",
+      "capabilitiesTitle": "Cosa può fare Mifos X Copilot",
       "capabilities": {
-        "lookup": "Cercare informazioni e profili dei clienti",
-        "loans": "Visualizzare dettagli dei prestiti e piani di rimborso",
-        "savings": "Controllare i saldi dei conti di risparmio",
-        "portfolio": "Ottenere informazioni sui portafogli dei clienti",
-        "navigate": "Navigare verso pagine specifiche in Mifos X"
+        "lookup": "Trovare un cliente e mostrarne il profilo",
+        "loans": "Mostrare dettagli del prestito e piani di rimborso",
+        "savings": "Controllare un saldo di risparmio",
+        "portfolio": "Riassumere il portafoglio di un cliente",
+        "navigate": "Portarti alla pagina giusta"
       },
-      "examplesTitle": "Esempi di richieste",
-      "importantTitle": "Importante",
+      "examplesTitle": "Cose da provare",
+      "importantTitle": "Da sapere",
       "important": {
-        "assist": "Le risposte dell'IA sono solo di supporto, non decisioni finali",
-        "verify": "Verifica sempre i dati finanziari critici prima di agire",
-        "noExecute": "L'IA non esegue transazioni autonomamente"
+        "assist": "Le risposte ti aiutano a decidere. Non sono la decisione.",
+        "verify": "Controlla i numeri prima di agire.",
+        "noExecute": "Nessun denaro si muove finché non confermi."
       }
     },
     "cardType": {
@@ -5557,18 +5557,79 @@
       "insight": "Approfondimento",
       "confirmation": "Conferma"
     },
-    "confirmWarning": "Questa azione coinvolge denaro reale. Si prega di confermare.",
-    "openAssistant": "Apri l'assistente IA",
+    "confirmWarning": "Questa operazione muove denaro reale. Controlla i dati, poi conferma.",
+    "openAssistant": "Apri Mifos X Copilot",
     "newChatTitle": "Nuova conversazione",
     "errors": {
       "invalidLength": "Il messaggio è vuoto o troppo lungo. Per favore accorcialo e riprova.",
       "injectionBlocked": "Il messaggio sembra un tentativo di aggirare le istruzioni, quindi non è stato inviato. Per favore riformulalo.",
-      "streamFailed": "Qualcosa è andato storto durante il contatto con l'assistente. Per favore riprova."
+      "streamFailed": "Mifos X Copilot non è raggiungibile. Riprova."
     },
     "confirm": {
       "reference": "Riferimento",
-      "pendingAnnouncement": "È richiesta una conferma prima di eseguire questa azione."
+      "pendingAnnouncement": "Controlla i dati prima che questa azione venga eseguita."
     },
-    "assistantAvatarAlt": "Assistente Mifos AI"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Data di attivazione",
+      "activeLoans": "Prestiti attivi",
+      "amount": "Importo",
+      "appliedFor": "Importo richiesto",
+      "approvalDate": "Data di approvazione",
+      "approvedAmount": "Importo approvato",
+      "approvedBy": "Approvato da",
+      "client": "Cliente",
+      "clientAccount": "Conto cliente",
+      "disbursementDate": "Data di erogazione",
+      "expectedDisbursement": "Erogazione prevista",
+      "firstName": "Nome",
+      "lastName": "Cognome",
+      "loanAccount": "Conto di prestito",
+      "mobileNumber": "Numero di cellulare",
+      "nextInstalment": "Prossima rata",
+      "office": "Ufficio",
+      "outstanding": "Importo residuo",
+      "principal": "Capitale",
+      "product": "Prodotto",
+      "reference": "Riferimento",
+      "repaymentAmount": "Importo del rimborso",
+      "repayments": "Rimborsi",
+      "savingsAccount": "Conto di risparmio",
+      "savingsBalance": "Saldo di risparmio",
+      "search": "Ricerca",
+      "status": "Stato",
+      "submittedOn": "Inserito il",
+      "transactionDate": "Data della transazione"
+    },
+    "demo": {
+      "product": "Prestito agricolo a termine",
+      "office": "Sede centrale",
+      "statusActive": "Attivo",
+      "statusApproved": "Approvato",
+      "writeIntro": "Posso farlo. Controlla i dati qui sotto e conferma prima che l'operazione venga eseguita.",
+      "approveSummary": "Approva {{product}} per {{client}}",
+      "loanIntro": "Ecco il prestito attivo di **{{client}}**:",
+      "loanTitle": "{{product}}, attivo",
+      "nextInstalment": "{{amount}}, in scadenza tra {{days}} giorni",
+      "clientIntro": "Ho trovato questo cliente:",
+      "modeNotice": "Sto funzionando in **modalità demo** e nessun gateway è ancora collegato, ma tutto quello che vedi qui (la risposta in streaming, le schede, il passaggio di conferma) è reale.",
+      "approved": "Approvato. Il prestito è ora registrato a tuo nome nella traccia di controllo.",
+      "approvedTitle": "Prestito approvato",
+      "approvedByYou": "Tu, con le tue autorizzazioni",
+      "cancelled": "Annullato. Non è stata eseguita alcuna operazione.",
+      "suggest": {
+        "schedule": "Mostra il piano di rimborso",
+        "recordRepayment": "Registra un rimborso",
+        "overdue": "Mostra i prestiti scaduti",
+        "theirLoans": "Mostra i suoi prestiti",
+        "kyc": "Mostra i documenti KYC",
+        "savings": "Controlla il saldo di risparmio",
+        "clientLoans": "Mostra i prestiti di questo cliente",
+        "approve": "Approva questo prestito",
+        "searchClient": "Cerca un cliente",
+        "disburse": "Eroga questo prestito",
+        "backToClient": "Torna al profilo del cliente"
+      }
+    }
   }
 }

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3726,7 +3726,7 @@
       "Auto Loan": "자동차 대출",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "신차 또는 중고차 구매를 위한 금융으로, 선택한 기간 동안 매월 일정한 할부금을 상환합니다.",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "\ub2e8\uae30 \uad6c\ub9e4\ub97c \uc704\ud55c \ud6c4\ubd88 \uacb0\uc81c \ubc29\uc2dd\uc758 \uae08\uc735\uc73c\ub85c, \ub300\uac1c \ubb34\uc774\uc790\uc774\uba70 \uace0\uc815 \ud560\ubd80\ub85c \uc0c1\ud658\ud569\ub2c8\ub2e4.",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "단기 구매를 위한 후불 결제 방식의 금융으로, 대개 무이자이며 고정 할부로 상환합니다.",
       "Consumer Durable Loan": "내구소비재 대출",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "전자제품, 가전제품 및 기타 내구재를 위한 판매 시점 금융으로, 무이자 할부 옵션이 제공되는 경우가 많습니다.",
       "Credit Card EMI": "신용카드 할부",
@@ -3738,17 +3738,17 @@
       "Quick secured loan against pledged gold ornaments or coins, with fast disbursal and minimal paperwork": "담보로 맡긴 금 장신구나 금화를 이용한 신속한 담보 대출로, 빠른 지급과 최소한의 서류 절차를 제공합니다.",
       "Home Loan": "주택 대출",
       "Invoice Discounting": "매출채권 할인",
-      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "\ubbf8\uc218\uae08 \uc1a1\uc7a5\uc744 \ub2f4\ubcf4\ub85c \ud55c \ub2e8\uae30 \uae08\uc735\uc73c\ub85c, \uace0\uac1d \uacb0\uc81c\uc77c \uc774\uc804\uc5d0 \uae30\uc5c5\uc758 \ud604\uae08 \ud750\ub984\uc744 \uac1c\uc120\ud569\ub2c8\ub2e4.",
+      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "미수금 송장을 담보로 한 단기 금융으로, 고객 결제일 이전에 기업의 현금 흐름을 개선합니다.",
       "JLG Loan": "JLG 대출",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "연대책임 그룹에 속한 개인을 위한 그룹 보증 소액 대출로, 주로 소득 창출 활동에 사용됩니다.",
       "Line of Credit": "한도 대출",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "\ud544\uc694\uc5d0 \ub530\ub77c \uc778\ucd9c, \uc0c1\ud658, \uc7ac\uc0ac\uc6a9\uc774 \uac00\ub2a5\ud55c \ud68c\uc804 \uc2e0\uc6a9 \ud55c\ub3c4\ub85c, \uc0ac\uc6a9\ud55c \uae08\uc561\uc5d0 \ub300\ud574\uc11c\ub9cc \uc774\uc790\uac00 \ubd80\uacfc\ub429\ub2c8\ub2e4.",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "필요에 따라 인출, 상환, 재사용이 가능한 회전 신용 한도로, 사용한 금액에 대해서만 이자가 부과됩니다.",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "기존 주거용 또는 상업용 부동산을 담보로 제공하고 받는 대출.",
       "Loan vs Securities / FD": "유가증권 / 정기예금 담보 대출",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "주식, 펀드 또는 정기예금을 담보로 제공하되 해당 투자를 처분하지 않고 제공되는 대출입니다.",
       "Long-tenure financing to purchase, construct, or renovate a residential property": "주거용 부동산의 구입, 건축 또는 개보수를 위한 장기 금융.",
       "Merchant Cash Advance": "가맹점 매출 선지급",
-      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "\ud5a5\ud6c4 \uce74\ub4dc \ub610\ub294 \ub514\uc9c0\ud138 \ub9e4\ucd9c\uc744 \ub2f4\ubcf4\ub85c \uc120\uc9c0\uae09\ub418\ub294 \uc6b4\uc804\uc790\ubcf8\uc73c\ub85c, \uc77c\uc77c \uac70\ub798\uc561\uc758 \uc77c\uc815 \ube44\uc728\ub85c \uc0c1\ud658\ud569\ub2c8\ub2e4.",
+      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "향후 카드 또는 디지털 매출을 담보로 선지급되는 운전자본으로, 일일 거래액의 일정 비율로 상환합니다.",
       "Mortgage Loan (LAP)": "부동산 담보 대출 (LAP)",
       "No resets have been recorded for this loan": "이 대출에 기록된 초기화가 없습니다.",
       "No variations added yet": "아직 추가된 변형이 없습니다",
@@ -3756,7 +3756,7 @@
       "A row with the greater than condition must repeat the cycle number above it": "‘초과’ 조건을 사용하는 행은 바로 위 행의 주기 번호를 그대로 사용해야 합니다",
       "Fix the loan cycle variations before creating the product": "상품을 생성하기 전에 대출 주기 변형을 수정하세요",
       "Personal Loan": "개인 대출",
-      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "\uc5ec\ud589, \uc758\ub8cc\ube44, \uacb0\ud63c \ub4f1 \uac1c\uc778\uc801\uc778 \ud544\uc694\ub97c \uc704\ud55c \ubb34\ub2f4\ubcf4 \ub300\ucd9c\ub85c, \uc720\uc5f0\ud55c \uc0c1\ud658 \uae30\uac04\uacfc \ucd5c\uc18c\ud55c\uc758 \uc11c\ub958 \uc808\ucc28\ub97c \uc81c\uacf5\ud569\ub2c8\ub2e4.",
+      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "여행, 의료비, 결혼 등 개인적인 필요를 위한 무담보 대출로, 유연한 상환 기간과 최소한의 서류 절차를 제공합니다.",
       "Custom / Advanced": "사용자 지정 / 고급",
       "Two Wheeler Loan": "이륜차 대출",
       "Finance for new or used two-wheelers with quick approval and flexible down payment options": "신차 및 중고 이륜차 구입 자금을 빠른 승인과 유연한 계약금 옵션으로 지원합니다.",
@@ -5495,7 +5495,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "현재 세션",
     "newChat": "새 채팅",
     "close": "닫기",
@@ -5504,21 +5504,21 @@
       "afternoon": "좋은 오후입니다",
       "evening": "좋은 저녁입니다"
     },
-    "welcomeHeading": "오늘 고객을 지원하는 데 어떻게 도와드릴까요?",
+    "welcomeHeading": "무엇을 도와드릴까요?",
     "suggestions": {
-      "clientDetails": "고객 John Doe의 세부 정보를 보여주세요",
-      "repaymentSchedule": "대출 #107의 상환 일정은 어떻게 되나요?",
-      "savingsBalance": "고객 #52의 예금 계좌 잔액을 보여주세요",
-      "overdueLoans": "이번 주에 연체된 대출은 몇 건인가요?"
+      "clientDetails": "이 고객의 프로필을 보여주세요",
+      "repaymentSchedule": "이 대출의 상환 일정은 어떻게 되나요?",
+      "savingsBalance": "이 고객의 예금 잔액은 얼마인가요?",
+      "overdueLoans": "이번 주에 연체된 대출은 무엇인가요?"
     },
     "input": {
-      "placeholder": "고객, 대출 또는 계좌에 대해 질문하세요...",
+      "placeholder": "고객, 대출 또는 계좌에 대해 물어보세요",
       "attach": "파일 첨부",
       "voice": "음성 입력",
       "send": "메시지 보내기",
       "stop": "생성 중지"
     },
-    "disclaimer": "Mifos Intelligence AI는 인간의 의사 결정을 대체하는 것이 아니라 지원하도록 설계되었습니다.",
+    "disclaimer": "Mifos X Copilot은 답을 찾도록 돕습니다. 자금이 움직이는 작업은 여전히 승인이 필요합니다.",
     "nav": {
       "recentChats": "최근 채팅",
       "chat": "채팅",
@@ -5533,20 +5533,20 @@
       "delete": "대화 삭제"
     },
     "help": {
-      "capabilitiesTitle": "Mifos Intelligence AI는 무엇을 할 수 있나요?",
+      "capabilitiesTitle": "Mifos X Copilot이 할 수 있는 일",
       "capabilities": {
-        "lookup": "고객 정보 및 프로필 조회",
-        "loans": "대출 세부 정보 및 상환 일정 보기",
-        "savings": "예금 계좌 잔액 확인",
-        "portfolio": "고객 포트폴리오에 대한 인사이트 확인",
-        "navigate": "Mifos X의 특정 페이지로 이동"
+        "lookup": "고객을 찾아 프로필 보기",
+        "loans": "대출 내역과 상환 일정 보기",
+        "savings": "예금 잔액 확인",
+        "portfolio": "고객 포트폴리오 요약",
+        "navigate": "필요한 페이지로 이동"
       },
-      "examplesTitle": "예시 질문",
-      "importantTitle": "중요",
+      "examplesTitle": "이렇게 물어보세요",
+      "importantTitle": "알아두기",
       "important": {
-        "assist": "AI 응답은 참고용일 뿐 최종 결정이 아닙니다",
-        "verify": "조치를 취하기 전에 항상 중요한 금융 데이터를 확인하세요",
-        "noExecute": "AI는 스스로 거래를 실행하지 않습니다"
+        "assist": "답변은 판단을 돕습니다. 판단 자체가 아닙니다.",
+        "verify": "숫자에 따라 행동하기 전에 확인하세요.",
+        "noExecute": "승인하기 전에는 자금이 움직이지 않습니다."
       }
     },
     "cardType": {
@@ -5556,18 +5556,79 @@
       "insight": "인사이트",
       "confirmation": "확인"
     },
-    "confirmWarning": "이 작업은 실제 자금과 관련이 있습니다. 확인해 주세요.",
-    "openAssistant": "AI 어시스턴트 열기",
+    "confirmWarning": "실제 자금이 움직입니다. 내용을 확인한 후 승인하세요.",
+    "openAssistant": "Mifos X Copilot 열기",
     "newChatTitle": "새 대화",
     "errors": {
       "invalidLength": "메시지가 비어 있거나 너무 깁니다. 줄여서 다시 시도해 주세요.",
       "injectionBlocked": "메시지가 지시 무시 시도로 보여 전송되지 않았습니다. 다시 작성해 주세요.",
-      "streamFailed": "어시스턴트 연결 중 문제가 발생했습니다. 다시 시도해 주세요."
+      "streamFailed": "Mifos X Copilot에 연결할 수 없습니다. 다시 시도해 주세요."
     },
     "confirm": {
       "reference": "참조",
-      "pendingAnnouncement": "이 작업을 실행하기 전에 확인이 필요합니다."
+      "pendingAnnouncement": "이 작업이 실행되기 전에 내용을 확인하세요."
     },
-    "assistantAvatarAlt": "Mifos AI 어시스턴트"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "활성화일",
+      "activeLoans": "활성 대출",
+      "amount": "금액",
+      "appliedFor": "신청 금액",
+      "approvalDate": "승인일",
+      "approvedAmount": "승인 금액",
+      "approvedBy": "승인자",
+      "client": "고객",
+      "clientAccount": "고객 계좌",
+      "disbursementDate": "지급일",
+      "expectedDisbursement": "예상 지급일",
+      "firstName": "이름",
+      "lastName": "성",
+      "loanAccount": "대출 계좌",
+      "mobileNumber": "휴대폰 번호",
+      "nextInstalment": "다음 상환금",
+      "office": "사무실",
+      "outstanding": "미결제 잔액",
+      "principal": "원금",
+      "product": "상품",
+      "reference": "참조",
+      "repaymentAmount": "상환 금액",
+      "repayments": "상환",
+      "savingsAccount": "예금 계좌",
+      "savingsBalance": "예금 잔액",
+      "search": "검색",
+      "status": "상태",
+      "submittedOn": "제출일",
+      "transactionDate": "거래일"
+    },
+    "demo": {
+      "product": "농업 기간대출",
+      "office": "본사",
+      "statusActive": "활성",
+      "statusApproved": "승인됨",
+      "writeIntro": "네, 처리해 드리겠습니다. 실행하기 전에 아래 내용을 확인하고 승인해 주세요.",
+      "approveSummary": "{{client}} 고객의 {{product}} 승인",
+      "loanIntro": "**{{client}}** 고객의 활성 대출입니다:",
+      "loanTitle": "{{product}}, 활성",
+      "nextInstalment": "{{amount}}, {{days}}일 후 상환 예정",
+      "clientIntro": "다음 고객을 찾았습니다:",
+      "modeNotice": "현재 **데모 모드**로 실행 중이라 아직 게이트웨이가 연결되어 있지 않습니다. 하지만 여기 보이는 것(스트리밍 응답, 카드, 확인 단계)은 모두 실제와 동일합니다.",
+      "approved": "승인되었습니다. 이 대출은 귀하의 사용자 계정으로 감사 추적에 기록되었습니다.",
+      "approvedTitle": "대출 승인 완료",
+      "approvedByYou": "본인 (본인 계정의 권한으로 실행됨)",
+      "cancelled": "취소되었습니다. 실행된 작업은 없습니다.",
+      "suggest": {
+        "schedule": "상환 일정을 보여주세요",
+        "recordRepayment": "상환을 기록해 주세요",
+        "overdue": "연체된 대출을 보여주세요",
+        "theirLoans": "이 고객의 대출을 보여주세요",
+        "kyc": "KYC 서류를 보여주세요",
+        "savings": "예금 잔액을 확인해 주세요",
+        "clientLoans": "이 고객의 대출 내역을 보여주세요",
+        "approve": "이 대출을 승인해 주세요",
+        "searchClient": "고객을 검색해 주세요",
+        "disburse": "이 대출을 지급해 주세요",
+        "backToClient": "고객 프로필로 돌아가기"
+      }
+    }
   }
 }

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3726,7 +3726,7 @@
       "Auto Loan": "Automobilio paskola",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finansavimas naujų ar naudotų automobilių pirkimui su fiksuotomis mėnesinėmis įmokomis pasirinktu laikotarpiu.",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "\u201ePirk dabar, mok\u0117k v\u0117liau\u201c finansavimas trumpalaikiams, da\u017enai be pal\u016bkan\u0173, pirkiniams, apmokamas fiksuotomis \u012fmokomis.",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "„Pirk dabar, mokėk vėliau“ finansavimas trumpalaikiams, dažnai be palūkanų, pirkiniams, apmokamas fiksuotomis įmokomis.",
       "Consumer Durable Loan": "Ilgalaikio vartojimo prekių paskola",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "Finansavimas pardavimo vietoje elektronikai, buitinei technikai ir kitoms ilgalaikio vartojimo prekėms, dažnai su nemokamomis įmokomis.",
       "Credit Card EMI": "Kredito kortelės dalinis mokėjimas",
@@ -3738,17 +3738,17 @@
       "Quick secured loan against pledged gold ornaments or coins, with fast disbursal and minimal paperwork": "Greita užtikrinta paskola už įkeistus aukso dirbinius ar monetas, su skubiu išmokėjimu ir minimaliais dokumentais.",
       "Home Loan": "Būsto paskola",
       "Invoice Discounting": "Sąskaitų faktūrų diskontavimas",
-      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "Trumpalaikis finansavimas pagal neapmok\u0117tas s\u0105skaitas fakt\u016bras, gerinantis \u012fmon\u0117s pinig\u0173 srautus dar prie\u0161 kliento mok\u0117jimo termin\u0105.",
+      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "Trumpalaikis finansavimas pagal neapmokėtas sąskaitas faktūras, gerinantis įmonės pinigų srautus dar prieš kliento mokėjimo terminą.",
       "JLG Loan": "JLG paskola",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "Grupės garantuojami mikrokreditai solidariosios atsakomybės grupės nariams, paprastai pajamas generuojančiai veiklai.",
       "Line of Credit": "Kredito linija",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Atnaujinamoji kredito linija, kuri\u0105 galima pagal poreik\u012f i\u0161siimti, gr\u0105\u017einti ir naudoti pakartotinai; pal\u016bkanos skai\u010diuojamos tik nuo panaudotos sumos.",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Atnaujinamoji kredito linija, kurią galima pagal poreikį išsiimti, grąžinti ir naudoti pakartotinai; palūkanos skaičiuojamos tik nuo panaudotos sumos.",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "Paskola, užtikrinta esamu gyvenamuoju ar komerciniu nekilnojamuoju turtu.",
       "Loan vs Securities / FD": "Paskola už vertybinius popierius / terminuotąjį indėlį",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "Kreditas, suteikiamas už akcijas, investicinius fondus ar terminuotuosius indėlius, neparduodant pačios investicijos.",
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Ilgalaikis finansavimas gyvenamajam būstui įsigyti, statyti ar renovuoti.",
       "Merchant Cash Advance": "Prekybininko grynųjų avansas",
-      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Apyvartinis kapitalas, avansuojamas pagal b\u016bsimus mok\u0117jimus kortele ar skaitmeninius pardavimus ir gr\u0105\u017einamas kaip dienos operacij\u0173 procentas.",
+      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Apyvartinis kapitalas, avansuojamas pagal būsimus mokėjimus kortele ar skaitmeninius pardavimus ir grąžinamas kaip dienos operacijų procentas.",
       "Mortgage Loan (LAP)": "Hipotekos paskola (LAP)",
       "No resets have been recorded for this loan": "Šiai paskolai neužregistruota jokių atstatymų.",
       "No variations added yet": "Kol kas nepridėta jokių variacijų",
@@ -3756,7 +3756,7 @@
       "A row with the greater than condition must repeat the cycle number above it": "Eilutė su sąlyga „daugiau nei“ turi pakartoti aukščiau esančios eilutės ciklo numerį",
       "Fix the loan cycle variations before creating the product": "Prieš kurdami produktą pataisykite paskolos ciklo variacijas",
       "Personal Loan": "Vartojimo paskola",
-      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Nesuteikiant u\u017estato teikiamas finansavimas asmeniniams poreikiams, tokiems kaip kelion\u0117s, medicinos i\u0161laidos ar vestuv\u0117s, su lanks\u010diu terminu ir minimaliais dokumentais.",
+      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Nesuteikiant užstato teikiamas finansavimas asmeniniams poreikiams, tokiems kaip kelionės, medicinos išlaidos ar vestuvės, su lanksčiu terminu ir minimaliais dokumentais.",
       "Custom / Advanced": "Pasirinktinė / išplėstinė",
       "Two Wheeler Loan": "Motociklų ir motorolerių paskola",
       "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Naujų ar naudotų motociklų ir motorolerių finansavimas su greitu patvirtinimu ir lanksčia pradine įmoka.",
@@ -5496,7 +5496,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "Dabartinė sesija",
     "newChat": "Naujas pokalbis",
     "close": "Uždaryti",
@@ -5505,21 +5505,21 @@
       "afternoon": "Laba diena",
       "evening": "Labas vakaras"
     },
-    "welcomeHeading": "Kaip galiu padėti jums aptarnauti klientus šiandien?",
+    "welcomeHeading": "Ką norėtumėte atlikti?",
     "suggestions": {
-      "clientDetails": "Parodykite kliento John Doe informaciją",
-      "repaymentSchedule": "Koks yra paskolos Nr. 107 grąžinimo grafikas?",
-      "savingsBalance": "Parodykite kliento Nr. 52 taupomosios sąskaitos likutį",
-      "overdueLoans": "Kiek paskolų yra pradelsta šią savaitę?"
+      "clientDetails": "Parodykite šio kliento profilį",
+      "repaymentSchedule": "Koks šios paskolos grąžinimo grafikas?",
+      "savingsBalance": "Koks šio kliento santaupų likutis?",
+      "overdueLoans": "Kurios paskolos pradelstos šią savaitę?"
     },
     "input": {
-      "placeholder": "Klauskite apie klientus, paskolas ar sąskaitas...",
+      "placeholder": "Klauskite apie klientą, paskolą ar sąskaitą",
       "attach": "Pridėti failą",
       "voice": "Balso įvestis",
       "send": "Siųsti žinutę",
       "stop": "Stabdyti generavimą"
     },
-    "disclaimer": "Mifos Intelligence AI skirta padėti, o ne pakeisti žmogaus sprendimų priėmimą.",
+    "disclaimer": "Mifos X Copilot padeda rasti atsakymus. Bet kokiam pinigų judėjimui vis tiek reikia jūsų patvirtinimo.",
     "nav": {
       "recentChats": "Naujausi pokalbiai",
       "chat": "Pokalbis",
@@ -5534,20 +5534,20 @@
       "delete": "Ištrinti pokalbį"
     },
     "help": {
-      "capabilitiesTitle": "Ką gali Mifos Intelligence AI?",
+      "capabilitiesTitle": "Ką gali Mifos X Copilot",
       "capabilities": {
-        "lookup": "Ieškoti klientų informacijos ir profilių",
-        "loans": "Peržiūrėti paskolų informaciją ir grąžinimo grafikus",
-        "savings": "Tikrinti taupomųjų sąskaitų likučius",
-        "portfolio": "Gauti įžvalgų apie klientų portfelius",
-        "navigate": "Pereiti į konkrečius Mifos X puslapius"
+        "lookup": "Rasti klientą ir parodyti jo profilį",
+        "loans": "Parodyti paskolos duomenis ir grąžinimo grafikus",
+        "savings": "Patikrinti santaupų likutį",
+        "portfolio": "Apibendrinti kliento portfelį",
+        "navigate": "Nuvesti į reikiamą puslapį"
       },
-      "examplesTitle": "Užklausų pavyzdžiai",
-      "importantTitle": "Svarbu",
+      "examplesTitle": "Ką išbandyti",
+      "importantTitle": "Verta žinoti",
       "important": {
-        "assist": "AI atsakymai skirti tik pagalbai, o ne galutiniams sprendimams",
-        "verify": "Prieš veikdami visada patikrinkite svarbius finansinius duomenis",
-        "noExecute": "AI pati nevykdo operacijų"
+        "assist": "Atsakymai padeda apsispręsti. Jie nėra sprendimas.",
+        "verify": "Patikrinkite skaičius prieš jais remdamiesi.",
+        "noExecute": "Pinigai nejuda, kol nepatvirtinate."
       }
     },
     "cardType": {
@@ -5557,18 +5557,79 @@
       "insight": "Įžvalga",
       "confirmation": "Patvirtinimas"
     },
-    "confirmWarning": "Šis veiksmas susijęs su tikrais pinigais. Patvirtinkite.",
-    "openAssistant": "Atidaryti DI asistentą",
+    "confirmWarning": "Čia juda tikri pinigai. Patikrinkite duomenis ir patvirtinkite.",
+    "openAssistant": "Atidaryti Mifos X Copilot",
     "newChatTitle": "Naujas pokalbis",
     "errors": {
       "invalidLength": "Žinutė tuščia arba per ilga. Sutrumpinkite ją ir bandykite dar kartą.",
       "injectionBlocked": "Žinutė atrodo kaip bandymas apeiti nurodymus, todėl nebuvo išsiųsta. Perfrazuokite ją.",
-      "streamFailed": "Jungiantis prie asistento įvyko klaida. Bandykite dar kartą."
+      "streamFailed": "Nepavyko pasiekti Mifos X Copilot. Bandykite dar kartą."
     },
     "confirm": {
       "reference": "Nuoroda",
-      "pendingAnnouncement": "Prieš vykdant šį veiksmą reikalingas patvirtinimas."
+      "pendingAnnouncement": "Prieš vykdant šį veiksmą patikrinkite duomenis."
     },
-    "assistantAvatarAlt": "Mifos DI asistentas"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Aktyvinimo data",
+      "activeLoans": "Aktyvios paskolos",
+      "amount": "Suma",
+      "appliedFor": "Prašoma suma",
+      "approvalDate": "Patvirtinimo data",
+      "approvedAmount": "Patvirtinta suma",
+      "approvedBy": "Patvirtino",
+      "client": "Klientas",
+      "clientAccount": "Kliento sąskaita",
+      "disbursementDate": "Išmokėjimo data",
+      "expectedDisbursement": "Numatomas išmokėjimas",
+      "firstName": "Pirmas vardas",
+      "lastName": "Pavardė",
+      "loanAccount": "Paskolos sąskaita",
+      "mobileNumber": "Mobiliojo nr.",
+      "nextInstalment": "Kita įmoka",
+      "office": "Biuras",
+      "outstanding": "Neapmokėta suma",
+      "principal": "Pagrindinė suma",
+      "product": "Produktas",
+      "reference": "Nuoroda",
+      "repaymentAmount": "Grąžinimo suma",
+      "repayments": "Grąžinimai",
+      "savingsAccount": "Taupomoji sąskaita",
+      "savingsBalance": "Santaupų likutis",
+      "search": "Paieška",
+      "status": "Būsena",
+      "submittedOn": "Pateikta",
+      "transactionDate": "Sandorio data"
+    },
+    "demo": {
+      "product": "Žemės ūkio terminuotoji paskola",
+      "office": "Pagrindinis biuras",
+      "statusActive": "Aktyvus",
+      "statusApproved": "Patvirtinta",
+      "writeIntro": "Tai galiu atlikti. Peržiūrėkite toliau pateiktus duomenis ir patvirtinkite, kad galėčiau įvykdyti.",
+      "approveSummary": "Patvirtinti: {{product}} — klientas {{client}}",
+      "loanIntro": "Štai aktyvi kliento **{{client}}** paskola:",
+      "loanTitle": "{{product}}, aktyvi",
+      "nextInstalment": "{{amount}}, terminas po {{days}} d.",
+      "clientIntro": "Radau šį klientą:",
+      "modeNotice": "Veikiu **demonstraciniu režimu**, vartai dar neprijungti, tačiau viskas, ką čia matote (srautinis atsakymas, kortelės, patvirtinimo žingsnis), yra tikra.",
+      "approved": "Patvirtinta. Paskola įrašyta audito žurnale jūsų vartotojo vardu.",
+      "approvedTitle": "Paskola patvirtinta",
+      "approvedByYou": "Jūs, su savo prisijungimu ir leidimais",
+      "cancelled": "Atšaukta. Nieko nebuvo įvykdyta.",
+      "suggest": {
+        "schedule": "Parodykite grąžinimo grafiką",
+        "recordRepayment": "Užregistruokite grąžinimą",
+        "overdue": "Parodykite pradelstas paskolas",
+        "theirLoans": "Parodykite šio kliento paskolas",
+        "kyc": "Parodykite KYC dokumentus",
+        "savings": "Patikrinkite santaupų likutį",
+        "clientLoans": "Parodykite šio kliento paskolas",
+        "approve": "Patvirtinkite šią paskolą",
+        "searchClient": "Ieškokite kliento",
+        "disburse": "Išmokėkite šią paskolą",
+        "backToClient": "Grįžkite į kliento profilį"
+      }
+    }
   }
 }

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3726,7 +3726,7 @@
       "Auto Loan": "Auto aizdevums",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finansējums jaunu vai lietotu automobiļu iegādei ar fiksētiem ikmēneša maksājumiem izvēlētajā termiņā.",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "\u201eP\u0113rc tagad, maks\u0101 v\u0113l\u0101k\u201c finans\u0113jums \u012bstermi\u0146a, bie\u017ei bezprocentu pirkumiem, kas tiek atmaks\u0101ts fiks\u0113t\u0101s da\u013c\u0101s.",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "„Pērc tagad, maksā vēlāk“ finansējums īstermiņa, bieži bezprocentu pirkumiem, kas tiek atmaksāts fiksētās daļās.",
       "Consumer Durable Loan": "Ilglietojuma preču aizdevums",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "Finansējums tirdzniecības vietā elektronikai, sadzīves tehnikai un citām ilglietojuma precēm, bieži ar bezprocentu maksājumiem.",
       "Credit Card EMI": "Kredītkartes maksājumi pa daļām",
@@ -3738,17 +3738,17 @@
       "Quick secured loan against pledged gold ornaments or coins, with fast disbursal and minimal paperwork": "Ātrs nodrošināts aizdevums pret ieķīlātām zelta rotaslietām vai monētām, ar strauju izmaksu un minimālu dokumentāciju.",
       "Home Loan": "Mājokļa aizdevums",
       "Invoice Discounting": "Rēķinu diskontēšana",
-      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "\u012astermi\u0146a finans\u0113jums pret neapmaks\u0101tiem r\u0113\u0137iniem, lai uzlabotu uz\u0146\u0113muma naudas pl\u016bsmu pirms klienta maks\u0101juma termi\u0146a.",
+      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "Īstermiņa finansējums pret neapmaksātiem rēķiniem, lai uzlabotu uzņēmuma naudas plūsmu pirms klienta maksājuma termiņa.",
       "JLG Loan": "JLG aizdevums",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "Grupas galvoti mikrokredīti solidāras atbildības grupas dalībniekiem, parasti ienākumus radošai darbībai.",
       "Line of Credit": "Kredītlīnija",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Atjaunojama kred\u012btl\u012bnija, ko var izmantot, atmaks\u0101t un izmantot atk\u0101rtoti p\u0113c nepiecie\u0161am\u012bbas; procenti tiek apr\u0113\u0137in\u0101ti tikai par izmantoto summu.",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Atjaunojama kredītlīnija, ko var izmantot, atmaksāt un izmantot atkārtoti pēc nepieciešamības; procenti tiek aprēķināti tikai par izmantoto summu.",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "Aizdevums pret esoša dzīvojamā vai komerciālā īpašuma ķīlu.",
       "Loan vs Securities / FD": "Aizdevums pret vērtspapīriem / termiņnoguldījumu",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "Kredīts pret akcijām, ieguldījumu fondiem vai termiņnoguldījumiem, nelikvidējot pašu ieguldījumu.",
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Ilgtermiņa finansējums mājokļa iegādei, būvniecībai vai renovācijai.",
       "Merchant Cash Advance": "Tirgotāja naudas avanss",
-      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Apgroz\u0101mais kapit\u0101ls, kas tiek avans\u0113ts pret n\u0101kotnes kar\u0161u vai digit\u0101lajiem p\u0101rdo\u0161anas ie\u0146\u0113mumiem un atmaks\u0101ts k\u0101 procentu\u0101la da\u013ca no ikdienas dar\u012bjumiem.",
+      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Apgrozāmais kapitāls, kas tiek avansēts pret nākotnes karšu vai digitālajiem pārdošanas ieņēmumiem un atmaksāts kā procentuāla daļa no ikdienas darījumiem.",
       "Mortgage Loan (LAP)": "Hipotekārais aizdevums (LAP)",
       "No resets have been recorded for this loan": "Šim aizdevumam nav reģistrēta neviena atiestatīšana.",
       "No variations added yet": "Vēl nav pievienota neviena variācija",
@@ -3756,7 +3756,7 @@
       "A row with the greater than condition must repeat the cycle number above it": "Rindai ar nosacījumu “lielāks nekā” jāatkārto iepriekšējās rindas cikla numurs",
       "Fix the loan cycle variations before creating the product": "Pirms produkta izveides izlabojiet aizdevuma cikla variācijas",
       "Personal Loan": "Patēriņa aizdevums",
-      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Nenodro\u0161in\u0101ts finans\u0113jums person\u012bg\u0101m vajadz\u012bb\u0101m, piem\u0113ram, ce\u013cojumiem, medic\u012bnas izdevumiem vai k\u0101z\u0101m, ar elast\u012bgu termi\u0146u un minim\u0101lu dokument\u0101ciju.",
+      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Nenodrošināts finansējums personīgām vajadzībām, piemēram, ceļojumiem, medicīnas izdevumiem vai kāzām, ar elastīgu termiņu un minimālu dokumentāciju.",
       "Custom / Advanced": "Pielāgots / paplašināts",
       "Two Wheeler Loan": "Divriteņu transportlīdzekļa aizdevums",
       "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Jaunu vai lietotu divriteņu transportlīdzekļu finansējums ar ātru apstiprinājumu un elastīgu pirmo iemaksu.",
@@ -5495,7 +5495,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "Pašreizējā sesija",
     "newChat": "Jauna saruna",
     "close": "Aizvērt",
@@ -5504,21 +5504,21 @@
       "afternoon": "Labdien",
       "evening": "Labvakar"
     },
-    "welcomeHeading": "Kā es varu jums šodien palīdzēt apkalpot klientus?",
+    "welcomeHeading": "Ko vēlaties darīt?",
     "suggestions": {
-      "clientDetails": "Parādiet klienta John Doe informāciju",
-      "repaymentSchedule": "Kāds ir aizdevuma Nr. 107 atmaksas grafiks?",
-      "savingsBalance": "Parādiet klienta Nr. 52 krājkonta atlikumu",
-      "overdueLoans": "Cik aizdevumu šonedēļ ir nokavēti?"
+      "clientDetails": "Parādiet šī klienta profilu",
+      "repaymentSchedule": "Kāds ir šī aizdevuma atmaksas grafiks?",
+      "savingsBalance": "Kāds ir šī klienta uzkrājumu atlikums?",
+      "overdueLoans": "Kuri aizdevumi šonedēļ ir nokavēti?"
     },
     "input": {
-      "placeholder": "Jautājiet par klientiem, aizdevumiem vai kontiem...",
+      "placeholder": "Jautājiet par klientu, aizdevumu vai kontu",
       "attach": "Pievienot failu",
       "voice": "Balss ievade",
       "send": "Sūtīt ziņojumu",
       "stop": "Apturēt ģenerēšanu"
     },
-    "disclaimer": "Mifos Intelligence AI ir paredzēta, lai palīdzētu, nevis aizstātu cilvēku lēmumu pieņemšanu.",
+    "disclaimer": "Mifos X Copilot palīdz atrast atbildes. Jebkurai naudas kustībai joprojām nepieciešams jūsu apstiprinājums.",
     "nav": {
       "recentChats": "Nesenās sarunas",
       "chat": "Saruna",
@@ -5533,20 +5533,20 @@
       "delete": "Dzēst sarunu"
     },
     "help": {
-      "capabilitiesTitle": "Ko Mifos Intelligence AI var darīt?",
+      "capabilitiesTitle": "Ko Mifos X Copilot var izdarīt",
       "capabilities": {
-        "lookup": "Meklēt klientu informāciju un profilus",
-        "loans": "Skatīt aizdevumu informāciju un atmaksas grafikus",
-        "savings": "Pārbaudīt krājkontu atlikumus",
-        "portfolio": "Iegūt ieskatu par klientu portfeļiem",
-        "navigate": "Pāriet uz konkrētām Mifos X lapām"
+        "lookup": "Atrast klientu un parādīt viņa profilu",
+        "loans": "Parādīt aizdevuma datus un atmaksas grafikus",
+        "savings": "Pārbaudīt uzkrājumu atlikumu",
+        "portfolio": "Apkopot klienta portfeli",
+        "navigate": "Aizvest uz vajadzīgo lapu"
       },
-      "examplesTitle": "Pieprasījumu piemēri",
-      "importantTitle": "Svarīgi",
+      "examplesTitle": "Ko izmēģināt",
+      "importantTitle": "Vērts zināt",
       "important": {
-        "assist": "AI atbildes ir paredzētas tikai kā palīdzība, nevis galīgie lēmumi",
-        "verify": "Pirms rīkojaties, vienmēr pārbaudiet svarīgus finanšu datus",
-        "noExecute": "AI pati neveic darījumus"
+        "assist": "Atbildes palīdz izlemt. Tās nav lēmums.",
+        "verify": "Pārbaudiet skaitļus, pirms rīkojaties.",
+        "noExecute": "Nauda nekustas, kamēr to neapstiprināt."
       }
     },
     "cardType": {
@@ -5556,18 +5556,79 @@
       "insight": "Ieskats",
       "confirmation": "Apstiprinājums"
     },
-    "confirmWarning": "Šī darbība ir saistīta ar reālu naudu. Lūdzu, apstipriniet.",
-    "openAssistant": "Atvērt MI asistentu",
+    "confirmWarning": "Šeit kustas reāla nauda. Pārbaudiet datus un tad apstipriniet.",
+    "openAssistant": "Atvērt Mifos X Copilot",
     "newChatTitle": "Jauna saruna",
     "errors": {
       "invalidLength": "Ziņojums ir tukšs vai pārāk garš. Lūdzu, saīsiniet to un mēģiniet vēlreiz.",
       "injectionBlocked": "Ziņojums izskatās pēc mēģinājuma apiet norādījumus, tāpēc tas netika nosūtīts. Lūdzu, pārformulējiet to.",
-      "streamFailed": "Sazinoties ar asistentu, radās kļūda. Lūdzu, mēģiniet vēlreiz."
+      "streamFailed": "Neizdevās sasniegt Mifos X Copilot. Lūdzu, mēģiniet vēlreiz."
     },
     "confirm": {
       "reference": "Atsauce",
-      "pendingAnnouncement": "Pirms šīs darbības veikšanas nepieciešams apstiprinājums."
+      "pendingAnnouncement": "Pārbaudiet datus, pirms šī darbība tiek izpildīta."
     },
-    "assistantAvatarAlt": "Mifos MI asistents"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Aktivizācijas datums",
+      "activeLoans": "Aktīvie aizdevumi",
+      "amount": "Summa",
+      "appliedFor": "Pieteiktā summa",
+      "approvalDate": "Apstiprināšanas datums",
+      "approvedAmount": "Apstiprinātā summa",
+      "approvedBy": "Apstiprināja",
+      "client": "Klients",
+      "clientAccount": "Klienta konts",
+      "disbursementDate": "Izmaksas datums",
+      "expectedDisbursement": "Paredzamā izmaksa",
+      "firstName": "Vārds",
+      "lastName": "Uzvārds",
+      "loanAccount": "Aizdevuma konts",
+      "mobileNumber": "Mobilā telefona numurs",
+      "nextInstalment": "Nākamā iemaksa",
+      "office": "Birojs",
+      "outstanding": "Nesamaksātais atlikums",
+      "principal": "Pamatsumma",
+      "product": "Produkts",
+      "reference": "Atsauce",
+      "repaymentAmount": "Atmaksas summa",
+      "repayments": "Atmaksas",
+      "savingsAccount": "Krājkonts",
+      "savingsBalance": "Uzkrājumu atlikums",
+      "search": "Meklēt",
+      "status": "Statuss",
+      "submittedOn": "Iesniegts",
+      "transactionDate": "Darījuma datums"
+    },
+    "demo": {
+      "product": "Lauksaimniecības termiņaizdevums",
+      "office": "Galvenais birojs",
+      "statusActive": "Aktīvs",
+      "statusApproved": "Apstiprināts",
+      "writeIntro": "To varu izdarīt. Lūdzu, pārbaudiet zemāk redzamos datus un apstipriniet, pirms to izpildu.",
+      "approveSummary": "Apstiprināt {{product}} klientam {{client}}",
+      "loanIntro": "Šis ir klienta **{{client}}** aktīvais aizdevums:",
+      "loanTitle": "{{product}}, aktīvs",
+      "nextInstalment": "{{amount}}, termiņš pēc {{days}} dienām",
+      "clientIntro": "Atradu šo klientu:",
+      "modeNotice": "Šobrīd darbojos **demonstrācijas režīmā**, vārteja vēl nav pievienota, taču viss, ko šeit redzat (straumētā atbilde, kartītes, apstiprināšanas solis), ir īsts.",
+      "approved": "Apstiprināts. Aizdevums revīzijas takā tagad ir reģistrēts uz jūsu lietotāja vārda.",
+      "approvedTitle": "Aizdevums apstiprināts",
+      "approvedByYou": "Jūs — ar savām lietotāja atļaujām",
+      "cancelled": "Atcelts. Nekas netika izpildīts.",
+      "suggest": {
+        "schedule": "Parādiet atmaksas grafiku",
+        "recordRepayment": "Reģistrējiet atmaksu",
+        "overdue": "Parādiet nokavētos aizdevumus",
+        "theirLoans": "Parādiet viņa aizdevumus",
+        "kyc": "Parādiet KYC dokumentus",
+        "savings": "Pārbaudiet uzkrājumu atlikumu",
+        "clientLoans": "Parādiet šī klienta aizdevumus",
+        "approve": "Apstipriniet šo aizdevumu",
+        "searchClient": "Meklējiet klientu",
+        "disburse": "Izmaksājiet šo aizdevumu",
+        "backToClient": "Atpakaļ uz klienta profilu"
+      }
+    }
   }
 }

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3726,7 +3726,7 @@
       "Auto Loan": "सवारी साधन ऋण",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "नयाँ वा प्रयोग भएका कार खरिदका लागि वित्तपोषण, छनोट गरिएको अवधिभर नियमित मासिक किस्तासहित।",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "\u091b\u094b\u091f\u094b \u0905\u0935\u0927\u093f\u0915\u093e, \u092a\u094d\u0930\u093e\u092f\u0903 \u092c\u094d\u092f\u093e\u091c\u0930\u0939\u093f\u0924 \u0916\u0930\u093f\u0926\u0915\u093e \u0932\u093e\u0917\u093f \u0905\u0939\u093f\u0932\u0947 \u0915\u093f\u0928\u094d\u0928\u0941\u0939\u094b\u0938\u094d, \u092a\u091b\u093f \u0924\u093f\u0930\u094d\u0928\u0941\u0939\u094b\u0938\u094d \u0935\u093f\u0924\u094d\u0924\u092a\u094b\u0937\u0923, \u0928\u093f\u0936\u094d\u091a\u093f\u0924 \u0915\u093f\u0938\u094d\u0924\u093e\u092e\u093e \u092d\u0941\u0915\u094d\u0924\u093e\u0928\u0940 \u0917\u0930\u093f\u0928\u0947\u0964",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "छोटो अवधिका, प्रायः ब्याजरहित खरिदका लागि अहिले किन्नुहोस्, पछि तिर्नुहोस् वित्तपोषण, निश्चित किस्तामा भुक्तानी गरिने।",
       "Consumer Durable Loan": "उपभोग्य वस्तु ऋण",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "इलेक्ट्रोनिक्स, घरायसी उपकरण र अन्य उपभोग्य वस्तुका लागि बिक्री केन्द्रमै उपलब्ध वित्तपोषण, प्रायः शून्य ब्याज किस्ता विकल्पसहित।",
       "Credit Card EMI": "क्रेडिट कार्ड किस्ता",
@@ -3738,17 +3738,17 @@
       "Quick secured loan against pledged gold ornaments or coins, with fast disbursal and minimal paperwork": "धितो राखिएको सुनका गहना वा सिक्काविरुद्ध द्रुत सुरक्षित ऋण, छिटो ऋण वितरण र न्यूनतम कागजी प्रक्रियासहित।",
       "Home Loan": "घर ऋण",
       "Invoice Discounting": "बिजक छुट",
-      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "\u0917\u094d\u0930\u093e\u0939\u0915\u0915\u094b \u092d\u0941\u0915\u094d\u0924\u093e\u0928\u0940 \u0905\u0935\u0927\u093f \u0906\u0909\u0928\u0941\u0905\u0918\u093f \u0935\u094d\u092f\u0935\u0938\u093e\u092f\u0915\u094b \u0928\u0917\u0926 \u092a\u094d\u0930\u0935\u093e\u0939 \u0938\u0941\u0927\u093e\u0930 \u0917\u0930\u094d\u0928 \u0905\u092d\u0941\u0915\u094d\u0924\u093e\u0928\u0940 \u092c\u0940\u091c\u0915\u0939\u0930\u0942\u0915\u094b \u0906\u0927\u093e\u0930\u092e\u093e \u0905\u0932\u094d\u092a\u0915\u093e\u0932\u0940\u0928 \u0935\u093f\u0924\u094d\u0924\u092a\u094b\u0937\u0923\u0964",
+      "Short-term financing against unpaid invoices to improve business cash flow before customer payment is due": "ग्राहकको भुक्तानी अवधि आउनुअघि व्यवसायको नगद प्रवाह सुधार गर्न अभुक्तानी बीजकहरूको आधारमा अल्पकालीन वित्तपोषण।",
       "JLG Loan": "JLG ऋण",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "संयुक्त दायित्व समूहका सदस्यहरूका लागि समूह जमानीमा आधारित लघु ऋण, प्रायः आय आर्जन गर्ने गतिविधिका लागि।",
       "Line of Credit": "ऋण सीमा",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "\u0906\u0935\u0936\u094d\u092f\u0915\u0924\u093e\u0905\u0928\u0941\u0938\u093e\u0930 \u0928\u093f\u0915\u093e\u0932\u094d\u0928, \u0924\u093f\u0930\u094d\u0928 \u0930 \u092a\u0941\u0928\u0903 \u092a\u094d\u0930\u092f\u094b\u0917 \u0917\u0930\u094d\u0928 \u0938\u0915\u093f\u0928\u0947 \u0918\u0941\u092e\u094d\u0924\u0940 \u090b\u0923 \u0938\u0940\u092e\u093e, \u092a\u094d\u0930\u092f\u094b\u0917 \u0917\u0930\u093f\u090f\u0915\u094b \u0930\u0915\u092e\u092e\u093e \u092e\u093e\u0924\u094d\u0930 \u092c\u094d\u092f\u093e\u091c \u0932\u093e\u0917\u094d\u0928\u0947\u0964",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "आवश्यकताअनुसार निकाल्न, तिर्न र पुनः प्रयोग गर्न सकिने घुम्ती ऋण सीमा, प्रयोग गरिएको रकममा मात्र ब्याज लाग्ने।",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "विद्यमान आवासीय वा व्यावसायिक सम्पत्ति धितोमा राखी प्रदान गरिने ऋण।",
       "Loan vs Securities / FD": "धितोपत्र / मुद्दती निक्षेप विरुद्ध ऋण",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "सेयर, म्युचुअल फन्ड वा मुद्दती निक्षेपलाई धितो राखेर, सो लगानी नबेची उपलब्ध गराइने कर्जा।",
       "Long-tenure financing to purchase, construct, or renovate a residential property": "आवासीय सम्पत्ति किन्न, निर्माण गर्न वा मर्मत गर्न दीर्घकालीन वित्तपोषण।",
       "Merchant Cash Advance": "व्यापारी नगद अग्रिम",
-      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "\u092d\u0935\u093f\u0937\u094d\u092f\u0915\u093e \u0915\u093e\u0930\u094d\u0921 \u0935\u093e \u0921\u093f\u091c\u093f\u091f\u0932 \u092c\u093f\u0915\u094d\u0930\u0940\u0915\u094b \u0906\u0927\u093e\u0930\u092e\u093e \u0905\u0917\u094d\u0930\u093f\u092e \u0926\u093f\u0907\u0928\u0947 \u0915\u093e\u0930\u094d\u092f\u0936\u0940\u0932 \u092a\u0941\u0901\u091c\u0940, \u0926\u0948\u0928\u093f\u0915 \u0915\u093e\u0930\u094b\u092c\u093e\u0930\u0915\u094b \u0928\u093f\u0936\u094d\u091a\u093f\u0924 \u092a\u094d\u0930\u0924\u093f\u0936\u0924\u0915\u093e \u0930\u0942\u092a\u092e\u093e \u092d\u0941\u0915\u094d\u0924\u093e\u0928\u0940 \u0917\u0930\u093f\u0928\u0947\u0964",
+      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "भविष्यका कार्ड वा डिजिटल बिक्रीको आधारमा अग्रिम दिइने कार्यशील पुँजी, दैनिक कारोबारको निश्चित प्रतिशतका रूपमा भुक्तानी गरिने।",
       "Mortgage Loan (LAP)": "धितो ऋण (LAP)",
       "No resets have been recorded for this loan": "यस ऋणका लागि कुनै रिसेट रेकर्ड गरिएको छैन।",
       "No variations added yet": "अहिलेसम्म कुनै भिन्नता थपिएको छैन",
@@ -3756,7 +3756,7 @@
       "A row with the greater than condition must repeat the cycle number above it": "‘भन्दा बढी’ सर्त भएको पङ्क्तिले माथिको पङ्क्तिकै चक्र संख्या दोहोर्‍याउनुपर्छ",
       "Fix the loan cycle variations before creating the product": "उत्पादन सिर्जना गर्नुअघि ऋण चक्र भिन्नताहरू सच्याउनुहोस्",
       "Personal Loan": "व्यक्तिगत ऋण",
-      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "\u092f\u093e\u0924\u094d\u0930\u093e, \u091a\u093f\u0915\u093f\u0924\u094d\u0938\u093e \u0916\u0930\u094d\u091a \u0935\u093e \u0935\u093f\u0935\u093e\u0939 \u091c\u0938\u094d\u0924\u093e \u0935\u094d\u092f\u0915\u094d\u0924\u093f\u0917\u0924 \u0906\u0935\u0936\u094d\u092f\u0915\u0924\u093e\u0915\u093e \u0932\u093e\u0917\u093f \u0927\u093f\u0924\u094b\u0930\u0939\u093f\u0924 \u090b\u0923, \u0932\u091a\u093f\u0932\u094b \u0905\u0935\u0927\u093f \u0930 \u0928\u094d\u092f\u0942\u0928\u0924\u092e \u0915\u093e\u0917\u091c\u093e\u0924\u0938\u0939\u093f\u0924\u0964",
+      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "यात्रा, चिकित्सा खर्च वा विवाह जस्ता व्यक्तिगत आवश्यकताका लागि धितोरहित ऋण, लचिलो अवधि र न्यूनतम कागजातसहित।",
       "Custom / Advanced": "अनुकूलित / उन्नत",
       "Two Wheeler Loan": "दुई पाङ्ग्रे सवारी ऋण",
       "Finance for new or used two-wheelers with quick approval and flexible down payment options": "नयाँ वा प्रयोग भइसकेका दुई पाङ्ग्रे सवारीका लागि छिटो स्वीकृति र लचिलो डाउन पेमेन्ट विकल्पसहितको वित्तीय सुविधा।",
@@ -5495,7 +5495,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "हालको सत्र",
     "newChat": "नयाँ कुराकानी",
     "close": "बन्द गर्नुहोस्",
@@ -5504,21 +5504,21 @@
       "afternoon": "शुभ अपराह्न",
       "evening": "शुभ सन्ध्या"
     },
-    "welcomeHeading": "आज म तपाईंलाई तपाईंका ग्राहकहरूलाई सहयोग गर्न कसरी मद्दत गर्न सक्छु?",
+    "welcomeHeading": "तपाईं के गर्न चाहनुहुन्छ?",
     "suggestions": {
-      "clientDetails": "ग्राहक John Doe को विवरण देखाउनुहोस्",
-      "repaymentSchedule": "ऋण #107 को भुक्तानी तालिका के हो?",
-      "savingsBalance": "ग्राहक #52 को बचत खाताको ब्यालेन्स देखाउनुहोस्",
-      "overdueLoans": "यो हप्ता कति ऋणहरू बाँकी छन्?"
+      "clientDetails": "यो ग्राहकको प्रोफाइल देखाउनुहोस्",
+      "repaymentSchedule": "यो ऋणको भुक्तानी तालिका के हो?",
+      "savingsBalance": "यो ग्राहकको बचत ब्यालेन्स कति छ?",
+      "overdueLoans": "यो हप्ता कुन ऋणहरू म्याद नाघेका छन्?"
     },
     "input": {
-      "placeholder": "ग्राहक, ऋण, वा खाताहरूको बारेमा सोध्नुहोस्...",
+      "placeholder": "ग्राहक, ऋण वा खाताको बारेमा सोध्नुहोस्",
       "attach": "फाइल संलग्न गर्नुहोस्",
       "voice": "आवाज इनपुट",
       "send": "सन्देश पठाउनुहोस्",
       "stop": "उत्पादन रोक्नुहोस्"
     },
-    "disclaimer": "Mifos Intelligence AI मानव निर्णयलाई प्रतिस्थापन गर्न होइन, सहयोग गर्न डिजाइन गरिएको हो।",
+    "disclaimer": "Mifos X Copilot ले जवाफ खोज्न मद्दत गर्छ। पैसा चल्ने कुनै पनि काममा तपाईंको स्वीकृति चाहिन्छ।",
     "nav": {
       "recentChats": "हालैका कुराकानीहरू",
       "chat": "कुराकानी",
@@ -5533,20 +5533,20 @@
       "delete": "कुराकानी मेटाउनुहोस्"
     },
     "help": {
-      "capabilitiesTitle": "Mifos Intelligence AI ले के गर्न सक्छ?",
+      "capabilitiesTitle": "Mifos X Copilot ले के गर्न सक्छ",
       "capabilities": {
-        "lookup": "ग्राहक जानकारी र प्रोफाइलहरू खोज्नुहोस्",
-        "loans": "ऋण विवरण र भुक्तानी तालिकाहरू हेर्नुहोस्",
-        "savings": "बचत खाताको ब्यालेन्स जाँच्नुहोस्",
-        "portfolio": "ग्राहक पोर्टफोलियोहरूको बारेमा अन्तर्दृष्टि प्राप्त गर्नुहोस्",
-        "navigate": "Mifos X मा निर्दिष्ट पृष्ठहरूमा नेभिगेट गर्नुहोस्"
+        "lookup": "ग्राहक खोजेर प्रोफाइल देखाउने",
+        "loans": "ऋण विवरण र भुक्तानी तालिका देखाउने",
+        "savings": "बचत ब्यालेन्स जाँच्ने",
+        "portfolio": "ग्राहकको पोर्टफोलियो संक्षेप गर्ने",
+        "navigate": "सही पृष्ठमा लैजाने"
       },
-      "examplesTitle": "उदाहरण प्रश्नहरू",
-      "importantTitle": "महत्त्वपूर्ण",
+      "examplesTitle": "प्रयास गर्न सकिने कुराहरू",
+      "importantTitle": "जान्न योग्य",
       "important": {
-        "assist": "AI प्रतिक्रियाहरू सहायताका लागि मात्र हुन्, अन्तिम निर्णय होइनन्",
-        "verify": "कार्य गर्नु अघि सधैं महत्त्वपूर्ण वित्तीय डेटा प्रमाणित गर्नुहोस्",
-        "noExecute": "AI ले आफैं कारोबार गर्दैन"
+        "assist": "जवाफले निर्णय गर्न मद्दत गर्छ। यो आफैँमा निर्णय होइन।",
+        "verify": "अंकहरूमा आधारित भएर काम गर्नुअघि जाँच गर्नुहोस्।",
+        "noExecute": "तपाईंले पुष्टि नगरेसम्म पैसा चल्दैन।"
       }
     },
     "cardType": {
@@ -5556,18 +5556,79 @@
       "insight": "अन्तर्दृष्टि",
       "confirmation": "पुष्टि"
     },
-    "confirmWarning": "यो कार्यमा वास्तविक पैसा संलग्न छ। कृपया पुष्टि गर्नुहोस्।",
-    "openAssistant": "AI सहायक खोल्नुहोस्",
+    "confirmWarning": "यसले वास्तविक पैसा चलाउँछ। विवरण जाँच गरेर मात्र पुष्टि गर्नुहोस्।",
+    "openAssistant": "Mifos X Copilot खोल्नुहोस्",
     "newChatTitle": "नयाँ कुराकानी",
     "errors": {
       "invalidLength": "सन्देश खाली छ वा धेरै लामो छ। कृपया छोटो पारेर फेरि प्रयास गर्नुहोस्।",
       "injectionBlocked": "सन्देश निर्देशन उल्लंघन गर्ने प्रयास जस्तो देखिन्छ, त्यसैले पठाइएन। कृपया फरक तरिकाले लेख्नुहोस्।",
-      "streamFailed": "सहायकसँग सम्पर्क गर्दा केही गडबड भयो। कृपया फेरि प्रयास गर्नुहोस्।"
+      "streamFailed": "Mifos X Copilot मा पुग्न सकिएन। कृपया फेरि प्रयास गर्नुहोस्।"
     },
     "confirm": {
       "reference": "सन्दर्भ",
-      "pendingAnnouncement": "यो कार्य चलाउनु अघि पुष्टि आवश्यक छ।"
+      "pendingAnnouncement": "यो कार्य चल्नुअघि विवरण जाँच गर्नुहोस्।"
     },
-    "assistantAvatarAlt": "Mifos AI सहायक"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "सक्रियता मिति",
+      "activeLoans": "सक्रिय ऋणहरू",
+      "amount": "रकम",
+      "appliedFor": "आवेदन रकम",
+      "approvalDate": "स्वीकृति मिति",
+      "approvedAmount": "स्वीकृत रकम",
+      "approvedBy": "स्वीकृत गर्ने",
+      "client": "ग्राहक",
+      "clientAccount": "ग्राहक खाता",
+      "disbursementDate": "वितरण मिति",
+      "expectedDisbursement": "अपेक्षित वितरण",
+      "firstName": "पहिलो नाम",
+      "lastName": "थर",
+      "loanAccount": "ऋण खाता",
+      "mobileNumber": "मोबाइल नम्बर",
+      "nextInstalment": "अर्को किस्ता",
+      "office": "कार्यालय",
+      "outstanding": "बाँकी रकम",
+      "principal": "प्रिन्सिपल",
+      "product": "उत्पादन",
+      "reference": "सन्दर्भ",
+      "repaymentAmount": "भुक्तानी रकम",
+      "repayments": "भुक्तानीहरू",
+      "savingsAccount": "बचत खाता",
+      "savingsBalance": "बचत ब्यालेन्स",
+      "search": "खोजी",
+      "status": "स्थिति",
+      "submittedOn": "पेश गरिएको मिति",
+      "transactionDate": "लेनदेन मिति"
+    },
+    "demo": {
+      "product": "कृषि अवधि ऋण",
+      "office": "प्रधान कार्यालय",
+      "statusActive": "सक्रिय",
+      "statusApproved": "स्वीकृत",
+      "writeIntro": "म यो गर्न सक्छु। तल दिइएको विवरण जाँच गर्नुहोस् र म चलाउनुअघि पुष्टि गर्नुहोस्।",
+      "approveSummary": "{{client}} का लागि {{product}} अनुमोदन गर्नुहोस्",
+      "loanIntro": "**{{client}}** को सक्रिय ऋण यहाँ छ:",
+      "loanTitle": "{{product}}, सक्रिय",
+      "nextInstalment": "{{amount}}, {{days}} दिनमा तिर्नुपर्ने",
+      "clientIntro": "मैले यो ग्राहक फेला पारेँ:",
+      "modeNotice": "म अहिले **डेमो मोड** मा चलिरहेको छु र कुनै गेटवे जोडिएको छैन, तर यहाँ देखिने सबै कुरा (स्ट्रिमिङ जवाफ, कार्डहरू, पुष्टि चरण) वास्तविक हो।",
+      "approved": "स्वीकृत भयो। यो ऋण अब अडिट ट्रेलमा तपाईंको प्रयोगकर्ता खातासँग अभिलेख भएको छ।",
+      "approvedTitle": "ऋण स्वीकृत भयो",
+      "approvedByYou": "तपाईं आफैँ, तपाईंकै लगइन र अनुमतिअनुसार",
+      "cancelled": "रद्द गरियो। कुनै पनि कार्य चलेन।",
+      "suggest": {
+        "schedule": "भुक्तानी तालिका देखाउनुहोस्",
+        "recordRepayment": "भुक्तानी दर्ता गर्नुहोस्",
+        "overdue": "म्याद नाघेका ऋणहरू देखाउनुहोस्",
+        "theirLoans": "उहाँका ऋणहरू देखाउनुहोस्",
+        "kyc": "KYC कागजातहरू देखाउनुहोस्",
+        "savings": "बचत ब्यालेन्स जाँच्नुहोस्",
+        "clientLoans": "यो ग्राहकका ऋणहरू देखाउनुहोस्",
+        "approve": "यो ऋण अनुमोदन गर्नुहोस्",
+        "searchClient": "ग्राहक खोज्नुहोस्",
+        "disburse": "यो ऋण वितरण गर्नुहोस्",
+        "backToClient": "ग्राहक प्रोफाइलमा फर्कनुहोस्"
+      }
+    }
   }
 }

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3726,7 +3726,7 @@
       "Auto Loan": "Crédito automóvel",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financiamento para a compra de automóveis novos ou usados com prestações mensais fixas durante o prazo escolhido.",
       "BNPL": "BNPL",
-      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Financiamento \u00abcompre agora, pague depois\u00bb para compras de curto prazo, muitas vezes sem juros, liquidado em presta\u00e7\u00f5es fixas.",
+      "Buy now, pay later financing for short-term, often interest-free purchases, settled in fixed installments": "Financiamento «compre agora, pague depois» para compras de curto prazo, muitas vezes sem juros, liquidado em prestações fixas.",
       "Consumer Durable Loan": "Crédito para bens duradouros",
       "Point-of-sale financing for electronics, appliances, and other durable goods, often with zero-cost EMI options": "Financiamento no ponto de venda para eletrónica, eletrodomésticos e outros bens duradouros, muitas vezes com prestações sem juros.",
       "Credit Card EMI": "Pagamento a prestações com cartão de crédito",
@@ -3742,13 +3742,13 @@
       "JLG Loan": "Crédito JLG",
       "Group-backed microloans for individuals in a Joint Liability Group, typically for income-generating activities": "Microcréditos garantidos pelo grupo para membros de um grupo de responsabilidade solidária, normalmente para atividades geradoras de rendimento.",
       "Line of Credit": "Linha de crédito",
-      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Uma linha de cr\u00e9dito renov\u00e1vel que pode ser utilizada, reembolsada e reutilizada conforme necess\u00e1rio, com juros cobrados apenas sobre o montante utilizado.",
+      "A revolving credit limit that can be drawn, repaid, and reused as needed, with interest charged only on the amount utilized": "Uma linha de crédito renovável que pode ser utilizada, reembolsada e reutilizada conforme necessário, com juros cobrados apenas sobre o montante utilizado.",
       "Loan against property where an existing residential or commercial asset is pledged as collateral": "Empréstimo garantido por um imóvel residencial ou comercial existente dado em garantia.",
       "Loan vs Securities / FD": "Crédito sobre títulos / depósito a prazo",
       "Credit extended against shares, mutual funds, or fixed deposits without liquidating the underlying investment": "Crédito concedido sobre ações, fundos de investimento ou depósitos a prazo sem liquidar o investimento subjacente.",
       "Long-tenure financing to purchase, construct, or renovate a residential property": "Financiamento de longo prazo para comprar, construir ou renovar um imóvel residencial.",
       "Merchant Cash Advance": "Adiantamento de tesouraria a comerciantes",
-      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Fundo de maneio adiantado sobre vendas futuras com cart\u00e3o ou digitais, reembolsado como uma percentagem das transa\u00e7\u00f5es di\u00e1rias.",
+      "Working capital advanced against future card or digital sales, repaid as a percentage of daily transactions": "Fundo de maneio adiantado sobre vendas futuras com cartão ou digitais, reembolsado como uma percentagem das transações diárias.",
       "Mortgage Loan (LAP)": "Crédito hipotecário (LAP)",
       "No resets have been recorded for this loan": "Não foram registadas redefinições para este empréstimo.",
       "No variations added yet": "Ainda não foram adicionadas variações",
@@ -3756,7 +3756,7 @@
       "A row with the greater than condition must repeat the cycle number above it": "Uma linha com a condição «maior que» deve repetir o número de ciclo da linha acima",
       "Fix the loan cycle variations before creating the product": "Corrija as variações por ciclo de crédito antes de criar o produto",
       "Personal Loan": "Empréstimo pessoal",
-      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Financiamento sem garantia para necessidades pessoais como viagens, despesas m\u00e9dicas ou casamentos, com prazo flex\u00edvel e documenta\u00e7\u00e3o m\u00ednima.",
+      "Unsecured funding for personal needs like travel, medical expenses, or weddings, with flexible tenure and minimal documentation": "Financiamento sem garantia para necessidades pessoais como viagens, despesas médicas ou casamentos, com prazo flexível e documentação mínima.",
       "Custom / Advanced": "Personalizado / Avançado",
       "Two Wheeler Loan": "Empréstimo para veículos de duas rodas",
       "Finance for new or used two-wheelers with quick approval and flexible down payment options": "Financiamento de veículos de duas rodas novos ou usados, com aprovação rápida e pagamento inicial flexível.",
@@ -5495,7 +5495,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "Sessão atual",
     "newChat": "Nova conversa",
     "close": "Fechar",
@@ -5504,21 +5504,21 @@
       "afternoon": "Boa tarde",
       "evening": "Boa noite"
     },
-    "welcomeHeading": "Como posso ajudá-lo a apoiar os seus clientes hoje?",
+    "welcomeHeading": "O que pretende fazer?",
     "suggestions": {
-      "clientDetails": "Mostre-me os detalhes do cliente John Doe",
-      "repaymentSchedule": "Qual é o plano de reembolso do empréstimo n.º 107?",
-      "savingsBalance": "Mostre o saldo da conta poupança do cliente n.º 52",
-      "overdueLoans": "Quantos empréstimos estão em atraso esta semana?"
+      "clientDetails": "Mostre o perfil deste cliente",
+      "repaymentSchedule": "Qual é o plano de reembolso deste empréstimo?",
+      "savingsBalance": "Qual é o saldo de poupança deste cliente?",
+      "overdueLoans": "Que empréstimos estão em atraso esta semana?"
     },
     "input": {
-      "placeholder": "Pergunte sobre clientes, empréstimos ou contas...",
+      "placeholder": "Pergunte sobre um cliente, um empréstimo ou uma conta",
       "attach": "Anexar ficheiro",
       "voice": "Entrada de voz",
       "send": "Enviar mensagem",
       "stop": "Parar geração"
     },
-    "disclaimer": "O Mifos Intelligence AI foi concebido para auxiliar, não substituir, a tomada de decisões humana.",
+    "disclaimer": "O Mifos X Copilot ajuda a encontrar respostas. Tudo o que movimenta dinheiro continua a precisar da sua aprovação.",
     "nav": {
       "recentChats": "Conversas recentes",
       "chat": "Conversa",
@@ -5533,20 +5533,20 @@
       "delete": "Eliminar conversa"
     },
     "help": {
-      "capabilitiesTitle": "O que pode o Mifos Intelligence AI fazer?",
+      "capabilitiesTitle": "O que o Mifos X Copilot pode fazer",
       "capabilities": {
-        "lookup": "Procurar informações e perfis de clientes",
-        "loans": "Ver detalhes de empréstimos e planos de reembolso",
-        "savings": "Consultar saldos de contas poupança",
-        "portfolio": "Obter informações sobre as carteiras de clientes",
-        "navigate": "Navegar para páginas específicas no Mifos X"
+        "lookup": "Encontrar um cliente e mostrar o seu perfil",
+        "loans": "Mostrar detalhes do empréstimo e planos de reembolso",
+        "savings": "Consultar um saldo de poupança",
+        "portfolio": "Resumir a carteira de um cliente",
+        "navigate": "Levá-lo à página certa"
       },
-      "examplesTitle": "Exemplos de perguntas",
-      "importantTitle": "Importante",
+      "examplesTitle": "Coisas para experimentar",
+      "importantTitle": "Vale a pena saber",
       "important": {
-        "assist": "As respostas da IA servem apenas de apoio, não são decisões finais",
-        "verify": "Verifique sempre os dados financeiros críticos antes de agir",
-        "noExecute": "A IA não executa transações por si própria"
+        "assist": "As respostas ajudam a decidir. Não são a decisão.",
+        "verify": "Verifique os números antes de agir com base neles.",
+        "noExecute": "Não se movimenta dinheiro até que confirme."
       }
     },
     "cardType": {
@@ -5556,18 +5556,79 @@
       "insight": "Análise",
       "confirmation": "Confirmação"
     },
-    "confirmWarning": "Esta ação envolve dinheiro real. Por favor, confirme.",
-    "openAssistant": "Abrir o assistente de IA",
+    "confirmWarning": "Isto movimenta dinheiro real. Verifique os dados e depois confirme.",
+    "openAssistant": "Abrir o Mifos X Copilot",
     "newChatTitle": "Nova conversa",
     "errors": {
       "invalidLength": "A mensagem está vazia ou é demasiado longa. Por favor, encurte-a e tente novamente.",
       "injectionBlocked": "A mensagem parece uma tentativa de contornar as instruções, por isso não foi enviada. Por favor, reformule-a.",
-      "streamFailed": "Ocorreu um erro ao contactar o assistente. Por favor, tente novamente."
+      "streamFailed": "Não foi possível contactar o Mifos X Copilot. Tente novamente."
     },
     "confirm": {
       "reference": "Referência",
-      "pendingAnnouncement": "É necessária confirmação antes de executar esta ação."
+      "pendingAnnouncement": "Verifique os dados antes de esta ação ser executada."
     },
-    "assistantAvatarAlt": "Assistente Mifos AI"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Data de ativação",
+      "activeLoans": "Empréstimos ativos",
+      "amount": "Montante",
+      "appliedFor": "Valor solicitado",
+      "approvalDate": "Data de aprovação",
+      "approvedAmount": "Valor aprovado",
+      "approvedBy": "Aprovado por",
+      "client": "Cliente",
+      "clientAccount": "Conta do cliente",
+      "disbursementDate": "Data de desembolso",
+      "expectedDisbursement": "Desembolso previsto",
+      "firstName": "Primeiro nome",
+      "lastName": "Sobrenome",
+      "loanAccount": "Conta de empréstimo",
+      "mobileNumber": "Número de telemóvel",
+      "nextInstalment": "Próxima prestação",
+      "office": "Escritório",
+      "outstanding": "Em dívida",
+      "principal": "Principal",
+      "product": "Produto",
+      "reference": "Referência",
+      "repaymentAmount": "Valor do reembolso",
+      "repayments": "Reembolsos",
+      "savingsAccount": "Conta poupança",
+      "savingsBalance": "Saldo de poupança",
+      "search": "Procurar",
+      "status": "Estado",
+      "submittedOn": "Enviado em",
+      "transactionDate": "Data da transação"
+    },
+    "demo": {
+      "product": "Empréstimo Agrícola a Prazo",
+      "office": "Sede",
+      "statusActive": "Ativo",
+      "statusApproved": "Aprovado",
+      "writeIntro": "Posso fazer isso. Por favor, reveja os dados abaixo e confirme antes de eu executar a ação.",
+      "approveSummary": "Aprovar {{product}} para {{client}}",
+      "loanIntro": "Eis o empréstimo ativo de **{{client}}**:",
+      "loanTitle": "{{product}}, ativo",
+      "nextInstalment": "{{amount}}, vence dentro de {{days}} dias",
+      "clientIntro": "Encontrei este cliente:",
+      "modeNotice": "Estou a funcionar em **modo de demonstração**, ainda sem gateway ligado, mas tudo o que vê aqui (a resposta em streaming, os cartões, o passo de confirmação) é real.",
+      "approved": "Aprovado. O empréstimo fica agora registado em seu nome na trilha de auditoria.",
+      "approvedTitle": "Empréstimo aprovado",
+      "approvedByYou": "Você, com as suas próprias permissões de acesso",
+      "cancelled": "Cancelado. Nada foi executado.",
+      "suggest": {
+        "schedule": "Mostre o plano de reembolso",
+        "recordRepayment": "Registe um reembolso",
+        "overdue": "Mostre os empréstimos em atraso",
+        "theirLoans": "Mostre os empréstimos do cliente",
+        "kyc": "Mostre os documentos KYC",
+        "savings": "Consulte o saldo de poupança",
+        "clientLoans": "Mostre os empréstimos deste cliente",
+        "approve": "Aprove este empréstimo",
+        "searchClient": "Procure um cliente",
+        "disburse": "Desembolse este empréstimo",
+        "backToClient": "Voltar ao perfil do cliente"
+      }
+    }
   }
 }

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -5492,7 +5492,7 @@
     }
   },
   "copilot": {
-    "brand": "Mifos Intelligence AI",
+    "brand": "Mifos X Copilot",
     "currentSession": "Kipindi cha sasa",
     "newChat": "Mazungumzo mapya",
     "close": "Funga",
@@ -5501,21 +5501,21 @@
       "afternoon": "Habari za mchana",
       "evening": "Habari za jioni"
     },
-    "welcomeHeading": "Ninawezaje kukusaidia kuhudumia wateja wako leo?",
+    "welcomeHeading": "Ungependa kufanya nini?",
     "suggestions": {
-      "clientDetails": "Nionyeshe maelezo ya mteja John Doe",
-      "repaymentSchedule": "Je, ratiba ya ulipaji wa mkopo #107 ni ipi?",
-      "savingsBalance": "Onyesha salio la akaunti ya akiba ya mteja #52",
-      "overdueLoans": "Ni mikopo mingapi imechelewa wiki hii?"
+      "clientDetails": "Nionyeshe wasifu wa mteja huyu",
+      "repaymentSchedule": "Ratiba ya ulipaji wa mkopo huu ni ipi?",
+      "savingsBalance": "Salio la akiba la mteja huyu ni kiasi gani?",
+      "overdueLoans": "Ni mikopo ipi imechelewa wiki hii?"
     },
     "input": {
-      "placeholder": "Uliza kuhusu wateja, mikopo, au akaunti...",
+      "placeholder": "Uliza kuhusu mteja, mkopo au akaunti",
       "attach": "Ambatisha faili",
       "voice": "Ingizo la sauti",
       "send": "Tuma ujumbe",
       "stop": "Simamisha uzalishaji"
     },
-    "disclaimer": "Mifos Intelligence AI imeundwa kusaidia, si kuchukua nafasi ya, maamuzi ya binadamu.",
+    "disclaimer": "Mifos X Copilot hukusaidia kupata majibu. Kila kinachohamisha pesa bado kinahitaji idhini yako.",
     "nav": {
       "recentChats": "Mazungumzo ya hivi karibuni",
       "chat": "Mazungumzo",
@@ -5530,20 +5530,20 @@
       "delete": "Futa mazungumzo"
     },
     "help": {
-      "capabilitiesTitle": "Mifos Intelligence AI inaweza kufanya nini?",
+      "capabilitiesTitle": "Mifos X Copilot inaweza kufanya nini",
       "capabilities": {
-        "lookup": "Tafuta taarifa na wasifu wa wateja",
-        "loans": "Angalia maelezo ya mikopo na ratiba za ulipaji",
-        "savings": "Angalia salio la akaunti za akiba",
-        "portfolio": "Pata maarifa kuhusu portfolio za wateja",
-        "navigate": "Nenda kwenye kurasa mahususi katika Mifos X"
+        "lookup": "Kutafuta mteja na kuonyesha wasifu wake",
+        "loans": "Kuonyesha maelezo ya mkopo na ratiba za ulipaji",
+        "savings": "Kukagua salio la akiba",
+        "portfolio": "Kufupisha portfolio ya mteja",
+        "navigate": "Kukupeleka kwenye ukurasa sahihi"
       },
-      "examplesTitle": "Mifano ya maswali",
-      "importantTitle": "Muhimu",
+      "examplesTitle": "Mambo ya kujaribu",
+      "importantTitle": "Ya kufahamu",
       "important": {
-        "assist": "Majibu ya AI ni kwa usaidizi tu, si maamuzi ya mwisho",
-        "verify": "Daima thibitisha data muhimu za kifedha kabla ya kuchukua hatua",
-        "noExecute": "AI haifanyi miamala yenyewe"
+        "assist": "Majibu hukusaidia kuamua. Si uamuzi wenyewe.",
+        "verify": "Kagua takwimu kabla ya kuzitegemea.",
+        "noExecute": "Hakuna pesa inayohama hadi uthibitishe."
       }
     },
     "cardType": {
@@ -5553,18 +5553,79 @@
       "insight": "Maarifa",
       "confirmation": "Uthibitisho"
     },
-    "confirmWarning": "Kitendo hiki kinahusisha pesa halisi. Tafadhali thibitisha.",
-    "openAssistant": "Fungua Msaidizi wa AI",
+    "confirmWarning": "Hii inahamisha pesa halisi. Kagua maelezo, kisha thibitisha.",
+    "openAssistant": "Fungua Mifos X Copilot",
     "newChatTitle": "Mazungumzo mapya",
     "errors": {
       "invalidLength": "Ujumbe ni tupu au mrefu sana. Tafadhali ufupishe na ujaribu tena.",
       "injectionBlocked": "Ujumbe unaonekana kama jaribio la kukiuka maelekezo, hivyo haukutumwa. Tafadhali uandike upya.",
-      "streamFailed": "Hitilafu imetokea wakati wa kuwasiliana na msaidizi. Tafadhali jaribu tena."
+      "streamFailed": "Imeshindwa kufikia Mifos X Copilot. Tafadhali jaribu tena."
     },
     "confirm": {
       "reference": "Rejeleo",
-      "pendingAnnouncement": "Uthibitisho unahitajika kabla ya kutekeleza kitendo hiki."
+      "pendingAnnouncement": "Kagua maelezo kabla kitendo hiki hakijatekelezwa."
     },
-    "assistantAvatarAlt": "Msaidizi wa Mifos AI"
+    "assistantAvatarAlt": "Mifos X Copilot",
+    "cardLabels": {
+      "activationDate": "Tarehe ya uanzishaji",
+      "activeLoans": "Mikopo inayotumika",
+      "amount": "Kiasi",
+      "appliedFor": "Kiasi kilichoombwa",
+      "approvalDate": "Tarehe ya kuidhinishwa",
+      "approvedAmount": "Kiasi kilichoidhinishwa",
+      "approvedBy": "Imeidhinishwa na",
+      "client": "Mteja",
+      "clientAccount": "Akaunti ya mteja",
+      "disbursementDate": "Tarehe ya utoaji",
+      "expectedDisbursement": "Utoaji unaotarajiwa",
+      "firstName": "Jina la kwanza",
+      "lastName": "Jina la familia",
+      "loanAccount": "Akaunti ya mkopo",
+      "mobileNumber": "Namba ya simu",
+      "nextInstalment": "Awamu inayofuata",
+      "office": "Ofisi",
+      "outstanding": "Salio linalobaki",
+      "principal": "Mtaji",
+      "product": "Bidhaa",
+      "reference": "Rejeleo",
+      "repaymentAmount": "Kiasi cha ulipaji",
+      "repayments": "Ulipaji",
+      "savingsAccount": "Akaunti ya akiba",
+      "savingsBalance": "Salio la akiba",
+      "search": "Tafuta",
+      "status": "Hali",
+      "submittedOn": "Imewasilishwa tarehe",
+      "transactionDate": "Tarehe ya muamala"
+    },
+    "demo": {
+      "product": "Mkopo wa Kilimo wa Muda Maalum",
+      "office": "Ofisi Kuu",
+      "statusActive": "Inayotumika",
+      "statusApproved": "Imeidhinishwa",
+      "writeIntro": "Naweza kufanya hivyo. Tafadhali kagua maelezo yaliyo hapa chini na uthibitishe kabla sijatekeleza.",
+      "approveSummary": "Idhinisha {{product}} kwa {{client}}",
+      "loanIntro": "Huu hapa mkopo unaotumika wa **{{client}}**:",
+      "loanTitle": "{{product}}, unaotumika",
+      "nextInstalment": "{{amount}}, inastahili kulipwa baada ya siku {{days}}",
+      "clientIntro": "Nimempata mteja huyu:",
+      "modeNotice": "Ninafanya kazi katika **hali ya onyesho**, bado hakuna lango lililounganishwa, lakini kila kitu unachokiona hapa (jibu linalotiririka, kadi, na hatua ya uthibitisho) ni halisi.",
+      "approved": "Imeidhinishwa. Sasa mkopo umerekodiwa kwa jina lako kwenye njia ya ukaguzi.",
+      "approvedTitle": "Mkopo umeidhinishwa",
+      "approvedByYou": "Wewe, kwa kitambulisho na ruhusa zako mwenyewe",
+      "cancelled": "Imeghairiwa. Hakuna kilichotekelezwa.",
+      "suggest": {
+        "schedule": "Nionyeshe ratiba ya ulipaji",
+        "recordRepayment": "Sajili ulipaji",
+        "overdue": "Nionyeshe mikopo iliyochelewa",
+        "theirLoans": "Nionyeshe mikopo yake",
+        "kyc": "Nionyeshe nyaraka za KYC",
+        "savings": "Kagua salio la akiba",
+        "clientLoans": "Nionyeshe mikopo ya mteja huyu",
+        "approve": "Idhinisha mkopo huu",
+        "searchClient": "Tafuta mteja",
+        "disburse": "Toa mkopo huu",
+        "backToClient": "Rudi kwenye wasifu wa mteja"
+      }
+    }
   }
 }


### PR DESCRIPTION
## What this changes

Two things a reviewer called out, both fair.

### The confirmation card spoke database

The card was rendering the tool's own arguments, so an officer about to
approve money read this:

```
loanId              12
approvedLoanAmount  28000
```

The gateway now sends labelled, formatted rows alongside the raw arguments,
and the card renders those:

```
Client            Aisha Bello
Loan account      000000000012
Product           Agriculture Term Loan
Applied for       NGN 30,000.00
Approved amount   NGN 28,000.00
Approval date     21 August 2026
```

The raw arguments stay on the wire as the record of what will execute, and
the card still falls back to them, humanised, if it ever meets a gateway too
old to send rows. The idempotency key is shown as a short reference rather
than a full UUID; the gateway keeps the whole thing for the audit trail.

### It had three different names

"Mifos Intelligence AI" in the header, "AI Assistant" on the launcher, "Mifos
AI assistant" on the avatar. It is **Mifos X Copilot** everywhere now, across
all thirteen locales.

Fineract no longer appears in anything an officer reads either. It is what
the platform runs on, not the word a loan officer uses.

## Also in this pass

- Sentence case throughout, rather than a mix of Title Case and sentence
  case in the same menu.
- The starter prompts no longer quote record numbers at people: "What is the
  repayment schedule for this loan?" rather than "for loan #107". Those
  prompts are the first thing anyone sees, and they were teaching the wrong
  vocabulary.
- Copy rewritten to say what it means. "Copilot helps you find answers.
  Anything that moves money still needs your approval." replaces "designed to
  assist, not replace, human decision making."
- Demo mode held to the same bar, since it is what anyone evaluating this
  will actually see.

## Tests

60 to 72. New cases cover row parsing, the gateway's row ordering being
preserved, and blank rows being dropped rather than rendered as empty lines.

## Requires

The gateway side is openMF/mcp-mifosx#434. This is backward compatible: a
gateway that sends no rows still produces a readable card.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation cards now show clearer, human-readable action details with formatted values and concise references.
  * Blank or unavailable action details are filtered from displays.
  * Copilot cards, confirmation labels, guidance, and demo content are localized across supported languages.
  * Demo loan and client information uses meaningful labels, titles, and formatted amounts.
  * Recent Chats refresh when opened, with improved account isolation and confirmation-card scrolling.

* **Documentation**
  * Refined Copilot guidance and safety messaging across supported languages.

* **Tests**
  * Added coverage for action-detail ordering, filtering, approval flows, and session isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->