### PR TITLE
feat(copilot): send the officer's office to the gateway

### DIFF
--- a/src/app/copilot/core/mcp-client.spec.ts
+++ b/src/app/copilot/core/mcp-client.spec.ts
@@ -25,6 +25,8 @@ const REQUEST: McpChatRequest = {
     loanId: null,
     screen: 'client-detail',
     loggedInUser: 'priya',
+    officeId: 4,
+    staffId: null,
     role: 'Loan Officer',
     language: 'en'
   }

--- a/src/app/copilot/core/models/copilot-context.model.ts
+++ b/src/app/copilot/core/models/copilot-context.model.ts
@@ -22,6 +22,14 @@ export interface CopilotContext {
   screen: string;
   /** Username decoded from the JWT. */
   loggedInUser: string;
+  /**
+   * The office the signed-in officer belongs to. Sent so the gateway can put a new client in
+   * the officer's own branch: it is a fact of the session, and letting the model choose a
+   * branch by being asked nicely is not something a bank can allow.
+   */
+  officeId: number | null;
+  /** The officer's staff record, where they have one. */
+  staffId: number | null;
   /** Role decoded from the JWT, used for permission checks. */
   role: string;
   /** Two-letter language code ('en', 'es', 'sw', ...) for AI responses. */

--- a/src/app/copilot/services/ai-context.service.ts
+++ b/src/app/copilot/services/ai-context.service.ts
@@ -47,6 +47,8 @@ export class AiContextService {
       loanId,
       screen: this.deriveScreen(clientId, loanId, url),
       loggedInUser: credentials?.username ?? '',
+      officeId: credentials?.officeId ?? null,
+      staffId: credentials?.staffId ?? null,
       role: this.currentRole(credentials?.roles),
       language: this.currentLanguage()
     };

--- a/src/app/copilot/services/chat.service.spec.ts
+++ b/src/app/copilot/services/chat.service.spec.ts
@@ -25,6 +25,8 @@ const CONTEXT: CopilotContext = {
   loanId: null,
   screen: 'client-detail',
   loggedInUser: 'priya',
+  officeId: 4,
+  staffId: null,
   role: 'Loan Officer',
   language: 'en'
 };

--- a/src/app/copilot/services/mcp-client.service.spec.ts
+++ b/src/app/copilot/services/mcp-client.service.spec.ts
@@ -25,6 +25,8 @@ const CONTEXT: CopilotContext = {
   loanId: 4521,
   screen: 'client-detail',
   loggedInUser: 'priya',
+  officeId: 4,
+  staffId: null,
   role: 'Loan Officer',
   language: 'en'
 };


### PR DESCRIPTION
Adds two fields to the context the Copilot panel sends with every turn: `officeId` and `staffId`. Nothing else changes.

The gateway used to create every client with `"officeId": 1` written into its tool manifest as a literal, so an officer in any branch other than head office created clients in the wrong branch, and nothing ever showed it because a test system with one office is right by accident. openMF/mcp-mifosx#438 replaces that literal with the officer's own office, which it reads from the session context this panel sends, and this panel was not sending it. `Credentials` already carries both fields from the authentication response, so nothing new is fetched.

Sending it beside the conversation rather than through it is the point. An office is a fact about who is signed in, not a decision. If it went through the language model then a branch could be chosen by a sentence, and a client could be created in someone else's branch by asking for it nicely. The model never sees the value.

Safe to merge in either order. Without the gateway change these fields are ignored; with the gateway change and without this one, client creation refuses with a message naming the missing detail rather than quietly posting a client with no office.

89 tests, unchanged and passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copilot context now includes the signed-in officer’s office and optional staff identifiers.
  * Context values default safely when unavailable, improving support for personalized Copilot interactions.

* **Tests**
  * Updated Copilot-related test scenarios to validate office and staff context information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->