### PR TITLE
WEB-1185: Colour Approve and Reject buttons green and red

### DIFF
--- a/src/app/system/manage-jobs/cob-workflow/loan-locked/loan-locked.component.html
+++ b/src/app/system/manage-jobs/cob-workflow/loan-locked/loan-locked.component.html
@@ -22,7 +22,7 @@
         <div class="flex-60">
           <button
             mat-raised-button
-            color="success"
+            class="mat-success"
             *mifosxHasPermission="'EXECUTE_INLINE_JOB'"
             (click)="runInlineCOB()"
           >

--- a/src/app/system/manage-jobs/cob-workflow/loan-locked/loan-locked.component.scss
+++ b/src/app/system/manage-jobs/cob-workflow/loan-locked/loan-locked.component.scss
@@ -10,16 +10,6 @@
   padding: 1%;
   margin: 1%;
 
-  .mat-raised-button.mat-success {
-    color: #fff;
-    background-color: #32cd32;
-  }
-
-  .mat-raised-button.mat-reject {
-    color: #fff;
-    background-color: #ffa726;
-  }
-
   #search-button {
     height: 2.5rem;
     margin-top: 1rem;

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.scss
@@ -77,22 +77,6 @@
     color: #fff !important;
   }
 
-  .mat-mdc-raised-button.mat-success,
-  .mat-mdc-raised-button.mat-reject {
-    color: #232323;
-    background-color: #fff;
-    box-shadow:
-      0 2px 2px 0 rgb(0 0 0 / 14%),
-      0 1px 5px 0 rgb(0 0 0 / 12%),
-      0 3px 1px -2px rgb(0 0 0 / 20%);
-  }
-
-  :host-context(.dark-theme) .mat-mdc-raised-button.mat-success,
-  :host-context(.dark-theme) .mat-mdc-raised-button.mat-reject {
-    background-color: #424242;
-    color: #fff;
-  }
-
   .tasks-action-btn {
     margin: 0;
   }

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/client-approval/client-approval.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/client-approval/client-approval.component.html
@@ -19,10 +19,9 @@
       </mat-form-field>
       <button
         mat-raised-button
-        color="success"
         *mifosxHasPermission="'ACTIVATE_CLIENT'"
         (click)="approveClients()"
-        class="tasks-action-btn"
+        class="tasks-action-btn mat-success"
       >
         <fa-icon icon="check" class="m-r-10"></fa-icon>{{ 'labels.buttons.Approve' | translate }}
       </button>

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/client-approval/client-approval.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/client-approval/client-approval.component.scss
@@ -38,11 +38,6 @@
     min-height: 48px;
   }
 
-  .mat-raised-button.mat-success {
-    color: #fff;
-    background-color: #008000ab;
-  }
-
   .view-details {
     cursor: pointer;
   }

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/council-approval/council-approval.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/council-approval/council-approval.component.html
@@ -18,10 +18,9 @@
       </mat-form-field>
       <button
         mat-raised-button
-        color="success"
         *mifosxHasPermission="['APPROVE_LOAN', 'APPROVE_LOAN_CHECKER']"
         (click)="approveLoan()"
-        class="tasks-action-btn"
+        class="tasks-action-btn mat-success"
       >
         <fa-icon icon="check" class="m-r-10"></fa-icon>{{ 'labels.buttons.Approve' | translate }}
       </button>

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/council-approval/council-approval.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/council-approval/council-approval.component.scss
@@ -38,11 +38,6 @@
     min-height: 48px;
   }
 
-  .mat-mdc-raised-button.mat-success {
-    color: #fff;
-    background-color: #008000ab;
-  }
-
   .view-details {
     cursor: pointer;
   }

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component.html
@@ -18,10 +18,9 @@
       </mat-form-field>
       <button
         mat-raised-button
-        color="success"
         *mifosxHasPermission="['APPROVE_LOAN', 'APPROVE_LOAN_CHECKER']"
         (click)="approveLoan()"
-        class="tasks-action-btn"
+        class="tasks-action-btn mat-success"
       >
         <fa-icon icon="check" class="m-r-10"></fa-icon>{{ 'labels.buttons.Approve' | translate }}
       </button>

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component.scss
@@ -38,11 +38,6 @@
     min-height: 48px;
   }
 
-  .mat-raised-button.mat-success {
-    color: #fff;
-    background-color: #008000ab;
-  }
-
   .view-details {
     cursor: pointer;
   }

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component.html
@@ -19,10 +19,9 @@
       </mat-form-field>
       <button
         mat-raised-button
-        color="success"
         *mifosxHasPermission="['APPROVE_LOAN', 'APPROVE_LOAN_CHECKER']"
         (click)="disburseLoan()"
-        class="tasks-action-btn"
+        class="tasks-action-btn mat-success"
       >
         <fa-icon icon="check" class="m-r-10"></fa-icon>{{ 'labels.menus.Disburse' | translate }}
       </button>

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component.scss
@@ -38,11 +38,6 @@
     min-height: 48px;
   }
 
-  .mat-raised-button.mat-success {
-    color: #fff;
-    background-color: #008000ab;
-  }
-
   .view-details {
     cursor: pointer;
   }

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component.html
@@ -19,19 +19,17 @@
       </mat-form-field>
       <button
         mat-raised-button
-        color="success"
         *mifosxHasPermission="'APPROVE_LOANRESCHEDULE'"
         (click)="bulkLoanReschedule('Approve')"
-        class="tasks-action-btn"
+        class="tasks-action-btn mat-success"
       >
         <fa-icon icon="check" class="m-r-10"></fa-icon>{{ 'labels.buttons.Approve' | translate }}
       </button>
       <button
         mat-raised-button
-        color="reject"
         *mifosxHasPermission="'APPROVE_LOANRESCHEDULE'"
         (click)="bulkLoanReschedule('Reject')"
-        class="tasks-action-btn"
+        class="tasks-action-btn mat-reject"
       >
         <fa-icon icon="times" class="m-r-10"></fa-icon>{{ 'labels.buttons.Reject' | translate }}
       </button>

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component.scss
@@ -38,11 +38,6 @@
     min-height: 48px;
   }
 
-  .mat-raised-button.mat-success {
-    color: #fff;
-    background-color: #008000ab;
-  }
-
   .view-details {
     cursor: pointer;
   }

--- a/src/app/tasks/view-checker-inbox/view-checker-inbox.component.html
+++ b/src/app/tasks/view-checker-inbox/view-checker-inbox.component.html
@@ -7,13 +7,13 @@
 -->
 
 <div class="layout-row align-end gap-1percent layout-lt-md-column container m-b-20">
-  <button mat-raised-button color="success" (click)="approveChecker()">
+  <button mat-raised-button class="mat-success" (click)="approveChecker()">
     <fa-icon icon="check" class="m-r-10"></fa-icon>{{ 'labels.buttons.Approve' | translate }}
   </button>
   <button mat-raised-button color="warn" (click)="deleteChecker()">
     <fa-icon icon="trash" class="m-r-10"></fa-icon>{{ 'labels.buttons.Delete' | translate }}
   </button>
-  <button mat-raised-button color="reject" (click)="rejectChecker()">
+  <button mat-raised-button class="mat-reject" (click)="rejectChecker()">
     <fa-icon icon="times" class="m-r-10"></fa-icon>{{ 'labels.buttons.Reject' | translate }}
   </button>
 </div>

--- a/src/app/tasks/view-checker-inbox/view-checker-inbox.component.scss
+++ b/src/app/tasks/view-checker-inbox/view-checker-inbox.component.scss
@@ -28,13 +28,3 @@ span {
 mat-divider {
   margin: 0 0 0.5em;
 }
-
-.mat-raised-button.mat-success {
-  color: #fff;
-  background-color: #008000ab;
-}
-
-.mat-raised-button.mat-reject {
-  color: #fff;
-  background-color: #ffca00;
-}

--- a/src/assets/styles/_design-tokens.scss
+++ b/src/assets/styles/_design-tokens.scss
@@ -37,6 +37,20 @@
   --ds-alert-bg: #ffebee;
   --ds-zero: #b0bec5;
 
+  /* Semantic action colours (button fills)
+
+     Deliberately identical in light and dark theme: these encode the *meaning*
+     of an action, not a surface, so the hue must not shift between themes.
+     Both pass WCAG AA against --ds-action-on-fill (5.13:1 and 5.62:1).
+     Hover and press states come from Material's state layer, so no separate
+     hover fills are needed. Shares hex values with --ds-paid / --ds-alert above
+     by coincidence of palette, not by derivation: those are status *text* that
+     lightens in dark theme, these are action *fills* that must not. Change one
+     without assuming the other follows. */
+  --ds-action-approve: #2e7d32;
+  --ds-action-reject: #c62828;
+  --ds-action-on-fill: #fff;
+
   /* Elevation */
   --ds-shadow-xs: 0 1px 2px rgb(13 43 94 / 6%);
   --ds-shadow-sm: 0 2px 8px rgb(13 43 94 / 10%);

--- a/src/main.scss
+++ b/src/main.scss
@@ -749,6 +749,43 @@ mifosx-notifications-page td {
   margin-right: 4px;
 }
 
+// ===== Semantic action buttons =====
+// Approve / Reject need to be told apart at a glance on maker-checker screens,
+// where the two sit side by side and a mis-click acts on a real loan.
+// These live here rather than in each component because eight had drifted into
+// their own copies. Nine of the eleven blocks removed were already inert: they
+// targeted `.mat-raised-button`, the pre-MDC host class, gone since Material 15.
+// The two in checker-inbox were live and deliberately neutral; replacing them is
+// an intentional part of this change, not cleanup. `color="success"` is not a
+// valid MatButton input either, so the class form below is the only hook left.
+// ---
+// Feed Material's own tokens rather than overriding `background-color`. The
+// component paints its fill from `.mat-mdc-raised-button:not(:disabled)`, which
+// carries the same (0,2,0) specificity as `.mat-mdc-raised-button.mat-success`
+// and is injected into <head> at runtime -- so it lands after this file and wins
+// the tie on any plain background-color override, leaving the colour visible
+// only on hover where the extra pseudo-classes break the tie. Setting the token
+// sidesteps the race entirely and matches how the theme colours `.mat-warn`.
+// Hover, focus, press and disabled then come from Material's own state layers.
+// ---
+// `_loan-product-tokens.scss` reaches the same conclusion for its themed
+// buttons; see the `primary-button` mixin there. Worth folding the two together
+// if a third caller appears.
+.mat-mdc-raised-button.mat-success,
+.mat-mdc-raised-button.mat-reject {
+  --mat-button-protected-label-text-color: var(--ds-action-on-fill);
+  --mat-button-protected-state-layer-color: var(--ds-action-on-fill);
+  --mat-button-protected-ripple-color: color-mix(in srgb, var(--ds-action-on-fill) 12%, transparent);
+}
+
+.mat-mdc-raised-button.mat-success {
+  --mat-button-protected-container-color: var(--ds-action-approve);
+}
+
+.mat-mdc-raised-button.mat-reject {
+  --mat-button-protected-container-color: var(--ds-action-reject);
+}
+
 .full-width-flex {
   display: flex;
   justify-content: flex-start;


### PR DESCRIPTION
## Description

This PR fixes the styling of the Approve, Reject and Disburse buttons across the Checker Inbox and related screens.

Previously, Approve and Reject were rendered with the default neutral button styling. The templates were using color="success" and color="reject", but these are not supported values for Angular Material's MatButton, so they had no effect.

There was also existing SCSS using .mat-raised-button.mat-success. Since the migration to MDC, Angular Material uses .mat-mdc-raised-button, so these selectors were no longer matching the buttons. The SCSS also expected a class while the templates were setting the colour through the color attribute.

### Changes made

-  Added shared semantic action tokens to src/assets/styles/_design-tokens.scss:
      --ds-action-approve
      --ds-action-reject
      --ds-action-on-fill
-  Added global .mat-success and .mat-reject styling in src/main.scss.
-  Used Material's --mat-button-protected-container-color token so the custom colours work correctly with the MDC   button states.
-  Replaced the unsupported color="success" / color="reject" attributes with mat-success / mat-reject classes.
-  Removed the old per-component .mat-raised-button.* styles.
-  Updated the affected Checker Inbox, View Checker Inbox and Loan Locked screens.
-  Kept the existing icons, permissions, click handlers and translated labels unchanged.

## Related issues and discussion

Jira: [WEB-1185](https://mifosforge.jira.com/browse/WEB-1185)

## Screenshots, if any

before:
<img width="1920" height="1112" alt="approvr reject button" src="https://github.com/user-attachments/assets/440b2979-ccc5-4c3a-a1e2-a196d370ac8d" />

after:
<img width="1920" height="1112" alt="button styling resolve" src="https://github.com/user-attachments/assets/ca1be3da-06f2-4698-b7de-3d1e6e099a35" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-1185]: https://mifosforge.jira.com/browse/WEB-1185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized Approve, Reject, Disburse, and COB action button styling across task and workflow screens.
  * Introduced consistent green approval and red rejection colors with readable text and coordinated hover, focus, and ripple states.
  * Improved visual consistency across light and dark themes while preserving existing button actions and permissions.
  * Centralized action color styling for more consistent appearance and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->