### PR TITLE
WEB-657: Working Capital - View transaction

### DIFF
--- a/src/app/loans/loans-view/_loan-tab-shared.scss
+++ b/src/app/loans/loans-view/_loan-tab-shared.scss
@@ -55,6 +55,81 @@
   --ch-zero: #6a8fad;
 }
 
+/* ── Transaction-type tokens (transactions list + detail) ──── */
+@mixin transaction-type-tokens {
+  :host {
+    --tx-repayment: var(--ch-paid);
+    --tx-repayment-bg: var(--ch-paid-bg);
+    --tx-disbursement: var(--ch-blue-700);
+    --tx-disbursement-bg: var(--ch-blue-50);
+    --tx-accrual: var(--ch-text-3);
+    --tx-accrual-bg: var(--ch-surface-h);
+    --tx-reversed: var(--ch-alert);
+    --tx-reversed-bg: var(--ch-alert-bg);
+    --tx-downpayment: #6a1b9a;
+    --tx-downpayment-bg: #f3e5f5;
+    --tx-chargeoff: var(--ch-partial);
+    --tx-chargeoff-bg: var(--ch-partial-bg);
+    --tx-reage: #283593;
+    --tx-reage-bg: #e8eaf6;
+    --tx-reamortize: #00695c;
+    --tx-reamortize-bg: #e0f2f1;
+    --tx-discount: #5d4037;
+    --tx-discount-bg: #efebe9;
+    --tx-linked: var(--ch-paid);
+    --tx-linked-bg: var(--ch-paid-bg);
+  }
+
+  :host-context(.dark-theme) {
+    --tx-downpayment: #ce93d8;
+    --tx-downpayment-bg: #1a0a26;
+    --tx-reage: #9fa8da;
+    --tx-reage-bg: #0d1230;
+    --tx-reamortize: #80cbc4;
+    --tx-reamortize-bg: #002f2b;
+    --tx-discount: #bcaaa4;
+    --tx-discount-bg: #231613;
+  }
+}
+
+/* ── Transaction-type badges (same system as charges-tab) ──── */
+$transaction-type-keys:
+  'repayment', 'disbursement', 'accrual', 'reversed', 'downpayment', 'chargeoff', 'reage', 'reamortize', 'discount',
+  'linked';
+
+@mixin transaction-badges {
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 9px;
+    border-radius: 20px;
+    font-size: 11px;
+    font-weight: 600;
+    border: 1px solid transparent;
+    white-space: nowrap;
+
+    .badge-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+  }
+
+  @each $key in $transaction-type-keys {
+    .badge-#{$key} {
+      background: var(--tx-#{$key}-bg);
+      color: var(--tx-#{$key});
+      border-color: var(--tx-#{$key});
+
+      .badge-dot {
+        background: var(--tx-#{$key});
+      }
+    }
+  }
+}
+
 /* ── Reusable layout mixins ────────────────────────────────── */
 @mixin card-container {
   border: 1px solid var(--ch-border);

--- a/src/app/loans/loans-view/loan-transaction-type.helper.ts
+++ b/src/app/loans/loans-view/loan-transaction-type.helper.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { LoanTransactionType } from 'app/loans/models/loan-transaction-type.model';
+
+/**
+ * Transaction-type classification shared by the transactions list and the
+ * transaction detail view so both style the same type the same way.
+ * Code-based matches back up the boolean flags because Working Capital
+ * responses do not always send them.
+ */
+
+export function isCapitalizedIncomeAmortizationTransaction(transactionType: LoanTransactionType): boolean {
+  return (
+    transactionType.capitalizedIncomeAmortization ||
+    transactionType.capitalizedIncomeAmortizationAdjustment ||
+    transactionType.code === 'loanTransactionType.capitalizedIncomeAmortization' ||
+    transactionType.code === 'loanTransactionType.capitalizedIncomeAmortizationAdjustment'
+  );
+}
+
+export function isBuyDownFeeAmortizationTransaction(transactionType: LoanTransactionType): boolean {
+  return (
+    transactionType.buyDownFeeAmortizationAdjustment ||
+    transactionType.code === 'loanTransactionType.buyDownFeeAmortization' ||
+    transactionType.code === 'loanTransactionType.buyDownFeeAmortizationAdjustment'
+  );
+}
+
+export function isDiscountFeeAmortizationTransaction(transactionType: LoanTransactionType): boolean {
+  return (
+    transactionType.code === 'loanTransactionType.discountFeeAmortization' ||
+    transactionType.code === 'loanTransactionType.discountFeeAmortizationAdjustment'
+  );
+}
+
+/** Accrual itself plus the amortization types that are accrual-like activity. */
+export function isAccrualKindTransaction(transactionType: LoanTransactionType): boolean {
+  return (
+    transactionType.accrual ||
+    transactionType.code === 'loanTransactionType.overdueCharge' ||
+    isCapitalizedIncomeAmortizationTransaction(transactionType) ||
+    isBuyDownFeeAmortizationTransaction(transactionType) ||
+    isDiscountFeeAmortizationTransaction(transactionType)
+  );
+}
+
+/**
+ * Discount Fee and its adjustment share one visual identity; the amortization
+ * members of the family style as accrual instead.
+ */
+export function isDiscountFeeKindTransaction(transactionType: LoanTransactionType): boolean {
+  return (
+    transactionType.discountFee ||
+    transactionType.code === 'loanTransactionType.discountFee' ||
+    transactionType.code === 'loanTransactionType.discountFeeAdjustment'
+  );
+}

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.scss
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.scss
@@ -8,36 +8,8 @@
 
 @use '../loan-tab-shared' as shared;
 
-/* ── Component-specific tokens (transaction state) ─────────── */
-:host {
-  --tx-disbursement: var(--ch-blue-700);
-  --tx-disbursement-bg: var(--ch-blue-50);
-  --tx-repayment: var(--ch-paid);
-  --tx-repayment-bg: var(--ch-paid-bg);
-  --tx-accrual: var(--ch-text-3);
-  --tx-accrual-bg: var(--ch-surface-h);
-  --tx-reversed: var(--ch-alert);
-  --tx-reversed-bg: var(--ch-alert-bg);
-  --tx-downpayment: #6a1b9a;
-  --tx-downpayment-bg: #f3e5f5;
-  --tx-chargeoff: var(--ch-partial);
-  --tx-chargeoff-bg: var(--ch-partial-bg);
-  --tx-reage: #283593;
-  --tx-reage-bg: #e8eaf6;
-  --tx-reamortize: #00695c;
-  --tx-reamortize-bg: #e0f2f1;
-  --tx-linked: var(--ch-paid);
-  --tx-linked-bg: var(--ch-paid-bg);
-}
-
-:host-context(.dark-theme) {
-  --tx-downpayment: #ce93d8;
-  --tx-downpayment-bg: #1a0a26;
-  --tx-reage: #9fa8da;
-  --tx-reage-bg: #0d1230;
-  --tx-reamortize: #80cbc4;
-  --tx-reamortize-bg: #002f2b;
-}
+/* ── Transaction-type tokens (shared with view-transaction) ── */
+@include shared.transaction-type-tokens;
 
 .transactions-container {
   @include shared.card-container;
@@ -193,6 +165,10 @@
     border-left: 3px solid var(--tx-linked);
   }
 
+  .row-discount .mat-mdc-cell:first-child {
+    border-left: 3px solid var(--tx-discount);
+  }
+
   /* Paginator */
   .mat-mdc-paginator {
     background: var(--ch-surface-h);
@@ -229,115 +205,8 @@
   color: var(--ch-text-2);
 }
 
-/* ── Transaction type badges (same system as charges-tab) ────── */
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 3px 9px;
-  border-radius: 20px;
-  font-size: 11px;
-  font-weight: 600;
-  border: 1px solid transparent;
-  white-space: nowrap;
-
-  .badge-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-}
-
-.badge-disbursement {
-  background: var(--tx-disbursement-bg);
-  color: var(--tx-disbursement);
-  border-color: var(--tx-disbursement);
-
-  .badge-dot {
-    background: var(--tx-disbursement);
-  }
-}
-
-.badge-repayment {
-  background: var(--tx-repayment-bg);
-  color: var(--tx-repayment);
-  border-color: var(--tx-repayment);
-
-  .badge-dot {
-    background: var(--tx-repayment);
-  }
-}
-
-.badge-accrual {
-  background: var(--tx-accrual-bg);
-  color: var(--tx-accrual);
-  border-color: var(--tx-accrual);
-
-  .badge-dot {
-    background: var(--tx-accrual);
-  }
-}
-
-.badge-reversed {
-  background: var(--tx-reversed-bg);
-  color: var(--tx-reversed);
-  border-color: var(--tx-reversed);
-
-  .badge-dot {
-    background: var(--tx-reversed);
-  }
-}
-
-.badge-downpayment {
-  background: var(--tx-downpayment-bg);
-  color: var(--tx-downpayment);
-  border-color: var(--tx-downpayment);
-
-  .badge-dot {
-    background: var(--tx-downpayment);
-  }
-}
-
-.badge-chargeoff {
-  background: var(--tx-chargeoff-bg);
-  color: var(--tx-chargeoff);
-  border-color: var(--tx-chargeoff);
-
-  .badge-dot {
-    background: var(--tx-chargeoff);
-  }
-}
-
-.badge-reage {
-  background: var(--tx-reage-bg);
-  color: var(--tx-reage);
-  border-color: var(--tx-reage);
-
-  .badge-dot {
-    background: var(--tx-reage);
-  }
-}
-
-.badge-reamortize {
-  background: var(--tx-reamortize-bg);
-  color: var(--tx-reamortize);
-  border-color: var(--tx-reamortize);
-
-  .badge-dot {
-    background: var(--tx-reamortize);
-  }
-}
-
-.badge-linked {
-  background: var(--tx-linked-bg);
-  color: var(--tx-linked);
-  border-color: var(--tx-linked);
-
-  .badge-dot {
-    background: var(--tx-linked);
-  }
-}
+/* ── Transaction type badges (shared with view-transaction) ──── */
+@include shared.transaction-badges;
 
 /* ── Monospace amounts (mirrors charges-tab .mono) ───────────── */
 .mono {

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
@@ -60,6 +60,7 @@ import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { FormatNumberPipe } from '../../../pipes/format-number.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { LoanProductBaseComponent } from 'app/products/loan-products/common/loan-product-base.component';
+import { isAccrualKindTransaction, isDiscountFeeKindTransaction } from '../loan-transaction-type.helper';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
@@ -317,6 +318,9 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
    * BUY_DOWN_FEE_ADJUSTMENT:41
    * BUY_DOWN_FEE_AMORTIZATION:42
    * DISCOUNT_FEE:44
+   * DISCOUNT_FEE_AMORTIZATION:45
+   * DISCOUNT_FEE_ADJUSTMENT:46
+   * DISCOUNT_FEE_AMORTIZATION_ADJUSTMENT:47
    */
   showTransaction(transactionsData: LoanTransaction): boolean {
     return [
@@ -343,7 +347,10 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
       40,
       41,
       42,
-      44
+      44,
+      45,
+      46,
+      47
     ].includes(transactionsData.type.id);
   }
 
@@ -372,6 +379,7 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
     if (this.isChargeOff(transaction.type)) return 'badge-chargeoff';
     if (this.isReAge(transaction.type)) return 'badge-reage';
     if (this.isReAmortize(transaction.type)) return 'badge-reamortize';
+    if (isDiscountFeeKindTransaction(transaction.type)) return 'badge-discount';
     if (transaction.transactionRelations?.length > 0) return 'badge-linked';
     return 'badge-repayment';
   }
@@ -422,6 +430,9 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
     }
     if (this.isReAmortize(transaction.type)) {
       return 'row-reamortize';
+    }
+    if (isDiscountFeeKindTransaction(transaction.type)) {
+      return 'row-discount';
     }
     if (transaction.transactionRelations && transaction.transactionRelations.length > 0) {
       return 'row-linked';
@@ -565,10 +576,6 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
     });
   }
 
-  private isAccrual(transactionType: LoanTransactionType): boolean {
-    return transactionType.accrual || transactionType.code === 'loanTransactionType.overdueCharge';
-  }
-
   private isChargeOff(transactionType: LoanTransactionType): boolean {
     return transactionType.chargeoff || transactionType.code === 'loanTransactionType.chargeOff';
   }
@@ -593,26 +600,8 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
     return transactionType.capitalizedIncome || transactionType.code === 'loanTransactionType.capitalizedIncome';
   }
 
-  private isBuyDownFeeAmortization(transactionType: LoanTransactionType): boolean {
-    return (
-      transactionType.buyDownFeeAmortizationAdjustment ||
-      transactionType.code === 'loanTransactionType.buyDownFeeAmortizationAdjustment'
-    );
-  }
-
   private isAccrualKindOf(transactionType: LoanTransactionType): boolean {
-    return (
-      this.isAccrual(transactionType) ||
-      this.isCapitalizedIncomeAmortization(transactionType) ||
-      this.isBuyDownFeeAmortization(transactionType)
-    );
-  }
-
-  private isCapitalizedIncomeAmortization(transactionType: LoanTransactionType): boolean {
-    return (
-      transactionType.capitalizedIncomeAmortization ||
-      transactionType.code === 'loanTransactionType.capitalizedIncomeAmortization'
-    );
+    return isAccrualKindTransaction(transactionType);
   }
 
   private isReAgoeOrReAmortize(transactionType: LoanTransactionType): boolean {

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.scss
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.scss
@@ -8,66 +8,13 @@
 
 @use 'assets/styles/helper';
 @use 'assets/styles/colours' as *;
+@use '../../loan-tab-shared' as shared;
 
-/* ── Design tokens (mirrors transactions-tab) ────────────────── */
+/* ── Design tokens: --ch-* and --tx-* come from loan-tab-shared ── */
+@include shared.transaction-type-tokens;
+
 :host {
-  --ch-blue-700: #1565c0;
-  --ch-blue-600: #1976d2;
-  --ch-blue-50: #e3f2fd;
-  --ch-surface-h: #ebf2fa;
-  --ch-border: #dde5f0;
-  --ch-text-3: #8fa5bc;
-  --ch-paid: #2e7d32;
-  --ch-paid-bg: #e8f5e9;
-  --ch-partial: #e65100;
-  --ch-partial-bg: #fff3e0;
-  --ch-alert: #c62828;
-  --ch-alert-bg: #ffebee;
   --ch-shadow-sm: 0 2px 8px rgb(13 43 94 / 10%);
-
-  /* Transaction state tokens */
-  --tx-repayment: var(--ch-paid);
-  --tx-repayment-bg: var(--ch-paid-bg);
-  --tx-disbursement: var(--ch-blue-700);
-  --tx-disbursement-bg: var(--ch-blue-50);
-  --tx-accrual: var(--ch-text-3);
-  --tx-accrual-bg: var(--ch-surface-h);
-  --tx-reversed: var(--ch-alert);
-  --tx-reversed-bg: var(--ch-alert-bg);
-  --tx-downpayment: #6a1b9a;
-  --tx-downpayment-bg: #f3e5f5;
-  --tx-chargeoff: var(--ch-partial);
-  --tx-chargeoff-bg: var(--ch-partial-bg);
-  --tx-reage: #283593;
-  --tx-reage-bg: #e8eaf6;
-  --tx-reamortize: #00695c;
-  --tx-reamortize-bg: #e0f2f1;
-  --tx-linked: var(--ch-paid);
-  --tx-linked-bg: var(--ch-paid-bg);
-
-  font-family: 'DM Sans', system-ui, sans-serif;
-  display: block;
-}
-
-/* ── Dark mode ───────────────────────────────────────────────── */
-:host-context(.dark-theme) {
-  --ch-blue-700: #5b9bd5;
-  --ch-blue-50: #0a2040;
-  --ch-surface-h: #132032;
-  --ch-border: #1e3050;
-  --ch-text-3: #6a8fad;
-  --ch-paid: #66bb6a;
-  --ch-paid-bg: #172b1a;
-  --ch-partial: #ffa726;
-  --ch-partial-bg: #281c0b;
-  --ch-alert: #ef9a9a;
-  --ch-alert-bg: #2b1212;
-  --tx-downpayment: #ce93d8;
-  --tx-downpayment-bg: #1a0a26;
-  --tx-reage: #9fa8da;
-  --tx-reage-bg: #0d1230;
-  --tx-reamortize: #80cbc4;
-  --tx-reamortize-bg: #002420;
 }
 
 .container {
@@ -135,6 +82,10 @@
   &.card-tx--linked {
     border-left: 4px solid var(--tx-linked);
   }
+
+  &.card-tx--discount {
+    border-left: 4px solid var(--tx-discount);
+  }
 }
 
 /* ── Transaction header ──────────────────────────────────────── */
@@ -147,115 +98,8 @@
   margin-bottom: 0.25rem;
 }
 
-/* ── Badge system (same as transactions-tab) ─────────────────── */
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 3px 9px;
-  border-radius: 20px;
-  font-size: 11px;
-  font-weight: 600;
-  border: 1px solid transparent;
-  white-space: nowrap;
-
-  .badge-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    flex-shrink: 0;
-  }
-}
-
-.badge-repayment {
-  background: var(--tx-repayment-bg);
-  color: var(--tx-repayment);
-  border-color: var(--tx-repayment);
-
-  .badge-dot {
-    background: var(--tx-repayment);
-  }
-}
-
-.badge-disbursement {
-  background: var(--tx-disbursement-bg);
-  color: var(--tx-disbursement);
-  border-color: var(--tx-disbursement);
-
-  .badge-dot {
-    background: var(--tx-disbursement);
-  }
-}
-
-.badge-accrual {
-  background: var(--tx-accrual-bg);
-  color: var(--tx-accrual);
-  border-color: var(--tx-accrual);
-
-  .badge-dot {
-    background: var(--tx-accrual);
-  }
-}
-
-.badge-reversed {
-  background: var(--tx-reversed-bg);
-  color: var(--tx-reversed);
-  border-color: var(--tx-reversed);
-
-  .badge-dot {
-    background: var(--tx-reversed);
-  }
-}
-
-.badge-downpayment {
-  background: var(--tx-downpayment-bg);
-  color: var(--tx-downpayment);
-  border-color: var(--tx-downpayment);
-
-  .badge-dot {
-    background: var(--tx-downpayment);
-  }
-}
-
-.badge-chargeoff {
-  background: var(--tx-chargeoff-bg);
-  color: var(--tx-chargeoff);
-  border-color: var(--tx-chargeoff);
-
-  .badge-dot {
-    background: var(--tx-chargeoff);
-  }
-}
-
-.badge-reage {
-  background: var(--tx-reage-bg);
-  color: var(--tx-reage);
-  border-color: var(--tx-reage);
-
-  .badge-dot {
-    background: var(--tx-reage);
-  }
-}
-
-.badge-reamortize {
-  background: var(--tx-reamortize-bg);
-  color: var(--tx-reamortize);
-  border-color: var(--tx-reamortize);
-
-  .badge-dot {
-    background: var(--tx-reamortize);
-  }
-}
-
-.badge-linked {
-  background: var(--tx-linked-bg);
-  color: var(--tx-linked);
-  border-color: var(--tx-linked);
-
-  .badge-dot {
-    background: var(--tx-linked);
-  }
-}
+/* ── Badge system (shared with transactions-tab) ─────────────── */
+@include shared.transaction-badges;
 
 /* ── Status pill (reversed / linked state override) ──────────── */
 .txn-status-pill {

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
@@ -50,6 +50,7 @@ import { TransactionPaymentDetailComponent } from '../../../../shared/transactio
 import { DateFormatPipe } from '../../../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { LoanAccountActionsBaseComponent } from '../../loan-account-actions/loan-account-actions-base.component';
+import { isAccrualKindTransaction, isDiscountFeeKindTransaction } from '../../loan-transaction-type.helper';
 
 /** Custom Dialogs */
 
@@ -448,12 +449,13 @@ export class ViewTransactionComponent extends LoanAccountActionsBaseComponent im
     if (!this.transactionType) return 'badge-repayment';
     const t = this.transactionType;
     if (this.transactionData.manuallyReversed || this.transactionData.reversed) return 'badge-reversed';
-    if (t.accrual || t.code === 'loanTransactionType.overdueCharge') return 'badge-accrual';
+    if (isAccrualKindTransaction(t)) return 'badge-accrual';
     if (t.disbursement) return 'badge-disbursement';
     if (t.downPayment || t.code === 'loanTransactionType.downPayment') return 'badge-downpayment';
     if (t.chargeoff || t.code === 'loanTransactionType.chargeOff') return 'badge-chargeoff';
     if (t.reAge) return 'badge-reage';
     if (t.reAmortize) return 'badge-reamortize';
+    if (isDiscountFeeKindTransaction(t)) return 'badge-discount';
     if (this.existTransactionRelations) return 'badge-linked';
     return 'badge-repayment';
   }
@@ -462,12 +464,13 @@ export class ViewTransactionComponent extends LoanAccountActionsBaseComponent im
     if (!this.transactionType) return 'card-tx--repayment';
     const t = this.transactionType;
     if (this.transactionData.manuallyReversed || this.transactionData.reversed) return 'card-tx--reversed';
-    if (t.accrual || t.code === 'loanTransactionType.overdueCharge') return 'card-tx--accrual';
+    if (isAccrualKindTransaction(t)) return 'card-tx--accrual';
     if (t.disbursement) return 'card-tx--disbursement';
     if (t.downPayment || t.code === 'loanTransactionType.downPayment') return 'card-tx--downpayment';
     if (t.chargeoff || t.code === 'loanTransactionType.chargeOff') return 'card-tx--chargeoff';
     if (t.reAge) return 'card-tx--reage';
     if (t.reAmortize) return 'card-tx--reamortize';
+    if (isDiscountFeeKindTransaction(t)) return 'card-tx--discount';
     if (this.existTransactionRelations) return 'card-tx--linked';
     return 'card-tx--repayment';
   }


### PR DESCRIPTION
## Description

Enable View Transaction for the full Discount Fee family (amortization id 45, adjustment id 46, amortization adjustment id 47) in the loan transactions tab, which the type allowlist previously excluded.

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for viewing and identifying discount-fee transactions (types 44–47).
  * Added dedicated badges, borders, and card styling for discount transactions.
  * Improved classification of accrual, capitalized income, buy-down fee, and discount-fee transactions.
  * Standardized transaction colors and badges across light and dark themes.
* **Bug Fixes**
  * Improved consistency of transaction styling and classification across transaction views.
  * Corrected spacing in undo confirmation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->