### PR TITLE
WEB-657: Working Capital - Modify application

### DIFF
--- a/src/app/core/http/error-handler.interceptor.spec.ts
+++ b/src/app/core/http/error-handler.interceptor.spec.ts
@@ -70,4 +70,16 @@ describe('ErrorHandlerInterceptor', () => {
     intercept('/fineract-provider/api/v1/configurations/name/enable-business-date', 404);
     expect(alert).toHaveBeenCalled();
   });
+
+  it('does not alert when no business date has been set on the instance', () => {
+    // Configuration enabled but the date was never created: the footer falls back to the system date.
+    const result = intercept('/fineract-provider/api/v1/businessdate/BUSINESS_DATE', 404);
+    expect(alert).not.toHaveBeenCalled();
+    expect(result).toBe('errored');
+  });
+
+  it('still alerts when the business date list is missing', () => {
+    intercept('/fineract-provider/api/v1/businessdate', 404);
+    expect(alert).toHaveBeenCalled();
+  });
 });

--- a/src/app/core/http/error-handler.interceptor.ts
+++ b/src/app/core/http/error-handler.interceptor.ts
@@ -126,8 +126,12 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
     const isClientImage404 = status === 404 && request.url.includes('/clients/') && request.url.includes('/images');
     // Analytics dashboard reports that don't exist on this server are silently handled by the data service fallbacks
     const isAnalyticsReport404 = status === 404 && request.url.includes('/runreports/');
+    // A business date exists only once it has been set on this instance, so its absence is a valid
+    // state: the footer falls back to the system date instead of interrupting the user with an
+    // alert. The trailing slash keeps the business date list lookup out of this exception.
+    const isBusinessDate404 = status === 404 && request.method === 'GET' && request.url.includes('/businessdate/');
 
-    if (!environment.production && !isClientImage404 && !isAnalyticsReport404) {
+    if (!environment.production && !isClientImage404 && !isAnalyticsReport404 && !isBusinessDate404) {
       log.error(`Request Error: ${errorMessage}`);
     }
 
@@ -157,7 +161,7 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
         message: errorMessage || this.translate.instant('errors.error.unauthorized.message')
       });
     } else if (status === 404) {
-      if (isClientImage404 || isAnalyticsReport404) {
+      if (isClientImage404 || isAnalyticsReport404 || isBusinessDate404) {
         return throwError(() => response);
       } else {
         this.alertService.alert({

--- a/src/app/loans/edit-loans-account/edit-loans-account.component.ts
+++ b/src/app/loans/edit-loans-account/edit-loans-account.component.ts
@@ -89,11 +89,11 @@ export class EditLoansAccountComponent extends LoanProductBaseComponent {
           this.loansAccountProductTemplate = data.loansAccountAndTemplate;
         } else if (this.loanProductService.isWorkingCapital) {
           this.loansAccountProductTemplate = data.loansAccountAndTemplate;
-          // The WC loan GET-by-id response has no `client`/`product` objects (they're only populated
-          // on the template-retrieval path) — the ids are the flat `clientId`/`loanProductId` fields.
+          // The working capital loan details endpoint serializes the client and product
+          // as flat fields (clientId/loanProductId) instead of nested objects.
           this.getWorkingCapitalLoanProductTemplate(
-            this.loansAccountProductTemplate.clientId,
-            this.loansAccountProductTemplate.loanProductId
+            this.loansAccountProductTemplate.client?.id ?? this.loansAccountProductTemplate.clientId,
+            this.loansAccountProductTemplate.product?.id ?? this.loansAccountProductTemplate.loanProductId
           );
         }
         this.loanProductsBasicDetails = data.loanProductsBasicDetails;
@@ -293,7 +293,7 @@ export class EditLoansAccountComponent extends LoanProductBaseComponent {
     const dateFormat = this.settingsService.dateFormat;
     const payload = {
       ...this.loansAccount,
-      clientId: this.loansAccountProductTemplate.client.id,
+      clientId: this.loansAccountProductTemplate.client?.id ?? this.loansAccountProductTemplate.clientId,
       submittedOnDate: this.dateUtils.formatDate(this.loansAccount.submittedOnDate, dateFormat),
       expectedDisbursementDate: this.dateUtils.formatDate(this.loansAccount.expectedDisbursementDate, dateFormat),
       locale,

--- a/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-details-step/loans-account-details-step.component.ts
@@ -160,9 +160,15 @@ export class LoansAccountDetailsStepComponent extends LoanProductBaseComponent i
         this.originatorCreationEnabled = config?.enabled ?? false;
         this.cdr.markForCheck();
       });
-    this.productList = this.loanProductsBasicDetails
-      ? this.loanProductsBasicDetails.sort(this.commons.dynamicSort('name'))
-      : [];
+    // Modifying an existing account cannot change the product type: term loans and working capital
+    // loans are different backend resources, so only products of the account's own type are offered.
+    const selectableProducts =
+      this.loanId != null
+        ? (this.loanProductsBasicDetails ?? []).filter(
+            (product: LoanProductBasicDetails) => product.productType === this.loanProductService.productType.value
+          )
+        : this.loanProductsBasicDetails;
+    this.productList = selectableProducts ? selectableProducts.sort(this.commons.dynamicSort('name')) : [];
     if (this.loansAccountTemplate) {
       this.addFormControlsBasedOnProductType();
       let loanProductId: number | null = null;

--- a/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-preview-step/loans-account-preview-step.component.html
@@ -506,11 +506,7 @@
     <fa-icon icon="arrow-left" class="m-r-10"></fa-icon>
     {{ 'labels.buttons.Previous' | translate }}
   </button>
-  <button
-    mat-raised-button
-    [routerLink]="['../..']"
-    [queryParams]="{ productType: loanProductService.productType.value }"
-  >
+  <button mat-raised-button [routerLink]="['..']" [queryParams]="{ productType: loanProductService.productType.value }">
     {{ 'labels.buttons.Cancel' | translate }}
   </button>
   <button mat-raised-button color="primary" (click)="submitEvent.emit()">

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.spec.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { SimpleChange } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { SettingsService } from 'app/settings/settings.service';
+import { LoanProductService } from 'app/products/loan-products/services/loan-product.service';
+import { LoansAccountTermsStepComponent } from './loans-account-terms-step.component';
+
+/**
+ * Response of GET /working-capital-loans/{id}?associations=all for an account
+ * submitted with a payment rate of 18% and a proposed discount fee of 50.
+ */
+const WC_LOAN_DETAILS: any = {
+  id: 1,
+  accountNo: '000000001',
+  clientId: 3,
+  loanProductId: 11,
+  status: { id: 100, code: 'loanStatusType.submitted.and.pending.approval', pendingApproval: true },
+  proposedPrincipal: 100,
+  approvedPrincipal: 0,
+  principal: 100,
+  currency: { code: 'EUR', name: 'Euro', decimalPlaces: 2, displaySymbol: '€' },
+  paymentRate: 18,
+  repaymentEvery: 30,
+  repaymentFrequencyType: { id: 'DAYS', code: 'DAYS', value: 'DAYS' },
+  proposedDiscountFee: 50,
+  delinquencyBucket: { id: 2, name: 'WC_DELINQUENCY_BUCKET', ranges: [] },
+  breachGraceDays: 0,
+  breachStartType: { id: '2', code: 'DISBURSEMENT', value: 'Disbursement' },
+  totalPaymentVolume: 360
+};
+
+/**
+ * Response of GET /working-capital-loans/template?clientId&productId, as reshaped by
+ * EditLoansAccountComponent.setTemplate(): the `loanData` payload plus the option lists.
+ */
+const WC_PRODUCT_TEMPLATE: any = {
+  currency: { code: 'EUR', name: 'Euro', decimalPlaces: 2, displaySymbol: '€' },
+  product: {
+    id: 11,
+    name: 'WCLP_ACC_DEF_REV_AM',
+    principal: 1000,
+    allowAttributeOverrides: {
+      periodPaymentFrequency: true,
+      periodPaymentFrequencyType: true,
+      discountDefault: true,
+      delinquencyBucketClassification: true,
+      breach: true
+    }
+  },
+  options: {
+    periodFrequencyTypeOptions: [],
+    delinquencyStartTypeOptions: [],
+    delinquencyBucketOptions: [],
+    breachOptions: [],
+    nearBreachOptions: []
+  }
+};
+
+describe('LoansAccountTermsStepComponent — Working Capital edit mode', () => {
+  let fixture: ComponentFixture<LoansAccountTermsStepComponent>;
+  let component: LoansAccountTermsStepComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoansAccountTermsStepComponent],
+      providers: [
+        { provide: LoanProductService, useValue: { isLoanProduct: false, isWorkingCapital: true } },
+        { provide: Router, useValue: {} },
+        { provide: MatDialog, useValue: {} },
+        { provide: SettingsService, useValue: { maxFutureDate: new Date() } },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { params: { loanId: '1' }, queryParamMap: new Map() } }
+        }
+      ]
+    })
+      .overrideComponent(LoansAccountTermsStepComponent, { set: { template: '', imports: [] } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(LoansAccountTermsStepComponent);
+    component = fixture.componentInstance;
+  });
+
+  /** Angular delivers the resolved account to both inputs before the first ngOnChanges. */
+  function firstChange(): void {
+    component.loansAccountProductTemplate = WC_LOAN_DETAILS;
+    component.loansAccountTemplate = WC_LOAN_DETAILS;
+    component.ngOnChanges({
+      loansAccountProductTemplate: new SimpleChange(undefined, WC_LOAN_DETAILS, true)
+    });
+  }
+
+  /** EditLoansAccountComponent.setTemplate() replaces the input once the async template arrives. */
+  function templateArrivesChange(): void {
+    const previous = component.loansAccountProductTemplate;
+    component.loansAccountProductTemplate = WC_PRODUCT_TEMPLATE;
+    component.ngOnChanges({
+      loansAccountProductTemplate: new SimpleChange(previous, WC_PRODUCT_TEMPLATE, false)
+    });
+  }
+
+  function terms() {
+    return component.loansAccountTermsForm.getRawValue();
+  }
+
+  it('fills the form from the account details on the first ngOnChanges', () => {
+    firstChange();
+
+    expect(terms().discount).toBe(50);
+    expect(terms().periodPaymentRate).toBe(18);
+    expect(terms().principalAmount).toBe(100);
+    expect(terms().totalPaymentVolume).toBe(360);
+  });
+
+  it('keeps the values after ngOnInit runs', () => {
+    firstChange();
+    component.ngOnInit();
+
+    expect(terms().discount).toBe(50);
+    expect(terms().periodPaymentRate).toBe(18);
+    expect(terms().totalPaymentVolume).toBe(360);
+  });
+
+  it('keeps the values after the async product template arrives', () => {
+    firstChange();
+    component.ngOnInit();
+    templateArrivesChange();
+
+    expect(terms().discount).toBe(50);
+    expect(terms().periodPaymentRate).toBe(18);
+    expect(terms().totalPaymentVolume).toBe(360);
+  });
+
+  it('keeps the values when the template arrives before ngOnInit', () => {
+    firstChange();
+    templateArrivesChange();
+    component.ngOnInit();
+
+    expect(terms().discount).toBe(50);
+    expect(terms().periodPaymentRate).toBe(18);
+    expect(terms().totalPaymentVolume).toBe(360);
+  });
+});

--- a/src/app/shared/footer/footer.component.ts
+++ b/src/app/shared/footer/footer.component.ts
@@ -142,13 +142,21 @@ export class FooterComponent implements OnInit, OnDestroy {
    * Get the Business Date data
    */
   setBusinessDate(): void {
-    this.systemService.getBusinessDate(SettingsService.businessDateType).subscribe((data: any) => {
-      this.businessDate = new Date(data.date);
-      this.settingsService.setBusinessDate(
-        this.dateUtils.formatDate(this.businessDate, SettingsService.businessDateFormat)
-      );
-      this.isBusinessDateDefined = true;
-      this.cdr.markForCheck();
+    this.systemService.getBusinessDate(SettingsService.businessDateType).subscribe({
+      next: (data: any) => {
+        this.businessDate = new Date(data.date);
+        this.settingsService.setBusinessDate(
+          this.dateUtils.formatDate(this.businessDate, SettingsService.businessDateFormat)
+        );
+        this.isBusinessDateDefined = true;
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        // The configuration is enabled but no business date has been set on this instance yet,
+        // so the footer hides it and the application keeps using the system date.
+        this.isBusinessDateDefined = false;
+        this.cdr.markForCheck();
+      }
     });
   }
 }


### PR DESCRIPTION
## Description

Fix TypeErrors when editing a working capital loan account by handling the flat `clientId`/`loanProductId` fields of the working capital loan details response, which does not include nested `client`/`product` objects.

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots

https://github.com/user-attachments/assets/97c4f275-1474-4a52-be89-3027b14ff08e


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved working-capital loan editing by supporting multiple account response formats.
  * Loan products are now filtered appropriately when editing an existing loan.
  * Fixed Cancel navigation in the loan preview step.
  * Preserved entered discount and payment rate values during working-capital loan editing.
  * Business date retrieval failures no longer trigger unnecessary alerts.
  * The application now handles unavailable business dates more gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->