### PR TITLE
WEB-1181: Add thinking output for the Copilot

### DIFF
--- a/src/app/copilot/components/thinking-trail/thinking-trail.component.html
+++ b/src/app/copilot/components/thinking-trail/thinking-trail.component.html
@@ -20,7 +20,7 @@
       type="button"
       class="trail__summary"
       [attr.aria-expanded]="open"
-      aria-controls="copilot-thinking"
+      [attr.aria-controls]="bodyId"
       (click)="toggle()"
     >
       <svg class="trail__chevron" [class.trail__chevron--open]="open" viewBox="0 0 24 24" aria-hidden="true">
@@ -30,7 +30,7 @@
       <span class="trail__count" *ngIf="elapsed">{{ elapsed }}</span>
     </button>
 
-    <div class="trail__body" id="copilot-thinking" *ngIf="open">
+    <div class="trail__body" [id]="bodyId" *ngIf="open">
       <!-- What it actually did. This is the part that is a record. -->
       <ol class="trail__steps" *ngIf="steps.length">
         <li *ngFor="let step of steps" class="trail__step">

--- a/src/app/copilot/components/thinking-trail/thinking-trail.component.spec.ts
+++ b/src/app/copilot/components/thinking-trail/thinking-trail.component.spec.ts
@@ -130,16 +130,26 @@ describe('ThinkingTrailComponent', () => {
   });
 
   /**
-   * A turn that spent four seconds thinking and eleven waiting on Fineract took fifteen, and
-   * fifteen is the number the officer sat through.
+   * Wall clock, not a sum of the parts. Thinking and a call can overlap, and the answer still
+   * has to stream after both, so adding them up is wrong in both directions at once.
    */
-  it('counts the whole turn, not just the thinking', () => {
+  it('shows the wait the officer actually sat through', () => {
     component.message = reply({
+      turnMs: 15000,
       notesElapsedMs: 4000,
       steps: [{ label: 'Looked up the client', readOnly: true, done: true, durationMs: 11000 }]
     });
 
     expect(component.elapsed).toBe('15s');
+  });
+
+  /** One panel per reply, or aria-controls names several elements at once. */
+  it('gives each reply its own disclosure id', () => {
+    component.message = reply({ id: 'm-7', workingNotes: 'thought' });
+    expect(component.bodyId).toBe('copilot-thinking-m-7');
+
+    component.message = reply({ id: 'm-8', workingNotes: 'thought' });
+    expect(component.bodyId).toBe('copilot-thinking-m-8');
   });
 
   it('says a duration in seconds', () => {

--- a/src/app/copilot/components/thinking-trail/thinking-trail.component.ts
+++ b/src/app/copilot/components/thinking-trail/thinking-trail.component.ts
@@ -45,6 +45,17 @@ export class ThinkingTrailComponent {
 
   open = false;
 
+  /**
+   * The id this disclosure controls, one per reply.
+   *
+   * <p>A conversation renders this component once per answer. A fixed id would put the same one
+   * on every panel, and each aria-controls would then name several elements at once, which is
+   * the situation the attribute exists to avoid.
+   */
+  get bodyId(): string {
+    return `copilot-thinking-${this.message.id}`;
+  }
+
   get steps(): CopilotStep[] {
     return this.message.steps ?? [];
   }
@@ -67,16 +78,15 @@ export class ThinkingTrailComponent {
   }
 
   /**
-   * How long the whole turn took, thinking and calls together.
+   * How long the officer waited, wall clock.
    *
-   * <p>Summed rather than taken from the model's own timer alone, because a turn that spent
-   * four seconds thinking and eleven waiting on Fineract took fifteen, and fifteen is the
-   * number the officer sat through.
+   * <p>Taken from the turn itself rather than summed from its parts. Adding the model's timer
+   * to each call's duration counts any overlap between the two twice and leaves out the time
+   * spent streaming the answer, so the figure could be wrong in both directions at once. What
+   * is wanted here is the wait, and the wait is from when the turn started to when it ended.
    */
   get elapsed(): string {
-    const total =
-      (this.message.notesElapsedMs ?? 0) + this.steps.reduce((sum, step) => sum + (step.durationMs ?? 0), 0);
-    return total > 0 ? this.seconds(total) : '';
+    return this.message.turnMs ? this.seconds(this.message.turnMs) : '';
   }
 
   /**

--- a/src/app/copilot/core/markdown.spec.ts
+++ b/src/app/copilot/core/markdown.spec.ts
@@ -88,6 +88,21 @@ describe('renderMarkdown', () => {
       expect(closed).toContain('&quot;a&quot;');
     });
 
+    /**
+     * A prompt is free text and may mention three backticks. Treating the first later fence as
+     * the close ended the block early and spilled the rest of the prompts into the answer.
+     */
+    it('is not closed early by backticks inside a prompt', () => {
+      const html = render(
+        lines('Here you go.', '```suggest', 'Show me a ```json example', 'List loan products', '```', 'Anything else?')
+      );
+
+      expect(html).not.toContain('List loan products');
+      expect(html).not.toContain('suggest');
+      expect(html).toContain('Here you go.');
+      expect(html).toContain('Anything else?');
+    });
+
     /** A real code block is not a suggest block and must survive untouched. */
     it('leaves other fenced blocks alone', () => {
       const html = render(lines('```json', '{"principal": 5000}', '```'));

--- a/src/app/copilot/core/markdown.ts
+++ b/src/app/copilot/core/markdown.ts
@@ -38,8 +38,9 @@ export function renderMarkdown(markdown: string | null | undefined): string {
  */
 function withoutHalfWrittenMarkup(markdown: string): string {
   const withoutSuggestions = markdown
-    // Closed, and any prompts the gateway sent as an event rather than prose.
-    .replace(/```suggest\s*[\s\S]*?```/gi, '')
+    // Closed. The closing fence has to open a line of its own, or a prompt that itself mentions
+    // three backticks ends the block early and spills the rest of the prompts into the answer.
+    .replace(/```suggest\b[\s\S]*?^[ \t]*```[ \t]*$/gim, '')
     // Opened mid-stream and not closed yet. This is what was on screen.
     .replace(/```suggest[\s\S]*$/i, '')
     // The opener itself, arriving a character at a time.

--- a/src/app/copilot/core/models/chat-message.model.ts
+++ b/src/app/copilot/core/models/chat-message.model.ts
@@ -49,6 +49,13 @@ export interface ChatMessage {
    * of anything, and the panel labels it so.
    */
   workingNotes?: string;
+  /**
+   * How long the whole turn took, from asking to answered.
+   *
+   * <p>Wall clock, not a sum of the parts: thinking and a tool call can overlap, and the answer
+   * still has to stream after both. This is the wait the officer actually sat through.
+   */
+  turnMs?: number;
   /** How long the model spent on those notes. */
   notesElapsedMs?: number;
   /** Client discussed in this message, for the audit trail. */

--- a/src/app/copilot/services/chat.service.ts
+++ b/src/app/copilot/services/chat.service.ts
@@ -95,6 +95,9 @@ export class ChatService {
   /** The last question sent, so a retryable failure can offer to send it again. */
   private lastPrompt: string | null = null;
 
+  /** When the turn in flight began, for the wall-clock duration the panel shows. */
+  private turnStartedAt = 0;
+
   /** Whether conversations are kept on this device, seeded from the officer's last choice. */
   private historyOn = ChatService.readHistoryPreference();
 
@@ -410,6 +413,10 @@ export class ChatService {
 
   private startStream(events: Observable<McpStreamEvent>): void {
     this.isStreaming$.next(true);
+    // Stamped here so the panel can say how long the officer waited. Summing the model's timer
+    // and each call's duration would count any overlap twice and miss the answer streaming
+    // after both, so the turn is measured end to end instead.
+    this.turnStartedAt = Date.now();
     this.pushMessage({
       id: this.nextId(),
       role: 'assistant',
@@ -503,6 +510,7 @@ export class ChatService {
    * is deliberately NOT turned into an approvable card.
    */
   private finalizeDraft(): void {
+    const turnMs = this.turnStartedAt ? Date.now() - this.turnStartedAt : undefined;
     this.updateDraft((draft) => {
       const suggestions = draft.suggestedPrompts?.length
         ? draft.suggestedPrompts
@@ -515,6 +523,7 @@ export class ChatService {
         ...draft,
         content,
         suggestedPrompts: suggestions.length ? suggestions : undefined,
+        turnMs,
         isStreaming: false
       };
     });

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -5935,7 +5935,7 @@
     },
     "trail": {
       "stepsNote": "Estos son los registros que consultó el asistente. La base de cualquier decisión sobre este cliente está en Fineract: las reglas del producto de crédito, el calendario de pagos y la política crediticia de su institución.",
-      "thinking": "Razonamiento",
+      "thinking": "Pensamiento",
       "notesCaution": "Texto de trabajo del propio asistente. No es un registro de cómo se produjo la respuesta, ni una evaluación crediticia. Verifique cada cifra con el expediente del cliente."
     },
     "actions": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -5957,7 +5957,7 @@
     },
     "trail": {
       "stepsNote": "Estos son los registros que consultó el asistente. La base de cualquier decisión sobre este cliente está en Fineract: las reglas del producto de crédito, el calendario de pagos y la política crediticia de su institución.",
-      "thinking": "Razonamiento",
+      "thinking": "Pensamiento",
       "notesCaution": "Texto de trabajo del propio asistente. No es un registro de cómo se produjo la respuesta, ni una evaluación crediticia. Verifique cada cifra con el expediente del cliente."
     },
     "actions": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -5934,7 +5934,7 @@
     },
     "trail": {
       "stepsNote": "Questi sono i record che l'assistente ha letto. La base di qualsiasi decisione su questo cliente è in Fineract: le regole del prodotto di prestito, il piano di rimborso e la politica creditizia del suo istituto.",
-      "thinking": "Ragionamento",
+      "thinking": "Pensiero",
       "notesCaution": "Testo di lavoro dell'assistente. Non è un resoconto di come è stata prodotta la risposta, né una valutazione del credito. Verifichi ogni importo sulla scheda del cliente."
     },
     "actions": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -5933,7 +5933,7 @@
     },
     "trail": {
       "stepsNote": "Estes são os registos que o assistente consultou. A base de qualquer decisão sobre este cliente está no Fineract: as regras do produto de crédito, o plano de reembolso e a política de crédito da sua instituição.",
-      "thinking": "Raciocínio",
+      "thinking": "Pensamento",
       "notesCaution": "Texto de trabalho do próprio assistente. Não é um registo de como a resposta foi produzida, nem uma avaliação de crédito. Verifique cada valor no processo do cliente."
     },
     "actions": {


### PR DESCRIPTION
Follow-up to #3913, which merged before these landed on it. All five came from review on that PR.

## Every panel shared one element id

Each reply renders the disclosure, and its body id was the fixed string `copilot-thinking`. With more than one answer on screen every panel carried the same one, so each `aria-controls` named several elements at once, which is exactly the situation that attribute exists to prevent. Derived from the message id now.

## The duration was neither the thinking nor the turn

It summed the model's timer and each call's duration and called the result the whole turn. It was wrong in both directions at once: thinking and a tool call can overlap, so the overlap was counted twice, and the answer still has to stream after both, so that part was never counted at all.

The service now stamps the turn when it starts and measures it when it ends, so the header shows the wait the officer actually sat through.

## A suggest block could be closed by its own contents

The block ended at the first three backticks that followed it. A prompt is free text and may itself mention three backticks, and when one did, the block closed early and the remaining prompts were rendered straight into the answer:

```
```suggest
Show me a ```json example      <- ended the block here
List loan products             <- this reached the officer
```
```

The closing fence now has to open a line of its own. Regression test added with exactly that content.

## A finished-only tool call lost its duration

A `tool_call` with `phase: finished` and no `started` before it was recorded as a completed step with no `durationMs`, so the step showed no time and the turn read as shorter than it was. That event shape is supported and covered by an existing test, so it was reachable.

## Four locales said Reasoning

The heading is Thinking. Spanish, Portuguese and Italian had it as `Razonamiento`, `Raciocínio` and `Ragionamento`, which all mean *reasoning*.

That is the word this panel deliberately avoids. It asserts the text is *why* the answer came out as it did, and a model's stated thinking frequently is not: measured chain-of-thought faithfulness sits at 25 to 39%, and the BIS Financial Stability Institute has put on record that reasoning models' explanations "do not necessarily reflect how the models actually arrive at their conclusions". In a lending context that is not a distinction worth blurring in translation.

They now say Thinking in their own languages: `Pensamiento`, `Pensamento`, `Pensiero`. French keeps `Réflexion`, which is thinking rather than reasoning; `Raisonnement` would have been the wrong one.

## Testing

168 unit tests, lint and build clean. A test is added for each of the five, including the id derivation and the wall-clock duration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Copilot response timing to show the full request-to-answer duration.
  - Improved disclosure behavior so each thinking trail is uniquely associated with its content.
  - Fixed rendering when suggested prompts contain backticks, preventing prompt text from appearing in answers.

- **Accessibility**
  - Improved screen-reader relationships for Copilot thinking trail disclosures.

- **Translations**
  - Updated the Copilot “thinking” label in Spanish, Italian, and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->