### PR TITLE
WEB-1194: Make focused input labels readable in dark mode

### DIFF
--- a/src/theme/_dark_content.scss
+++ b/src/theme/_dark_content.scss
@@ -184,6 +184,21 @@ body.dark-theme {
     color: white !important;
   }
 
+  // A focused field is painted with the primary hue, and the dark palette carries the same dark
+  // blue as the light one, so against the dark field surface the label and the underline fall to
+  // about 1.6:1. Lighten the brand hue the way the loan product tokens do for their accent, using
+  // Material's own tokens so the label, the underline and the outlined border all follow.
+  // The tokens have to sit on the field itself: `mat.all-component-colors` emits the same ones on
+  // `.dark-theme`, and being included later it would win a tie there. Screens that supply their own
+  // accent do so through `--lp-accent` on their host, so read that first and fall back to ours.
+  .mat-mdc-form-field {
+    --mifosx-field-focus: #{color-mix(in srgb, var(--brand-primary-100, #5ba2ec) 50%, var(--mat-app-text-color, #fff))};
+    --mat-form-field-filled-focus-label-text-color: var(--lp-accent, var(--mifosx-field-focus));
+    --mat-form-field-filled-focus-active-indicator-color: var(--lp-accent, var(--mifosx-field-focus));
+    --mat-form-field-outlined-focus-label-text-color: var(--lp-accent, var(--mifosx-field-focus));
+    --mat-form-field-outlined-focus-outline-color: var(--lp-accent, var(--mifosx-field-focus));
+  }
+
   // Override Material typography heading colors for dark theme
   h2.mat-h2,
   h3.mat-h3,


### PR DESCRIPTION

## Description
In dark mode, clicking inside an input field makes its label and the line below it turn dark blue on a dark grey field, so they are very hard to see. The contrast is around 1.6:1 where 4.5:1 is expected for text. This happens on every input field in the app, not just one page.

The dark palette in src/theme/_material-palette.scss uses the same blue as the light one (#1074b9), and Material picks that colour for the focused label and the underline.

## Changes Made
- Added an override in src/theme/_dark_content.scss, inside the existing .dark-theme block, to give focused fields a lighter blue.
- Used color-mix on --brand-primary-100 instead of a fixed hex, same as _loan-product-tokens.scss does, so the colour still follows the brand colour if it is changed.
- Set Material's own form field tokens instead of styling the label and line directly. A direct rule had the same specificity as Material's and was losing. The tokens also cover appearance="outline" fields.
- Tokens read var(--lp-accent, ...) first, so loan product screens keep their own accent.

## Related issues and discussion

https://mifosforge.jira.com/browse/WEB-1194

## Screenshots, if any
before:
<img width="1920" height="1028" alt="{CD72A102-B199-4034-AA47-14CA2E9E8258}" src="https://github.com/user-attachments/assets/3ea0f469-23af-43fe-8ca7-e9be18437dc3" />

after:
<img width="1920" height="1080" alt="{F385A4D5-8384-4032-9AC1-B48B19DD1ECF}" src="https://github.com/user-attachments/assets/393081ed-9753-4e4b-a92d-278b4a4e303a" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved dark-theme form fields with clearer focus colors for labels, indicators, and outlines.
  * Enhanced focus visibility while maintaining consistency with the application’s branding and text colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->