### PR TITLE
WEB-657: Working Capital - Avoid Waive Loan Charge

### DIFF
--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.html
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.html
@@ -303,7 +303,7 @@
                     {{ 'labels.buttons.Pay Charge' | translate }}
                   </button>
                 }
-                @if (!charge.actionFlag) {
+                @if (allowWaive(charge)) {
                   <button mat-menu-item (click)="waiveCharge(charge.id)">
                     <mat-icon matMenuItemIcon>check_circle</mat-icon>
                     {{ 'labels.buttons.Waive Charge' | translate }}

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
@@ -157,8 +157,14 @@ export class ChargesTabComponent extends LoanAccountTabBaseComponent implements 
     this.selection.changed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.cdr.detectChanges());
   }
 
+  /** Working Capital loans do not support the waive charge command. */
+  allowWaive(charge: LoanCharge): boolean {
+    return !charge.actionFlag && !this.loanProductService.isWorkingCapital;
+  }
+
   private buildColumns(): void {
-    const hasMultiple = this.chargesData.length > 1;
+    // Selection only exists to bulk-waive, which Working Capital does not support.
+    const hasMultiple = this.chargesData.length > 1 && !this.loanProductService.isWorkingCapital;
     this.displayedColumns = [
       ...(hasMultiple ? ['select'] : []),
       'name',

--- a/src/app/loans/loans-view/view-charge/view-charge.component.ts
+++ b/src/app/loans/loans-view/view-charge/view-charge.component.ts
@@ -82,7 +82,8 @@ export class ViewChargeComponent extends LoanAccountTabBaseComponent {
       .subscribe((data: { loansAccountCharge: any; loanDetailsData: any }) => {
         this.chargeData = data.loansAccountCharge;
         this.allowPayCharge = this.chargeData.chargePayable && !this.chargeData.paid;
-        this.allowWaive = !this.chargeData.chargeTimeType.waived;
+        // Working Capital loans do not support the waive charge command.
+        this.allowWaive = !this.chargeData.chargeTimeType.waived && !this.loanProductService.isWorkingCapital;
         this.loansAccountData = data.loanDetailsData;
       });
   }


### PR DESCRIPTION
## Description

Hide the waive charge action for Working Capital loans, whose charge resource does not support the waive command (the backend rejects it with a 400). The option was reachable from three places and all are now gated by product type: the row actions menu in the charges tab, the bulk "Waive Selected" bar (the selection checkboxes only existed to feed it, so they are removed for WC too), and the Waive button on the charge detail view.

Term loan behavior is unchanged; Adjust Charge and Pay Charge remain available for Working Capital.

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented charge waivers for Working Capital loans.
  * Updated charge actions to display the “Waive Charge” option only when eligible.
  * Disabled charge selection and bulk-waive actions for Working Capital loans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->