### PR TITLE
WEB-1189: Repair search spec selectors for IME regression test

### DIFF
--- a/src/app/clients/clients.component.spec.ts
+++ b/src/app/clients/clients.component.spec.ts
@@ -116,7 +116,7 @@ describe('ClientsComponent — debounce search', () => {
   });
 
   it('should not search during IME composition but should search on compositionend', () => {
-    const inputEl: HTMLInputElement = fixture.nativeElement.querySelector('input[matInput]');
+    const inputEl: HTMLInputElement = fixture.nativeElement.querySelector('.search input');
 
     inputEl.dispatchEvent(new CompositionEvent('compositionstart'));
     fixture.detectChanges();
@@ -139,7 +139,7 @@ describe('ClientsComponent — debounce search', () => {
 
   it('should not fire debounced search after component is destroyed', () => {
     component.onSearchInput('carol');
-    component.ngOnDestroy();
+    fixture.destroy();
     jest.advanceTimersByTime(DEBOUNCE_MS);
     expect(clientsService.searchByText).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Description

Two tests in `clients.component.spec.ts` fail on committed `dev`, leaving the suite red for everyone.

The spec queries `input[matInput]`, but the client list redesign replaced the `mat-form-field` search box with a plain input. The selector matches nothing, so the test throws on a null element before reaching any assertion — meaning the IME composition behaviour it was written to protect has been uncovered ever since. It now selects the input by its container.

The destroy test called `component.ngOnDestroy()` and expected the pending debounce to be cancelled. Teardown runs through `takeUntilDestroyed(destroyRef)`, which fires on real component destruction, not on a manual lifecycle call, so the test asserted a contract the component never promised. It now uses `fixture.destroy()` to exercise the real path.

Both changes are test-side. No production behaviour is affected.

## Related issues and discussion

# WEB-1189
## Screenshots, if any
NA
## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated client search test coverage to reflect the current search input behavior.
  * Added fixture cleanup when testing cancellation of pending searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->