### PR TITLE
WEB-1188: Prevent Loan account navigation freeze

### DIFF
--- a/src/app/loans/loans-routing.module.ts
+++ b/src/app/loans/loans-routing.module.ts
@@ -42,7 +42,6 @@ import { LoanAccountDashboardComponent } from './loans-view/loan-account-dashboa
 /** Custom Resolvers */
 import { LoanDetailsResolver } from './common-resolvers/loan-details.resolver';
 import { LoanNotesResolver } from './common-resolvers/loan-notes.resolver';
-import { LoanDatatablesResolver } from './common-resolvers/loan-datatables.resolver';
 import { LoanDatatableResolver } from './common-resolvers/loan-datatable.resolver';
 import { LoanActionButtonResolver } from './common-resolvers/loan-action-button.resolver';
 import { LoansAccountTemplateResolver } from './common-resolvers/loans-account-template.resolver';
@@ -63,7 +62,6 @@ import { LoanDelinquencyTagsTabComponent } from './loans-view/loan-delinquency-t
 import { LoanReschedulesResolver } from './common-resolvers/loan-reschedules.resolver';
 import { RescheduleLoanTabComponent } from './loans-view/reschedule-loan-tab/reschedule-loan-tab.component';
 import { AdjustLoanChargeComponent } from './loans-view/loan-account-actions/adjust-loan-charge/adjust-loan-charge.component';
-import { LoanArrearDelinquencyResolver } from './common-resolvers/loan-arrear-delinquency.resolver';
 import { ExternalAssetOwnerTabComponent } from './loans-view/external-asset-owner-tab/external-asset-owner-tab.component';
 import { ExternalAssetOwnerResolver } from './common-resolvers/external-asset-owner.resolver';
 import { ExternalAssetOwnerActiveTransferResolver } from './common-resolvers/external-asset-owner-active-transfer.resolver';
@@ -114,9 +112,7 @@ const routes: Routes = [
         data: { title: 'Loan View', routeParamBreadcrumb: 'loanId' },
         component: LoansViewComponent,
         resolve: {
-          loanDetailsData: LoanDetailsResolver,
-          loanDatatables: LoanDatatablesResolver,
-          loanArrearsDelinquencyConfig: LoanArrearDelinquencyResolver
+          loanDetailsData: LoanDetailsResolver
         },
         children: [
           {
@@ -491,7 +487,6 @@ const routes: Routes = [
   providers: [
     LoanDetailsResolver,
     LoanNotesResolver,
-    LoanDatatablesResolver,
     LoanDatatableResolver,
     LoanDelinquencyTagsResolver,
     LoanActionButtonResolver,

--- a/src/app/loans/loans-view/loans-view.component.spec.ts
+++ b/src/app/loans/loans-view/loans-view.component.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright since 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateService } from '@ngx-translate/core';
+import { BehaviorSubject, of, Subject } from 'rxjs';
+import { ErrorHandlerService } from 'app/core/error-handler/error-handler.service';
+import { LoansService } from 'app/loans/loans.service';
+import { LoanProductService } from 'app/products/loan-products/services/loan-product.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { SystemService } from 'app/system/system.service';
+import { LoansViewComponent } from './loans-view.component';
+
+describe('LoansViewComponent', () => {
+  const loanDetailsData = {
+    loanProductName: 'Test loan',
+    status: { active: false, value: 'Submitted and pending approval' },
+    currency: { code: 'USD' },
+    transactions: [] as any[]
+  };
+
+  let routeData$: BehaviorSubject<any>;
+  let datatables$: Subject<any[]>;
+  let arrearsConfiguration$: Subject<any>;
+  let loansServiceStub: any;
+  let systemServiceStub: any;
+
+  function createComponent(): LoansViewComponent {
+    const routeStub = {
+      data: routeData$,
+      params: new BehaviorSubject({ loanId: '1' }),
+      snapshot: {
+        params: { loanId: '1' },
+        queryParamMap: convertToParamMap({})
+      }
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ActivatedRoute, useValue: routeStub },
+        { provide: LoansService, useValue: loansServiceStub },
+        { provide: SystemService, useValue: systemServiceStub },
+        {
+          provide: LoanProductService,
+          useValue: {
+            isLoanProduct: true,
+            isWorkingCapital: false,
+            initialize: jest.fn()
+          }
+        },
+        { provide: Router, useValue: { url: '/clients/1/loans-accounts/1/general', navigate: jest.fn() } },
+        { provide: TranslateService, useValue: { instant: (key: string) => key } },
+        { provide: SettingsService, useValue: {} },
+        { provide: ErrorHandlerService, useValue: { handleError: jest.fn() } },
+        { provide: MatDialog, useValue: { open: jest.fn() } }
+      ]
+    });
+
+    return TestBed.runInInjectionContext(() => new LoansViewComponent());
+  }
+
+  beforeEach(() => {
+    routeData$ = new BehaviorSubject({ loanDetailsData });
+    datatables$ = new Subject<any[]>();
+    arrearsConfiguration$ = new Subject<any>();
+    loansServiceStub = {
+      getLoanDataTables: jest.fn(() => datatables$),
+      getEntityDataTableChecks: jest.fn(() => of({ pageItems: [] })),
+      saveLoanDisbursementDetailsData: jest.fn()
+    };
+    systemServiceStub = {
+      getConfigurationByName: jest.fn(() => arrearsConfiguration$)
+    };
+  });
+
+  it('does not wait for datatables or the arrears configuration before consuming route-resolved loan details', () => {
+    const component = createComponent();
+
+    expect(component.loanDetailsData).toEqual(loanDetailsData);
+    expect(component.datatablesReady).toBe(false);
+    expect(loansServiceStub.getLoanDataTables).toHaveBeenCalledWith('m_loan');
+    expect(systemServiceStub.getConfigurationByName).toHaveBeenCalledWith('loan-arrears-delinquency-display-data');
+  });
+
+  it('populates deferred datatables and arrears configuration independently when each request completes', () => {
+    const component = createComponent();
+    const datatables = [{ registeredTableName: 'loan_extra' }];
+
+    arrearsConfiguration$.next({ value: 2 });
+
+    expect(component.loanDisplayArrearsDelinquency).toBe(2);
+    expect(component.datatablesReady).toBe(false);
+
+    datatables$.next(datatables);
+
+    expect(component.loanDatatables).toEqual(datatables);
+    expect(component.datatablesReady).toBe(true);
+  });
+});

--- a/src/app/loans/loans-view/loans-view.component.ts
+++ b/src/app/loans/loans-view/loans-view.component.ts
@@ -14,6 +14,7 @@ import { MatDialog } from '@angular/material/dialog';
 
 /** rxjs Imports */
 import { catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 /** Custom Services */
 import { LoansService } from '../loans.service';
@@ -60,6 +61,7 @@ import { StatusLookupPipe } from '@pipes/status-lookup.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { LoanProducts } from 'app/products/loan-products/loan-products';
 import { LoanProductBaseComponent } from 'app/products/loan-products/common/loan-product-base.component';
+import { SystemService } from 'app/system/system.service';
 
 @Component({
   selector: 'mifosx-loans-view',
@@ -99,18 +101,19 @@ export class LoansViewComponent extends LoanProductBaseComponent implements OnIn
   private translateService = inject(TranslateService);
   private settingsService = inject(SettingsService);
   private errorHandler = inject(ErrorHandlerService);
+  private systemService = inject(SystemService);
   dialog = inject(MatDialog);
 
   /** Loan Details Data */
   loanDetailsData: any;
   /** Loan Datatables */
-  loanDatatables: any;
+  loanDatatables: any[] = [];
   /** Whether datatable filtering has completed */
   datatablesReady = false;
   /** Recalculate Interest */
   recalculateInterest: any;
   /** loan Arrears Delinquency config value */
-  loanDisplayArrearsDelinquency: number;
+  loanDisplayArrearsDelinquency = 0;
   /** Status */
   status: string;
   entityType: string;
@@ -135,39 +138,68 @@ export class LoansViewComponent extends LoanProductBaseComponent implements OnIn
     const loansService = this.loansService;
     this.loanProductService.initialize(LoanProductBaseComponent.resolveProductTypeDefault(this.route, 'loan'));
 
-    this.route.data
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((data: { loanDetailsData: any; loanDatatables: any; loanArrearsDelinquencyConfig: any }) => {
-        this.loanDetailsData = data.loanDetailsData;
-        if (!this.loanDetailsData.loanProductName) {
-          this.loanDetailsData.loanProductName = this.loanDetailsData.product?.name;
-        }
-        this.loanDatatables = data.loanDatatables || [];
-        this.loanStatus = this.loanDetailsData.status;
-        this.currency = this.loanDetailsData.currency;
-        if (this.loanProductService.isLoanProduct) {
-          this.loanDisplayArrearsDelinquency = data.loanArrearsDelinquencyConfig.value || 0;
-          this.loanSubStatus = this.loanDetailsData.subStatus === undefined ? null : this.loanDetailsData.subStatus;
-          loansService.saveLoanDisbursementDetailsData(this.loanDetailsData.disbursementDetails);
-          if (this.loanStatus.active) {
-            this.loanDetailsData.transactions.forEach((lt: LoanTransaction) => {
-              if (!lt.manuallyReversed) {
-                if (lt.type.reAge) {
-                  this.loanReAged = true;
-                } else if (lt.type.reAmortize) {
-                  this.loanReAmortized = true;
-                }
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { loanDetailsData: any }) => {
+      this.loanDetailsData = data.loanDetailsData;
+      if (!this.loanDetailsData.loanProductName) {
+        this.loanDetailsData.loanProductName = this.loanDetailsData.product?.name;
+      }
+      this.loanStatus = this.loanDetailsData.status;
+      this.currency = this.loanDetailsData.currency;
+      if (this.loanProductService.isLoanProduct) {
+        this.loanSubStatus = this.loanDetailsData.subStatus === undefined ? null : this.loanDetailsData.subStatus;
+        loansService.saveLoanDisbursementDetailsData(this.loanDetailsData.disbursementDetails);
+        if (this.loanStatus.active) {
+          this.loanDetailsData.transactions.forEach((lt: LoanTransaction) => {
+            if (!lt.manuallyReversed) {
+              if (lt.type.reAge) {
+                this.loanReAged = true;
+              } else if (lt.type.reAmortize) {
+                this.loanReAmortized = true;
               }
-            });
-          }
-          // Filter datatables based on entity datatable checks
+            }
+          });
+        }
+      }
+      this.loadDeferredRouteData();
+      this.setConditionalButtons();
+    });
+    this.loanId = this.route.snapshot.params['loanId'];
+  }
+
+  /**
+   * Loads account metadata that is not required to activate the General route.
+   * This keeps the account header and General tab responsive while the optional
+   * datatable navigation and arrears display configuration are retrieved.
+   */
+  loadDeferredRouteData(): void {
+    this.datatablesReady = false;
+    const appTable = this.loanProductService.isWorkingCapital ? 'm_wc_loan' : 'm_loan';
+
+    this.loansService
+      .getLoanDataTables(appTable)
+      .pipe(
+        catchError(() => of([])),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((loanDatatables: any) => {
+        this.loanDatatables = loanDatatables || [];
+
+        if (this.loanProductService.isLoanProduct) {
           this.filterDatatablesByProduct();
         } else {
           this.datatablesReady = true;
         }
-        this.setConditionalButtons();
       });
-    this.loanId = this.route.snapshot.params['loanId'];
+
+    this.systemService
+      .getConfigurationByName('loan-arrears-delinquency-display-data')
+      .pipe(
+        catchError(() => of({ value: 0 })),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((loanArrearsDelinquencyConfig) => {
+        this.loanDisplayArrearsDelinquency = loanArrearsDelinquencyConfig?.value || 0;
+      });
   }
 
   ngOnInit() {


### PR DESCRIPTION
## Description

Improves Loan account navigation by preventing nonessential datatable and arrears configuration requests from blocking the initial General page load. Loan details remain required for route activation, while supporting data is loaded asynchronously after navigation.

## Related issues and discussion

WEB-1188

## Screenshots, if any


https://github.com/user-attachments/assets/2ab27f93-b7d0-49cc-a25e-cb1fdda70f7f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Loan details now appear without waiting for supplementary table and arrears information to load.
  * Loan tables and arrears/delinquency display settings load independently in the background.
  * Added fallback handling so loan views remain usable when supplementary data cannot be retrieved.

* **Tests**
  * Added coverage for immediate loan detail loading and independent deferred data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->