### PR TITLE
WEB-657: Add delinquency bucket picker for loan application and modification

### DIFF
--- a/src/app/loans/create-loans-account/create-loans-account.component.ts
+++ b/src/app/loans/create-loans-account/create-loans-account.component.ts
@@ -314,12 +314,19 @@ export class CreateLoansAccountComponent extends LoanProductBaseComponent implem
         delete payload['breachId'];
         delete payload['nearBreachId'];
       }
+      if (
+        !Object.hasOwn(this.productDetails.allowAttributeOverrides, 'delinquencyBucketClassification') ||
+        this.productDetails.allowAttributeOverrides.delinquencyBucketClassification === false
+      ) {
+        delete payload['delinquencyBucketId'];
+      }
     }
 
     // No Empty values to be sent
     [
       'delinquencyGraceDays',
-      'delinquencyStartType'
+      'delinquencyStartType',
+      'delinquencyBucketId'
     ].forEach((attr: string) => {
       if (payload[attr] === null || payload[attr] === '') {
         delete payload[attr];

--- a/src/app/loans/edit-loans-account/edit-loans-account.component.ts
+++ b/src/app/loans/edit-loans-account/edit-loans-account.component.ts
@@ -89,9 +89,11 @@ export class EditLoansAccountComponent extends LoanProductBaseComponent {
           this.loansAccountProductTemplate = data.loansAccountAndTemplate;
         } else if (this.loanProductService.isWorkingCapital) {
           this.loansAccountProductTemplate = data.loansAccountAndTemplate;
+          // The WC loan GET-by-id response has no `client`/`product` objects (they're only populated
+          // on the template-retrieval path) — the ids are the flat `clientId`/`loanProductId` fields.
           this.getWorkingCapitalLoanProductTemplate(
-            this.loansAccountProductTemplate.client.id,
-            this.loansAccountProductTemplate.product.id
+            this.loansAccountProductTemplate.clientId,
+            this.loansAccountProductTemplate.loanProductId
           );
         }
         this.loanProductsBasicDetails = data.loanProductsBasicDetails;
@@ -317,9 +319,22 @@ export class EditLoansAccountComponent extends LoanProductBaseComponent {
       ) {
         delete payload['discount'];
       }
+      if (
+        !Object.hasOwn(this.productDetails.allowAttributeOverrides, 'breach') ||
+        this.productDetails.allowAttributeOverrides.breach === false
+      ) {
+        delete payload['breachId'];
+        delete payload['nearBreachId'];
+      }
+      if (
+        !Object.hasOwn(this.productDetails.allowAttributeOverrides, 'delinquencyBucketClassification') ||
+        this.productDetails.allowAttributeOverrides.delinquencyBucketClassification === false
+      ) {
+        delete payload['delinquencyBucketId'];
+      }
     }
 
-    // No Empty values to be sent
+    // No Empty values to be sent.
     [
       'delinquencyGraceDays',
       'delinquencyStartType'
@@ -328,6 +343,9 @@ export class EditLoansAccountComponent extends LoanProductBaseComponent {
         delete payload[attr];
       }
     });
+    if (payload['delinquencyBucketId'] === '') {
+      payload['delinquencyBucketId'] = null;
+    }
 
     this.loansService
       .updateLoansAccount(this.loanProductService.loanAccountPath, this.loanId, payload)

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
@@ -133,6 +133,13 @@
       </div>
     }
 
+    @if (loansAccount.delinquencyBucketId) {
+      <div class="flex-fill">
+        <span class="flex-30">{{ 'labels.inputs.Delinquency Bucket' | translate }}:</span>
+        <span class="flex-60">{{ getDelinquencyBucket(loansAccount.delinquencyBucketId)?.name }}</span>
+      </div>
+    }
+
     @if (loansAccount.breachId) {
       <div class="flex-fill">
         <span class="flex-30">{{ 'labels.inputs.Breach' | translate }}:</span>

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.ts
@@ -43,7 +43,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { LoanProductBaseComponent } from 'app/products/loan-products/common/loan-product-base.component';
 import { LoanProductBasicDetails } from 'app/loans/models/loan-product.model';
 import { LongTextComponent } from 'app/shared/long-text/long-text.component';
-import { Breach, NearBreach } from 'app/products/loan-products/models/loan-product.model';
+import { Breach, DelinquencyBucket, NearBreach } from 'app/products/loan-products/models/loan-product.model';
 import { BreachDisplayComponent } from 'app/shared/loan/breach-display/breach-display.component';
 import { OptionData, StringEnumOptionData } from 'app/shared/models/option-data.model';
 
@@ -204,6 +204,17 @@ export class LoansAccountPreviewStepComponent extends LoanProductBaseComponent i
       return '';
     }
     return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+  }
+
+  getDelinquencyBucket(delinquencyBucketId: number | null | undefined): DelinquencyBucket | null {
+    if (delinquencyBucketId === null || delinquencyBucketId === undefined) {
+      return null;
+    }
+    return (
+      this.loansAccountProductTemplate.options?.delinquencyBucketOptions?.find(
+        (b: DelinquencyBucket) => b.id === delinquencyBucketId
+      ) || null
+    );
   }
 
   getBreach(breachId: number | null | undefined): Breach | null {

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.html
@@ -102,6 +102,27 @@
       </mat-form-field>
 
       <mat-form-field class="flex-48">
+        <mat-label>{{ 'labels.inputs.Delinquency Bucket' | translate }}</mat-label>
+        <mat-select formControlName="delinquencyBucketId">
+          @for (delinquencyBucket of delinquencyBucketOptions; track delinquencyBucket) {
+            <mat-option [value]="delinquencyBucket.id">
+              {{ delinquencyBucket.name }}
+            </mat-option>
+          }
+        </mat-select>
+        @if (loansAccountTermsForm.controls.delinquencyBucketId && allowAttributeOverridesDelinquencyBucket) {
+          <button
+            matSuffix
+            mat-icon-button
+            aria-label="{{ 'labels.buttons.Clear' | translate }}"
+            (click)="clearProperty($event, 'delinquencyBucketId')"
+          >
+            <fa-icon icon="close" size="md"></fa-icon>
+          </button>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="flex-48">
         <mat-label>{{ 'labels.inputs.Breach' | translate }}</mat-label>
         <mat-select formControlName="breachId" class="breach-id-select" panelClass="breach-select-panel">
           <mat-select-trigger>

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -24,7 +24,12 @@ import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
 import { LoansAccountAddCollateralDialogComponent } from 'app/loans/custom-dialog/loans-account-add-collateral-dialog/loans-account-add-collateral-dialog.component';
 import { LoanProducts } from 'app/products/loan-products/loan-products';
-import { Breach, LoanProduct, NearBreach } from 'app/products/loan-products/models/loan-product.model';
+import {
+  Breach,
+  DelinquencyBucket,
+  LoanProduct,
+  NearBreach
+} from 'app/products/loan-products/models/loan-product.model';
 import { SettingsService } from 'app/settings/settings.service';
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
 import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
@@ -191,9 +196,11 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
   allowAttributeOverrides: any | null = null;
 
   delinquencyStartTypeOptions: StringEnumOptionData[] = [];
+  delinquencyBucketOptions: DelinquencyBucket[] = [];
   breachOptions: Breach[] = [];
   nearBreachOptions: NearBreach[] = [];
   allowAttributeOverridesBreach: boolean = true;
+  allowAttributeOverridesDelinquencyBucket: boolean = true;
 
   constructor() {
     super();
@@ -346,6 +353,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
       this.currency = this.resolveCurrency(this.loansAccountTermsData);
       this.termFrequencyTypeData = this.loansAccountTermsData.options?.periodFrequencyTypeOptions;
       this.delinquencyStartTypeOptions = this.loansAccountTermsData.options?.delinquencyStartTypeOptions;
+      this.delinquencyBucketOptions = this.loansAccountTermsData.options?.delinquencyBucketOptions ?? [];
       this.breachOptions = this.loansAccountTermsData.options?.breachOptions ?? [];
       this.nearBreachOptions = this.loansAccountTermsData.options?.nearBreachOptions ?? [];
       const templateChange = changes['loansAccountProductTemplate'];
@@ -357,14 +365,19 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
       if (this.loanId != null && 'accountNo' in this.loansAccountTemplate) {
         this.loansAccountTermsData = this.loansAccountTemplate;
         this.loansAccountTermsForm.patchValue({
-          discount: this.loansAccountTermsData.discountProposed || this.loansAccountTermsData.discount || '',
+          discount:
+            this.loansAccountTermsData.proposedDiscountFee ||
+            this.loansAccountTermsData.approvedDiscountFee ||
+            this.loansAccountTermsData.discountFee ||
+            '',
           principalAmount: this.loansAccountTermsData.proposedPrincipal,
-          periodPaymentRate: this.loansAccountTermsData.periodPaymentRate,
+          periodPaymentRate: this.loansAccountTermsData.paymentRate,
           totalPaymentVolume: this.loansAccountTermsData.totalPaymentVolume,
           repaymentEvery: this.loansAccountTermsData.repaymentEvery,
           repaymentFrequencyType: this.loansAccountTermsData.repaymentFrequencyType?.id,
           delinquencyGraceDays: this.loansAccountTermsData.delinquencyGraceDays,
           delinquencyStartType: this.loansAccountTermsData.delinquencyStartType?.code,
+          delinquencyBucketId: this.loansAccountTermsData.delinquencyBucket?.id,
           breachId: this.loansAccountTermsData.breach?.id,
           nearBreachId: this.loansAccountTermsData.nearBreach?.id,
           breachGraceDays: this.loansAccountTermsData.breachGraceDays ?? 0
@@ -376,33 +389,60 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
           principalAmount: this.loansAccountTermsData.product.principal,
           delinquencyGraceDays: this.loansAccountTermsData.product.delinquencyGraceDays || '',
           delinquencyStartType: this.loansAccountTermsData.product.delinquencyStartType?.code || '',
+          delinquencyBucketId: this.loansAccountTermsData.product.delinquencyBucket?.id || '',
           breachId: this.loansAccountTermsData.product.breach?.id || '',
           nearBreachId: this.loansAccountTermsData.product.nearBreach?.id || '',
           breachGraceDays: this.loansAccountTermsData.product.breachGraceDays ?? 0
         });
         this.cdr.markForCheck();
       }
-      this.allowAttributeOverrides = this.loansAccountProductTemplate.product.allowAttributeOverrides;
-      if (
-        !this.allowAttributeOverrides.periodPaymentFrequency ||
-        this.allowAttributeOverrides.periodPaymentFrequency === false
-      ) {
-        this.loansAccountTermsForm.controls.repaymentEvery.disable();
-      }
-      if (
-        !this.allowAttributeOverrides.periodPaymentFrequencyType ||
-        this.allowAttributeOverrides.periodPaymentFrequencyType === false
-      ) {
-        this.loansAccountTermsForm.controls.repaymentFrequencyType.disable();
-      }
-      if (!this.allowAttributeOverrides.discountDefault || this.allowAttributeOverrides.discountDefault === false) {
-        this.loansAccountTermsForm.controls.discount.disable();
-      }
-      if (!this.allowAttributeOverrides.breach || this.allowAttributeOverrides.breach === false) {
-        this.allowAttributeOverridesBreach = false;
-        this.loansAccountTermsForm.controls.breachId.disable();
-        this.loansAccountTermsForm.controls.nearBreachId.disable();
-        this.loansAccountTermsForm.controls.breachGraceDays.disable();
+      // On the first change, loansAccountProductTemplate is still the raw account-details response
+      // (no `product`) — the WC template with `product.allowAttributeOverrides` arrives asynchronously
+      // and triggers a second ngOnChanges once loaded.
+      if (this.loansAccountProductTemplate.product) {
+        this.allowAttributeOverrides = this.loansAccountProductTemplate.product.allowAttributeOverrides;
+        if (
+          !this.allowAttributeOverrides.periodPaymentFrequency ||
+          this.allowAttributeOverrides.periodPaymentFrequency === false
+        ) {
+          this.loansAccountTermsForm.controls.repaymentEvery.disable();
+        } else {
+          this.loansAccountTermsForm.controls.repaymentEvery.enable();
+        }
+        if (
+          !this.allowAttributeOverrides.periodPaymentFrequencyType ||
+          this.allowAttributeOverrides.periodPaymentFrequencyType === false
+        ) {
+          this.loansAccountTermsForm.controls.repaymentFrequencyType.disable();
+        } else {
+          this.loansAccountTermsForm.controls.repaymentFrequencyType.enable();
+        }
+        if (!this.allowAttributeOverrides.discountDefault || this.allowAttributeOverrides.discountDefault === false) {
+          this.loansAccountTermsForm.controls.discount.disable();
+        } else {
+          this.loansAccountTermsForm.controls.discount.enable();
+        }
+        if (
+          !this.allowAttributeOverrides.delinquencyBucketClassification ||
+          this.allowAttributeOverrides.delinquencyBucketClassification === false
+        ) {
+          this.allowAttributeOverridesDelinquencyBucket = false;
+          this.loansAccountTermsForm.controls.delinquencyBucketId.disable();
+        } else {
+          this.allowAttributeOverridesDelinquencyBucket = true;
+          this.loansAccountTermsForm.controls.delinquencyBucketId.enable();
+        }
+        if (!this.allowAttributeOverrides.breach || this.allowAttributeOverrides.breach === false) {
+          this.allowAttributeOverridesBreach = false;
+          this.loansAccountTermsForm.controls.breachId.disable();
+          this.loansAccountTermsForm.controls.nearBreachId.disable();
+          this.loansAccountTermsForm.controls.breachGraceDays.disable();
+        } else {
+          this.allowAttributeOverridesBreach = true;
+          this.loansAccountTermsForm.controls.breachId.enable();
+          this.loansAccountTermsForm.controls.nearBreachId.enable();
+          this.loansAccountTermsForm.controls.breachGraceDays.enable();
+        }
       }
     }
   }
@@ -490,21 +530,44 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
         );
       }
     } else if (this.loanProductService.isWorkingCapital) {
+      // Editing an existing account: read from the account-specific input, not the product
+      // template — loansAccountProductTemplate is still the raw account response at this point
+      // only by timing coincidence (the async WC template hasn't loaded yet), and once it does
+      // load its `loanData` is blank product-default data for a new loan, not this account's values.
+      const isEditingAccount = this.loanId != null && this.loansAccountTemplate?.accountNo;
+      if (isEditingAccount) {
+        this.loansAccountTermsData = this.loansAccountTemplate;
+      }
       if (this.loansAccountTermsData) {
+        // Creating a new account: fall back to the product default for anything not yet set.
         this.loansAccountTermsForm.patchValue({
-          principalAmount: this.loansAccountTermsData.principal || this.loansAccountTermsData.product.principal,
+          principalAmount: isEditingAccount
+            ? this.loansAccountTermsData.principal
+            : this.loansAccountTermsData.principal || this.loansAccountTermsData.product?.principal,
           periodPaymentRate: this.loansAccountTermsData.periodPaymentRate,
           repaymentEvery: this.loansAccountTermsData.repaymentEvery,
-          repaymentFrequencyType: this.loansAccountTermsData.repaymentFrequencyType.id,
-          delinquencyGraceDays:
-            this.loansAccountTermsData.delinquencyGraceDays || this.loansAccountTermsData.product.delinquencyGraceDays,
-          delinquencyStartType:
-            this.loansAccountTermsData.delinquencyStartType?.id ||
-            this.loansAccountTermsData.product.delinquencyStartType?.id,
-          breachId: this.loansAccountTermsData.breach?.id || this.loansAccountTermsData.product.breach?.id,
-          nearBreachId: this.loansAccountTermsData.nearBreach?.id || this.loansAccountTermsData.product.nearBreach?.id,
-          breachGraceDays:
-            this.loansAccountTermsData.breachGraceDays ?? this.loansAccountTermsData.product.breachGraceDays ?? ''
+          repaymentFrequencyType: this.loansAccountTermsData.repaymentFrequencyType?.id,
+          delinquencyGraceDays: isEditingAccount
+            ? this.loansAccountTermsData.delinquencyGraceDays
+            : this.loansAccountTermsData.delinquencyGraceDays ||
+              this.loansAccountTermsData.product?.delinquencyGraceDays,
+          delinquencyStartType: isEditingAccount
+            ? this.loansAccountTermsData.delinquencyStartType?.id
+            : this.loansAccountTermsData.delinquencyStartType?.id ||
+              this.loansAccountTermsData.product?.delinquencyStartType?.id,
+          delinquencyBucketId: isEditingAccount
+            ? this.loansAccountTermsData.delinquencyBucket?.id
+            : this.loansAccountTermsData.delinquencyBucket?.id ||
+              this.loansAccountTermsData.product?.delinquencyBucket?.id,
+          breachId: isEditingAccount
+            ? this.loansAccountTermsData.breach?.id
+            : this.loansAccountTermsData.breach?.id || this.loansAccountTermsData.product?.breach?.id,
+          nearBreachId: isEditingAccount
+            ? this.loansAccountTermsData.nearBreach?.id
+            : this.loansAccountTermsData.nearBreach?.id || this.loansAccountTermsData.product?.nearBreach?.id,
+          breachGraceDays: isEditingAccount
+            ? (this.loansAccountTermsData.breachGraceDays ?? '')
+            : (this.loansAccountTermsData.breachGraceDays ?? this.loansAccountTermsData.product?.breachGraceDays ?? '')
         });
       }
     }
@@ -815,6 +878,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
           ]
         ],
         delinquencyStartType: [''],
+        delinquencyBucketId: [''],
         breachId: [''],
         nearBreachId: [''],
         breachGraceDays: ['']
@@ -1021,7 +1085,11 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
   }
 
   clearProperty($event: Event, propertyName: string): void {
-    if (propertyName === 'breachId') {
+    if (propertyName === 'delinquencyBucketId') {
+      this.loansAccountTermsForm.patchValue({
+        delinquencyBucketId: ''
+      });
+    } else if (propertyName === 'breachId') {
       this.loansAccountTermsForm.patchValue({
         breachId: '',
         nearBreachId: '',

--- a/src/app/loans/loans-view/account-details/account-details.component.html
+++ b/src/app/loans/loans-view/account-details/account-details.component.html
@@ -331,6 +331,12 @@
         </div>
         <div class="fact-grid">
           @if (loanProductService.isWorkingCapital) {
+            @if (loanDetails.delinquencyBucket?.name) {
+              <div class="fact">
+                <div class="fact-label">{{ 'labels.inputs.Delinquency Bucket' | translate }}</div>
+                <div class="fact-value">{{ loanDetails.delinquencyBucket.name }}</div>
+              </div>
+            }
             @if (has(loanDetails.breachGraceDays)) {
               <div class="fact">
                 <div class="fact-label">{{ 'labels.inputs.Breach Grace Days' | translate }}</div>

--- a/src/app/loans/loans-view/account-details/account-details.component.ts
+++ b/src/app/loans/loans-view/account-details/account-details.component.ts
@@ -77,6 +77,7 @@ export class AccountDetailsComponent extends LoanProductBaseComponent {
 
   hasWcDelinquencyFacts(): boolean {
     return (
+      !!this.loanDetails.delinquencyBucket?.name ||
       this.has(this.loanDetails.breachGraceDays) ||
       this.has(this.loanDetails.delinquencyGraceDays) ||
       !!this.loanDetails.delinquencyStartType ||


### PR DESCRIPTION
## Description

Previously during WC loan creation the delinquency bucket could not be selected.

<img width="1416" height="1169" alt="loan_creation_no_delinquency" src="https://github.com/user-attachments/assets/6d71a86f-be0e-4f30-a6c3-09b4a9b6c3b7" />

The dedicated "delinquency and breach" section on the account details page didn't show anything about the delinquency bucket either.

<img width="1407" height="1306" alt="loan_details_no_delinquency" src="https://github.com/user-attachments/assets/b8e10040-b18e-4756-b6b1-a42349f32a7f" />

Both have been fixed and Delinquency Bucket shows up correctly for WC loans.

<img width="2514" height="1606" alt="loan_creation_delinquency" src="https://github.com/user-attachments/assets/64ebfbd0-52a0-4432-a0df-693a16db5467" />

<img width="2514" height="1756" alt="loan_summary_delinquency" src="https://github.com/user-attachments/assets/4504cc2c-9128-4a3c-9a8b-d92b7ae9a406" />

<img width="2514" height="1942" alt="loan_details_delinquency" src="https://github.com/user-attachments/assets/0427a50b-9dc4-4967-bc91-4992a13eb18e" />

## Related issues and discussion

#{WEB-657}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Delinquency Bucket selector when creating or editing working-capital loans.
  - Users can clear the selected bucket when permitted.
  - Selected delinquency bucket details now appear in loan previews and account details.
  - New loans use configured product defaults, while edits preserve existing account values.

- **Bug Fixes**
  - Loan submissions and updates now omit delinquency and breach fields when overrides are unavailable, disabled, or empty.
  - Improved handling of delinquency bucket values based on configured permissions and product defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->