### PR TITLE
WEB-657: Working Capital - Recovery payment

### DIFF
--- a/src/app/loans/common-resolvers/loan-action-button.resolver.ts
+++ b/src/app/loans/common-resolvers/loan-action-button.resolver.ts
@@ -78,7 +78,9 @@ export class LoanActionButtonResolver {
     } else if (loanActionButton === 'Disburse to Savings') {
       return this.loansService.getLoanActionTemplate(loanId, 'disburseToSavings');
     } else if (loanActionButton === 'Recovery Payment') {
-      return this.loansService.getLoanActionTemplate(loanId, 'recoverypayment');
+      return this.loanProductService.isLoanProduct
+        ? this.loansService.getLoanActionTemplate(loanId, 'recoverypayment')
+        : this.loansService.getWorkingCapitalLoanActionTemplate(loanId, 'recoveryPayment');
     } else if (loanActionButton === 'View Guarantors') {
       return this.loansService.getGuarantors(loanId).pipe(catchError(() => of([])));
     } else if (loanActionButton === 'Create Guarantor') {

--- a/src/app/loans/loans-view/_loan-tab-shared.scss
+++ b/src/app/loans/loans-view/_loan-tab-shared.scss
@@ -78,6 +78,8 @@
     --tx-discount-bg: #efebe9;
     --tx-linked: var(--ch-paid);
     --tx-linked-bg: var(--ch-paid-bg);
+    --tx-recovery: #00838f;
+    --tx-recovery-bg: #e0f7fa;
   }
 
   :host-context(.dark-theme) {
@@ -89,6 +91,8 @@
     --tx-reamortize-bg: #002f2b;
     --tx-discount: #bcaaa4;
     --tx-discount-bg: #231613;
+    --tx-recovery: #4dd0e1;
+    --tx-recovery-bg: #06282e;
   }
 }
 

--- a/src/app/loans/loans-view/general-tab/general-tab.component.html
+++ b/src/app/loans/loans-view/general-tab/general-tab.component.html
@@ -51,6 +51,18 @@
         </div>
       }
 
+      @if (loanProductService.isWorkingCapital && loanDetails.writtenOffOnDate) {
+        <div class="section">
+          <div class="section-head">
+            <h3 class="section-title">{{ 'labels.heading.Recovery' | translate }}</h3>
+          </div>
+          <mifosx-working-capital-recovery-panel
+            [balance]="loanDetails.balance"
+            [currencyCode]="currencyCode"
+          ></mifosx-working-capital-recovery-panel>
+        </div>
+      }
+
       @if (hasNumberOfRepayments() || loanDetails.timeline?.expectedMaturityDate) {
         <div class="section">
           <div class="section-head">

--- a/src/app/loans/loans-view/general-tab/general-tab.component.ts
+++ b/src/app/loans/loans-view/general-tab/general-tab.component.ts
@@ -17,6 +17,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { LoanProductService } from 'app/products/loan-products/services/loan-product.service';
 import { LoanProductBaseComponent } from 'app/products/loan-products/common/loan-product-base.component';
 import { LoanSummaryBalanceComponentComponent } from './loan-summary-balance-component/loan-summary-balance-component.component';
+import { WorkingCapitalRecoveryPanelComponent } from '../working-capital/loan-recovery-panel/loan-recovery-panel.component';
 
 @Component({
   selector: 'mifosx-general-tab',
@@ -29,7 +30,8 @@ import { LoanSummaryBalanceComponentComponent } from './loan-summary-balance-com
     CurrencyPipe,
     DateFormatPipe,
     FormatNumberPipe,
-    LoanSummaryBalanceComponentComponent
+    LoanSummaryBalanceComponentComponent,
+    WorkingCapitalRecoveryPanelComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/src/app/loans/loans-view/loan-account-actions/loan-account-actions.component.html
+++ b/src/app/loans/loans-view/loan-account-actions/loan-account-actions.component.html
@@ -62,7 +62,11 @@
   <mifosx-loan-reschedule [dataObject]="actionButtonData"></mifosx-loan-reschedule>
 }
 @if (actions['Recovery Payment']) {
-  <mifosx-recovery-repayment [dataObject]="actionButtonData"></mifosx-recovery-repayment>
+  @if (isWorkingCapital) {
+    <mifosx-working-capital-recovery-payment [dataObject]="actionButtonData"></mifosx-working-capital-recovery-payment>
+  } @else {
+    <mifosx-recovery-repayment [dataObject]="actionButtonData"></mifosx-recovery-repayment>
+  }
 }
 @if (actions['View Guarantors']) {
   <mifosx-view-guarantors [dataObject]="actionButtonData"></mifosx-view-guarantors>

--- a/src/app/loans/loans-view/loan-account-actions/loan-account-actions.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/loan-account-actions.component.ts
@@ -49,6 +49,7 @@ import { BreachConfigComponent } from '../working-capital/loan-account-actions/b
 import { WorkingCapitalChargeOffComponent } from '../working-capital/loan-account-actions/charge-off/charge-off.component';
 import { WorkingCapitalWriteOffComponent } from '../working-capital/loan-account-actions/write-off/write-off.component';
 import { WorkingCapitalUndoWriteOffComponent } from '../working-capital/loan-account-actions/undo-write-off/undo-write-off.component';
+import { WorkingCapitalRecoveryPaymentComponent } from '../working-capital/loan-account-actions/recovery-payment/recovery-payment.component';
 import { LoanProductService } from 'app/products/loan-products/services/loan-product.service';
 
 /**
@@ -96,7 +97,8 @@ import { LoanProductService } from 'app/products/loan-products/services/loan-pro
     BreachConfigComponent,
     WorkingCapitalChargeOffComponent,
     WorkingCapitalWriteOffComponent,
-    WorkingCapitalUndoWriteOffComponent
+    WorkingCapitalUndoWriteOffComponent,
+    WorkingCapitalRecoveryPaymentComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/src/app/loans/loans-view/loan-accounts-button-config.ts
+++ b/src/app/loans/loans-view/loan-accounts-button-config.ts
@@ -8,23 +8,28 @@
 
 import { OptionData } from 'app/shared/models/option-data.model';
 
+/**
+ * One entry of the account actions menu.
+ *
+ * `disabled` and `disabledTooltip` let an action stay visible while being
+ * blocked by a business rule, so the user reads why instead of discovering it
+ * through a rejected request.
+ */
+export interface LoansAccountButton {
+  name: string;
+  icon?: string;
+  taskPermissionName?: string;
+  disabled?: boolean;
+  disabledTooltip?: string;
+}
+
 /** Loan/Working Capital Account Buttons Configuration */
 export class LoansAccountButtonConfiguration {
-  optionArray: {
-    name: string;
-    taskPermissionName?: string;
-  }[];
+  optionArray: LoansAccountButton[];
 
-  optionPaymentArray: {
-    name: string;
-    taskPermissionName?: string;
-  }[];
+  optionPaymentArray: LoansAccountButton[];
 
-  buttonsArray: {
-    name: string;
-    icon: string;
-    taskPermissionName?: string;
-  }[];
+  buttonsArray: LoansAccountButton[];
 
   private readonly isWorkingCapital: boolean;
 
@@ -253,8 +258,14 @@ export class LoansAccountButtonConfiguration {
         ];
         break;
       case 'Closed (written off)':
-        // Terminal state: only Undo Write-off remains available.
+        // The loan stays closed: a recovery payment records money collected
+        // after the write-off without reopening it.
         this.buttonsArray = [
+          {
+            name: 'Recovery Payment',
+            icon: 'briefcase',
+            taskPermissionName: 'RECOVERYPAYMENT_WORKINGCAPITALLOAN'
+          },
           {
             name: 'Undo Write-off',
             icon: 'undo',
@@ -431,12 +442,29 @@ export class LoansAccountButtonConfiguration {
     }
   }
 
-  addOption(option: { name: string; icon?: string; taskPermissionName?: string }) {
+  addOption(option: LoansAccountButton) {
     this.optionArray.push(option);
   }
 
-  addButton(option: { name: string; icon: string; taskPermissionName?: string }) {
+  addButton(option: LoansAccountButton) {
     this.buttonsArray.push(option);
+  }
+
+  /**
+   * Blocks an action that is visible but not allowed right now.
+   *
+   * The button is kept in the menu on purpose: hiding it would leave the user
+   * wondering where the action went, while a disabled entry with a tooltip
+   * states the rule.
+   * @param name Action name as declared in the configuration
+   * @param tooltipKey Translation key explaining why it is blocked
+   */
+  disableButton(name: string, tooltipKey: string) {
+    const button = this.buttonsArray?.find((item) => item.name === name);
+    if (button) {
+      button.disabled = true;
+      button.disabledTooltip = tooltipKey;
+    }
   }
 
   private isContractTermination(substatus: OptionData): boolean {

--- a/src/app/loans/loans-view/loans-view.component.html
+++ b/src/app/loans/loans-view/loans-view.component.html
@@ -100,18 +100,6 @@
                       </td>
                     </tr>
                   }
-                  @if (loanProductService.isWorkingCapital && loanDetailsData.writtenOffOnDate) {
-                    <tr>
-                      <td>{{ 'labels.inputs.Written Off On' | translate }}:</td>
-                      <td>
-                        <span class="written-off-badge">{{ 'labels.status.Written Off' | translate }}</span>
-                        <span class="m-l-10">{{ loanDetailsData.writtenOffOnDate | dateFormat }}</span>
-                        @if (loanDetailsData.writeOffReason?.name) {
-                          <span class="m-l-10">· {{ loanDetailsData.writeOffReason.name }}</span>
-                        }
-                      </td>
-                    </tr>
-                  }
                 </tbody>
               </table>
             </div>
@@ -256,14 +244,41 @@
       </div>
     </mifosx-account-header>
 
+    @if (isWorkingCapitalWrittenOff) {
+      <div class="written-off-banner">
+        <span class="written-off-badge">{{ 'labels.status.Written Off' | translate }}</span>
+        <span class="banner-item">
+          {{ 'labels.inputs.Written Off On' | translate }}: {{ loanDetailsData.writtenOffOnDate | dateFormat }}
+        </span>
+        @if (loanDetailsData.writeOffReason?.name) {
+          <span class="banner-item">
+            {{ 'labels.inputs.Reason for Write-Off' | translate }}: {{ loanDetailsData.writeOffReason.name }}
+          </span>
+        }
+      </div>
+    }
+
     <mat-menu #accountMenu="matMenu">
       @for (item of buttonConfig.singleButtons; track item) {
-        <button mat-menu-item *mifosxHasPermission="item.taskPermissionName" (click)="loanAction(item.name)">
-          <mat-icon matListIcon>
-            <fa-icon icon="{{ item.icon }}" size="sm"></fa-icon>
-          </mat-icon>
-          <span>{{ 'labels.menus.' + item.name | translate }}</span>
-        </button>
+        <!-- The tooltip lives on the wrapper: a disabled button fires no mouse events. -->
+        <span
+          class="menu-item-wrapper"
+          *mifosxHasPermission="item.taskPermissionName"
+          [matTooltip]="item.disabledTooltip | translate"
+          [matTooltipDisabled]="!item.disabled"
+        >
+          <button mat-menu-item [disabled]="item.disabled" (click)="loanAction(item.name)">
+            <mat-icon matListIcon>
+              <fa-icon icon="{{ item.icon }}" size="sm"></fa-icon>
+            </mat-icon>
+            <span>{{ 'labels.menus.' + item.name | translate }}</span>
+            <!-- The tooltip above is mouse-only: a screen reader gets the same
+                 reason from here, since a disabled item takes no hover. -->
+            @if (item.disabled) {
+              <span class="menu-item-reason">{{ item.disabledTooltip | translate }}</span>
+            }
+          </button>
+        </span>
       }
 
       @if (buttonConfig.optionsPayment.length) {

--- a/src/app/loans/loans-view/loans-view.component.scss
+++ b/src/app/loans/loans-view/loans-view.component.scss
@@ -24,7 +24,7 @@
   font-weight: 400;
 }
 
-// Written-off pill shown in the account header for Working Capital loans.
+// Written-off pill shown in the write-off banner for Working Capital loans.
 .written-off-badge {
   display: inline-block;
   padding: 2px 8px;
@@ -33,7 +33,49 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.03em;
+  color: #fff;
   background-color: var(--md-sys-color-error, #b3261e);
+}
+
+// Banner marking a written-off account. A written-off loan is closed with a
+// zero balance, exactly like a settled one, so the state gets its own strip
+// under the header instead of a line lost inside the metadata table.
+.written-off-banner {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  margin: 0 16px 8px;
+  padding: 10px 16px;
+  border-radius: 8px;
+  border-left: 4px solid var(--md-sys-color-error, #b3261e);
+  background-color: rgb(179 38 30 / 8%);
+  font-size: 14px;
+}
+
+.banner-item {
+  font-weight: 500;
+}
+
+// Wrapper carrying the tooltip of a blocked menu action. Needs to be a block so
+// the menu item inside keeps the full width of the panel.
+.menu-item-wrapper {
+  display: block;
+}
+
+// Reason a menu action is blocked, read by screen readers only: the tooltip on
+// the wrapper needs a hover the disabled item never receives.
+.menu-item-reason {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
 }
 
 .datatable-scroll-x {

--- a/src/app/loans/loans-view/loans-view.component.ts
+++ b/src/app/loans/loans-view/loans-view.component.ts
@@ -37,6 +37,7 @@ import {
   WorkingCapitalMarkAsFraudDialogResult
 } from './working-capital/loan-account-actions/mark-as-fraud-dialog/mark-as-fraud-dialog.component';
 import { LoanStatus } from '../models/loan-status.model';
+import { mapWorkingCapitalWriteOffBalance } from '../models/working-capital/working-capital-loan-account.model';
 import { Currency } from 'app/shared/models/general.model';
 import { SettingsService } from 'app/settings/settings.service';
 import { DelinquencyPausePeriod } from '../models/loan-account.model';
@@ -144,6 +145,10 @@ export class LoansViewComponent extends LoanProductBaseComponent implements OnIn
         this.loanDetailsData.loanProductName = this.loanDetailsData.product?.name;
       }
       this.loanStatus = this.loanDetailsData.status;
+      // The action menu is rebuilt at the end of this block, so the status it
+      // reads has to come from the details that were just resolved: ngOnInit
+      // does not run again when the route reuses this component.
+      this.status = this.loanDetailsData.status?.value;
       this.currency = this.loanDetailsData.currency;
       if (this.loanProductService.isLoanProduct) {
         this.loanSubStatus = this.loanDetailsData.subStatus === undefined ? null : this.loanDetailsData.subStatus;
@@ -507,6 +512,22 @@ export class LoansViewComponent extends LoanProductBaseComponent implements OnIn
       }
     }
 
+    // Recovery gating for a written-off Working Capital loan. Both rules read
+    // the same figures, so they are mapped once here.
+    if (this.loanProductService.isWorkingCapital && this.status === 'Closed (written off)') {
+      const writeOffBalance = mapWorkingCapitalWriteOffBalance(this.loanDetailsData.balance);
+      if (writeOffBalance) {
+        if (writeOffBalance.writtenOffOutstanding <= 0) {
+          this.buttonConfig.disableButton('Recovery Payment', 'tooltips.Nothing left to recover');
+        }
+        // Undoing the write-off would restore the full balance while the money
+        // already recovered stays booked as income: the same money counted twice.
+        if (writeOffBalance.totalRecovered > 0) {
+          this.buttonConfig.disableButton('Undo Write-off', 'tooltips.Reverse the recovery payments first');
+        }
+      }
+    }
+
     // Fraud flag for Working Capital loans. It sits outside the status branches
     // above because the backend only restricts marking: the loan must be active
     // to be flagged, but clearing the flag stays valid in every status, and
@@ -526,6 +547,16 @@ export class LoansViewComponent extends LoanProductBaseComponent implements OnIn
         });
       }
     }
+  }
+
+  /**
+   * Whether the account is a written-off Working Capital loan.
+   *
+   * A written-off loan looks exactly like a settled one - closed, zero balance -
+   * so the header needs an explicit marker to tell them apart.
+   */
+  get isWorkingCapitalWrittenOff(): boolean {
+    return this.loanProductService.isWorkingCapital && !!this.loanDetailsData?.writtenOffOnDate;
   }
 
   loanAction(actionName: string) {

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.scss
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.scss
@@ -153,6 +153,12 @@
     border-left: 3px solid var(--tx-chargeoff);
   }
 
+  // Recovery payments are income after a write-off, not debt reduction, so the
+  // row is marked apart from a plain repayment.
+  .row-recovery .mat-mdc-cell:first-child {
+    border-left: 3px solid var(--tx-recovery);
+  }
+
   .row-reage .mat-mdc-cell:first-child {
     border-left: 3px solid var(--tx-reage);
   }

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
@@ -43,6 +43,7 @@ import {
   buildWorkingCapitalUndoChargeOffPayload
 } from '../working-capital/loan-account-actions/undo-charge-off-dialog/undo-charge-off-dialog.component';
 import { TranslateService } from '@ngx-translate/core';
+import { resolveRecoveryPaymentErrorMessage } from '../working-capital/recovery-payment-error.helper';
 import { LoanTransaction } from 'app/products/loan-products/models/loan-account.model';
 import { LoanTransactionType } from 'app/loans/models/loan-transaction-type.model';
 import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-base';
@@ -380,6 +381,7 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
     if (this.isReAge(transaction.type)) return 'badge-reage';
     if (this.isReAmortize(transaction.type)) return 'badge-reamortize';
     if (isDiscountFeeKindTransaction(transaction.type)) return 'badge-discount';
+    if (this.isRecoveryRepayment(transaction.type)) return 'badge-recovery';
     if (transaction.transactionRelations?.length > 0) return 'badge-linked';
     return 'badge-repayment';
   }
@@ -402,6 +404,9 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
     }
     if (this.isReAmortize(transaction.type)) {
       return 'reamortize';
+    }
+    if (this.isRecoveryRepayment(transaction.type)) {
+      return 'recovery';
     }
     if (transaction.transactionRelations && transaction.transactionRelations.length > 0) {
       return 'linked';
@@ -433,6 +438,9 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
     }
     if (isDiscountFeeKindTransaction(transaction.type)) {
       return 'row-discount';
+    }
+    if (this.isRecoveryRepayment(transaction.type)) {
+      return 'row-recovery';
     }
     if (transaction.transactionRelations && transaction.transactionRelations.length > 0) {
       return 'row-linked';
@@ -505,12 +513,13 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
               this.reload();
             });
         } else {
-          this.loansService
-            .applyWorkingCapitalLoanActionCommand(loanId, payload, command, transactionId)
-            .subscribe((responseCmd: any) => {
+          this.loansService.applyWorkingCapitalLoanActionCommand(loanId, payload, command, transactionId).subscribe({
+            next: () => {
               transaction.reversed = true;
               this.reload();
-            });
+            },
+            error: (error: unknown) => this.reportWorkingCapitalUndoError(error)
+          });
         }
       }
     });
@@ -548,9 +557,12 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
         }
         const payload = buildWorkingCapitalUndoChargeOffPayload(result, this.settingsService.language.code);
         // The undo charge-off command targets the loan, not a single transaction.
-        this.loansService.applyWorkingCapitalLoanActionCommand(loanId, payload, 'undoChargeOff').subscribe(() => {
-          transaction.reversed = true;
-          this.reload();
+        this.loansService.applyWorkingCapitalLoanActionCommand(loanId, payload, 'undoChargeOff').subscribe({
+          next: () => {
+            transaction.reversed = true;
+            this.reload();
+          },
+          error: (error: unknown) => this.reportWorkingCapitalUndoError(error)
         });
       });
   }
@@ -582,6 +594,14 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
 
   isWriteOff(transactionType: LoanTransactionType): boolean {
     return transactionType.writeOff || transactionType.code === 'loanTransactionType.writeOff';
+  }
+
+  /**
+   * A recovery payment is money collected after a write-off. It is recognised as
+   * income instead of reducing debt, so it is marked apart from a repayment.
+   */
+  isRecoveryRepayment(transactionType: LoanTransactionType): boolean {
+    return transactionType.recoveryRepayment || transactionType.code === 'loanTransactionType.recoveryRepayment';
   }
 
   private isDownPayment(transactionType: LoanTransactionType): boolean {
@@ -707,6 +727,21 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
           }
         });
       });
+  }
+
+  /**
+   * Reports a failed Working Capital reversal with the backend's own rule.
+   *
+   * HTTP 403 is expected for anyone but a super user: the generic undo command
+   * is authorized with a permission derived at runtime that is not seeded, so
+   * the message says so instead of showing a bare error.
+   * @param error Failed HTTP response
+   */
+  private reportWorkingCapitalUndoError(error: unknown): void {
+    const alert = resolveRecoveryPaymentErrorMessage(error, this.translateService);
+    if (alert) {
+      this.alertService.alert(alert);
+    }
   }
 
   displaySubMenu(transaction: LoanTransaction): boolean {

--- a/src/app/loans/loans-view/working-capital/loan-account-actions/recovery-payment/recovery-payment.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-account-actions/recovery-payment/recovery-payment.component.html
@@ -1,0 +1,150 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<div class="container mat-elevation-z8">
+  <mat-card>
+    <form [formGroup]="recoveryPaymentForm" (ngSubmit)="submit()">
+      <mat-card-content>
+        <div class="layout-column">
+          <p class="recovery-hint">
+            {{ 'labels.text.Recovery Payment Description' | translate }}
+          </p>
+
+          <mat-form-field (click)="recoveryDatePicker.open()">
+            <mat-label>{{ 'labels.inputs.Transaction Date' | translate }}</mat-label>
+            <input
+              matInput
+              [min]="minDate"
+              [max]="maxDate"
+              [matDatepicker]="recoveryDatePicker"
+              required
+              formControlName="transactionDate"
+            />
+            <mat-datepicker-toggle matSuffix [for]="recoveryDatePicker"></mat-datepicker-toggle>
+            <mat-datepicker #recoveryDatePicker></mat-datepicker>
+            @if (recoveryPaymentForm.controls.transactionDate.hasError('required')) {
+              <mat-error>
+                {{ 'labels.inputs.Transaction Date' | translate }} {{ 'labels.commons.is' | translate }}
+                <strong>{{ 'labels.commons.required' | translate }}</strong>
+              </mat-error>
+            }
+            @if (recoveryPaymentForm.controls.transactionDate.hasError('matDatepickerMax')) {
+              <mat-error>
+                {{ 'errors.recoveryPayment.futureDate' | translate }}
+              </mat-error>
+            }
+            @if (recoveryPaymentForm.controls.transactionDate.hasError('matDatepickerMin')) {
+              <mat-error>
+                {{ 'errors.recoveryPayment.dateOutOfRange' | translate }}
+              </mat-error>
+            }
+          </mat-form-field>
+
+          <mat-form-field>
+            <mat-label>{{ 'labels.inputs.Transaction Amount' | translate }}</mat-label>
+            <input matInput type="number" required formControlName="transactionAmount" />
+            @if (currency) {
+              <span matSuffix class="currency-suffix">{{ currency.displaySymbol || currency.code }}</span>
+            }
+            @if (maxRecoverableAmount !== null) {
+              <mat-hint>
+                {{ 'labels.inputs.Pending Recovery' | translate }}: {{ maxRecoverableAmount | formatNumber }}
+              </mat-hint>
+            }
+            @if (recoveryPaymentForm.controls.transactionAmount.hasError('required')) {
+              <mat-error>
+                {{ 'labels.inputs.Transaction Amount' | translate }} {{ 'labels.commons.is' | translate }}
+                <strong>{{ 'labels.commons.required' | translate }}</strong>
+              </mat-error>
+            }
+            @if (recoveryPaymentForm.controls.transactionAmount.hasError('max')) {
+              <mat-error>
+                {{ 'errors.recoveryPayment.greaterThanRemaining' | translate }}
+              </mat-error>
+            }
+            @if (recoveryPaymentForm.controls.transactionAmount.hasError('min')) {
+              <mat-error>
+                {{ 'errors.recoveryPayment.amountMustBePositive' | translate }}
+              </mat-error>
+            }
+          </mat-form-field>
+
+          <mat-form-field>
+            <mat-label>{{ 'labels.inputs.Payment Type' | translate }}</mat-label>
+            <mat-select formControlName="paymentTypeId">
+              @for (paymentType of paymentTypes; track paymentType.id) {
+                <mat-option [value]="paymentType.id">
+                  {{ paymentType.name }}
+                </mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+
+          <div class="m-b-10">
+            <mat-slide-toggle [checked]="showPaymentDetails" (change)="togglePaymentDetails()">
+              {{ 'labels.inputs.Show Payment Details' | translate }}
+            </mat-slide-toggle>
+          </div>
+
+          @if (showPaymentDetails) {
+            <mat-form-field>
+              <mat-label>{{ 'labels.inputs.Account' | translate }} #</mat-label>
+              <input matInput formControlName="accountNumber" />
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>{{ 'labels.inputs.Cheque' | translate }} #</mat-label>
+              <input matInput formControlName="checkNumber" />
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>{{ 'labels.inputs.Routing Code' | translate }}</mat-label>
+              <input matInput formControlName="routingCode" />
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>{{ 'labels.inputs.Reciept' | translate }} #</mat-label>
+              <input matInput formControlName="receiptNumber" />
+            </mat-form-field>
+            <mat-form-field>
+              <mat-label>{{ 'labels.inputs.Bank' | translate }} #</mat-label>
+              <input matInput formControlName="bankNumber" />
+            </mat-form-field>
+          }
+
+          <mat-form-field>
+            <mat-label>{{ 'labels.inputs.Note' | translate }}</mat-label>
+            <textarea
+              matInput
+              formControlName="note"
+              cdkTextareaAutosize
+              cdkAutosizeMinRows="2"
+              maxlength="1000"
+            ></textarea>
+          </mat-form-field>
+
+          <mat-form-field>
+            <mat-label>{{ 'labels.inputs.External Id' | translate }}</mat-label>
+            <input matInput formControlName="externalId" />
+          </mat-form-field>
+        </div>
+
+        <mat-card-actions class="layout-row align-center gap-5px responsive-column">
+          <button type="button" mat-raised-button (click)="gotoLoanDefaultView()">
+            {{ 'labels.buttons.Cancel' | translate }}
+          </button>
+          <button
+            mat-raised-button
+            color="primary"
+            [disabled]="!recoveryPaymentForm.valid || isSubmitting"
+            *mifosxHasPermission="requiredPermission"
+          >
+            {{ 'labels.buttons.Submit' | translate }}
+          </button>
+        </mat-card-actions>
+      </mat-card-content>
+    </form>
+  </mat-card>
+</div>

--- a/src/app/loans/loans-view/working-capital/loan-account-actions/recovery-payment/recovery-payment.component.scss
+++ b/src/app/loans/loans-view/working-capital/loan-account-actions/recovery-payment/recovery-payment.component.scss
@@ -1,0 +1,19 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.container {
+  max-width: 37rem;
+}
+
+.recovery-hint {
+  margin-bottom: 20px;
+}
+
+.currency-suffix {
+  opacity: 0.7;
+}

--- a/src/app/loans/loans-view/working-capital/loan-account-actions/recovery-payment/recovery-payment.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-account-actions/recovery-payment/recovery-payment.component.ts
@@ -1,0 +1,250 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, Validators } from '@angular/forms';
+import { CdkTextareaAutosize } from '@angular/cdk/text-field';
+import { MatSlideToggle } from '@angular/material/slide-toggle';
+import { TranslateService } from '@ngx-translate/core';
+import { catchError, throwError } from 'rxjs';
+
+/** Custom Services / Utils */
+import { Dates } from 'app/core/utils/dates';
+import { AlertService } from 'app/core/alert/alert.service';
+import { ErrorHandlerService } from 'app/core/error-handler/error-handler.service';
+import { FormatNumberPipe } from 'app/pipes/format-number.pipe';
+import { LoanAccountActionsBaseComponent } from 'app/loans/loans-view/loan-account-actions/loan-account-actions-base.component';
+import { resolveRecoveryPaymentErrorMessage } from 'app/loans/loans-view/working-capital/recovery-payment-error.helper';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+/** Custom Models */
+import { Currency, PaymentType } from 'app/shared/models/general.model';
+import {
+  WorkingCapitalPaymentDetails,
+  WorkingCapitalRecoveryPaymentRequest
+} from 'app/loans/models/working-capital/working-capital-loan-account.model';
+
+/**
+ * Working Capital Loan Recovery Payment action.
+ *
+ * Registers money collected on an already written-off loan. The loan stays in
+ * CLOSED_WRITTEN_OFF and its outstanding balance stays at zero: the amount is
+ * recognised as recovery income, so the only figure that moves is the recovered
+ * total. Posts to
+ * POST /working-capital-loans/{loanId}/transactions?command=recoveryPayment.
+ *
+ * The form deliberately has no classification control. A recovery has no
+ * allocation, and sending classificationId makes the backend reject the call.
+ */
+@Component({
+  selector: 'mifosx-working-capital-recovery-payment',
+  templateUrl: './recovery-payment.component.html',
+  styleUrl: './recovery-payment.component.scss',
+  standalone: true,
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    CdkTextareaAutosize,
+    MatSlideToggle,
+    FormatNumberPipe
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WorkingCapitalRecoveryPaymentComponent extends LoanAccountActionsBaseComponent implements OnInit {
+  private formBuilder = inject(FormBuilder);
+  private dateUtils = inject(Dates);
+  private errorHandler = inject(ErrorHandlerService);
+  private alertService = inject(AlertService);
+  private translateService = inject(TranslateService);
+  private destroyRef = inject(DestroyRef);
+  private cdr = inject(ChangeDetectorRef);
+
+  /** Minimum date allowed. */
+  minDate = new Date(2000, 0, 1);
+  /** Maximum date allowed (business date; a recovery cannot be in the future). */
+  maxDate = new Date();
+  /** Whether a submit request is in flight. */
+  isSubmitting = false;
+  /** Whether the optional payment detail fields are visible. */
+  showPaymentDetails = false;
+  /** Payment type dropdown options. */
+  paymentTypes: PaymentType[] = [];
+  /** Loan currency, used to label the amount field. */
+  currency: Currency | null = null;
+  /**
+   * Remaining recoverable amount, taken from the template's expectedAmount.
+   * It is the client-side ceiling for the entered amount.
+   */
+  maxRecoverableAmount: number | null = null;
+
+  /** Typed Recovery Payment form. */
+  recoveryPaymentForm = this.formBuilder.group({
+    transactionDate: this.formBuilder.control<Date | null>(null, Validators.required),
+    transactionAmount: this.formBuilder.control<number | null>(null, [
+      Validators.required,
+      Validators.min(0.001)
+    ]),
+    paymentTypeId: this.formBuilder.control<number | null>(null),
+    accountNumber: this.formBuilder.control<string>(''),
+    checkNumber: this.formBuilder.control<string>(''),
+    routingCode: this.formBuilder.control<string>(''),
+    receiptNumber: this.formBuilder.control<string>(''),
+    bankNumber: this.formBuilder.control<string>(''),
+    note: this.formBuilder.control<string>('', Validators.maxLength(1000)),
+    externalId: this.formBuilder.control<string>('')
+  });
+
+  /**
+   * Permission gating the submit button. Held in the component so the template
+   * never carries the raw permission string.
+   */
+  readonly requiredPermission = 'RECOVERYPAYMENT_WORKINGCAPITALLOAN';
+
+  constructor() {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.maxDate = this.settingsService.businessDate;
+    this.paymentTypes = this.dataObject?.paymentTypeOptions ?? [];
+    this.currency = this.dataObject?.currency ?? null;
+
+    // expectedAmount is the remainder still recoverable, so it doubles as the
+    // prefilled amount and as the maximum the server will accept.
+    const expectedAmount = Number(this.dataObject?.expectedAmount);
+    if (Number.isFinite(expectedAmount) && expectedAmount > 0) {
+      this.maxRecoverableAmount = expectedAmount;
+      this.recoveryPaymentForm.controls.transactionAmount.addValidators(Validators.max(expectedAmount));
+      this.recoveryPaymentForm.controls.transactionAmount.setValue(expectedAmount);
+    }
+    this.recoveryPaymentForm.controls.transactionDate.setValue(this.settingsService.businessDate);
+    this.cdr.markForCheck();
+  }
+
+  /** Toggles the optional payment detail fields. */
+  togglePaymentDetails(): void {
+    this.showPaymentDetails = !this.showPaymentDetails;
+  }
+
+  /** Submits the recovery payment form. */
+  submit(): void {
+    if (this.recoveryPaymentForm.invalid || this.isSubmitting) {
+      this.recoveryPaymentForm.markAllAsTouched();
+      return;
+    }
+
+    this.isSubmitting = true;
+    const dateFormat = this.settingsService.dateFormat;
+    const locale = this.settingsService.language.code;
+    const formValue = this.recoveryPaymentForm.getRawValue();
+
+    const payload: WorkingCapitalRecoveryPaymentRequest = {
+      transactionDate: this.dateUtils.formatDate(formValue.transactionDate, dateFormat),
+      transactionAmount: Number(formValue.transactionAmount),
+      locale,
+      dateFormat
+    };
+    const note = formValue.note?.trim();
+    if (note) {
+      payload.note = note;
+    }
+    const externalId = formValue.externalId?.trim();
+    if (externalId) {
+      payload.externalId = externalId;
+    }
+    const paymentDetails = this.buildPaymentDetails();
+    if (paymentDetails) {
+      payload.paymentDetails = paymentDetails;
+    }
+
+    this.loanService
+      .applyWorkingCapitalLoanActionCommand(this.loanId, payload, 'recoveryPayment')
+      .pipe(
+        catchError((error) => this.handleSubmitError(error)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe({
+        next: () => {
+          this.gotoLoanDefaultView();
+        },
+        error: () => {
+          this.isSubmitting = false;
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  /**
+   * Builds the nested paymentDetails block, omitting it entirely when the user
+   * filled nothing in.
+   */
+  private buildPaymentDetails(): WorkingCapitalPaymentDetails | null {
+    const formValue = this.recoveryPaymentForm.getRawValue();
+    const paymentDetails: WorkingCapitalPaymentDetails = {};
+    if (formValue.paymentTypeId != null) {
+      paymentDetails.paymentTypeId = formValue.paymentTypeId;
+    }
+    if (this.showPaymentDetails) {
+      const fields: [
+        keyof WorkingCapitalPaymentDetails,
+        string | null
+      ][] = [
+        [
+          'accountNumber',
+          formValue.accountNumber
+        ],
+        [
+          'checkNumber',
+          formValue.checkNumber
+        ],
+        [
+          'routingCode',
+          formValue.routingCode
+        ],
+        [
+          'receiptNumber',
+          formValue.receiptNumber
+        ],
+        [
+          'bankNumber',
+          formValue.bankNumber
+        ]
+      ];
+      fields.forEach(
+        ([
+          field,
+          value
+        ]) => {
+          const trimmed = value?.trim();
+          if (trimmed) {
+            (paymentDetails as Record<string, unknown>)[field] = trimmed;
+          }
+        }
+      );
+    }
+    return Object.keys(paymentDetails).length > 0 ? paymentDetails : null;
+  }
+
+  /**
+   * Reports the failure with the backend's own rule when it is a known
+   * validation, falling back to the generic handler otherwise.
+   *
+   * The date floor is validated server-side on purpose: today it is the last
+   * transaction date and the rule is expected to be relaxed, so replicating it
+   * here would only make the UI wrong twice.
+   */
+  private handleSubmitError(error: unknown) {
+    const alert = resolveRecoveryPaymentErrorMessage(error, this.translateService);
+    if (alert) {
+      this.alertService.alert(alert);
+      return throwError(() => error);
+    }
+    return this.errorHandler.handleError(error as any, 'Loan Recovery Payment');
+  }
+}

--- a/src/app/loans/loans-view/working-capital/loan-recovery-panel/loan-recovery-panel.component.html
+++ b/src/app/loans/loans-view/working-capital/loan-recovery-panel/loan-recovery-panel.component.html
@@ -1,0 +1,78 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+@if (writeOffBalance) {
+  <div class="recovery-panel">
+    <div class="recovery-figures">
+      <div class="figure">
+        <div class="figure-label">{{ 'labels.inputs.Written Off Amount' | translate }}</div>
+        <div class="figure-value">
+          {{ writeOffBalance.totalWrittenOff | currency: currencyCode : 'symbol-narrow' : '1.2-2' }}
+        </div>
+      </div>
+      <div class="figure figure-recovered">
+        <div class="figure-label">{{ 'labels.inputs.Total Recovered' | translate }}</div>
+        <div class="figure-value">
+          {{ writeOffBalance.totalRecovered | currency: currencyCode : 'symbol-narrow' : '1.2-2' }}
+        </div>
+      </div>
+      <div class="figure figure-lead">
+        <div class="figure-label">{{ 'labels.inputs.Pending Recovery' | translate }}</div>
+        <div class="figure-value">
+          {{ writeOffBalance.writtenOffOutstanding | currency: currencyCode : 'symbol-narrow' : '1.2-2' }}
+        </div>
+      </div>
+    </div>
+
+    <div class="recovery-progress">
+      <div
+        class="progress-track"
+        role="progressbar"
+        [attr.aria-label]="'labels.heading.Progress Bar' | translate"
+        [attr.aria-valuenow]="writeOffBalance.recoveredPercentage"
+        aria-valuemin="0"
+        aria-valuemax="100"
+      >
+        <div
+          class="progress-fill"
+          [class.progress-complete]="writeOffBalance.fullyRecovered"
+          [style.width.%]="writeOffBalance.recoveredPercentage"
+        ></div>
+      </div>
+      <div class="progress-caption">
+        <span class="progress-percent">{{ writeOffBalance.recoveredPercentage | number: '1.0-0' }}%</span>
+        @if (writeOffBalance.fullyRecovered) {
+          <span class="recovery-complete-tag">{{ 'labels.text.Recovery Completed' | translate }}</span>
+        }
+      </div>
+    </div>
+
+    @if (writeOffBalance.principalWrittenOff || writeOffBalance.feeWrittenOff || writeOffBalance.penaltyWrittenOff) {
+      <div class="recovery-breakdown">
+        <div class="breakdown-item">
+          <span class="breakdown-label">{{ 'labels.inputs.Principal' | translate }}</span>
+          <span class="breakdown-value">
+            {{ writeOffBalance.principalWrittenOff | currency: currencyCode : 'symbol-narrow' : '1.2-2' }}
+          </span>
+        </div>
+        <div class="breakdown-item">
+          <span class="breakdown-label">{{ 'labels.inputs.Fees' | translate }}</span>
+          <span class="breakdown-value">
+            {{ writeOffBalance.feeWrittenOff | currency: currencyCode : 'symbol-narrow' : '1.2-2' }}
+          </span>
+        </div>
+        <div class="breakdown-item">
+          <span class="breakdown-label">{{ 'labels.inputs.Penalties' | translate }}</span>
+          <span class="breakdown-value">
+            {{ writeOffBalance.penaltyWrittenOff | currency: currencyCode : 'symbol-narrow' : '1.2-2' }}
+          </span>
+        </div>
+      </div>
+    }
+  </div>
+}

--- a/src/app/loans/loans-view/working-capital/loan-recovery-panel/loan-recovery-panel.component.scss
+++ b/src/app/loans/loans-view/working-capital/loan-recovery-panel/loan-recovery-panel.component.scss
@@ -1,0 +1,136 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// Reused so the panel inherits the same tokens (and their dark-theme
+// overrides) as the tabs it is embedded in.
+@use '../../loan-tab-shared' as shared;
+
+.recovery-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* ── The three figures ─────────────────────────────────────── */
+.recovery-figures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.figure {
+  flex: 1 1 160px;
+  min-width: 140px;
+  padding: 16px;
+  border: 1px solid var(--ch-border);
+  border-radius: 8px;
+  background: var(--ch-surface);
+}
+
+.figure-label {
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ch-text-3);
+  margin-bottom: 8px;
+}
+
+.figure-value {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ch-text-1);
+}
+
+// Recovered is the good news: green, one step below the lead figure.
+.figure-recovered {
+  border-color: var(--ch-paid);
+  background: var(--ch-paid-bg);
+
+  .figure-value {
+    color: var(--ch-paid);
+  }
+}
+
+// Pending recovery is the number the officer acts on, so it gets the strongest
+// treatment of the three.
+.figure-lead {
+  border-color: var(--ch-partial);
+  background: var(--ch-partial-bg);
+
+  .figure-value {
+    font-size: 20px;
+    color: var(--ch-partial);
+  }
+}
+
+/* ── Progress bar ──────────────────────────────────────────── */
+.progress-track {
+  height: 8px;
+  border-radius: 8px;
+  background: var(--ch-surface-h);
+  border: 1px solid var(--ch-border);
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--ch-blue-600);
+  transition: width 200ms ease;
+}
+
+.progress-complete {
+  background: var(--ch-paid);
+}
+
+.progress-caption {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--ch-text-2);
+}
+
+.progress-percent {
+  font-weight: 600;
+}
+
+.recovery-complete-tag {
+  padding: 2px 8px;
+  border-radius: 16px;
+  font-size: 11px;
+  font-weight: 600;
+  background: var(--ch-paid-bg);
+  color: var(--ch-paid);
+  border: 1px solid var(--ch-paid);
+}
+
+/* ── Written-off breakdown ─────────────────────────────────── */
+.recovery-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 24px;
+  font-size: 12.5px;
+  color: var(--ch-text-2);
+}
+
+.breakdown-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.breakdown-label {
+  color: var(--ch-text-3);
+}
+
+.breakdown-value {
+  font-weight: 600;
+  color: var(--ch-text-1);
+}

--- a/src/app/loans/loans-view/working-capital/loan-recovery-panel/loan-recovery-panel.component.ts
+++ b/src/app/loans/loans-view/working-capital/loan-recovery-panel/loan-recovery-panel.component.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CurrencyPipe } from '@angular/common';
+
+/** Custom Models */
+import {
+  WorkingCapitalBalances,
+  WorkingCapitalWriteOffBalance,
+  mapWorkingCapitalWriteOffBalance
+} from 'app/loans/models/working-capital/working-capital-loan-account.model';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+/**
+ * Recovery panel of a written-off Working Capital loan.
+ *
+ * Shows how much of the written-off loss has been recovered and, above all, how
+ * much is still recoverable: the outstanding balance stays at zero after a
+ * write-off, so this is the only place where the remaining exposure is visible.
+ */
+@Component({
+  selector: 'mifosx-working-capital-recovery-panel',
+  templateUrl: './loan-recovery-panel.component.html',
+  styleUrl: './loan-recovery-panel.component.scss',
+  standalone: true,
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    CurrencyPipe
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class WorkingCapitalRecoveryPanelComponent {
+  /** Loan currency code used to format the amounts. */
+  @Input() currencyCode: string | null = null;
+
+  /** Derived write-off and recovery figures. */
+  writeOffBalance: WorkingCapitalWriteOffBalance | null = null;
+
+  /** Raw `balance` block of the loan; mapped once on assignment. */
+  @Input()
+  set balance(balance: WorkingCapitalBalances | null | undefined) {
+    this.writeOffBalance = mapWorkingCapitalWriteOffBalance(balance);
+  }
+}

--- a/src/app/loans/loans-view/working-capital/recovery-payment-error.helper.ts
+++ b/src/app/loans/loans-view/working-capital/recovery-payment-error.helper.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { TranslateService } from '@ngx-translate/core';
+
+/**
+ * Validation codes the recovery payment and the generic undo commands return,
+ * mapped to translation keys.
+ *
+ * `cannot.be.before.write.off.date` is mapped even though the backend does not
+ * emit it yet: the date floor is expected to move from "last transaction" to
+ * "write-off date", and having both entries means that change needs no UI work.
+ */
+const RECOVERY_PAYMENT_ERROR_KEYS: Record<string, string> = {
+  'error.msg.wc.loan.is.not.written.off': 'errors.recoveryPayment.loanNotWrittenOff',
+  'cannot.be.greater.than.remaining.written.off.amount': 'errors.recoveryPayment.greaterThanRemaining',
+  'cannot.undo.write.off.with.recovery.payments': 'errors.recoveryPayment.undoWriteOffWithRecoveries',
+  'cannot.be.before.last.transaction.date': 'errors.recoveryPayment.beforeLastTransactionDate',
+  'cannot.be.before.write.off.date': 'errors.recoveryPayment.beforeWriteOffDate',
+  'transaction.already.undone': 'errors.recoveryPayment.alreadyUndone',
+  'cannot.be.a.future.date': 'errors.recoveryPayment.futureDate'
+};
+
+/** Text-bearing fields a Fineract error carries, at the top level or nested. */
+interface FineractErrorEntry {
+  userMessageGlobalisationCode?: string;
+  defaultUserMessage?: string;
+  developerMessage?: string;
+}
+
+/** Body of a failed Fineract request. */
+interface FineractErrorBody extends FineractErrorEntry {
+  errors?: FineractErrorEntry[];
+}
+
+/**
+ * Collects every text-bearing field of a Fineract error payload.
+ *
+ * The validation code shows up in a different field depending on how the
+ * backend wraps the failure, so all of them are scanned rather than betting on
+ * one shape.
+ */
+function errorHaystack(body: FineractErrorBody): string {
+  return [
+    body.defaultUserMessage,
+    body.developerMessage,
+    body.userMessageGlobalisationCode,
+    ...(Array.isArray(body.errors)
+      ? body.errors.flatMap((item) => [
+          item?.userMessageGlobalisationCode,
+          item?.defaultUserMessage,
+          item?.developerMessage
+        ])
+      : [])
+  ]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ');
+}
+
+/** Translated alert to raise for a recognised recovery payment failure. */
+export interface RecoveryPaymentErrorAlert {
+  type: string;
+  message: string;
+}
+
+/**
+ * Maps a failed recovery payment or reversal to a translated alert.
+ *
+ * HTTP 403 gets its own message because the generic undo command is authorized
+ * with a permission that is derived at runtime and is not seeded in
+ * m_permission, so every Working Capital reversal fails for anyone other than a
+ * user holding ALL_FUNCTIONS. Returns null when the error is not recognised, so
+ * callers can fall back to the generic error handling.
+ * @param error Failed HTTP response
+ * @param translate Translation service
+ * @returns Alert to show, or null when the error is not recognised
+ */
+export function resolveRecoveryPaymentErrorMessage(
+  error: unknown,
+  translate: TranslateService
+): RecoveryPaymentErrorAlert | null {
+  const response = error as HttpErrorResponse;
+  // The body is whatever the server returned; only the fields declared above
+  // are read, and each one is checked before use.
+  const body: FineractErrorBody | null = response?.error ?? null;
+  if (body) {
+    const haystack = errorHaystack(body);
+    // Longest codes first: several of them share a prefix with a shorter one.
+    const match = Object.keys(RECOVERY_PAYMENT_ERROR_KEYS)
+      .sort((a, b) => b.length - a.length)
+      .find((code) => haystack.includes(code));
+    if (match) {
+      const message = translateOrNull(translate, RECOVERY_PAYMENT_ERROR_KEYS[match]);
+      return message ? { type: translate.instant('errors.error.bad.request.type'), message } : null;
+    }
+  }
+  if (response?.status === 403) {
+    const message = translateOrNull(translate, 'errors.recoveryPayment.reversalForbidden');
+    return message ? { type: translate.instant('errors.error.unauthorized.type'), message } : null;
+  }
+  return null;
+}
+
+/** Returns the translation, or null when the key has no entry. */
+function translateOrNull(translate: TranslateService, key: string): string | null {
+  const translated = translate.instant(key);
+  return translated !== key ? translated : null;
+}

--- a/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
+++ b/src/app/loans/models/working-capital/working-capital-loan-account.model.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Currency } from 'app/shared/models/general.model';
+import { Currency, PaymentType } from 'app/shared/models/general.model';
 
 /** Code value option used to populate the charge-off reason dropdown. */
 export interface WorkingCapitalChargeOffReasonOption {
@@ -88,6 +88,17 @@ export interface WorkingCapitalBalances {
   unrealizedIncome: number;
   overpaymentAmount: number;
   breachPastDueAmount: number | null | undefined;
+  /** Gross amount written off. It does not go down as recoveries come in. */
+  totalWrittenOff?: number;
+  principalWrittenOff?: number;
+  feeWrittenOff?: number;
+  penaltyWrittenOff?: number;
+  /** Amount collected after the write-off. See mapWorkingCapitalWriteOffBalance for the field name caveat. */
+  totalRecovered?: number;
+  /** Alternative name the backend may adopt for totalRecovered. */
+  totalRecoveryPayment?: number;
+  /** totalWrittenOff - totalRecovered: what can still be recovered. */
+  writtenOffOutstanding?: number;
 }
 
 export interface WorkingCapitalLoanDiscountUpdateRequest {
@@ -182,4 +193,110 @@ export interface WorkingCapitalUndoWriteOffRequest {
   reversalExternalId?: string;
   note?: string;
   locale: string;
+}
+
+/** Payment data accepted by the Working Capital transaction commands. */
+export interface WorkingCapitalPaymentDetails {
+  paymentTypeId?: number;
+  accountNumber?: string;
+  checkNumber?: string;
+  routingCode?: string;
+  receiptNumber?: string;
+  bankNumber?: string;
+}
+
+/**
+ * Response of GET /working-capital-loans/{loanId}/template?templateType=recoveryPayment.
+ *
+ * `expectedAmount` is the remaining recoverable amount, not the gross written-off
+ * one: on a loan written off for 100 with 30 already recovered it returns 70.
+ */
+export interface WorkingCapitalRecoveryPaymentTemplate {
+  expectedAmount: number;
+  currency: Currency;
+  paymentTypeOptions: PaymentType[];
+}
+
+/**
+ * Request body for POST /working-capital-loans/{loanId}/transactions?command=recoveryPayment.
+ *
+ * `classificationId` is deliberately absent: a recovery has no allocation, and
+ * sending it makes the backend reject the whole request.
+ */
+export interface WorkingCapitalRecoveryPaymentRequest {
+  transactionDate: string;
+  transactionAmount: number;
+  note?: string;
+  externalId?: string;
+  paymentDetails?: WorkingCapitalPaymentDetails;
+  locale: string;
+  dateFormat: string;
+}
+
+/**
+ * Request body for POST /working-capital-loans/{loanId}/transactions/{transactionId}?command=undo,
+ * the generic reversal shared by repayment, goodwill credit, payout refund and recovery payment.
+ */
+export interface WorkingCapitalUndoTransactionRequest {
+  reversalExternalId?: string;
+  note?: string;
+  locale: string;
+}
+
+/** Write-off and recovery figures derived from the loan balance, ready to render. */
+export interface WorkingCapitalWriteOffBalance {
+  /** Gross written-off amount. Stays put as recoveries come in. */
+  totalWrittenOff: number;
+  principalWrittenOff: number;
+  feeWrittenOff: number;
+  penaltyWrittenOff: number;
+  /** Amount already recovered after the write-off. */
+  totalRecovered: number;
+  /** Amount still recoverable. Drives both the panel and the action availability. */
+  writtenOffOutstanding: number;
+  /** Share of the written-off amount already recovered, 0-100. */
+  recoveredPercentage: number;
+  /** True once there is nothing left to recover. */
+  fullyRecovered: boolean;
+}
+
+/** Reads an amount that may arrive as null, undefined or a string. */
+function toAmount(value: unknown): number {
+  const amount = Number(value ?? 0);
+  return Number.isFinite(amount) ? amount : 0;
+}
+
+/**
+ * Single mapping point between the loan balance payload and the write-off /
+ * recovery figures the UI renders.
+ *
+ * `totalRecovered` is read together with `totalRecoveryPayment` because the
+ * backend has an open decision to rename it; accepting both names here means
+ * the rename costs nothing anywhere else. `writtenOffOutstanding` is recomputed
+ * when the payload omits it so the panel never shows a blank remainder.
+ * @param balance The `balance` block of GET /working-capital-loans/{loanId}
+ * @returns Derived figures, or null when there is no balance to read
+ */
+export function mapWorkingCapitalWriteOffBalance(
+  balance: WorkingCapitalBalances | null | undefined
+): WorkingCapitalWriteOffBalance | null {
+  if (!balance) {
+    return null;
+  }
+  const totalWrittenOff = toAmount(balance.totalWrittenOff);
+  const totalRecovered = toAmount(balance.totalRecovered ?? balance.totalRecoveryPayment);
+  const writtenOffOutstanding =
+    balance.writtenOffOutstanding != null
+      ? toAmount(balance.writtenOffOutstanding)
+      : Math.max(totalWrittenOff - totalRecovered, 0);
+  return {
+    totalWrittenOff,
+    principalWrittenOff: toAmount(balance.principalWrittenOff),
+    feeWrittenOff: toAmount(balance.feeWrittenOff),
+    penaltyWrittenOff: toAmount(balance.penaltyWrittenOff),
+    totalRecovered,
+    writtenOffOutstanding,
+    recoveredPercentage: totalWrittenOff > 0 ? Math.min(100, (totalRecovered / totalWrittenOff) * 100) : 0,
+    fullyRecovered: totalWrittenOff > 0 && writtenOffOutstanding <= 0
+  };
 }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -445,6 +445,18 @@
       "noBreachConfiguration": "Tento úvěr nemá konfiguraci porušení.",
       "loanIsNotActive": "Hodnocení porušení lze změnit pouze tehdy, když je úvěr aktivní.",
       "breachIsDisabled": "Hodnocení porušení je pro tento úvěr zakázáno. Povolte je, abyste mohli tuto akci provést."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "Tato vymožená platba už byla stornována.",
+      "amountMustBePositive": "Částka musí být větší než nula.",
+      "beforeLastTransactionDate": "Datum vymožené platby nemůže předcházet poslední transakci úvěru.",
+      "beforeWriteOffDate": "Datum vymožené platby nemůže předcházet datu odpisu.",
+      "dateOutOfRange": "Datum platby z vymáhání je mimo rozsah povolený pro tento úvěr.",
+      "futureDate": "Datum vymožené platby nemůže být v budoucnosti.",
+      "greaterThanRemaining": "Částka nemůže být vyšší než zbývající částka k vymožení.",
+      "loanNotWrittenOff": "Tento úvěr není odepsaný, proto nemůže přijmout vymoženou platbu.",
+      "reversalForbidden": "Nemáte oprávnění stornovat transakce provozního kapitálu. Požádejte administrátora, aby storno provedl.",
+      "undoWriteOffWithRecoveries": "Odpis nelze vrátit zpět, dokud má úvěr vymožené platby. Nejprve je stornujte."
     }
   },
   "labels": {
@@ -1783,7 +1795,8 @@
       "Natural Person": "Natural Person",
       "Personal References (2 Family Members, 1 Acquaintance)": "Osobní reference (2 rodinní příslušníci, 1 známý)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Prohlášení konečných skutečných majitelů - právnické osoby",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Prohlášení konečných skutečných majitelů - fyzické osoby"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Prohlášení konečných skutečných majitelů - fyzické osoby",
+      "Recovery": "Vymáhání"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Účet opustí NPA až po uhrazení všech nedoplatků",
@@ -3739,7 +3752,10 @@
       "Submitted Date": "Datum odeslání",
       "No Ext": "Č. ext.",
       "No Int": "Č. int.",
-      "Age of the business": "Stáří podniku"
+      "Age of the business": "Stáří podniku",
+      "Written Off Amount": "Odepsaná částka",
+      "Total Recovered": "Celkem vymoženo",
+      "Pending Recovery": "Zbývá vymoci"
     },
     "links": {
       "Community": "Společenství",
@@ -4963,7 +4979,9 @@
       "Person PEP PLD Question 3": "Máte rodinný vztah (2) s akcionářem, zaměstnancem nebo funkcionářem subjektu?",
       "the contents of": "obsah",
       "the": "vybrané",
-      "items selected of": "položky z"
+      "items selected of": "položky z",
+      "Recovery Completed": "Vymáhání dokončeno",
+      "Recovery Payment Description": "Eviduje peníze přijaté po odpisu. Úvěr zůstává uzavřený a jeho zůstatek zůstává nulový; mění se pouze celková vymožená částka."
     },
     "permissions": {
       "actions": {
@@ -5885,7 +5903,9 @@
     "Yes": "Ano",
     "loan product will be active and available to clients": "Datum, kdy bude úvěrový produkt aktivní a dostupný klientům. Pokud nevyplníte, bude úvěrový produkt aktivní, jakmile bude vytvořen.",
     "loan product will become inactive and unavailable to clients": "Datum, kdy se úvěrový produkt stane neaktivním a nedostupným pro klienty. Pokud je prázdné, produkt zatížení se nikdy nestane neaktivním.",
-    "to": "do"
+    "to": "do",
+    "Nothing left to recover": "U tohoto úvěru už není co vymáhat.",
+    "Reverse the recovery payments first": "Odpis nelze vrátit zpět, dokud má úvěr vymožené platby. Nejprve je stornujte."
   },
   "countries": {
     "AF": "Afghánistán",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -445,6 +445,18 @@
       "noBreachConfiguration": "Dieses Darlehen hat keine Verstoßkonfiguration.",
       "loanIsNotActive": "Die Verstoßbewertung kann nur geändert werden, solange das Darlehen aktiv ist.",
       "breachIsDisabled": "Die Verstoßbewertung ist für dieses Darlehen deaktiviert. Aktivieren Sie sie, um diese Aktion auszuführen."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "Diese Einbringung wurde bereits storniert.",
+      "amountMustBePositive": "Der Betrag muss größer als null sein.",
+      "beforeLastTransactionDate": "Das Datum der Einbringung darf nicht vor der letzten Transaktion des Darlehens liegen.",
+      "beforeWriteOffDate": "Das Datum der Einbringung darf nicht vor dem Abschreibungsdatum liegen.",
+      "dateOutOfRange": "Das Datum der Einbringung liegt außerhalb des für dieses Darlehen zulässigen Bereichs.",
+      "futureDate": "Das Datum der Einbringung darf nicht in der Zukunft liegen.",
+      "greaterThanRemaining": "Der Betrag darf den ausstehenden Betrag der Einbringung nicht überschreiten.",
+      "loanNotWrittenOff": "Dieses Darlehen ist nicht abgeschrieben und kann daher keine Einbringung verbuchen.",
+      "reversalForbidden": "Sie haben keine Berechtigung, Betriebsmittelkredit-Transaktionen zu stornieren. Bitten Sie einen Administrator, die Stornierung durchzuführen.",
+      "undoWriteOffWithRecoveries": "Die Abschreibung kann nicht rückgängig gemacht werden, solange eine Einbringung vorhanden ist. Stornieren Sie diese zuerst."
     }
   },
   "labels": {
@@ -1784,7 +1796,8 @@
       "Resource Provider / Beneficial Owner": "Mittelgeber / Wirtschaftlich Berechtigter",
       "Personal References (2 Family Members, 1 Acquaintance)": "Persönliche Referenzen (2 Familienmitglieder, 1 Bekannter)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Erklärung der wirtschaftlich Berechtigten - juristische Personen",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Erklärung der wirtschaftlich Berechtigten - natürliche Personen"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Erklärung der wirtschaftlich Berechtigten - natürliche Personen",
+      "Recovery": "Einbringung"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Konto verlässt NPA erst nach Ausgleich aller Rückstände",
@@ -2484,7 +2497,7 @@
       "Income from Goodwill Credit Interest": "Erträge aus Goodwill-Guthabenzinsen",
       "Income from Goodwill Credit Penalty": "Erträge aus Goodwill-Kreditstrafe",
       "Income from Interest": "Einkünfte aus Zinsen",
-      "Income from Recovery Repayments": "Erträge aus Sanierungsrückzahlungen",
+      "Income from Recovery Repayments": "Erträge aus der Einbringung",
       "Income from fees": "Einnahmen aus Gebühren",
       "Income from fees Repayments": "Einnahmen aus Gebührenrückzahlungen",
       "Income from penalties": "Einnahmen aus Strafen",
@@ -3740,7 +3753,10 @@
       "Submitted Date": "Einreichungsdatum",
       "No Ext": "Nr. außen",
       "No Int": "Nr. innen",
-      "Age of the business": "Alter des Unternehmens"
+      "Age of the business": "Alter des Unternehmens",
+      "Written Off Amount": "Abgeschriebener Betrag",
+      "Total Recovered": "Gesamtbetrag der Einbringung",
+      "Pending Recovery": "Ausstehender Betrag der Einbringung"
     },
     "links": {
       "Community": "Gemeinschaft",
@@ -3845,7 +3861,7 @@
       "Re-Age": "Altern",
       "Re-Amortize": "Amortisieren",
       "Recover From Guarantor": "Rückforderung vom Bürgen",
-      "Recovery Payment": "Wiederherstellungszahlung",
+      "Recovery Payment": "Einbringung",
       "Reject": "Ablehnen",
       "Reports": "Berichte",
       "Reschedule": "Neu planen",
@@ -4963,7 +4979,9 @@
       "Person PEP PLD Question 3": "Haben Sie eine familiäre Beziehung (2) zu einem Anteilseigner, Mitarbeiter oder leitenden Angestellten der juristischen Person?",
       "the contents of": "den Inhalt von",
       "the": "die",
-      "items selected of": "ausgewählten Elemente von"
+      "items selected of": "ausgewählten Elemente von",
+      "Recovery Completed": "Einbringung abgeschlossen",
+      "Recovery Payment Description": "Erfasst Geld, das nach der Abschreibung eingegangen ist. Das Darlehen bleibt geschlossen und der Saldo bleibt bei null; nur der Gesamtbetrag der Einbringung ändert sich."
     },
     "permissions": {
       "actions": {
@@ -5028,7 +5046,7 @@
         "REAGING": "Neustrukturierung",
         "REAMORTIZE": "Neu amortisieren",
         "RECOVERGUARANTEES": "Bürgschaften einfordern",
-        "RECOVERYPAYMENT": "Rückzahlung einfordern",
+        "RECOVERYPAYMENT": "Einbringung",
         "REJECT": "Ablehnen",
         "REJECTADDITIONAL": "Zusätzlich ablehnen",
         "RELEASEAMOUNT": "Betrag freigeben",
@@ -5425,7 +5443,7 @@
       "REAGING": "Neualterung",
       "REAMORTIZE": "Neu tilgen",
       "RECOVERGUARANTEES": "Garantien einziehen",
-      "RECOVERYPAYMENT": "Rückforderungszahlung",
+      "RECOVERYPAYMENT": "Einbringung",
       "REJECT": "Ablehnen",
       "REJECTADDITIONAL": "Zusätzlich ablehnen",
       "RELEASEAMOUNT": "Betrag freigeben",
@@ -5884,7 +5902,9 @@
     "Yes": "Ja",
     "loan product will be active and available to clients": "Das Datum, an dem das Kreditprodukt aktiv und für Kunden gefunden sein wird. Wenn das Feld leer ist, ist das Kreditprodukt aktiv, sobald es erstellt wird.",
     "loan product will become inactive and unavailable to clients": "Das Datum, an dem das Kreditprodukt inaktiv wird und für Kunden nicht mehr gefunden ist. Wenn es leer ist, wird das Ladeprodukt niemals inaktiv.",
-    "to": "zu"
+    "to": "zu",
+    "Nothing left to recover": "Bei diesem Darlehen ist kein Betrag zur Einbringung mehr ausstehend.",
+    "Reverse the recovery payments first": "Die Abschreibung kann nicht rückgängig gemacht werden, solange eine Einbringung vorhanden ist. Stornieren Sie diese zuerst."
   },
   "countries": {
     "AF": "Afghanistan",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -447,6 +447,18 @@
       "noBreachConfiguration": "This loan has no breach configuration.",
       "loanIsNotActive": "Breach evaluation can only be changed while the loan is active.",
       "breachIsDisabled": "Breach evaluation is disabled for this loan. Enable it to run this action."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "This recovery payment was already reversed.",
+      "amountMustBePositive": "The amount must be greater than zero.",
+      "beforeLastTransactionDate": "The recovery payment date cannot be earlier than the last transaction on the loan.",
+      "beforeWriteOffDate": "The recovery payment date cannot be earlier than the write-off date.",
+      "dateOutOfRange": "The recovery payment date is outside the range allowed for this loan.",
+      "futureDate": "The recovery payment date cannot be in the future.",
+      "greaterThanRemaining": "The amount cannot be greater than the pending recovery amount.",
+      "loanNotWrittenOff": "This loan is not written off, so it cannot take a recovery payment.",
+      "reversalForbidden": "You do not have permission to reverse Working Capital transactions. Ask an administrator to run this reversal.",
+      "undoWriteOffWithRecoveries": "The write-off cannot be undone while the loan has recovery payments. Reverse them first."
     }
   },
   "labels": {
@@ -1796,7 +1808,8 @@
       "Natural Person": "Natural Person",
       "Personal References (2 Family Members, 1 Acquaintance)": "Personal References (2 Family Members, 1 Acquaintance)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Declaration of Ultimate Beneficial Owners - Legal Entities",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaration of Ultimate Beneficial Owners - Natural Persons"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaration of Ultimate Beneficial Owners - Natural Persons",
+      "Recovery": "Recovery"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Account moves out of NPA only on arrears completion",
@@ -3761,7 +3774,10 @@
       "Submitted Date": "Submitted Date",
       "No Ext": "No Ext.",
       "No Int": "No Int.",
-      "Age of the business": "Age of the business"
+      "Age of the business": "Age of the business",
+      "Written Off Amount": "Written Off Amount",
+      "Total Recovered": "Total Recovered",
+      "Pending Recovery": "Pending Recovery"
     },
     "links": {
       "Community": "Community",
@@ -5100,7 +5116,9 @@
       "Person PEP PLD Question 3": "Do you have any family relationship (2) with any shareholder, employee, or officer of the Entity?",
       "the contents of": "the contents of",
       "the": "the",
-      "items selected of": "items selected of"
+      "items selected of": "items selected of",
+      "Recovery Completed": "Recovery completed",
+      "Recovery Payment Description": "Records money collected after the write-off. The loan stays closed and its balance stays at zero; only the recovered total changes."
     },
     "permissions": {
       "actions": {
@@ -5758,7 +5776,9 @@
     "Yes": "Yes",
     "loan product will be active and available to clients": "The date that the loan product will be active and available to clients. If blank, the loan product will be active as soon as it is created.",
     "loan product will become inactive and unavailable to clients": "The date that the loan product will become inactive and unavailable to clients. If blank, the load product will never become inactive.",
-    "Reporting Dashboard": "CB-ILD Reporting Dashboard"
+    "Reporting Dashboard": "CB-ILD Reporting Dashboard",
+    "Nothing left to recover": "There is nothing left to recover on this loan.",
+    "Reverse the recovery payments first": "Undo write-off is blocked while the loan has recovery payments. Reverse them first."
   },
   "countries": {
     "AF": "Afghanistan",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -443,6 +443,18 @@
       "noBreachConfiguration": "Este préstamo no tiene configuración de incumplimiento.",
       "loanIsNotActive": "La evaluación de incumplimiento solo se puede cambiar mientras el préstamo está activo.",
       "breachIsDisabled": "La evaluación de incumplimiento está deshabilitada para este préstamo. Habilítala para ejecutar esta acción."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "Esta recuperación ya fue reversada.",
+      "amountMustBePositive": "El monto debe ser mayor que cero.",
+      "beforeLastTransactionDate": "La fecha de la recuperación no puede ser anterior a la última transacción del préstamo.",
+      "beforeWriteOffDate": "La fecha de la recuperación no puede ser anterior a la fecha del castigo.",
+      "dateOutOfRange": "La fecha del pago de recuperación está fuera del rango permitido para este préstamo.",
+      "futureDate": "La fecha de la recuperación no puede ser futura.",
+      "greaterThanRemaining": "El monto no puede ser mayor al monto por recuperar.",
+      "loanNotWrittenOff": "Este préstamo no está castigado, por lo que no admite una recuperación.",
+      "reversalForbidden": "No tiene permiso para reversar transacciones de Capital de Trabajo. Solicite a un administrador que realice la reversión.",
+      "undoWriteOffWithRecoveries": "No se puede reversar el castigo mientras el préstamo tenga recuperaciones. Revérselas primero."
     }
   },
   "labels": {
@@ -1782,7 +1794,8 @@
       "Resource Provider / Beneficial Owner": "Proveedor de recursos / Beneficiario final",
       "Personal References (2 Family Members, 1 Acquaintance)": "Referencias personales (2 familiares, 1 conocido)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Declaración de beneficiarios finales - personas jurídicas",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaración de beneficiarios finales - personas naturales"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaración de beneficiarios finales - personas naturales",
+      "Recovery": "Recuperación"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "La cuenta sale de NPA solo tras liquidar todos los atrasos",
@@ -3739,7 +3752,10 @@
       "Submitted Date": "Fecha de envío",
       "No Ext": "Núm. ext.",
       "No Int": "Núm. int.",
-      "Age of the business": "Antigüedad del negocio"
+      "Age of the business": "Antigüedad del negocio",
+      "Written Off Amount": "Monto castigado",
+      "Total Recovered": "Total recuperado",
+      "Pending Recovery": "Por recuperar"
     },
     "links": {
       "Community": "Comunidad",
@@ -4963,7 +4979,9 @@
       "Person PEP PLD Question 3": "Tiene alguna relación familiar (2) con algún accionista, empleado o directivo de la entidad?",
       "the contents of": "el contenido de",
       "the": "los",
-      "items selected of": "elementos seleccionados de"
+      "items selected of": "elementos seleccionados de",
+      "Recovery Completed": "Recuperación completa",
+      "Recovery Payment Description": "Registra dinero cobrado después del castigo. El préstamo sigue cerrado y su saldo sigue en cero; solo cambia el total recuperado."
     },
     "permissions": {
       "actions": {
@@ -5596,7 +5614,9 @@
     "Withdraw": "Retirar",
     "Yes": "Sí",
     "loan product will be active and available to clients": "La fecha en que el producto de Crédito estará activo y disponibles para los clientes. Si está en blanco, el producto de Crédito estará activo tan pronto como se cree.",
-    "loan product will become inactive and unavailable to clients": "La fecha en que el producto de Crédito quedará inactivo y no estará disponibles para los clientes. Si está en blanco, el producto de carga nunca quedará inactivo."
+    "loan product will become inactive and unavailable to clients": "La fecha en que el producto de Crédito quedará inactivo y no estará disponibles para los clientes. Si está en blanco, el producto de carga nunca quedará inactivo.",
+    "Nothing left to recover": "No queda nada por recuperar en este préstamo.",
+    "Reverse the recovery payments first": "No se puede reversar el castigo mientras el préstamo tenga recuperaciones. Revérselas primero."
   },
   "countries": {
     "AF": "Afganistán",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -444,6 +444,18 @@
       "noBreachConfiguration": "Este préstamo no tiene configuración de incumplimiento.",
       "loanIsNotActive": "La evaluación de incumplimiento solo se puede cambiar mientras el préstamo está activo.",
       "breachIsDisabled": "La evaluación de incumplimiento está deshabilitada para este préstamo. Habilítala para ejecutar esta acción."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "Esta recuperación ya fue reversada.",
+      "amountMustBePositive": "El monto debe ser mayor que cero.",
+      "beforeLastTransactionDate": "La fecha de la recuperación no puede ser anterior a la última transacción del préstamo.",
+      "beforeWriteOffDate": "La fecha de la recuperación no puede ser anterior a la fecha del castigo.",
+      "dateOutOfRange": "La fecha del pago de recuperación está fuera del rango permitido para este préstamo.",
+      "futureDate": "La fecha de la recuperación no puede ser futura.",
+      "greaterThanRemaining": "El monto no puede ser mayor al monto por recuperar.",
+      "loanNotWrittenOff": "Este préstamo no está castigado, por lo que no admite una recuperación.",
+      "reversalForbidden": "No tiene permiso para reversar transacciones de Capital de Trabajo. Solicite a un administrador que realice la reversión.",
+      "undoWriteOffWithRecoveries": "No se puede reversar el castigo mientras el préstamo tenga recuperaciones. Revérselas primero."
     }
   },
   "labels": {
@@ -1788,7 +1800,8 @@
       "Natural Person": "Natural Person",
       "Personal References (2 Family Members, 1 Acquaintance)": "Referencias personales (2 familiares, 1 conocido)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Declaración de beneficiarios finales - personas morales",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaración de beneficiarios finales - personas físicas"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaración de beneficiarios finales - personas físicas",
+      "Recovery": "Recuperación"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "La cuenta sale de NPA solo tras liquidar todos los atrasos",
@@ -3744,7 +3757,10 @@
       "Submitted Date": "Fecha de envío",
       "No Ext": "Núm. ext.",
       "No Int": "Núm. int.",
-      "Age of the business": "Antigüedad del negocio"
+      "Age of the business": "Antigüedad del negocio",
+      "Written Off Amount": "Monto castigado",
+      "Total Recovered": "Total recuperado",
+      "Pending Recovery": "Por recuperar"
     },
     "links": {
       "Community": "Comunidad",
@@ -4987,7 +5003,9 @@
       "Person PEP PLD Question 3": "Tiene alguna relación familiar (2) con algún accionista, empleado o funcionario de la entidad?",
       "the contents of": "el contenido de",
       "the": "los",
-      "items selected of": "elementos seleccionados de"
+      "items selected of": "elementos seleccionados de",
+      "Recovery Completed": "Recuperación completa",
+      "Recovery Payment Description": "Registra dinero cobrado después del castigo. El préstamo sigue cerrado y su saldo sigue en cero; solo cambia el total recuperado."
     },
     "permissions": {
       "actions": {
@@ -5620,7 +5638,9 @@
     "Withdraw": "Retirar",
     "Yes": "Sí",
     "loan product will be active and available to clients": "La fecha en que el producto de Crédito estará activo y disponible para los clientes. Si está en blanco, el producto de Crédito estará activo tan pronto como se cree.",
-    "loan product will become inactive and unavailable to clients": "La fecha en que el producto de Crédito quedará inactivo y no estará disponible para los clientes. Si está en blanco, el producto de Crédito nunca quedará inactivo."
+    "loan product will become inactive and unavailable to clients": "La fecha en que el producto de Crédito quedará inactivo y no estará disponible para los clientes. Si está en blanco, el producto de Crédito nunca quedará inactivo.",
+    "Nothing left to recover": "No queda nada por recuperar en este préstamo.",
+    "Reverse the recovery payments first": "No se puede reversar el castigo mientras el préstamo tenga recuperaciones. Revérselas primero."
   },
   "countries": {
     "AF": "Afganistán",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -443,6 +443,18 @@
       "noBreachConfiguration": "Ce prêt n'a aucune configuration de manquement.",
       "loanIsNotActive": "L'évaluation des manquements ne peut être modifiée que lorsque le prêt est actif.",
       "breachIsDisabled": "L'évaluation des manquements est désactivée pour ce prêt. Activez-la pour exécuter cette action."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "Ce recouvrement a déjà été annulé.",
+      "amountMustBePositive": "Le montant doit être supérieur à zéro.",
+      "beforeLastTransactionDate": "La date du recouvrement ne peut pas être antérieure à la dernière transaction du prêt.",
+      "beforeWriteOffDate": "La date du recouvrement ne peut pas être antérieure à la date du passage en perte.",
+      "dateOutOfRange": "La date du paiement de recouvrement est en dehors de la plage autorisée pour ce prêt.",
+      "futureDate": "La date du recouvrement ne peut pas être dans le futur.",
+      "greaterThanRemaining": "Le montant ne peut pas dépasser le montant restant à recouvrer.",
+      "loanNotWrittenOff": "Ce prêt n'est pas passé en perte : il ne peut pas recevoir de recouvrement.",
+      "reversalForbidden": "Vous n'avez pas la permission d'annuler des transactions de fonds de roulement. Demandez à un administrateur d'effectuer cette annulation.",
+      "undoWriteOffWithRecoveries": "Le passage en perte ne peut pas être annulé tant que le prêt comporte des recouvrements. Annulez-les d’abord."
     }
   },
   "labels": {
@@ -1785,7 +1797,8 @@
       "Resource Provider / Beneficial Owner": "Fournisseur de ressources / Bénéficiaire effectif",
       "Personal References (2 Family Members, 1 Acquaintance)": "Références personnelles (2 membres de la famille, 1 connaissance)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Déclaration des bénéficiaires effectifs ultimes - personnes morales",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Déclaration des bénéficiaires effectifs ultimes - personnes physiques"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Déclaration des bénéficiaires effectifs ultimes - personnes physiques",
+      "Recovery": "Recouvrement"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Le compte ne sort du statut NPA qu'après apurement des arriérés",
@@ -3741,7 +3754,10 @@
       "Submitted Date": "Date de soumission",
       "No Ext": "N° ext.",
       "No Int": "N° int.",
-      "Age of the business": "Ancienneté de l’activité"
+      "Age of the business": "Ancienneté de l’activité",
+      "Written Off Amount": "Montant passé en perte",
+      "Total Recovered": "Total recouvré",
+      "Pending Recovery": "Reste à recouvrer"
     },
     "links": {
       "Community": "Communauté",
@@ -4964,7 +4980,9 @@
       "Person PEP PLD Question 3": "Avez-vous un lien familial (2) avec un actionnaire, employé ou dirigeant de l’entité ?",
       "the contents of": "le contenu de",
       "the": "les",
-      "items selected of": "éléments sélectionnés de"
+      "items selected of": "éléments sélectionnés de",
+      "Recovery Completed": "Recouvrement terminé",
+      "Recovery Payment Description": "Enregistre l'argent encaissé après le passage en perte. Le prêt reste clôturé et son solde reste à zéro ; seul le total recouvré change."
     },
     "permissions": {
       "actions": {
@@ -5597,7 +5615,9 @@
     "Withdraw": "Retirer",
     "Yes": "Oui",
     "loan product will be active and available to clients": "La date à laquelle le produit de prêt sera actif et disponible pour les clients. Si ce champ est vide, le produit de prêt sera actif dès sa création.",
-    "loan product will become inactive and unavailable to clients": "Date à laquelle le produit de prêt deviendra inactif et indisponible pour les clients. S'il est vide, le produit ne deviendra jamais inactif."
+    "loan product will become inactive and unavailable to clients": "Date à laquelle le produit de prêt deviendra inactif et indisponible pour les clients. S'il est vide, le produit ne deviendra jamais inactif.",
+    "Nothing left to recover": "Il ne reste rien à recouvrer sur ce prêt.",
+    "Reverse the recovery payments first": "L'annulation du passage en perte est bloquée tant que le prêt comporte des recouvrements. Annulez-les d'abord."
   },
   "countries": {
     "AF": "Afghanistan",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -443,6 +443,18 @@
       "noBreachConfiguration": "Questo prestito non ha una configurazione delle violazioni.",
       "loanIsNotActive": "La valutazione delle violazioni può essere modificata solo mentre il prestito è attivo.",
       "breachIsDisabled": "La valutazione delle violazioni è disabilitata per questo prestito. Abilitala per eseguire questa azione."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "Questo recupero è già stato stornato.",
+      "amountMustBePositive": "L'importo deve essere maggiore di zero.",
+      "beforeLastTransactionDate": "La data del recupero non può essere precedente all'ultima transazione del prestito.",
+      "beforeWriteOffDate": "La data del recupero non può essere precedente alla data dello stralcio.",
+      "dateOutOfRange": "La data del pagamento di recupero è fuori dall’intervallo consentito per questo prestito.",
+      "futureDate": "La data del recupero non può essere futura.",
+      "greaterThanRemaining": "L'importo non può superare l'importo ancora da recuperare.",
+      "loanNotWrittenOff": "Questo prestito non è stralciato, quindi non può ricevere un recupero.",
+      "reversalForbidden": "Non hai il permesso di stornare transazioni di capitale circolante. Chiedi a un amministratore di eseguire lo storno.",
+      "undoWriteOffWithRecoveries": "Lo stralcio non può essere annullato finché il prestito ha recuperi. Stornali prima."
     }
   },
   "labels": {
@@ -1782,7 +1794,8 @@
       "Resource Provider / Beneficial Owner": "Fornitore di risorse / Titolare effettivo",
       "Personal References (2 Family Members, 1 Acquaintance)": "Referenze personali (2 familiari, 1 conoscente)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Dichiarazione dei titolari effettivi ultimi - persone giuridiche",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Dichiarazione dei titolari effettivi ultimi - persone fisiche"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Dichiarazione dei titolari effettivi ultimi - persone fisiche",
+      "Recovery": "Recupero"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Il conto esce da NPA solo dopo il saldo di tutti gli arretrati",
@@ -3738,7 +3751,10 @@
       "Submitted Date": "Data di invio",
       "No Ext": "N. est.",
       "No Int": "N. int.",
-      "Age of the business": "Anzianità dell’attività"
+      "Age of the business": "Anzianità dell’attività",
+      "Written Off Amount": "Importo stralciato",
+      "Total Recovered": "Totale recuperato",
+      "Pending Recovery": "Da recuperare"
     },
     "links": {
       "Community": "Comunità",
@@ -4962,7 +4978,9 @@
       "Person PEP PLD Question 3": "Ha un rapporto familiare (2) con un azionista, dipendente o funzionario dell’entità?",
       "the contents of": "il contenuto di",
       "the": "gli",
-      "items selected of": "elementi selezionati di"
+      "items selected of": "elementi selezionati di",
+      "Recovery Completed": "Recupero completato",
+      "Recovery Payment Description": "Registra il denaro incassato dopo lo stralcio. Il prestito resta chiuso e il saldo resta a zero; cambiano sia il totale recuperato sia l'importo ancora da recuperare."
     },
     "permissions": {
       "actions": {
@@ -5595,7 +5613,9 @@
     "Withdraw": "Ritirare",
     "Yes": "Sì",
     "loan product will be active and available to clients": "La data in cui il prodotto di prestito sarà attivo e disponibile per i clienti. Se vuoto, il prodotto di prestito sarà attivo non appena verrà creato.",
-    "loan product will become inactive and unavailable to clients": "La data in cui il prodotto di prestito diventerà inattivo e non disponibile per i clienti. Se vuoto, il prodotto di prestito non diventerà mai inattivo."
+    "loan product will become inactive and unavailable to clients": "La data in cui il prodotto di prestito diventerà inattivo e non disponibile per i clienti. Se vuoto, il prodotto di prestito non diventerà mai inattivo.",
+    "Nothing left to recover": "Non resta nulla da recuperare su questo prestito.",
+    "Reverse the recovery payments first": "Lo stralcio non può essere annullato finché il prestito ha recuperi. Stornali prima."
   },
   "countries": {
     "AF": "Afghanistan",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -443,6 +443,18 @@
       "noBreachConfiguration": "이 대출에는 위반 구성이 없습니다.",
       "loanIsNotActive": "위반 평가는 대출이 활성 상태일 때만 변경할 수 있습니다.",
       "breachIsDisabled": "이 대출의 위반 평가가 비활성화되어 있습니다. 이 작업을 실행하려면 활성화하세요."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "이 회수 거래는 이미 취소되었습니다.",
+      "amountMustBePositive": "금액은 0보다 커야 합니다.",
+      "beforeLastTransactionDate": "회수 거래일은 대출의 마지막 거래일보다 이전일 수 없습니다.",
+      "beforeWriteOffDate": "회수 거래일은 상각일보다 이전일 수 없습니다.",
+      "dateOutOfRange": "회수 납입 일자가 이 대출에 허용된 범위를 벗어났습니다.",
+      "futureDate": "회수 거래일은 미래일 수 없습니다.",
+      "greaterThanRemaining": "금액은 회수 잔액을 초과할 수 없습니다.",
+      "loanNotWrittenOff": "이 대출은 상각되지 않았으므로 회수 거래를 등록할 수 없습니다.",
+      "reversalForbidden": "운전자본 거래를 취소할 권한이 없습니다. 관리자에게 취소를 요청하세요.",
+      "undoWriteOffWithRecoveries": "대출에 회수 거래가 있는 동안에는 상각을 취소할 수 없습니다. 먼저 회수 거래를 취소하세요."
     }
   },
   "labels": {
@@ -1783,7 +1795,8 @@
       "Resource Provider / Beneficial Owner": "자원 제공자 / 실소유자",
       "Personal References (2 Family Members, 1 Acquaintance)": "개인 참고인(가족 2명, 지인 1명)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "최종 실소유자 선언 - 법인",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "최종 실소유자 선언 - 자연인"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "최종 실소유자 선언 - 자연인",
+      "Recovery": "회수"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "모든 연체가 해소된 후에만 NPA에서 해제",
@@ -3738,7 +3751,10 @@
       "Submitted Date": "제출일",
       "No Ext": "외부 번호",
       "No Int": "내부 번호",
-      "Age of the business": "사업 기간"
+      "Age of the business": "사업 기간",
+      "Written Off Amount": "상각 금액",
+      "Total Recovered": "총 회수액",
+      "Pending Recovery": "회수 잔액"
     },
     "links": {
       "Community": "지역 사회",
@@ -4961,7 +4977,9 @@
       "Person PEP PLD Question 3": "해당 법인의 주주, 직원 또는 임원과 가족 관계 (2)가 있습니까?",
       "the contents of": "다음의 내용",
       "the": "선택된",
-      "items selected of": "개 항목:"
+      "items selected of": "개 항목:",
+      "Recovery Completed": "회수 완료",
+      "Recovery Payment Description": "상각 이후 수령한 금액을 기록합니다. 대출은 마감 상태로 유지되고 잔액도 0으로 유지되며, 총 회수액만 변경됩니다."
     },
     "permissions": {
       "actions": {
@@ -5594,7 +5612,9 @@
     "Withdraw": "철회하다",
     "Yes": "예",
     "loan product will be active and available to clients": "대출 상품이 활성화되어 고객에게 제공되는 날짜입니다. 비어 있으면 대출 상품이 생성되자마자 활성화됩니다.",
-    "loan product will become inactive and unavailable to clients": "대출 상품이 비활성화되어 고객이 사용할 수 없게 되는 날짜입니다. 비어 있으면 로드 제품이 비활성화되지 않습니다."
+    "loan product will become inactive and unavailable to clients": "대출 상품이 비활성화되어 고객이 사용할 수 없게 되는 날짜입니다. 비어 있으면 로드 제품이 비활성화되지 않습니다.",
+    "Nothing left to recover": "이 대출에서 더 이상 회수할 금액이 없습니다.",
+    "Reverse the recovery payments first": "대출에 회수 거래가 있는 동안에는 상각을 취소할 수 없습니다. 먼저 회수 거래를 취소하세요."
   },
   "countries": {
     "AF": "아프가니스탄",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -443,6 +443,18 @@
       "noBreachConfiguration": "Ši paskola neturi pažeidimų konfigūracijos.",
       "loanIsNotActive": "Pažeidimų vertinimą galima keisti tik tada, kai paskola aktyvi.",
       "breachIsDisabled": "Šios paskolos pažeidimų vertinimas išjungtas. Įjunkite jį, kad galėtumėte atlikti šį veiksmą."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "Šis susigrąžinimo mokėjimas jau buvo atšauktas.",
+      "amountMustBePositive": "Suma turi būti didesnė už nulį.",
+      "beforeLastTransactionDate": "Susigrąžinimo data negali būti ankstesnė nei paskutinės paskolos operacijos data.",
+      "beforeWriteOffDate": "Susigrąžinimo data negali būti ankstesnė nei nurašymo data.",
+      "dateOutOfRange": "Susigrąžinimo mokėjimo data yra už šiai paskolai leidžiamo intervalo ribų.",
+      "futureDate": "Susigrąžinimo data negali būti ateityje.",
+      "greaterThanRemaining": "Suma negali viršyti likusios susigrąžinti sumos.",
+      "loanNotWrittenOff": "Ši paskola nėra nurašyta, todėl negali priimti susigrąžinimo mokėjimo.",
+      "reversalForbidden": "Neturite teisės atšaukti apyvartinio kapitalo operacijų. Paprašykite administratoriaus atlikti atšaukimą.",
+      "undoWriteOffWithRecoveries": "Nurašymo negalima atšaukti, kol paskola turi susigrąžinimo mokėjimų. Pirmiausia juos stornuokite."
     }
   },
   "labels": {
@@ -1781,7 +1793,8 @@
       "Resource Provider / Beneficial Owner": "Lėšų teikėjas / tikrasis naudos gavėjas",
       "Personal References (2 Family Members, 1 Acquaintance)": "Asmeninės rekomendacijos (2 šeimos nariai, 1 pažįstamas)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Galutinių naudos gavėjų deklaracija - juridiniai asmenys",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Galutinių naudos gavėjų deklaracija - fiziniai asmenys"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Galutinių naudos gavėjų deklaracija - fiziniai asmenys",
+      "Recovery": "Susigrąžinimas"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Sąskaita išeina iš NPA tik padengus visus įsiskolinimus",
@@ -3737,7 +3750,10 @@
       "Submitted Date": "Pateikimo data",
       "No Ext": "Išor. Nr.",
       "No Int": "Vid. Nr.",
-      "Age of the business": "Verslo amžius"
+      "Age of the business": "Verslo amžius",
+      "Written Off Amount": "Nurašyta suma",
+      "Total Recovered": "Iš viso susigrąžinta",
+      "Pending Recovery": "Liko susigrąžinti"
     },
     "links": {
       "Community": "bendruomenė",
@@ -4962,7 +4978,9 @@
       "Person PEP PLD Question 3": "Ar turite šeiminį ryšį (2) su juridinio asmens akcininku, darbuotoju ar pareigūnu?",
       "the contents of": "turinį",
       "the": "pasirinkti",
-      "items selected of": "elementai iš"
+      "items selected of": "elementai iš",
+      "Recovery Completed": "Susigrąžinimas baigtas",
+      "Recovery Payment Description": "Registruoja pinigus, surinktus po nurašymo. Paskola lieka uždaryta, o jos likutis lieka nulinis; keičiasi tik susigrąžinta suma."
     },
     "permissions": {
       "actions": {
@@ -5595,7 +5613,9 @@
     "Withdraw": "Atsitraukti",
     "Yes": "Taip",
     "loan product will be active and available to clients": "Data, kada paskolos produktas bus aktyvus ir bus prieinamas klientams. Jei tuščia, paskolos produktas bus aktyvus, kai tik bus sukurtas.",
-    "loan product will become inactive and unavailable to clients": "Data, kai paskolos produktas taps neaktyvus ir nepasiekiamas klientams. Jei tuščia, įkėlimo produktas niekada netaps neaktyvus."
+    "loan product will become inactive and unavailable to clients": "Data, kai paskolos produktas taps neaktyvus ir nepasiekiamas klientams. Jei tuščia, paskolos produktas niekada netaps neaktyvus.",
+    "Nothing left to recover": "Šioje paskoloje nebėra ko susigrąžinti.",
+    "Reverse the recovery payments first": "Nurašymo negalima atšaukti, kol paskola turi susigrąžinimo mokėjimų. Pirmiausia juos stornuokite."
   },
   "countries": {
     "AF": "Afganistanas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -443,6 +443,18 @@
       "noBreachConfiguration": "Šim aizdevumam nav pārkāpumu konfigurācijas.",
       "loanIsNotActive": "Pārkāpumu novērtēšanu var mainīt tikai tad, kad aizdevums ir aktīvs.",
       "breachIsDisabled": "Šim aizdevumam pārkāpumu novērtēšana ir atspējota. Iespējojiet to, lai veiktu šo darbību."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "Šis atgūšanas maksājums jau ir stornēts.",
+      "amountMustBePositive": "Summai jābūt lielākai par nulli.",
+      "beforeLastTransactionDate": "Atgūšanas maksājuma datums nevar būt agrāks par aizdevuma pēdējo darījumu.",
+      "beforeWriteOffDate": "Atgūšanas maksājuma datums nevar būt agrāks par norakstīšanas datumu.",
+      "dateOutOfRange": "Atgūšanas maksājuma datums ir ārpus šim aizdevumam atļautā diapazona.",
+      "futureDate": "Atgūšanas maksājuma datums nevar būt nākotnē.",
+      "greaterThanRemaining": "Summa nevar pārsniegt vēl atgūstamo summu.",
+      "loanNotWrittenOff": "Šis aizdevums nav norakstīts, tāpēc tas nevar pieņemt atgūšanas maksājumu.",
+      "reversalForbidden": "Jums nav atļaujas stornēt apgrozāmā kapitāla darījumus. Lūdziet administratoram veikt stornēšanu.",
+      "undoWriteOffWithRecoveries": "Norakstīšanu nevar atsaukt, kamēr aizdevumam ir atgūšanas maksājumi. Vispirms tos storno."
     }
   },
   "labels": {
@@ -1782,7 +1794,8 @@
       "Resource Provider / Beneficial Owner": "Resursu nodrošinātājs / patiesais labuma guvējs",
       "Personal References (2 Family Members, 1 Acquaintance)": "Personīgās atsauksmes (2 ģimenes locekļi, 1 paziņa)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Patieso labuma guvēju deklarācija - juridiskas personas",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Patieso labuma guvēju deklarācija - fiziskas personas"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Patieso labuma guvēju deklarācija - fiziskas personas",
+      "Recovery": "Atgūšana"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Konts iziet no NPA tikai pēc visu parādu segšanas",
@@ -3738,7 +3751,10 @@
       "Submitted Date": "Iesniegšanas datums",
       "No Ext": "Ār. Nr.",
       "No Int": "Iekš. Nr.",
-      "Age of the business": "Uzņēmējdarbības ilgums"
+      "Age of the business": "Uzņēmējdarbības ilgums",
+      "Written Off Amount": "Norakstītā summa",
+      "Total Recovered": "Kopā atgūts",
+      "Pending Recovery": "Vēl atgūstams"
     },
     "links": {
       "Community": "kopiena",
@@ -4961,7 +4977,9 @@
       "Person PEP PLD Question 3": "Vai jums ir ģimenes attiecības (2) ar juridiskās personas akcionāru, darbinieku vai amatpersonu?",
       "the contents of": "saturu",
       "the": "atlasītie",
-      "items selected of": "vienumi no"
+      "items selected of": "vienumi no",
+      "Recovery Completed": "Atgūšana pabeigta",
+      "Recovery Payment Description": "Reģistrē naudu, kas saņemta pēc norakstīšanas. Aizdevums paliek slēgts un tā atlikums paliek nulle; mainās tikai atgūtā kopsumma."
     },
     "permissions": {
       "actions": {
@@ -5594,7 +5612,9 @@
     "Withdraw": "Izņemt",
     "Yes": "Jā",
     "loan product will be active and available to clients": "Datums, kad aizdevuma produkts būs aktīvs un pieejams klientiem. Ja lauks ir tukšs, aizdevuma produkts būs aktīvs, tiklīdz tas tiks izveidots.",
-    "loan product will become inactive and unavailable to clients": "Datums, kad aizdevuma produkts kļūs neaktīvs un klientiem nebūs pieejams. Ja lauks ir tukšs, ielādes produkts nekad nekļūs neaktīvs."
+    "loan product will become inactive and unavailable to clients": "Datums, kad aizdevuma produkts kļūs neaktīvs un klientiem nebūs pieejams. Ja lauks ir tukšs, ielādes produkts nekad nekļūs neaktīvs.",
+    "Nothing left to recover": "Šajā aizdevumā vairs nav ko atgūt.",
+    "Reverse the recovery payments first": "Norakstīšanu nevar atsaukt, kamēr aizdevumam ir atgūšanas maksājumi. Vispirms tos storno."
   },
   "countries": {
     "AF": "Afganistāna",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -443,6 +443,18 @@
       "noBreachConfiguration": "यो ऋणमा उल्लंघन कन्फिगरेसन छैन।",
       "loanIsNotActive": "ऋण सक्रिय हुँदा मात्र उल्लंघन मूल्यांकन परिवर्तन गर्न सकिन्छ।",
       "breachIsDisabled": "यो ऋणको उल्लंघन मूल्यांकन असक्षम छ। यो कार्य चलाउन यसलाई सक्षम गर्नुहोस्।"
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "यो असुली भुक्तानी पहिले नै फिर्ता गरिएको छ।",
+      "amountMustBePositive": "रकम शून्यभन्दा बढी हुनुपर्छ।",
+      "beforeLastTransactionDate": "असुली भुक्तानीको मिति ऋणको अन्तिम कारोबारभन्दा अगाडिको हुन सक्दैन।",
+      "beforeWriteOffDate": "असुली भुक्तानीको मिति मिनाहा मितिभन्दा अगाडिको हुन सक्दैन।",
+      "dateOutOfRange": "रिकभरी भुक्तानीको मिति यो ऋणका लागि अनुमति दिइएको दायराभन्दा बाहिर छ।",
+      "futureDate": "असुली भुक्तानीको मिति भविष्यको हुन सक्दैन।",
+      "greaterThanRemaining": "रकम असुल गर्न बाँकी रकमभन्दा बढी हुन सक्दैन।",
+      "loanNotWrittenOff": "यो ऋण मिनाहा गरिएको छैन, त्यसैले असुली भुक्तानी लिन सकिँदैन।",
+      "reversalForbidden": "तपाईंसँग कार्यशील पुँजी कारोबार फिर्ता गर्ने अनुमति छैन। प्रशासकलाई यो फिर्ता गर्न अनुरोध गर्नुहोस्।",
+      "undoWriteOffWithRecoveries": "ऋणमा असुली भुक्तानी रहेसम्म मिनाहा फिर्ता गर्न मिल्दैन। पहिले ती फिर्ता गर्नुहोस्।"
     }
   },
   "labels": {
@@ -1781,7 +1793,8 @@
       "Resource Provider / Beneficial Owner": "स्रोत प्रदायक / वास्तविक लाभग्राही",
       "Personal References (2 Family Members, 1 Acquaintance)": "व्यक्तिगत सन्दर्भहरू (२ परिवारका सदस्य, १ परिचित)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "अन्तिम लाभग्राही मालिकहरूको घोषणा - कानुनी संस्थाहरू",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "अन्तिम लाभग्राही मालिकहरूको घोषणा - प्राकृतिक व्यक्तिहरू"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "अन्तिम लाभग्राही मालिकहरूको घोषणा - प्राकृतिक व्यक्तिहरू",
+      "Recovery": "असुली"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "सबै बक्यौता भुक्तानी भएपछि मात्र खाता NPA बाट बाहिरिन्छ",
@@ -3737,7 +3750,10 @@
       "Submitted Date": "पेश गरिएको मिति",
       "No Ext": "बाह्य नं.",
       "No Int": "आन्तरिक नं.",
-      "Age of the business": "व्यवसायको उमेर"
+      "Age of the business": "व्यवसायको उमेर",
+      "Written Off Amount": "मिनाहा रकम",
+      "Total Recovered": "कुल असुली",
+      "Pending Recovery": "असुल गर्न बाँकी"
     },
     "links": {
       "Community": "समुदाय",
@@ -4961,7 +4977,9 @@
       "Person PEP PLD Question 3": "के तपाईंको संस्थाका कुनै शेयरधनी, कर्मचारी वा पदाधिकारीसँग पारिवारिक सम्बन्ध (2) छ?",
       "the contents of": "को सामग्री",
       "the": "चयन गरिएका",
-      "items selected of": "वस्तुहरू"
+      "items selected of": "वस्तुहरू",
+      "Recovery Completed": "असुली पूरा भयो",
+      "Recovery Payment Description": "मिनाहा पछि संकलित रकम अभिलेख गर्छ। ऋण बन्द नै रहन्छ र मौज्दात शून्य नै रहन्छ; कुल असुली मात्र परिवर्तन हुन्छ।"
     },
     "permissions": {
       "actions": {
@@ -5594,7 +5612,9 @@
     "Withdraw": "निकाल्नु",
     "Yes": "हो",
     "loan product will be active and available to clients": "ऋण उत्पादन सक्रिय र ग्राहकहरूको लागि उपलब्ध हुने मिति। खाली भएमा, ऋण उत्पादन सिर्जना हुने बित्तिकै सक्रिय हुनेछ।",
-    "loan product will become inactive and unavailable to clients": "ऋण उत्पादन निष्क्रिय र ग्राहकहरु को लागी अनुपलब्ध हुने मिति। यदि खाली छ भने, लोड उत्पादन कहिल्यै निष्क्रिय हुनेछैन।"
+    "loan product will become inactive and unavailable to clients": "ऋण उत्पादन निष्क्रिय र ग्राहकहरु को लागी अनुपलब्ध हुने मिति। यदि खाली छ भने, ऋण उत्पादन कहिल्यै निष्क्रिय हुनेछैन।",
+    "Nothing left to recover": "यस ऋणमा असुल गर्न बाँकी केही छैन।",
+    "Reverse the recovery payments first": "ऋणमा असुली भुक्तानी रहेसम्म मिनाहा फिर्ता गर्न मिल्दैन। पहिले ती फिर्ता गर्नुहोस्।"
   },
   "countries": {
     "AF": "अफगानिस्तान",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -443,6 +443,18 @@
       "noBreachConfiguration": "Este empréstimo não tem configuração de violações.",
       "loanIsNotActive": "A avaliação de violações só pode ser alterada enquanto o empréstimo estiver ativo.",
       "breachIsDisabled": "A avaliação de violações está desativada para este empréstimo. Ative-a para executar esta ação."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "Esta recuperação já foi revertida.",
+      "amountMustBePositive": "O montante deve ser superior a zero.",
+      "beforeLastTransactionDate": "A data da recuperação não pode ser anterior à última transação do empréstimo.",
+      "beforeWriteOffDate": "A data da recuperação não pode ser anterior à data do abate.",
+      "dateOutOfRange": "A data do pagamento de recuperação está fora do intervalo permitido para este empréstimo.",
+      "futureDate": "A data da recuperação não pode ser futura.",
+      "greaterThanRemaining": "O montante não pode ser superior ao montante por recuperar.",
+      "loanNotWrittenOff": "Este empréstimo não está abatido, pelo que não aceita uma recuperação.",
+      "reversalForbidden": "Não tem permissão para reverter transações de Fundo de Maneio. Peça a um administrador que execute a reversão.",
+      "undoWriteOffWithRecoveries": "O abate não pode ser anulado enquanto o empréstimo tiver recuperações. Reverta-as primeiro."
     }
   },
   "labels": {
@@ -1781,7 +1793,8 @@
       "Resource Provider / Beneficial Owner": "Fornecedor de recursos / Beneficiário efetivo",
       "Personal References (2 Family Members, 1 Acquaintance)": "Referências pessoais (2 familiares, 1 conhecido)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Declaração dos beneficiários efetivos finais - pessoas coletivas",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaração dos beneficiários efetivos finais - pessoas singulares"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaração dos beneficiários efetivos finais - pessoas singulares",
+      "Recovery": "Recuperação"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "A conta sai de NPA apenas após a regularização de todos os atrasos",
@@ -3737,7 +3750,10 @@
       "Submitted Date": "Data de submissão",
       "No Ext": "N.º ext.",
       "No Int": "N.º int.",
-      "Age of the business": "Antiguidade do negócio"
+      "Age of the business": "Antiguidade do negócio",
+      "Written Off Amount": "Montante abatido",
+      "Total Recovered": "Total recuperado",
+      "Pending Recovery": "Por recuperar"
     },
     "links": {
       "Community": "Comunidade",
@@ -4961,7 +4977,9 @@
       "Person PEP PLD Question 3": "Tem alguma relação familiar (2) com algum acionista, colaborador ou dirigente da entidade?",
       "the contents of": "o conteúdo de",
       "the": "os",
-      "items selected of": "itens selecionados de"
+      "items selected of": "itens selecionados de",
+      "Recovery Completed": "Recuperação concluída",
+      "Recovery Payment Description": "Regista dinheiro cobrado após o abate. O empréstimo permanece fechado e o saldo permanece a zero; apenas muda o total recuperado."
     },
     "permissions": {
       "actions": {
@@ -5594,7 +5612,9 @@
     "Withdraw": "Retirar",
     "Yes": "Sim",
     "loan product will be active and available to clients": "A data em que o produto de empréstimo estará ativo e disponível para os clientes. Se estiver em branco, o produto de empréstimo estará ativo assim que for criado.",
-    "loan product will become inactive and unavailable to clients": "A data em que o produto de empréstimo ficará inativo e indisponível para os clientes. Se estiver em branco, o produto de empréstimo nunca ficará inativo."
+    "loan product will become inactive and unavailable to clients": "A data em que o produto de empréstimo ficará inativo e indisponível para os clientes. Se estiver em branco, o produto de empréstimo nunca ficará inativo.",
+    "Nothing left to recover": "Não há nada por recuperar neste empréstimo.",
+    "Reverse the recovery payments first": "Não é possível anular o abate enquanto o empréstimo tiver recuperações. Reverta-as primeiro."
   },
   "countries": {
     "AF": "Afeganistão",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -443,6 +443,18 @@
       "noBreachConfiguration": "Mkopo huu hauna usanidi wa ukiukaji.",
       "loanIsNotActive": "Tathmini ya ukiukaji inaweza kubadilishwa tu wakati mkopo uko hai.",
       "breachIsDisabled": "Tathmini ya ukiukaji imezimwa kwa mkopo huu. Iwashe ili kutekeleza kitendo hiki."
+    },
+    "recoveryPayment": {
+      "alreadyUndone": "Malipo haya ya urejeshaji tayari yametenguliwa.",
+      "amountMustBePositive": "Kiasi lazima kiwe kikubwa kuliko sifuri.",
+      "beforeLastTransactionDate": "Tarehe ya malipo ya urejeshaji haiwezi kuwa kabla ya muamala wa mwisho wa mkopo.",
+      "beforeWriteOffDate": "Tarehe ya malipo ya urejeshaji haiwezi kuwa kabla ya tarehe ya kufuta deni.",
+      "dateOutOfRange": "Tarehe ya malipo ya urejeshaji iko nje ya kipindi kinachoruhusiwa kwa mkopo huu.",
+      "futureDate": "Tarehe ya malipo ya urejeshaji haiwezi kuwa ya baadaye.",
+      "greaterThanRemaining": "Kiasi hakiwezi kuzidi kiasi kilichosalia kurejeshwa.",
+      "loanNotWrittenOff": "Mkopo huu haujafutwa, hivyo hauwezi kupokea malipo ya urejeshaji.",
+      "reversalForbidden": "Huna ruhusa ya kutengua miamala ya Mtaji wa Kufanya Kazi. Muombe msimamizi atengue muamala huu.",
+      "undoWriteOffWithRecoveries": "Kufuta deni hakuwezi kutenguliwa wakati mkopo una malipo ya urejeshaji. Tengua malipo hayo kwanza."
     }
   },
   "labels": {
@@ -1779,7 +1791,8 @@
       "Resource Provider / Beneficial Owner": "Mtoa rasilimali / Mnufaika halisi",
       "Personal References (2 Family Members, 1 Acquaintance)": "Marejeleo binafsi (wanafamilia 2, mtu 1 anayefahamiana nawe)",
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Tamko la wamiliki wanufaika wa mwisho - taasisi za kisheria",
-      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Tamko la wamiliki wanufaika wa mwisho - watu binafsi"
+      "Declaration of Ultimate Beneficial Owners - Natural Persons": "Tamko la wamiliki wanufaika wa mwisho - watu binafsi",
+      "Recovery": "Urejeshaji"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Akaunti hutoka NPA baada tu ya kulipa madeni yote yaliyochelewa",
@@ -3735,7 +3748,10 @@
       "Submitted Date": "Tarehe ya kuwasilisha",
       "No Ext": "Na. nje",
       "No Int": "Na. ndani",
-      "Age of the business": "Umri wa biashara"
+      "Age of the business": "Umri wa biashara",
+      "Written Off Amount": "Kiasi kilichofutwa",
+      "Total Recovered": "Jumla iliyorejeshwa",
+      "Pending Recovery": "Kinachosalia kurejeshwa"
     },
     "links": {
       "Community": "Jumuiya",
@@ -4958,7 +4974,9 @@
       "Person PEP PLD Question 3": "Je, una uhusiano wa kifamilia (2) na mwanahisa, mfanyakazi au afisa wa taasisi?",
       "the contents of": "maudhui ya",
       "the": "vipengee",
-      "items selected of": "vilivyochaguliwa vya"
+      "items selected of": "vilivyochaguliwa vya",
+      "Recovery Completed": "Urejeshaji umekamilika",
+      "Recovery Payment Description": "Husajili fedha zilizokusanywa baada ya kufuta deni. Mkopo unabaki umefungwa na salio lake linabaki sifuri; kinachobadilika ni jumla iliyorejeshwa pekee."
     },
     "permissions": {
       "actions": {
@@ -5591,7 +5609,9 @@
     "Withdraw": "Kutoa",
     "Yes": "Ndiyo",
     "loan product will be active and available to clients": "Tarehe ambayo bidhaa ya mkopo itaanza kutumika na inapatikana kwa wateja. Ikiwa tupu, bidhaa ya mkopo itaanza kutumika mara tu itakapoundwa.",
-    "loan product will become inactive and unavailable to clients": "Tarehe ambayo bidhaa ya mkopo itaacha kutumika na haitapatikana kwa wateja. Ikiwa tupu, bidhaa ya kupakia haitafanya kazi kamwe."
+    "loan product will become inactive and unavailable to clients": "Tarehe ambayo bidhaa ya mkopo itaacha kutumika na haitapatikana kwa wateja. Ikiwa tupu, bidhaa ya kupakia haitafanya kazi kamwe.",
+    "Nothing left to recover": "Hakuna kilichosalia kurejeshwa katika mkopo huu.",
+    "Reverse the recovery payments first": "Kufuta deni hakuwezi kutenguliwa wakati mkopo una malipo ya urejeshaji. Tengua malipo hayo kwanza."
   },
   "countries": {
     "AF": "Afghanistani",


### PR DESCRIPTION
## Description

Add the Recovery Payment action to written-off Working Capital loans, posting to POST /working-capital-loans/{id}/transactions?command=recoveryPayment with an amount capped by the template's remaining recoverable balance, optional payment details, note and external id. Show a recovery panel and a write-off banner with recovered vs. still recoverable figures, badge recovery transactions apart from repayments, and disable (with tooltip) Recovery Payment when nothing is left and Undo Write-off once money has been recovered. Includes translation keys for the 13 locales.

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added recovery tracking for written-off working-capital loans, including totals, outstanding balances, progress, and write-off breakdowns.
  - Added recovery payment forms with validation, payment details, notes, and external IDs.
  - Added context-specific recovery actions and a written-off loan banner with status, date, and reason.
  - Added recovery transaction badges and visual indicators.
  - Added localized recovery labels, guidance, and validation messages.

- **Bug Fixes**
  - Improved recovery payment error messages and transaction identification.
  - Disabled unavailable recovery and write-off reversal actions.
  - Improved accessibility for disabled actions and loan navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->