### PR TITLE
docs: link the Copilot documentation from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Mifos® X Web App is a modern single-page application (SPA) built on top of the 
 - [Production Mode](#production-mode)
 - [Interbank Transfer Menu](#interbank-transfer-menu)
 - [Role-Based Access Control](#role-based-access-control-rbac)
+- [Mifos Copilot](#mifos-copilot)
 - [Releases](#releases)
 - [Contributing](#contributing)
 - [Related Projects](#related-projects)
@@ -577,6 +578,27 @@ Set `MIFOS_PRODUCTION_MODE_ENABLE_RBAC=true` to activate permission-based UI con
 - **KYC Officer**: Client identity verification
 - **PLD Officer (AML)**: Anti-money laundering monitoring
 - **Product Owner**: Product and system configuration
+
+## Mifos Copilot
+
+Mifos Copilot is an AI assistant panel inside the web app. An officer types what they need in
+plain language, and the Copilot finds clients, reads repayment schedules, and submits, approves
+and disburses loans. Anything that changes a record pauses first: the reply stops and shows a
+confirmation card naming the client, the product and the amount, and nothing runs until a human
+approves it.
+
+The web app never holds an LLM key and never calls a model directly. It talks only to the
+Copilot Gateway, which keeps the key server-side and runs every banking action with the
+logged-in officer's own Fineract credential, so existing permissions and the audit trail still
+apply.
+
+- **[Copilot Gateway documentation](https://github.com/openMF/mcp-mifosx/blob/main/gateway/README.md)** covers how it works, the tools it can use, the confirmation flow, and how to run and deploy the gateway.
+- **[Gateway repository](https://github.com/openMF/mcp-mifosx)** is where the gateway lives.
+- [Mifos Copilot Settings](#mifos-copilot-settings) lists the two environment variables that turn the panel on and point it at a gateway.
+
+The panel is off by default. With `MIFOS_COPILOT_MCP_BASE_URL` empty it answers from built-in
+mock responses and contacts no server, which is enough for demos and UI work without running a
+gateway.
 
 ## Releases
 


### PR DESCRIPTION
Requested by @victor-romero: the README's only link for the Copilot points at its two environment variables, and nothing points at the documentation.

## The problem

`Configuration Options > Mifos Copilot Settings` lists `MIFOS_ENABLE_COPILOT` and `MIFOS_COPILOT_MCP_BASE_URL`, and that is the whole of it. Someone reading the README can switch the panel on without learning what it does, that a gateway has to be running for it to do anything real, or that writes pause for a human confirmation.

Meanwhile the gateway carries a full README in openMF/mcp-mifosx and the web app never links to it.

## The change

One new `## Mifos Copilot` section before `Releases`, linking:

- the [Copilot Gateway documentation](https://github.com/openMF/mcp-mifosx/blob/main/gateway/README.md), which covers the tools, the confirmation flow, and running and deploying the gateway
- the [gateway repository](https://github.com/openMF/mcp-mifosx)
- the existing settings section, so the two are connected in both directions

It also states the two things a reader most needs to know up front: every write pauses for an explicit human approval, and the web app never holds an LLM key or calls a model directly, because it talks only to the gateway, which acts with the officer's own Fineract credential.

## Scope

Additions only, 22 lines. No existing text is modified. The one edit outside the new section is its line in the table of contents, which lists every other top-level section.

Both links checked and returning 200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Mifos Copilot to the documentation table of contents.
  * Documented AI assistant capabilities and confirmation requirements for record-changing actions.
  * Added details about gateway-only architecture, configuration, related documentation, and mock responses when no gateway is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->