### PR TITLE
fix(login): align the header controls with the login card

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -65,11 +65,21 @@
     <!-- Header Controls -->
     <div class="login-header">
       @if (allowServerSwitch()) {
-        <mifosx-server-selector class="header-control" appearance="outline" [showLabel]="false">
+        <mifosx-server-selector
+          class="header-control"
+          appearance="outline"
+          subscriptSizing="dynamic"
+          [showLabel]="false"
+        >
         </mifosx-server-selector>
       }
       <mifosx-theme-toggle class="header-control theme-toggle"></mifosx-theme-toggle>
-      <mifosx-language-selector class="header-control" appearance="outline" [showLabel]="false">
+      <mifosx-language-selector
+        class="header-control"
+        appearance="outline"
+        subscriptSizing="dynamic"
+        [showLabel]="false"
+      >
       </mifosx-language-selector>
     </div>
 

--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -384,12 +384,22 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.75rem 1rem;
   background: transparent;
   flex-shrink: 0; // Safari fix: prevent header from growing
   max-height: 76px; // Safari fix: constrain header height
   flex-wrap: nowrap;
   overflow: hidden;
+
+  // Keep the controls on the same column as the login card content. The box has
+  // to track .login-card exactly: the same side inset as .login-card-container,
+  // the same max-width, and the same horizontal padding as .login-card. Without
+  // this the header fills the panel while the card is capped and centred, so the
+  // two rows drift apart once the panel is wider than the card (viewports above
+  // ~1707px, where 30% of the viewport exceeds 480px + the container padding).
+  width: calc(100% - 2rem); // .login-card-container side padding
+  max-width: 480px; // .login-card max-width
+  margin-inline: auto;
+  padding: 0.75rem 1.5rem; // .login-card horizontal padding
 
   .header-control {
     opacity: 0.8;
@@ -402,6 +412,15 @@
 
   .theme-toggle {
     flex-shrink: 0; // Prevent toggle from growing
+
+    // Both selectors are capped (250px / 100px), so once the row is wider than
+    // they can fill, the leftover would sit as a gap on the right and the
+    // language selector would stop short of the card's right edge. Take up the
+    // slack here so the trailing controls stay flush with the column. The
+    // server selector is behind an @if, and renders empty when the deployment
+    // has a single server, so this must not depend on how many children the
+    // row actually has.
+    margin-inline-start: auto;
   }
 
   // Theme Toggle Button Styles
@@ -723,6 +742,18 @@
 
   .login-header {
     flex-shrink: 0;
+
+    // Card goes full-bleed here: no container padding, no cap, 2rem card padding.
+    width: 100%;
+    max-width: none;
+    padding: 0.75rem 2rem;
+
+    // The card spans the viewport here while the controls stay capped, so the
+    // row has far more slack than it does on desktop. Keep the controls grouped
+    // together rather than pushing the trailing two across the whole screen.
+    .theme-toggle {
+      margin-inline-start: 0;
+    }
   }
 
   .login-card-container {
@@ -791,7 +822,8 @@
   }
 
   .login-header {
-    padding: 0.75rem 1rem;
+    width: calc(100% - 2rem); // .login-card-container side padding
+    padding: 0.75rem 1rem; // .login-card horizontal padding
     gap: 0.25rem;
 
     ::ng-deep mifosx-language-selector {
@@ -880,7 +912,8 @@
 /* stylelint-disable-next-line media-feature-range-notation -- Safari compatibility */
 @media (max-width: 480px) {
   .login-header {
-    padding: 0.5rem 0.75rem;
+    width: calc(100% - 1rem); // .login-card-container side padding
+    padding: 0.5rem 0.875rem; // .login-card horizontal padding
     gap: 0.25rem;
   }
 

--- a/src/app/shared/language-selector/language-selector.component.html
+++ b/src/app/shared/language-selector/language-selector.component.html
@@ -5,7 +5,12 @@
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
-<mat-form-field id="language-selector" [appearance]="appearance" [class.outlined-variant]="appearance === 'outline'">
+<mat-form-field
+  id="language-selector"
+  [appearance]="appearance"
+  [subscriptSizing]="subscriptSizing"
+  [class.outlined-variant]="appearance === 'outline'"
+>
   @if (showLabel) {
     <mat-label>{{ 'labels.inputs.Language' | translate }}</mat-label>
   }

--- a/src/app/shared/language-selector/language-selector.component.ts
+++ b/src/app/shared/language-selector/language-selector.component.ts
@@ -9,6 +9,7 @@
 /** Angular Imports */
 import { ChangeDetectionStrategy, Component, inject, Input } from '@angular/core';
 import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms';
+import { SubscriptSizing } from '@angular/material/form-field';
 
 /** Custom Services */
 import { TranslateService } from '@ngx-translate/core';
@@ -39,6 +40,13 @@ export class LanguageSelectorComponent {
 
   /** Show label in the form field. Defaults to true. */
   @Input() showLabel: boolean = true;
+
+  /**
+   * Whether the hint/error row below the control reserves space when empty.
+   * Defaults to 'fixed', matching Angular Material. Pass 'dynamic' where the
+   * selector sits in a row that has to align with something else.
+   */
+  @Input() subscriptSizing: SubscriptSizing = 'fixed';
 
   /** Language selector form control. */
   languageSelector = new UntypedFormControl();

--- a/src/app/shared/server-selector/server-selector.component.html
+++ b/src/app/shared/server-selector/server-selector.component.html
@@ -7,7 +7,12 @@
 -->
 
 @if (existMoreThanOneServer) {
-  <mat-form-field id="server-selector" [appearance]="appearance" [class.outlined-variant]="appearance === 'outline'">
+  <mat-form-field
+    id="server-selector"
+    [appearance]="appearance"
+    [subscriptSizing]="subscriptSizing"
+    [class.outlined-variant]="appearance === 'outline'"
+  >
     @if (showLabel) {
       <mat-label>{{ 'labels.inputs.Server' | translate }}</mat-label>
     }

--- a/src/app/shared/server-selector/server-selector.component.ts
+++ b/src/app/shared/server-selector/server-selector.component.ts
@@ -13,7 +13,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { UntypedFormBuilder, Validators } from '@angular/forms';
 /** Custom Services */
 import { SettingsService } from 'app/settings/settings.service';
-import { MatFormField, MatLabel, MatPrefix, MatError } from '@angular/material/form-field';
+import { MatFormField, MatLabel, MatPrefix, MatError, SubscriptSizing } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
@@ -41,6 +41,13 @@ export class ServerSelectorComponent implements OnInit {
 
   /** Show label in the form field. Defaults to true. */
   @Input() showLabel: boolean = true;
+
+  /**
+   * Whether the hint/error row below the control reserves space when empty.
+   * Defaults to 'fixed', matching Angular Material. Pass 'dynamic' where the
+   * selector sits in a row that has to align with something else.
+   */
+  @Input() subscriptSizing: SubscriptSizing = 'fixed';
 
   /** Input server. */
   form: any;


### PR DESCRIPTION

## Description

Aligned the header controls with the login card so they share the same content width, horizontal inset, and responsive spacing across screen sizes.
Removed the unused form-field subscript space from the server and language selectors so their height matches the controls they display and the header no longer clips vertically.
Kept the theme toggle aligned with the card edge by allowing it to use the available space when the selectors do not fill the column, while preserving the tablet layout where the card becomes full-width.

These changes keep the header controls visually aligned with the username and password fields and prevent inconsistent spacing or clipping at different viewport sizes.

## Related issues and discussion

https://mifosforge.jira.com/browse/WEB-1187

## Screenshots, if any

before:
<img width="1920" height="1112" alt="login page margin issue" src="https://github.com/user-attachments/assets/6e698a1d-556f-439e-94c2-082b6c8a1bb6" />
after:
<img width="1920" height="1080" alt="login page" src="https://github.com/user-attachments/assets/79f84120-deaa-4bd5-b390-b4e839030ced" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved login page header alignment and sizing across desktop, tablet, and mobile layouts.
  * Refined spacing for header controls, theme toggles, server selectors, and language selectors.
  * Removed unnecessary spacing beneath server and language selection fields.
  * Improved selector alignment by supporting dynamic field spacing where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->