### PR TITLE
WEB-1190: Host Classic step components in the Custom/Advanced loan product wizard

### DIFF
--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.html
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.html
@@ -19,6 +19,38 @@
       <ng-template matStepLabel>{{ step.title }}</ng-template>
 
       <div [formGroup]="form" class="step-panel">
+        <!--
+          Classic mode (Custom/Advanced): host Classic's own Details / Currency / Terms / Settings
+          components instead of the config-driven field grid, so the field set, its conditional
+          visibility, its validators and its payload are Classic's by construction. Every other step
+          below is already shared with Classic and needs no branch.
+        -->
+        <ng-container *ngIf="usesClassicSteps && step.classicStep && loanProductsTemplate">
+          <div class="wizard-classic-step">
+            <mifosx-loan-product-details-step
+              *ngIf="step.classicStep === 'details'"
+              [loanProductsTemplate]="loanProductsTemplate"
+            ></mifosx-loan-product-details-step>
+
+            <mifosx-loan-product-currency-step
+              *ngIf="step.classicStep === 'currency'"
+              [loanProductsTemplate]="loanProductsTemplate"
+            ></mifosx-loan-product-currency-step>
+
+            <mifosx-loan-product-terms-step
+              *ngIf="step.classicStep === 'terms'"
+              [loanProductsTemplate]="loanProductsTemplate"
+            ></mifosx-loan-product-terms-step>
+
+            <mifosx-loan-product-settings-step
+              *ngIf="step.classicStep === 'settings'"
+              [loanProductsTemplate]="loanProductsTemplate"
+              [isLinkedToFloatingInterestRates]="floatingRatesMirrorControl"
+              (advancePaymentStrategy)="onClassicAdvancePaymentStrategy($event)"
+            ></mifosx-loan-product-settings-step>
+          </div>
+        </ng-container>
+
         <ng-container *ngIf="step.kind === 'payment-allocation' && loanProductsTemplate">
           <mifosx-loan-product-payment-strategy-step
             [advancedPaymentAllocations]="advancedPaymentAllocations"
@@ -48,7 +80,8 @@
             <mifosx-loan-product-accounting-step
               [loanProductsTemplate]="loanProductsTemplate"
               [accountingRuleData]="accountingRuleData"
-              [loanProductFormValid]="form.valid"
+              [loanProductFormValid]="usesClassicSteps ? classicFormsValid : form.valid"
+              [deferredIncomeRecognition]="deferredIncomeRecognition"
             ></mifosx-loan-product-accounting-step>
           </div>
         </ng-container>
@@ -88,7 +121,8 @@
             step.kind !== 'interest-refund' &&
             step.kind !== 'deferred-income' &&
             step.kind !== 'borrower-cycle' &&
-            step.kind !== 'review'
+            step.kind !== 'review' &&
+            !(usesClassicSteps && step.classicStep)
           "
         >
           <div class="field-grid">
@@ -147,6 +181,12 @@
           </div>
         </ng-container>
 
+        <!--
+          Classic mode reviews through Classic's own preview component, which renders the full
+          `mifosx-loan-product-summary` — charges, payment allocation and the terms tables the
+          wizard's field-driven summary cannot show. Its submit event is the wizard's submit.
+        -->
+        <!-- Shared Review header: identical banner in both modes, sourced through reviewValue(). -->
         <ng-container *ngIf="step.kind === 'review'">
           <div class="review-banner">
             <div>
@@ -175,7 +215,36 @@
               </div>
             </div>
           </div>
+        </ng-container>
 
+        <ng-container *ngIf="step.kind === 'review' && usesClassicSteps">
+          <!--
+            The summary itself waits for a complete product: LoanProductSummaryComponent dereferences
+            it in ngOnChanges and throws on a partial one (which is why Classic hides its whole
+            preview step until then). The STEP stays visible either way, naming what is still missing
+            rather than silently disappearing from the stepper.
+          -->
+          <div class="wizard-classic-review" *ngIf="loanProductsTemplate && classicFormsValid">
+            <mifosx-loan-product-preview-step
+              [loanProductsTemplate]="loanProductsTemplate"
+              [accountingRuleData]="accountingRuleData"
+              [loanProduct]="classicPreviewProduct"
+              [isValid]="classicFormsValid"
+              (submitEvent)="submit()"
+            ></mifosx-loan-product-preview-step>
+          </div>
+
+          <div class="review-pending" *ngIf="!classicFormsValid">
+            <p class="review-pending__title">
+              {{ 'labels.text.Complete these steps to preview the product' | translate }}
+            </p>
+            <ul class="review-pending__steps">
+              <li *ngFor="let stepTitle of incompleteClassicSteps">{{ stepTitle | translate }}</li>
+            </ul>
+          </div>
+        </ng-container>
+
+        <ng-container *ngIf="step.kind === 'review' && !usesClassicSteps">
           <ng-container *ngFor="let group of reviewGroups; trackBy: trackBySectionTitle">
             <div class="review-section">
               <p class="review-section__title">{{ group.title }}</p>
@@ -231,7 +300,12 @@
           <button mat-raised-button color="primary" matStepperNext *ngIf="i < visibleSteps.length - 1">
             {{ 'labels.buttons.Next' | translate }}
           </button>
-          <button mat-raised-button color="primary" *ngIf="i === visibleSteps.length - 1" (click)="submit()">
+          <button
+            mat-raised-button
+            color="primary"
+            *ngIf="i === visibleSteps.length - 1 && !usesClassicSteps"
+            (click)="submit()"
+          >
             {{ 'labels.buttons.Create Loan Product' | translate }}
           </button>
         </div>

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.scss
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.scss
@@ -299,3 +299,76 @@ mat-checkbox {
   color: var(--mat-sys-error, #b3261e);
   font-size: 0.875rem;
 }
+
+// Shown on the Review step while the hosted Classic steps are still incomplete, in place of the
+// product summary (which cannot render a partial product).
+.review-pending {
+  padding: var(--lp-space-16) var(--lp-space-24);
+  border: 1px dashed var(--lp-outline);
+  border-radius: var(--lp-radius);
+
+  &__title {
+    margin: 0 0 var(--lp-space-8);
+    font-weight: 600;
+    color: var(--lp-text);
+  }
+
+  &__steps {
+    margin: 0;
+    padding-left: var(--lp-space-24);
+    color: var(--lp-text-muted);
+  }
+}
+
+/* =================== Hosted Classic steps (Custom/Advanced) =================== */
+
+/**
+ * Custom/Advanced hosts Classic's Details / Currency / Terms / Settings components, and Classic's
+ * summary on the Review step.
+ *
+ * Deliberately TYPOGRAPHY ONLY. Classic's layout classes (`flex-48`, `layout-row-wrap`, ...) are
+ * global utilities in `src/main.scss`, so they already apply inside these components and lay them
+ * out exactly as they do in the Classic flow. An earlier attempt here re-flowed those cells to match
+ * `.field-grid`; because an attribute selector outranks an element selector, it also beat the
+ * heading rule below and left section headings sharing a row with the first field while every
+ * checkbox stretched into its own column. Restyling the type is enough to make the two flows read
+ * alike, and it cannot break a layout it does not touch.
+ */
+.wizard-classic-step,
+.wizard-classic-review {
+  display: block;
+
+  /* Classic's section headings are page-level (h2/h3/h4); inside a wizard step they read as
+     oversized field labels unless toned down to the shell's eyebrow treatment. */
+  ::ng-deep h2,
+  ::ng-deep h3,
+  ::ng-deep h4 {
+    color: var(--lp-text-muted);
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+}
+
+.wizard-classic-step {
+  /* Classic ships a Previous/Next row per step; the wizard shell already renders unified step
+     actions, so the embedded nav would be a second, conflicting set of buttons. Same reason, and
+     same remedy, as the reused Charges step above. */
+  ::ng-deep .stepper-buttons {
+    display: none;
+  }
+}
+
+.wizard-classic-review {
+  /* Classic's summary pairs a `.flex-40` label with a `.flex-60` value; colour them like
+     `.review-row__label` / `.review-row__value` so the facts read the same as the guided Review. */
+  ::ng-deep .flex-40 {
+    color: var(--lp-text-muted);
+  }
+
+  ::ng-deep .flex-60 {
+    color: var(--lp-text);
+    font-weight: 500;
+  }
+}

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { FormBuilder, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, UntypedFormControl, Validators } from '@angular/forms';
 import { DatePipe } from '@angular/common';
 import { TranslateService } from '@ngx-translate/core';
 import { Router } from '@angular/router';
@@ -237,8 +237,11 @@ describe('LoanProductWizardComponent', () => {
   });
 
   it('shows the payment allocation step only for the advanced strategy', () => {
+    // Driven through a guided profile: Custom/Advanced now hosts Classic's Settings step, so its
+    // strategy arrives via `onClassicAdvancePaymentStrategy` rather than the flat FormGroup (see the
+    // Classic-mode specs below).
     const component = createComponent();
-    component.profileMode = 'custom-advanced';
+    component.profileMode = 'bnpl';
     component.loanProductsTemplate = { currencyOptions: [{ code: 'INR' }] };
 
     component.ngOnInit();
@@ -371,42 +374,325 @@ describe('LoanProductWizardComponent', () => {
     expect(component.currencySymbol).toBe('KSh');
   });
 
-  it('produces a Classic-equivalent payload for Custom/Advanced once the advanced strategy is selected', () => {
+  it('exposes deferredIncomeRecognition so the Accounting step can reveal its GL accounts', () => {
+    // The Accounting step gates four GL account fields on this input — Income from Capitalization,
+    // Income from Buy Down, Buy Down Expense and Deferred Income Liability. Classic's host passes it;
+    // the wizard did not, so those accounts never appeared and a capitalized-income product could not
+    // supply the mappings Fineract requires.
     const component = createComponent();
     component.profileMode = 'custom-advanced';
     component.loanProductsTemplate = {
       currencyOptions: [{ code: 'INR' }],
-      transactionProcessingStrategyOptions: [
-        { code: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced Payment Allocation' }
-      ],
-      advancedPaymentAllocationTransactionTypes: [{ id: 1, code: 'DEFAULT', value: 'Default' }],
-      advancedPaymentAllocationTypes: [
-        { id: 1, code: 'PENALTY', value: 'Penalty' },
-        { id: 2, code: 'FEE', value: 'Fee' }
-      ],
-      advancedPaymentAllocationFutureInstallmentAllocationRules: [
-        { id: 1, code: 'NEXT_INSTALLMENT', value: 'Next installment' }
-      ],
-      supportedInterestRefundTypes: [{ id: 'MERCHANT_ISSUED_REFUND' }]
+      enableIncomeCapitalization: true,
+      capitalizedIncomeCalculationTypeOptions: [{ id: 'FLAT' }],
+      capitalizedIncomeStrategyOptions: [{ id: 'EQUAL_AMORTIZATION' }],
+      capitalizedIncomeTypeOptions: [{ id: 'FEE' }],
+      enableBuyDownFee: false
     };
-
     component.ngOnInit();
-    component.form.patchValue({
-      transactionProcessingStrategyCode: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
-      loanScheduleType: 'Progressive'
+
+    component.onClassicAdvancePaymentStrategy(LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
+
+    expect(component.deferredIncomeRecognition?.capitalizedIncome?.enableIncomeCapitalization).toBe(true);
+    expect(component.deferredIncomeRecognition?.capitalizedIncome?.capitalizedIncomeCalculationType).toEqual({
+      id: 'FLAT'
     });
+  });
+
+  it('sources the Review banner from the hosted Classic forms', () => {
+    // The banner is the shared header across every template, so Custom/Advanced must fill it too.
+    // Its keys are spread across three hosted steps, and none of them is the flat FormGroup.
+    const component = createComponent();
+    component.profileMode = 'custom-advanced';
+    component.loanProductsTemplate = { currencyOptions: [{ code: 'INR' }] };
+    component.ngOnInit();
+
+    component.loanProductDetailsStep = {
+      loanProductDetailsForm: new FormGroup({
+        name: new UntypedFormControl('Advance Loan Demo'),
+        shortName: new UntypedFormControl('ADB'),
+        externalId: new UntypedFormControl('ADB01')
+      })
+    } as any;
+    component.loanProductCurrencyStep = {
+      loanProductCurrencyForm: new FormGroup({ currencyCode: new UntypedFormControl('INR') })
+    } as any;
+    component.loanProductTermsStep = {
+      loanProductTermsForm: new FormGroup({
+        principal: new UntypedFormControl(90000),
+        numberOfRepayments: new UntypedFormControl(40),
+        repaymentFrequencyType: new UntypedFormControl(2),
+        interestRatePerPeriod: new UntypedFormControl(9),
+        interestRateFrequencyType: new UntypedFormControl(2)
+      })
+    } as any;
+
+    expect(component.reviewName).toBe('Advance Loan Demo');
+    expect(component.reviewShortName).toBe('ADB');
+    expect(component.reviewExternalId).toBe('ADB01');
+    expect(component.reviewCurrencyCode).toBe('INR');
+    expect(component.formattedPrincipal).toContain('90,000');
+    expect(component.scheduleLabel).toContain('40');
+    expect(component.interestLabel).toContain('9%');
+  });
+
+  it('keeps the Review step visible and names the steps still blocking the summary', () => {
+    // The step must never disappear from the stepper. Only the SUMMARY waits for a complete product:
+    // LoanProductSummaryComponent dereferences it in ngOnChanges (`codeValue.name`) and throws on a
+    // partial one, which is why Classic hides its whole preview step. The wizard shows the step and
+    // lists what is outstanding instead.
+    const component = createComponent();
+    component.profileMode = 'custom-advanced';
+    component.loanProductsTemplate = { currencyOptions: [{ code: 'INR' }] };
+    component.ngOnInit();
+
+    expect(component.visibleSteps.some((step) => step.kind === 'review')).toBe(true);
+    expect(component.classicFormsValid).toBe(false);
+    // Translation keys, not display text — the template pipes them through `translate`.
+    expect(component.incompleteClassicSteps).toEqual([
+      'labels.heading.Details',
+      'labels.heading.Currency',
+      'labels.heading.Terms',
+      'labels.heading.Settings',
+      'labels.heading.Accounting'
+    ]);
+
+    // A real (empty, therefore valid) FormGroup rather than a `{ valid: true }` literal: the component
+    // also reads controls off these forms, so the stub has to behave like one.
+    const validForm = () => new FormGroup({});
+    component.loanProductDetailsStep = { loanProductDetailsForm: validForm() } as any;
+    component.loanProductCurrencyStep = { loanProductCurrencyForm: validForm() } as any;
+    component.loanProductTermsStep = { loanProductTermsForm: validForm() } as any;
+    component.loanProductSettingsStep = { loanProductSettingsForm: validForm() } as any;
+    component.loanProductAccountingStep = { loanProductAccountingForm: validForm() } as any;
+
+    expect(component.incompleteClassicSteps).toEqual([]);
+    expect(component.classicFormsValid).toBe(true);
+    // Review was visible throughout.
+    expect(component.visibleSteps.some((step) => step.kind === 'review')).toBe(true);
+  });
+
+  it('gives the sibling steps stable controls that exist before their ngOnInit', () => {
+    // Regression: these were bound to @ViewChild getters, which are undefined during the first change
+    // detection. The Charges step reads `currencyCode.value` in its template (TypeError) AND captures
+    // the control once in ngOnInit, so a later-resolving getter would leave it on a stale instance.
+    // The Settings step captures `isLinkedToFloatingInterestRates` the same way, but with `?.` — it
+    // failed silently, never forcing interest recalculation on when a floating rate was linked.
+    const component = createComponent();
+    component.profileMode = 'custom-advanced';
+    component.loanProductsTemplate = { currencyOptions: [{ code: 'INR' }] };
+    component.ngOnInit();
+
+    // No hosted step has been created yet — exactly the state the sibling steps initialise in.
+    expect(component.loanProductCurrencyStep).toBeUndefined();
+    expect(component.chargesCurrencyControl).toBeDefined();
+    expect(component.chargesMultiDisburseControl).toBeDefined();
+    expect(component.floatingRatesMirrorControl).toBeDefined();
+  });
+
+  it('mirrors the hosted Classic values into the controls the sibling steps subscribed to', async () => {
+    const component = createComponent();
+    component.profileMode = 'custom-advanced';
+    component.loanProductsTemplate = { currencyOptions: [{ code: 'INR' }] };
+    component.ngOnInit();
+
+    const hostedCurrency = new UntypedFormControl('USD');
+    const hostedMultiDisburse = new UntypedFormControl(false);
+    const hostedFloatingRates = new UntypedFormControl(false);
+    component.loanProductCurrencyStep = {
+      loanProductCurrencyForm: new FormGroup({ currencyCode: hostedCurrency })
+    } as any;
+    component.loanProductSettingsStep = {
+      loanProductSettingsForm: new FormGroup({ multiDisburseLoan: hostedMultiDisburse })
+    } as any;
+    component.loanProductTermsStep = {
+      loanProductTermsForm: new FormGroup({ isLinkedToFloatingInterestRates: hostedFloatingRates })
+    } as any;
+
+    component.ngAfterViewChecked();
+    await Promise.resolve();
+
+    // Seeded from the hosted forms...
+    expect(component.chargesCurrencyControl.value).toBe('USD');
+
+    // ...and kept in step afterwards, which is what makes the siblings react.
+    hostedCurrency.setValue('EUR');
+    hostedFloatingRates.setValue(true);
+    await Promise.resolve();
+
+    expect(component.chargesCurrencyControl.value).toBe('EUR');
+    expect(component.floatingRatesMirrorControl?.value).toBe(true);
+  });
+
+  it('assembles the Custom/Advanced payload from the hosted Classic steps', () => {
+    // Classic mode reads each hosted step's own getter instead of the flat FormGroup, so the test
+    // stands the steps in directly — the same contract `CreateLoanProductClassicComponent` consumes.
+    const component = createComponent();
+    component.profileMode = 'custom-advanced';
+    component.loanProductsTemplate = { currencyOptions: [{ code: 'INR' }] };
+    component.ngOnInit();
+
+    component.loanProductDetailsStep = { loanProductDetails: { name: 'Custom LP', shortName: 'CLP' } } as any;
+    component.loanProductCurrencyStep = { loanProductCurrency: { currencyCode: 'INR' } } as any;
+    component.loanProductTermsStep = { loanProductTerms: { principal: 50000, minPrincipal: 1000 } } as any;
+    component.loanProductSettingsStep = {
+      loanProductSettings: { amortizationType: 1, useDueForRepaymentsConfigurations: false }
+    } as any;
+    component.loanProductChargesStep = { loanProductCharges: { charges: [{ id: 7 }] } } as any;
+    component.loanProductAccountingStep = { loanProductAccounting: { accountingRule: 1 } } as any;
 
     const payload = component.buildPayloadForSubmit();
-    const paymentAllocation = payload.paymentAllocation as Array<Record<string, unknown>>;
 
-    // Same DEFAULT allocation the reused AdvancedPaymentStrategy service builds for Personal Loan / Classic.
-    expect(paymentAllocation[0].transactionType).toBe('DEFAULT');
-    expect(paymentAllocation[0].paymentAllocationOrder).toEqual([
-      { order: 1, paymentAllocationRule: 'PENALTY' },
-      { order: 2, paymentAllocationRule: 'FEE' }
-    ]);
-    // Same template-default forwarding Classic/Personal use; no dedicated Interest Refund UI in either wizard.
-    expect(payload.supportedInterestRefundTypes).toEqual([{ id: 'MERCHANT_ISSUED_REFUND' }]);
+    // Every hosted step contributes, in Classic's spread order.
+    expect(payload).toMatchObject({
+      name: 'Custom LP',
+      shortName: 'CLP',
+      currencyCode: 'INR',
+      principal: 50000,
+      minPrincipal: 1000,
+      amortizationType: 1,
+      accountingRule: 1
+    });
+    expect(payload.charges).toEqual([{ id: 7 }]);
+    // UI-only key, dropped exactly as Classic's submitLoanProduct drops it.
+    expect(payload).not.toHaveProperty('useDueForRepaymentsConfigurations');
+    // Advanced-allocation extras stay out while the standard strategy is selected.
+    expect(payload).not.toHaveProperty('paymentAllocation');
+    expect(payload).not.toHaveProperty('supportedInterestRefundTypes');
+  });
+
+  it('re-wires the mirrors if the hosted Classic forms are replaced', async () => {
+    // The wiring is keyed on control instances, not a one-shot flag: were the hosted steps ever torn
+    // down and recreated, a boolean guard would leave the wizard subscribed to the destroyed forms
+    // and the Charges step would silently stop reacting to currency changes.
+    const component = createComponent();
+    component.profileMode = 'custom-advanced';
+    component.loanProductsTemplate = { currencyOptions: [{ code: 'INR' }] };
+    component.ngOnInit();
+
+    const hostSteps = (currency: string) => {
+      component.loanProductCurrencyStep = {
+        loanProductCurrencyForm: new FormGroup({ currencyCode: new UntypedFormControl(currency) })
+      } as any;
+      component.loanProductSettingsStep = {
+        loanProductSettingsForm: new FormGroup({ multiDisburseLoan: new UntypedFormControl(false) })
+      } as any;
+      component.loanProductTermsStep = {
+        loanProductTermsForm: new FormGroup({ isLinkedToFloatingInterestRates: new UntypedFormControl(false) })
+      } as any;
+    };
+
+    hostSteps('USD');
+    component.ngAfterViewChecked();
+    await Promise.resolve();
+    expect(component.chargesCurrencyControl.value).toBe('USD');
+
+    // Steps replaced with brand-new form instances — the mirrors must follow them.
+    hostSteps('EUR');
+    component.ngAfterViewChecked();
+    await Promise.resolve();
+    expect(component.chargesCurrencyControl.value).toBe('EUR');
+
+    const replacedCurrency = component.loanProductCurrencyStep!.loanProductCurrencyForm.get('currencyCode')!;
+    replacedCurrency.setValue('GBP');
+    await Promise.resolve();
+    expect(component.chargesCurrencyControl.value).toBe('GBP');
+  });
+
+  it('reads the advanced strategy from the hosted Settings form, not just the emitted flag', () => {
+    // The Settings step emits `advancePaymentStrategy` from a valueChanges subscription registered in
+    // its constructor, so its ngOnInit patch does fire it. Not relying on that ordering: the three
+    // conditional steps and their payload extras all hang off this boolean, so it is derived from the
+    // control that owns it and degrades to the emitted flag only before the @ViewChild resolves.
+    const component = createComponent();
+    component.profileMode = 'custom-advanced';
+    component.loanProductsTemplate = { currencyOptions: [{ code: 'INR' }] };
+    component.ngOnInit();
+
+    // No hosted step yet, and no emission: falls back to the flag.
+    expect(component.isAdvancedPaymentStrategy).toBe(false);
+
+    // Hosted form says advanced, but the output never fired — still detected.
+    component.loanProductSettingsStep = {
+      loanProductSettingsForm: new FormGroup({
+        transactionProcessingStrategyCode: new UntypedFormControl(LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY)
+      })
+    } as any;
+
+    expect(component.isAdvancedPaymentStrategy).toBe(true);
+    expect(component.visibleSteps.some((step) => step.kind === 'payment-allocation')).toBe(true);
+    expect(component.visibleSteps.some((step) => step.kind === 'interest-refund')).toBe(true);
+  });
+
+  it('previews the same configuration it submits', () => {
+    // Regression: the advanced-allocation extras were assembled inside the payload builder, so the
+    // Review summary showed a product WITHOUT the payment allocation, credit allocation, refund types
+    // and deferred-income settings that were then sent. An operator could approve one configuration
+    // and create another. Preview and payload must come from a single model.
+    const component = createComponent();
+    component.profileMode = 'custom-advanced';
+    component.loanProductsTemplate = {
+      currencyOptions: [{ code: 'INR' }],
+      enableIncomeCapitalization: true,
+      capitalizedIncomeCalculationTypeOptions: [{ id: 'FLAT' }],
+      capitalizedIncomeStrategyOptions: [{ id: 'EQUAL_AMORTIZATION' }],
+      capitalizedIncomeTypeOptions: [{ id: 'FEE' }],
+      enableBuyDownFee: false
+    };
+    component.ngOnInit();
+    component.loanProductDetailsStep = { loanProductDetails: { name: 'Custom LP' } } as any;
+    component.loanProductAccountingStep = { loanProductAccounting: { accountingRule: 1 } } as any;
+
+    component.onClassicAdvancePaymentStrategy(LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
+    component.setPaymentAllocation([{ transactionType: 'DEFAULT' }] as any);
+    component.setCreditAllocation([{ transactionType: 'CHARGEBACK' }] as any);
+    component.setSupportedInterestRefundTypes([{ id: 'MERCHANT_ISSUED_REFUND' }] as any);
+
+    const preview = component.classicPreviewProduct;
+    const payload = component.buildPayloadForSubmit();
+
+    // Everything the operator is asked to approve is present in the preview...
+    expect(preview.paymentAllocation).toEqual([{ transactionType: 'DEFAULT' }]);
+    expect(preview.creditAllocation).toEqual([{ transactionType: 'CHARGEBACK' }]);
+    expect(preview.supportedInterestRefundTypes).toEqual([{ id: 'MERCHANT_ISSUED_REFUND' }]);
+    expect(preview.enableIncomeCapitalization).toBe(true);
+    expect(preview.capitalizedIncomeCalculationType).toEqual({ id: 'FLAT' });
+
+    // ...and reaches the payload unchanged, bar the id-mapping Classic also applies at submit time.
+    expect(payload.paymentAllocation).toEqual(preview.paymentAllocation);
+    expect(payload.creditAllocation).toEqual(preview.creditAllocation);
+    expect(payload.enableIncomeCapitalization).toBe(preview.enableIncomeCapitalization);
+    expect(payload.capitalizedIncomeCalculationType).toEqual(preview.capitalizedIncomeCalculationType);
+    expect(payload.supportedInterestRefundTypes).toEqual(['MERCHANT_ISSUED_REFUND']);
+  });
+
+  it('adds the advanced-allocation extras once the Classic Settings step reports that strategy', () => {
+    const component = createComponent();
+    component.profileMode = 'custom-advanced';
+    component.loanProductsTemplate = {
+      currencyOptions: [{ code: 'INR' }],
+      enableIncomeCapitalization: false,
+      enableBuyDownFee: false
+    };
+    component.ngOnInit();
+    component.loanProductDetailsStep = { loanProductDetails: { name: 'Custom LP' } } as any;
+    component.loanProductAccountingStep = { loanProductAccounting: { accountingRule: 1 } } as any;
+
+    // The strategy arrives through the hosted Settings step's output, as it does in Classic.
+    component.onClassicAdvancePaymentStrategy(LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
+    expect(component.isAdvancedPaymentStrategy).toBe(true);
+
+    component.setPaymentAllocation([{ transactionType: 'DEFAULT' }] as any);
+    component.setSupportedInterestRefundTypes([{ id: 'MERCHANT_ISSUED_REFUND' }] as any);
+
+    const payload = component.buildPayloadForSubmit();
+
+    expect(payload.paymentAllocation).toEqual([{ transactionType: 'DEFAULT' }]);
+    // Mapped to the id list Classic submits, not the raw option objects.
+    expect(payload.supportedInterestRefundTypes).toEqual(['MERCHANT_ISSUED_REFUND']);
+    // The template disables both deferred-income halves, so only the flags travel.
+    expect(payload.enableIncomeCapitalization).toBe(false);
+    expect(payload.enableBuyDownFee).toBe(false);
   });
 
   it('seeds daysInYearType/daysInMonthType from the template id, not the display value (numeric enum)', () => {
@@ -415,7 +701,7 @@ describe('LoanProductWizardComponent', () => {
     // longer masked by HIDDEN_DEFAULTS in the custom-advanced merge, that string reached the payload
     // and the backend rejected `daysInYearType = "Actual"`. The form/payload must carry the integer id.
     const component = createComponent();
-    component.profileMode = 'custom-advanced';
+    component.profileMode = 'bnpl';
     component.loanProductsTemplate = {
       currencyOptions: [{ code: 'INR' }],
       transactionProcessingStrategyOptions: [{ code: 'mifos-standard-strategy', name: 'Mifos standard' }],
@@ -502,9 +788,9 @@ describe('LoanProductWizardComponent', () => {
   });
 
   describe('reduces required input to profile/strategy-determined fields (Item 3)', () => {
-    function customAdvancedComponent(): LoanProductWizardComponent {
+    function fieldGridComponent(): LoanProductWizardComponent {
       const component = createComponent();
-      component.profileMode = 'custom-advanced';
+      component.profileMode = 'bnpl';
       component.loanProductsTemplate = {
         currencyOptions: [{ code: 'INR' }],
         transactionProcessingStrategyOptions: [
@@ -524,14 +810,18 @@ describe('LoanProductWizardComponent', () => {
       return component.visibleFields(stepOwning(component, key)).map((field) => field.key);
     }
 
-    it('hides single-option and strategy-determined selects in Custom/Advanced by default', () => {
-      const component = customAdvancedComponent();
+    it('hides single-option and strategy-determined selects on a non-advanced strategy', () => {
+      const component = fieldGridComponent();
+      // Set the strategy explicitly rather than leaning on a profile default: this profile seeds the
+      // advanced stack, and the rule under test is "these fields are determined by the strategy",
+      // not "this profile happens to start non-advanced".
+      component.form.patchValue({ transactionProcessingStrategyCode: 'mifos-standard-strategy' });
 
       // Single-option selects: nothing for the user to choose.
       expect(visibleKeysFor(component, 'repaymentStartDateType')).not.toContain('repaymentStartDateType');
+      // Charge-off behaviour is Progressive + advanced only, so the standard strategy hides it.
       expect(visibleKeysFor(component, 'loanChargeOffBehaviour')).not.toContain('loanChargeOffBehaviour');
 
-      // Advanced-strategy-only fields, hidden while the default (non-advanced) strategy is selected.
       const settingsKeys = visibleKeysFor(component, 'loanScheduleProcessingType');
       expect(settingsKeys).not.toContain('loanScheduleProcessingType');
       expect(settingsKeys).not.toContain('daysInYearCustomStrategy');
@@ -543,7 +833,7 @@ describe('LoanProductWizardComponent', () => {
     });
 
     it('reveals loanScheduleProcessingType only for the advanced strategy (mirrors Classic)', () => {
-      const component = customAdvancedComponent();
+      const component = fieldGridComponent();
 
       component.form.patchValue({ transactionProcessingStrategyCode: 'mifos-standard-strategy' });
       expect(visibleKeysFor(component, 'loanScheduleProcessingType')).not.toContain('loanScheduleProcessingType');
@@ -555,7 +845,7 @@ describe('LoanProductWizardComponent', () => {
     });
 
     it('reveals daysInYearCustomStrategy only for the advanced strategy AND ACTUAL days-in-year', () => {
-      const component = customAdvancedComponent();
+      const component = fieldGridComponent();
       component.form.patchValue({
         transactionProcessingStrategyCode: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
         daysInYearType: 360
@@ -567,7 +857,7 @@ describe('LoanProductWizardComponent', () => {
     });
 
     it('keeps complete payload parity — hidden fields are still emitted with their defaults', () => {
-      const component = customAdvancedComponent();
+      const component = fieldGridComponent();
 
       // Default (non-advanced) strategy: the same values the wizard emitted before the fields were hidden.
       const before = component.buildPayloadForSubmit();
@@ -651,15 +941,18 @@ describe('LoanProductWizardComponent', () => {
       };
 
       component.ngOnInit();
-      component.form.patchValue({ transactionProcessingStrategyCode: 'mifos-standard-strategy' });
+      component.loanProductDetailsStep = { loanProductDetails: { name: 'Custom LP' } } as any;
+      component.loanProductSettingsStep = {
+        loanProductSettings: { transactionProcessingStrategyCode: 'mifos-standard-strategy' }
+      } as any;
       const payload = component.buildPayloadForSubmit();
 
       expect(payload.transactionProcessingStrategyCode).toBe('mifos-standard-strategy');
       // Non-advanced strategy: Classic Edit's non-advanced path expects no payment allocation.
       expect(payload.paymentAllocation).toBeUndefined();
       expect(payload.creditAllocation).toBeUndefined();
-      expect(typeof payload.allowAttributeOverrides).toBe('object');
-      expect(Object.keys(payload).some((key) => key.startsWith('allowAttributeOverrides.'))).toBe(false);
+      // The wizard-only helper keys never existed in Classic mode: the hosted steps emit Classic's
+      // own field names, so there is nothing to rename or strip.
       WIZARD_ONLY_KEYS.forEach((key) => expect(payload[key]).toBeUndefined());
     });
   });
@@ -678,9 +971,9 @@ describe('LoanProductWizardComponent', () => {
       return component;
     }
 
-    function customAdvancedComponent(): LoanProductWizardComponent {
+    function fieldGridComponent(): LoanProductWizardComponent {
       const component = createComponent();
-      component.profileMode = 'custom-advanced';
+      component.profileMode = 'bnpl';
       component.loanProductsTemplate = {
         currencyOptions: [{ code: 'INR' }],
         transactionProcessingStrategyOptions: [
@@ -697,7 +990,7 @@ describe('LoanProductWizardComponent', () => {
     }
 
     it('every Review row corresponds to a currently-visible wizard field (single source of truth)', () => {
-      const component = customAdvancedComponent();
+      const component = fieldGridComponent();
       const visibleLabels = new Set(
         component.steps.flatMap((step) => component.visibleFields(step)).map((field) => field.label)
       );
@@ -705,7 +998,7 @@ describe('LoanProductWizardComponent', () => {
     });
 
     it('omits hidden defaults, backend-only params and buildPayload-injected values', () => {
-      const component = customAdvancedComponent();
+      const component = fieldGridComponent();
       const labels = reviewLabels(component);
       // Profile/strategy-determined fields hidden from the wizard must not appear in its Review either.
       expect(labels).not.toContain('Repayment start date type');
@@ -726,7 +1019,7 @@ describe('LoanProductWizardComponent', () => {
     });
 
     it('reflects a user select via the field option label (form-driven, not payload-driven)', () => {
-      const component = customAdvancedComponent();
+      const component = fieldGridComponent();
       component.form.patchValue({ amortizationType: 0 });
       const row = component.reviewGroups
         .flatMap((group) => group.rows)
@@ -735,17 +1028,17 @@ describe('LoanProductWizardComponent', () => {
     });
 
     it('renders visible checkboxes as Yes/No and drops empty optional fields', () => {
-      const component = customAdvancedComponent();
-      const topup = component.reviewGroups
+      const component = fieldGridComponent();
+      const equalAmortization = component.reviewGroups
         .flatMap((g) => g.rows)
-        .find((r) => r.label === 'labels.inputs.Allow top-up loans');
-      expect(topup?.display).toBe('No');
+        .find((r) => r.label === 'labels.inputs.Is Equal Amortization');
+      expect(equalAmortization?.display).toBe('No');
       // externalId is visible but empty by default → dropped from the summary.
       expect(reviewLabels(component)).not.toContain('labels.inputs.External ID');
     });
 
     it('sources the banner from the form state', () => {
-      const component = customAdvancedComponent();
+      const component = fieldGridComponent();
       component.form.patchValue({ name: 'My LP', shortName: 'MLP', principal: 60000, currencyCode: 'USD' });
       expect(component.reviewName).toBe('My LP');
       expect(component.reviewShortName).toBe('MLP');
@@ -827,88 +1120,10 @@ describe('LoanProductWizardComponent', () => {
       });
     });
 
-    it('locks the Custom/Advanced visible field set', () => {
-      // Five controls that used to appear unconditionally are now gated on their controlling field,
-      // matching the Classic Settings/Terms steps. On an untouched Custom/Advanced form every one of
-      // those controllers is off, so none of the five is listed here; ticking the controller reveals
-      // them again (see the conditional-visibility specs below).
-      //   multiDisburseLoan (default false) -> outstandingLoanBalance, disallowExpectedDisbursements
-      //   delinquencyBucketId (default none) -> enableInstallmentLevelDelinquency
-      //   allowApprovedDisbursedAmountsOverApplied (default false)
-      //     -> overAppliedCalculationType, overAppliedNumber
-      expect(visibleKeysByStep(customAdvancedComponent())).toEqual({
-        Details: [
-          'name',
-          'shortName',
-          'externalId',
-          'description',
-          'startDate',
-          'closeDate',
-          'includeInBorrowerCycle'
-        ],
-        Currency: [
-          'currencyCode',
-          'digitsAfterDecimal',
-          'inMultiplesOf',
-          'installmentAmountInMultiplesOf',
-          'useBorrowerCycle'
-        ],
-        Terms: [
-          'principal',
-          'numberOfRepayments',
-          'interestRatePerPeriod',
-          'interestRateFrequencyType',
-          'repaymentEvery',
-          'repaymentFrequencyType',
-          'isLinkedToFloatingInterestRates',
-          'allowApprovedDisbursedAmountsOverApplied',
-          'minimumDaysBetweenDisbursalAndFirstRepayment',
-          'interestRecognitionOnDisbursementDate'
-        ],
-        Settings: [
-          'amortizationType',
-          'interestType',
-          'allowPartialPeriodInterestCalculation',
-          'isEqualAmortization',
-          'interestCalculationPeriodType',
-          'loanScheduleType',
-          'transactionProcessingStrategyCode',
-          'graceOnPrincipalPayment',
-          'graceOnInterestPayment',
-          'interestFreePeriod',
-          'daysInYearType',
-          'daysInMonthType',
-          'principalThresholdForLastInstallment',
-          'canUseForTopup',
-          'isInterestRecalculationEnabled',
-          'delinquencyBucketId',
-          'canDefineInstallmentAmount',
-          'allowVariableInstallments',
-          'multiDisburseLoan',
-          'inArrearsTolerance',
-          'graceOnArrearsAgeing',
-          'overdueDaysForNPA',
-          'accountMovesOutOfNPAOnlyOnArrearsCompletion',
-          'holdGuaranteeFunds',
-          'allowAttributeOverrides.amortizationType',
-          'allowAttributeOverrides.interestType',
-          'allowAttributeOverrides.transactionProcessingStrategyCode',
-          'allowAttributeOverrides.interestCalculationPeriodType',
-          'allowAttributeOverrides.inArrearsTolerance',
-          'allowAttributeOverrides.repaymentEvery',
-          'allowAttributeOverrides.graceOnPrincipalAndInterestPayment',
-          'allowAttributeOverrides.graceOnArrearsAgeing',
-          'enableDownPayment',
-          'enableIncomeCapitalization',
-          'enableBuydownFees'
-        ],
-        'Advanced Configuration': [
-          'useGlobalConfigForRepaymentEvent',
-          'dueDaysForRepaymentEvent',
-          'overDueDaysForRepaymentEvent'
-        ]
-      });
-    });
+    // NOTE: the Custom/Advanced visible-field-set and flat-form seeding goldens were removed when
+    // this profile moved to Classic's hosted step components — the config field grid and the flat
+    // FormGroup no longer drive it. Its surface is now locked by the step-sequence golden above and
+    // by Classic's own step specs; the field-grid engine stays covered through the guided profiles.
 
     it('locks the Personal Loan visible step sequence', () => {
       expect(personalComponent().visibleSteps.map((step) => step.title)).toEqual([
@@ -924,6 +1139,9 @@ describe('LoanProductWizardComponent', () => {
     });
 
     it('locks the Custom/Advanced visible step sequence', () => {
+      // Custom/Advanced hosts Classic's own step components, so two steps disappear because Classic
+      // already contains them: Loan Cycle Variations lives inside Classic's Terms step, and the
+      // Advanced Configuration fields are Classic's Event Settings block inside its Settings step.
       expect(customAdvancedComponent().visibleSteps.map((step) => step.title)).toEqual([
         'Details',
         'Currency',
@@ -931,8 +1149,20 @@ describe('LoanProductWizardComponent', () => {
         'Settings',
         'Charges',
         'Accounting',
-        'Advanced Configuration',
         'Review'
+      ]);
+    });
+
+    it('renders Custom/Advanced through Classic step components, not the field grid', () => {
+      const component = customAdvancedComponent();
+
+      expect(component.usesClassicSteps).toBe(true);
+      // The four steps that were re-declared as config fields now delegate to Classic's components.
+      expect(component.visibleSteps.filter((step) => step.classicStep).map((step) => step.classicStep)).toEqual([
+        'details',
+        'currency',
+        'terms',
+        'settings'
       ]);
     });
 
@@ -951,21 +1181,6 @@ describe('LoanProductWizardComponent', () => {
         loanScheduleType: 'Progressive',
         multiDisburseLoan: true,
         allowVariableInstallments: true,
-        enableDownPayment: false,
-        disbursedAmountPercentageForDownPayment: 35,
-        currencyCode: 'INR'
-      });
-    });
-
-    it('locks the Custom/Advanced form seeding when the template omits the seeded fields', () => {
-      expect(customAdvancedComponent().form.getRawValue()).toMatchObject({
-        principal: '',
-        numberOfRepayments: 12,
-        interestRatePerPeriod: '',
-        transactionProcessingStrategyCode: 'interest-principal-penalties-fees-order-strategy',
-        loanScheduleType: 'Progressive',
-        multiDisburseLoan: false,
-        allowVariableInstallments: false,
         enableDownPayment: false,
         disbursedAmountPercentageForDownPayment: 35,
         currencyCode: 'INR'

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
@@ -6,8 +6,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild, inject } from '@angular/core';
-import { FormBuilder, FormGroup, UntypedFormControl, ValidatorFn, Validators } from '@angular/forms';
+import {
+  AfterViewChecked,
+  Component,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  SimpleChanges,
+  ViewChild,
+  inject
+} from '@angular/core';
+import { FormBuilder, FormGroup, UntypedFormControl, UntypedFormGroup, ValidatorFn, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import {
@@ -20,6 +30,8 @@ import {
   forcesProgressiveStack,
   hiddenDefaultsFor,
   isGuidedProfileMode,
+  usesClassicSteps,
+  ClassicStep,
   rendersDeferredIncomeStep,
   rendersBorrowerCycleStep,
   rendersInterestRefundStep,
@@ -57,6 +69,13 @@ import {
   BorrowerCycleVariations
 } from './borrower-cycle-step/loan-product-borrower-cycle-step.component';
 import { GlAccountDisplayComponent } from '../../../shared/accounting/gl-account-display/gl-account-display.component';
+// The four Classic step components Custom/Advanced hosts in place of the config-driven field grid,
+// plus Classic's own preview so its Review shows the same summary Classic's does.
+import { LoanProductDetailsStepComponent } from '../loan-product-stepper/loan-product-details-step/loan-product-details-step.component';
+import { LoanProductCurrencyStepComponent } from '../loan-product-stepper/loan-product-currency-step/loan-product-currency-step.component';
+import { LoanProductTermsStepComponent } from '../loan-product-stepper/loan-product-terms-step/loan-product-terms-step.component';
+import { LoanProductSettingsStepComponent } from '../loan-product-stepper/loan-product-settings-step/loan-product-settings-step.component';
+import { LoanProductPreviewStepComponent } from '../loan-product-stepper/loan-product-preview-step/loan-product-preview-step.component';
 import { LoanProductService } from '../services/loan-product.service';
 import { Router } from '@angular/router';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -170,12 +189,17 @@ const ACCOUNTING_REVIEW_ACCOUNTS: ReadonlyArray<{ key: string; title: string }> 
     LoanProductInterestRefundStepComponent,
     LoanProductDeferredIncomeRecognitionStepComponent,
     LoanProductBorrowerCycleStepComponent,
+    LoanProductDetailsStepComponent,
+    LoanProductCurrencyStepComponent,
+    LoanProductTermsStepComponent,
+    LoanProductSettingsStepComponent,
+    LoanProductPreviewStepComponent,
     GlAccountDisplayComponent
   ],
   templateUrl: './loan-product-wizard.component.html',
   styleUrls: ['./loan-product-wizard.component.scss']
 })
-export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy {
+export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewChecked, OnDestroy {
   private readonly fb = inject(FormBuilder);
   private readonly productsService = inject(ProductsService);
   private readonly loanProducts = inject(LoanProducts);
@@ -231,6 +255,22 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
   @ViewChild(LoanProductBorrowerCycleStepComponent)
   loanProductBorrowerCycleStep?: LoanProductBorrowerCycleStepComponent;
 
+  // The four Classic step components hosted for Custom/Advanced. Each owns its own typed FormGroup
+  // and exposes a payload getter, exactly as in Classic's create flow — the wizard reads them at
+  // submit time instead of assembling those fields from its flat FormGroup.
+  @ViewChild(LoanProductDetailsStepComponent) loanProductDetailsStep?: LoanProductDetailsStepComponent;
+  @ViewChild(LoanProductCurrencyStepComponent) loanProductCurrencyStep?: LoanProductCurrencyStepComponent;
+  @ViewChild(LoanProductTermsStepComponent) loanProductTermsStep?: LoanProductTermsStepComponent;
+  @ViewChild(LoanProductSettingsStepComponent) loanProductSettingsStep?: LoanProductSettingsStepComponent;
+
+  /**
+   * Whether the Classic Settings step has reported the advanced payment allocation strategy. In
+   * Classic mode the strategy lives in that step's own FormGroup, not the wizard's flat one, so it
+   * arrives through the step's `advancePaymentStrategy` output — the same signal Classic's host
+   * listens to.
+   */
+  private classicAdvancedPaymentStrategy = false;
+
   /** Selected refund types, mirroring Classic's `supportedInterestRefundTypes` field. */
   supportedInterestRefundTypes: StringEnumOptionData[] = [];
   /** Deferred income state the reused step binds to, mirroring Classic's field of the same name. */
@@ -269,6 +309,11 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
   // `patchValue` reset — see `syncDependentResets`.
   private lastSeenMultiDisburseLoan?: boolean;
   private lastSeenProgressiveSchedule?: boolean;
+  // Classic-mode bridge between the hosted Classic forms and the controls the Charges step binds to.
+  private readonly classicMirrorSubscriptions: Subscription[] = [];
+  // Bridge between the hosted Classic forms and the wizard controls its sibling steps bind to.
+  // Holds the control instances currently mirrored, so re-created hosted steps are re-wired.
+  private wiredClassicControls?: { currency: unknown; multiDisburse: unknown; floatingRates: unknown };
 
   ngOnInit(): void {
     this.initializeForm();
@@ -281,8 +326,96 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
     }
   }
 
+  ngAfterViewChecked(): void {
+    // The hosted Classic steps live inside *ngFor/*ngIf, so their @ViewChild refs cannot be `static`
+    // and are not guaranteed by ngAfterViewInit. Retry each pass until wired, then never again.
+    this.wireClassicControlMirrors();
+  }
+
   ngOnDestroy(): void {
     this.formValueChangesSubscription?.unsubscribe();
+    this.classicMirrorSubscriptions.forEach((subscription) => subscription.unsubscribe());
+  }
+
+  /**
+   * In Classic mode the authoritative values live in the hosted Classic forms, but three of them are
+   * consumed by SIBLING steps that capture their control once, in `ngOnInit`, before any `@ViewChild`
+   * has resolved:
+   *   - `currencyCode` / `multiDisburseLoan` -> the Charges step, which clears its selections on change;
+   *   - `isLinkedToFloatingInterestRates` -> the Settings step, which forces interest recalculation and
+   *     partial-period interest on when it becomes true (and subscribes with `?.`, so a missing control
+   *     fails silently rather than loudly).
+   * Each sibling is therefore bound to the wizard's own stable control, and this mirrors the hosted
+   * value into it — reproducing what Classic gets for free by passing its own step forms directly.
+   *
+   * Runs once, as soon as both hosted forms exist. The patches are deferred to a microtask because
+   * they happen during the after-view phase, and writing a value the template already read in the
+   * same tick raises ExpressionChangedAfterItHasBeenCheckedError in dev mode.
+   */
+  private wireClassicControlMirrors(): void {
+    if (!this.usesClassicSteps) {
+      return;
+    }
+    const currencyControl = this.loanProductCurrencyStep?.loanProductCurrencyForm?.get('currencyCode');
+    const multiDisburseControl = this.loanProductSettingsStep?.loanProductSettingsForm?.get('multiDisburseLoan');
+    const floatingRatesControl = this.loanProductTermsStep?.loanProductTermsForm?.get(
+      'isLinkedToFloatingInterestRates'
+    );
+    if (!currencyControl || !multiDisburseControl || !floatingRatesControl) {
+      return;
+    }
+
+    // Keyed on the CONTROL INSTANCES rather than a one-shot boolean. If Angular ever tears down and
+    // recreates the hosted steps, the wizard would otherwise stay subscribed to the destroyed forms'
+    // controls and the Charges step would silently stop reacting to currency / multi-disbursal
+    // changes — the same stale-subscription failure this mirror exists to prevent. Comparing
+    // instances makes the wiring self-correcting: it re-subscribes to whatever is current, and is a
+    // no-op on every other change-detection pass.
+    if (
+      this.wiredClassicControls?.currency === currencyControl &&
+      this.wiredClassicControls?.multiDisburse === multiDisburseControl &&
+      this.wiredClassicControls?.floatingRates === floatingRatesControl
+    ) {
+      return;
+    }
+    this.classicMirrorSubscriptions.forEach((subscription) => subscription.unsubscribe());
+    this.classicMirrorSubscriptions.length = 0;
+    this.wiredClassicControls = {
+      currency: currencyControl,
+      multiDisburse: multiDisburseControl,
+      floatingRates: floatingRatesControl
+    };
+
+    const mirror = (key: string, value: unknown): void => {
+      // emitEvent stays TRUE: the consuming steps react through their own valueChanges subscriptions,
+      // which is the entire point of the mirror.
+      Promise.resolve().then(() => this.form?.get(key)?.setValue(value));
+    };
+
+    (
+      [
+        [
+          'currencyCode',
+          currencyControl
+        ],
+        [
+          'multiDisburseLoan',
+          multiDisburseControl
+        ],
+        [
+          'isLinkedToFloatingInterestRates',
+          floatingRatesControl
+        ]
+      ] as const
+    ).forEach(
+      ([
+        key,
+        control
+      ]) => {
+        mirror(key, control.value);
+        this.classicMirrorSubscriptions.push(control.valueChanges.subscribe((value) => mirror(key, value)));
+      }
+    );
   }
 
   /** Translation key for the active profile's name, shown in the wizard header. */
@@ -318,9 +451,79 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
    * selected repayment strategy is the advanced payment allocation strategy — exactly like the
    * `@if (isAdvancedPaymentStrategy)` guard in the Classic stepper template.
    */
+  /**
+   * Whether this profile hosts Classic's four step components instead of the config-driven field
+   * grid. The single seam between the two rendering modes: it selects the template branch, the
+   * source of `isAdvancedPaymentStrategy`, the validity check and the payload assembly.
+   */
+  get usesClassicSteps(): boolean {
+    return usesClassicSteps(this.profileMode);
+  }
+
   get isAdvancedPaymentStrategy(): boolean {
+    if (this.usesClassicSteps) {
+      // Derived from the hosted Settings form, which owns the control, rather than trusting the
+      // cached flag alone. The flag is only as good as the `advancePaymentStrategy` emission that
+      // sets it, and this profile's payment allocation, interest-refund and deferred-income steps —
+      // plus the payload extras they contribute — all hang off this one boolean. Reading the source
+      // of truth means a missed emission degrades to "reads the form" instead of silently building
+      // a product without its allocation data. The flag remains the fallback for the window before
+      // the step's @ViewChild resolves.
+      const strategy = this.loanProductSettingsStep?.loanProductSettingsForm?.get(
+        'transactionProcessingStrategyCode'
+      )?.value;
+      return typeof strategy === 'string'
+        ? LoanProducts.isAdvancedPaymentAllocationStrategy(strategy)
+        : this.classicAdvancedPaymentStrategy;
+    }
     const strategyCode = this.form?.get('transactionProcessingStrategyCode')?.value;
     return typeof strategyCode === 'string' && LoanProducts.isAdvancedPaymentAllocationStrategy(strategyCode);
+  }
+
+  /** The Classic Terms form, exposed for the hosted steps' cross-references. */
+  get classicTermsForm(): UntypedFormGroup | undefined {
+    return this.loanProductTermsStep?.loanProductTermsForm;
+  }
+
+  /**
+   * The stable control the hosted Settings step binds to. See {@link wireClassicControlMirrors} for
+   * why it cannot be the Terms form's control directly.
+   */
+  get floatingRatesMirrorControl(): UntypedFormControl | null {
+    return (this.form?.get('isLinkedToFloatingInterestRates') as UntypedFormControl) ?? null;
+  }
+
+  /**
+   * Mirrors Classic's host: the Settings step reports the selected repayment strategy, which gates the
+   * Payment Allocation, Interest Refund and Deferred Income steps and seeds the deferred-income
+   * defaults. Copied from `CreateLoanProductClassicComponent.advancePaymentStrategy` so both flows
+   * derive the same starting state from the same template options.
+   */
+  onClassicAdvancePaymentStrategy(value: string): void {
+    this.classicAdvancedPaymentStrategy = LoanProducts.isAdvancedPaymentAllocationStrategy(value);
+    if (!this.classicAdvancedPaymentStrategy || !this.loanProductsTemplate) {
+      return;
+    }
+    const template = this.loanProductsTemplate;
+    this.deferredIncomeRecognition = {
+      capitalizedIncome: template.enableIncomeCapitalization
+        ? {
+            enableIncomeCapitalization: true,
+            capitalizedIncomeCalculationType: template.capitalizedIncomeCalculationTypeOptions?.[0],
+            capitalizedIncomeStrategy: template.capitalizedIncomeStrategyOptions?.[0],
+            capitalizedIncomeType: template.capitalizedIncomeTypeOptions?.[0]
+          }
+        : { enableIncomeCapitalization: false },
+      buyDownFee: template.enableBuyDownFee
+        ? {
+            enableBuyDownFee: true,
+            buyDownFeeCalculationType: template.buyDownFeeCalculationTypeOptions?.[0],
+            buyDownFeeStrategy: template.buyDownFeeStrategyOptions?.[0],
+            buyDownFeeIncomeType: template.buyDownFeeIncomeTypeOptions?.[0],
+            merchantBuyDownFee: true
+          }
+        : { enableBuyDownFee: false }
+    };
   }
 
   /**
@@ -338,6 +541,21 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
 
   get visibleSteps(): FormStep[] {
     return this.steps.filter((step) => {
+      // Classic mode renders the four hosted components unconditionally: each owns its own internal
+      // show/hide rules, which is the whole point of hosting them.
+      if (this.usesClassicSteps && step.classicStep) {
+        return true;
+      }
+      if (this.usesClassicSteps) {
+        // Two steps become duplicates once Classic's own components are hosted:
+        //   - Loan Cycle Variations: Classic's Terms step owns the three variation FormArrays and
+        //     renders them inline under `useBorrowerCycle`.
+        //   - Advanced Configuration: Classic's Settings step owns the same Event Settings block
+        //     (`useDueForRepaymentsConfigurations` plus the due / overdue day inputs).
+        if (step.kind === 'borrower-cycle' || step.title === 'Advanced Configuration') {
+          return false;
+        }
+      }
       if (step.kind === 'review') {
         return true;
       }
@@ -353,11 +571,13 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
       // Same gate Classic puts on both steps (`@if (isAdvancedPaymentStrategy)` in
       // create-loan-product-classic.component.html), plus the profile opt-in: only profiles whose
       // sheet marks these groups Applicable render them.
+      // Classic renders both for ANY advanced-payment-allocation product, so Classic mode drops the
+      // per-profile opt-in and keeps only Classic's own strategy gate.
       if (step.kind === 'interest-refund') {
-        return rendersInterestRefundStep(this.profileMode) && this.isAdvancedPaymentStrategy;
+        return (this.usesClassicSteps || rendersInterestRefundStep(this.profileMode)) && this.isAdvancedPaymentStrategy;
       }
       if (step.kind === 'deferred-income') {
-        return rendersDeferredIncomeStep(this.profileMode) && this.isAdvancedPaymentStrategy;
+        return (this.usesClassicSteps || rendersDeferredIncomeStep(this.profileMode)) && this.isAdvancedPaymentStrategy;
       }
       // Same gate Classic puts on the block (`@if (loanProductTermsForm.value.useBorrowerCycle)` in
       // loan-product-terms-step.component.html), plus the profile opt-in: only JLG's sheet marks the
@@ -373,6 +593,17 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
    * Controls handed to the reused Classic Charges step. It expects plain `UntypedFormControl`s (it
    * subscribes to their `valueChanges` to clear the selected charges when currency / multi-disbursal
    * changes), so the wizard exposes its own form controls under the same shapes Classic passes.
+   */
+  /**
+   * ALWAYS the wizard's own control, in both modes.
+   *
+   * The reused Charges step reads `currencyCode.value` on every change detection AND captures the
+   * control once in its `ngOnInit` (`this.currencyCode.valueChanges.subscribe(...)`). A `@ViewChild`
+   * is still undefined during that first pass, so handing it the hosted Classic form's control threw
+   * `Cannot read properties of undefined (reading 'value')` and, had it resolved later, would have
+   * left the step subscribed to a stale instance. The wizard's flat control exists from
+   * `initializeForm()`, so it is a stable target; {@link wireClassicChargeControlMirrors} keeps its
+   * value in step with the hosted Classic forms.
    */
   get chargesCurrencyControl(): UntypedFormControl {
     return this.form?.get('currencyCode') as UntypedFormControl;
@@ -703,7 +934,151 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
     ].includes(key);
   }
 
+  /**
+   * Classic's `loanProductFormValid`: the four hosted steps plus accounting, and — on the advanced
+   * payment allocation strategy — the deferred income step, whose dependents carry `required`.
+   * The Charges step has no validators in either flow.
+   */
+  get classicFormsValid(): boolean {
+    const forms = [
+      this.loanProductDetailsStep?.loanProductDetailsForm,
+      this.loanProductCurrencyStep?.loanProductCurrencyForm,
+      this.loanProductTermsStep?.loanProductTermsForm,
+      this.loanProductSettingsStep?.loanProductSettingsForm,
+      this.loanProductAccountingStep?.loanProductAccountingForm
+    ];
+    if (forms.some((form) => !form || form.invalid)) {
+      return false;
+    }
+    if (this.isAdvancedPaymentStrategy) {
+      const deferredIncomeForm = this.loanProductDeferredIncomeRecognitionStep?.loanDeferredIncomeRecognitionForm;
+      return !!deferredIncomeForm && deferredIncomeForm.valid;
+    }
+    return true;
+  }
+
+  /**
+   * Titles of the hosted steps that are not yet valid, in wizard order.
+   *
+   * Classic hides its preview step entirely until the whole product is valid
+   * (`@if (loanProductFormValid)`), which is a hard requirement rather than a stylistic one: the
+   * summary dereferences the assembled product in `ngOnChanges` (`codeValue.name` in
+   * `setCurrentValues`) and throws on an incomplete one. The wizard keeps the Review step visible at
+   * all times — a step that vanishes from the stepper is worse than one that explains itself — and
+   * gates only the summary, telling the operator exactly which steps still need attention.
+   */
+  get incompleteClassicSteps(): string[] {
+    // Translation KEYS, not labels: this list is rendered to the operator, so the template pipes each
+    // through `translate`. All six already exist, so no new keys are introduced.
+    const steps: Array<{ title: string; form?: { invalid: boolean } }> = [
+      { title: 'labels.heading.Details', form: this.loanProductDetailsStep?.loanProductDetailsForm },
+      { title: 'labels.heading.Currency', form: this.loanProductCurrencyStep?.loanProductCurrencyForm },
+      { title: 'labels.heading.Terms', form: this.loanProductTermsStep?.loanProductTermsForm },
+      { title: 'labels.heading.Settings', form: this.loanProductSettingsStep?.loanProductSettingsForm },
+      { title: 'labels.heading.Accounting', form: this.loanProductAccountingStep?.loanProductAccountingForm }
+    ];
+    // Only required on the advanced payment allocation strategy, which is the only case where the
+    // step renders at all (and where Classic also demands its validity).
+    if (this.isAdvancedPaymentStrategy) {
+      steps.push({
+        // No sentence-case key exists for the full step name; this is the closest existing one.
+        title: 'labels.inputs.Deferred income',
+        form: this.loanProductDeferredIncomeRecognitionStep?.loanDeferredIncomeRecognitionForm
+      });
+    }
+    return steps.filter(({ form }) => !form || form.invalid).map(({ title }) => title);
+  }
+
+  /**
+   * The payload for Classic mode, assembled the way `CreateLoanProductClassicComponent` assembles it:
+   * spread each hosted step's own getter, then apply the advanced-payment-allocation extras and the
+   * two create-time fixups from its `submitLoanProduct`. Deliberately does NOT go through the config
+   * `buildPayload` — the hidden defaults and profile transforms there exist to complete a curated
+   * guided form, and Classic's steps already emit a complete product.
+   */
+  /**
+   * The assembled-but-not-yet-built product, mirroring Classic's `loanProduct` getter. Classic feeds
+   * exactly this shape to its preview step (before `LoanProducts.buildPayload` stamps dateFormat /
+   * locale and strips the UI-only keys), so the wizard's Classic-mode Review shows what Classic shows.
+   */
+  get classicPreviewProduct(): Record<string, any> {
+    const loanProduct: Record<string, any> = {
+      ...this.loanProductDetailsStep?.loanProductDetails,
+      ...this.loanProductCurrencyStep?.loanProductCurrency,
+      ...this.loanProductTermsStep?.loanProductTerms,
+      ...this.loanProductSettingsStep?.loanProductSettings,
+      ...this.loanProductChargesStep?.loanProductCharges,
+      ...this.loanProductAccountingStep?.loanProductAccounting
+    };
+
+    // The advanced-allocation extras belong to the PRODUCT, not to the submit step: Classic's own
+    // `loanProduct` getter adds them here and feeds that same object to its preview. Assembling them
+    // later, inside the payload builder, would have let the Review present a configuration the create
+    // request then contradicted — the operator could approve a product without the payment allocation,
+    // credit allocation, interest-refund types or deferred-income settings that were actually sent.
+    if (this.isAdvancedPaymentStrategy) {
+      loanProduct['paymentAllocation'] = this.paymentAllocation;
+      loanProduct['creditAllocation'] = this.creditAllocation;
+      // Raw option objects here, exactly as Classic holds them; `buildClassicPayload` maps them to the
+      // id list the create contract wants, mirroring Classic's `mapStringEnumOptionToIdList`.
+      loanProduct['supportedInterestRefundTypes'] = this.supportedInterestRefundTypes;
+
+      const capitalizedIncome = this.deferredIncomeRecognition?.capitalizedIncome;
+      if (capitalizedIncome) {
+        loanProduct['enableIncomeCapitalization'] = capitalizedIncome.enableIncomeCapitalization;
+        if (capitalizedIncome.enableIncomeCapitalization) {
+          loanProduct['capitalizedIncomeCalculationType'] = capitalizedIncome.capitalizedIncomeCalculationType;
+          loanProduct['capitalizedIncomeStrategy'] = capitalizedIncome.capitalizedIncomeStrategy;
+          loanProduct['capitalizedIncomeType'] = capitalizedIncome.capitalizedIncomeType;
+        }
+      }
+
+      const buyDownFee = this.deferredIncomeRecognition?.buyDownFee;
+      if (buyDownFee) {
+        loanProduct['enableBuyDownFee'] = buyDownFee.enableBuyDownFee;
+        if (buyDownFee.enableBuyDownFee) {
+          loanProduct['buyDownFeeCalculationType'] = buyDownFee.buyDownFeeCalculationType;
+          loanProduct['buyDownFeeStrategy'] = buyDownFee.buyDownFeeStrategy;
+          loanProduct['buyDownFeeIncomeType'] = buyDownFee.buyDownFeeIncomeType;
+          loanProduct['merchantBuyDownFee'] = buyDownFee.merchantBuyDownFee;
+        }
+      }
+    }
+
+    return loanProduct;
+  }
+
+  /**
+   * The create payload for Classic mode: {@link classicPreviewProduct} — the exact model the Review
+   * shows — passed through `LoanProducts.buildPayload`, then Classic's two create-time fixups from
+   * `submitLoanProduct`. One model, so preview and submission can never disagree.
+   */
+  private buildClassicPayload(): any {
+    const payload = this.loanProducts.buildPayload(this.classicPreviewProduct, this.itemsByDefault || []);
+
+    // The global-configuration toggle nulls the explicit repayment-event days and is itself UI-only.
+    if (payload['useDueForRepaymentsConfigurations'] === true) {
+      payload['dueDaysForRepaymentEvent'] = null;
+      payload['overDueDaysForRepaymentEvent'] = null;
+    }
+    delete payload['useDueForRepaymentsConfigurations'];
+
+    // Refund types are only meaningful — and only accepted — on the advanced payment allocation
+    // strategy, and travel as an id list rather than the option objects the preview renders.
+    if (this.isAdvancedPaymentStrategy) {
+      payload['supportedInterestRefundTypes'] = (this.supportedInterestRefundTypes ?? []).map((type) => type.id);
+    } else {
+      delete payload['supportedInterestRefundTypes'];
+      delete payload['daysInYearCustomStrategy'];
+    }
+
+    return payload;
+  }
+
   buildPayloadForSubmit(): any {
+    if (this.usesClassicSteps) {
+      return this.buildClassicPayload();
+    }
     const formValue = this.getRawFormValueWithFormattedDates();
     // Fold the charges selected in the reused Classic step into the same `charges` key the payload
     // builder reads (`buildChargeReferences` -> `LoanProducts.buildPayload` map them to `[{ id }]`).
@@ -1178,20 +1553,46 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
     return String(value);
   }
 
+  /**
+   * Value lookup for the Review banner, mode-aware so both flows show the identical header.
+   *
+   * Guided profiles read the flat FormGroup. Classic mode reads whichever hosted step owns the
+   * control — the banner keys (name, shortName, externalId, currencyCode, principal, the repayment
+   * pair and the interest pair) are spread across Details, Currency and Terms.
+   */
+  private reviewValue(key: string): unknown {
+    if (!this.usesClassicSteps) {
+      return this.form?.get(key)?.value;
+    }
+    const hostedForms = [
+      this.loanProductDetailsStep?.loanProductDetailsForm,
+      this.loanProductCurrencyStep?.loanProductCurrencyForm,
+      this.loanProductTermsStep?.loanProductTermsForm,
+      this.loanProductSettingsStep?.loanProductSettingsForm
+    ];
+    for (const form of hostedForms) {
+      const control = form?.get(key);
+      if (control) {
+        return control.value;
+      }
+    }
+    return undefined;
+  }
+
   get reviewName(): string {
-    return (this.form?.get('name')?.value as string) || '';
+    return (this.reviewValue('name') as string) || '';
   }
 
   get reviewShortName(): string {
-    return (this.form?.get('shortName')?.value as string) || '';
+    return (this.reviewValue('shortName') as string) || '';
   }
 
   get reviewExternalId(): string {
-    return (this.form?.get('externalId')?.value as string) || '';
+    return (this.reviewValue('externalId') as string) || '';
   }
 
   get reviewCurrencyCode(): string {
-    return (this.form?.get('currencyCode')?.value as string) || '';
+    return (this.reviewValue('currencyCode') as string) || '';
   }
 
   get currencySymbol(): string {
@@ -1204,25 +1605,27 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   get formattedPrincipal(): string {
-    const principal = this.form?.get('principal')?.value;
+    const principal = this.reviewValue('principal');
     if (!principal && principal !== 0) {
       return '—';
     }
-    return `${this.currencySymbol}${Number(principal).toLocaleString('en-IN')}`;
+    // The operator's active locale, not a hardcoded one: `en-IN` groups digits in the Indian
+    // system (1,00,000), which is wrong for every other locale the app ships.
+    return `${this.currencySymbol}${Number(principal).toLocaleString(this.settingsService.languageCode)}`;
   }
 
   get scheduleLabel(): string {
-    const repaymentCount = this.form?.get('numberOfRepayments')?.value;
-    const repaymentPeriod = this.formatValue('repaymentFrequencyType', this.form?.get('repaymentFrequencyType')?.value);
+    const repaymentCount = this.reviewValue('numberOfRepayments');
+    const repaymentPeriod = this.formatValue('repaymentFrequencyType', this.reviewValue('repaymentFrequencyType'));
     return `${repaymentCount || '—'} × ${repaymentPeriod}`;
   }
 
   get interestLabel(): string {
-    const rate = this.form?.get('interestRatePerPeriod')?.value;
+    const rate = this.reviewValue('interestRatePerPeriod');
     if (!rate && rate !== 0) {
       return '—';
     }
-    const period = this.formatValue('interestRateFrequencyType', this.form?.get('interestRateFrequencyType')?.value);
+    const period = this.formatValue('interestRateFrequencyType', this.reviewValue('interestRateFrequencyType'));
     return `${rate}% ${period.toLowerCase()}`;
   }
 
@@ -1465,6 +1868,24 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
     // own FormGroup (with the mandatory GL account validators for Cash/Accrual), so it must be checked
     // alongside the wizard form — otherwise a Cash product with unselected accounts would POST and the
     // backend would reject it with "fundSourceAccountId is mandatory". Surface the errors instead.
+    // In Classic mode the flat FormGroup holds none of the product's data — the four hosted steps do
+    // — so validity and the "mark everything touched" pass run against their forms instead.
+    if (this.usesClassicSteps) {
+      if (!this.classicFormsValid) {
+        [
+          this.loanProductDetailsStep?.loanProductDetailsForm,
+          this.loanProductCurrencyStep?.loanProductCurrencyForm,
+          this.loanProductTermsStep?.loanProductTermsForm,
+          this.loanProductSettingsStep?.loanProductSettingsForm,
+          this.loanProductAccountingStep?.loanProductAccountingForm,
+          this.loanProductDeferredIncomeRecognitionStep?.loanDeferredIncomeRecognitionForm
+        ].forEach((form) => form?.markAllAsTouched());
+        return;
+      }
+      this.postLoanProduct(this.buildPayloadForSubmit());
+      return;
+    }
+
     const accountingForm = this.loanProductAccountingStep?.loanProductAccountingForm;
     // Classic's `loanProductFormValid` additionally requires `loanIncomeCapitalizationForm.valid`
     // whenever the advanced payment allocation strategy is selected: the reused Deferred Income
@@ -1480,9 +1901,13 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
       deferredIncomeForm?.markAllAsTouched();
       return;
     }
-    const final = this.buildPayloadForSubmit();
+    this.postLoanProduct(this.buildPayloadForSubmit());
+  }
+
+  /** The create call and success navigation, shared by both rendering modes. */
+  private postLoanProduct(payload: any): void {
     this.productsService
-      .createLoanProduct(this.loanProductService.loanProductPath, final)
+      .createLoanProduct(this.loanProductService.loanProductPath, payload)
       .subscribe((response: any) => {
         this.router.navigate(
           [
@@ -1638,6 +2063,10 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   private refreshReviewPayload(): void {
+    // Classic mode previews through Classic's own preview step, fed by buildClassicPayload().
+    if (this.usesClassicSteps) {
+      return;
+    }
     if (!this.form) {
       this.reviewPayload = {};
       return;

--- a/src/app/products/loan-products/wizard/loan-product.config.ts
+++ b/src/app/products/loan-products/wizard/loan-product.config.ts
@@ -129,12 +129,42 @@ export type FormStepKind =
   | 'deferred-income'
   | 'borrower-cycle'
   | 'review';
+/**
+ * The four Classic step components the wizard can host INSTEAD of rendering a step's `fields`
+ * config: `LoanProductDetailsStepComponent`, `LoanProductCurrencyStepComponent`,
+ * `LoanProductTermsStepComponent` and `LoanProductSettingsStepComponent`.
+ *
+ * The wizard already reuses Classic's other six steps (payment allocation, charges, accounting,
+ * interest refund, deferred income, borrower cycle) for every profile. These four were the only ones
+ * re-declared as config fields, and that re-declaration was the sole source of the
+ * Custom/Advanced-vs-Classic divergence. Custom/Advanced now hosts the real components, so its field
+ * set, validation and payload are Classic's by construction rather than by maintenance.
+ *
+ * Guided profiles keep rendering the `fields` config: their whole purpose is to expose a curated
+ * subset, which the full Classic steps would defeat.
+ */
+export type ClassicStep = 'details' | 'currency' | 'terms' | 'settings';
+
 export interface FormStep {
   id: number;
   title: string;
   icon: string;
   fields: FormField[];
   kind?: FormStepKind;
+  /**
+   * The Classic component that replaces this step's `fields` rendering when the profile uses the
+   * Classic steps (see {@link usesClassicSteps}). Absent for steps with no Classic counterpart.
+   */
+  classicStep?: ClassicStep;
+}
+
+/**
+ * Profiles that host Classic's four step components instead of the config-driven field grid.
+ * Custom/Advanced is the only one: it is the "complete control" mode, so its surface must be exactly
+ * Classic's. Every guided template renders its curated `fields` config instead.
+ */
+export function usesClassicSteps(profileMode: LoanWizardProfileMode): boolean {
+  return profileMode === 'custom-advanced';
 }
 
 export const PRODUCT_CARDS: ProductCard[] = [
@@ -345,6 +375,7 @@ export const FORM_STEPS: FormStep[] = [
   {
     id: 1,
     title: 'Details',
+    classicStep: 'details',
     icon: 'ti-id',
     fields: [
       {
@@ -393,6 +424,7 @@ export const FORM_STEPS: FormStep[] = [
   {
     id: 2,
     title: 'Currency',
+    classicStep: 'currency',
     icon: 'ti-currency-dollar',
     fields: [
       // The tenant's configured currencies, sourced from the backend template at render time exactly
@@ -429,6 +461,7 @@ export const FORM_STEPS: FormStep[] = [
   {
     id: 3,
     title: 'Terms',
+    classicStep: 'terms',
     icon: 'ti-calculator',
     fields: [
       {
@@ -544,6 +577,7 @@ export const FORM_STEPS: FormStep[] = [
   {
     id: 4,
     title: 'Settings',
+    classicStep: 'settings',
     icon: 'ti-settings',
     fields: [
       {

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -4008,6 +4008,7 @@
       "Breach evaluation will resume": "Hodnocení porušení bude obnoveno {{date}}. Úvěr bude od tohoto data znovu hodnocen."
     },
     "text": {
+      "Complete these steps to preview the product": "Dokončete tyto kroky, abyste zobrazili náhled produktu",
       "Agriculture Loan": "Zemědělský úvěr",
       "Auto Loan": "Úvěr na automobil",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financování nákupu nových i ojetých vozů s pevnými měsíčními splátkami po zvolenou dobu splatnosti.",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -4009,6 +4009,7 @@
       "Breach evaluation will resume": "Die Verstoßbewertung wird am {{date}} fortgesetzt. Das Darlehen wird ab diesem Datum wieder bewertet."
     },
     "text": {
+      "Complete these steps to preview the product": "Schließen Sie diese Schritte ab, um eine Vorschau des Produkts anzuzeigen",
       "Agriculture Loan": "Agrarkredit",
       "Auto Loan": "Autokredit",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finanzierung für den Kauf von Neu- oder Gebrauchtwagen mit festen monatlichen Raten über eine gewählte Laufzeit.",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -4031,6 +4031,7 @@
       "Breach evaluation will resume": "Breach evaluation resumes on {{date}}. The loan is evaluated again from that date."
     },
     "text": {
+      "Complete these steps to preview the product": "Complete these steps to preview the product",
       "Country": "Country",
       "Agriculture Loan": "Agriculture Loan",
       "Auto Loan": "Auto Loan",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -4008,6 +4008,7 @@
       "Breach evaluation will resume": "La evaluación de incumplimiento se reanuda el {{date}}. El préstamo se vuelve a evaluar a partir de esa fecha."
     },
     "text": {
+      "Complete these steps to preview the product": "Complete estos pasos para ver la vista previa del producto",
       "Agriculture Loan": "Crédito Agrícola",
       "Auto Loan": "Crédito Automotriz",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financiamiento para la compra de autos nuevos o usados con cuotas mensuales fijas durante el plazo elegido.",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -4012,6 +4012,7 @@
       "Breach evaluation will resume": "La evaluación de incumplimiento se reanuda el {{date}}. El préstamo se vuelve a evaluar a partir de esa fecha."
     },
     "text": {
+      "Complete these steps to preview the product": "Complete estos pasos para ver la vista previa del producto",
       "Agriculture Loan": "Crédito Agrícola",
       "Auto Loan": "Crédito Automotriz",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financiamiento para la compra de autos nuevos o usados con cuotas mensuales fijas durante el plazo elegido.",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -4010,6 +4010,7 @@
       "Breach evaluation will resume": "L'évaluation des manquements reprend le {{date}}. Le prêt est de nouveau évalué à partir de cette date."
     },
     "text": {
+      "Complete these steps to preview the product": "Complétez ces étapes pour afficher l'aperçu du produit",
       "Agriculture Loan": "Prêt agricole",
       "Auto Loan": "Prêt automobile",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financement pour l'achat de voitures neuves ou d'occasion avec des mensualités fixes sur une durée choisie.",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -4006,6 +4006,7 @@
       "Breach evaluation will resume": "La valutazione delle violazioni riprende il {{date}}. Il prestito viene valutato di nuovo a partire da quella data."
     },
     "text": {
+      "Complete these steps to preview the product": "Completare questi passaggi per visualizzare l'anteprima del prodotto",
       "Agriculture Loan": "Prestito agricolo",
       "Auto Loan": "Prestito auto",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finanziamento per l'acquisto di auto nuove o usate con rate mensili fisse per la durata scelta.",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -4006,6 +4006,7 @@
       "Breach evaluation will resume": "{{date}}부터 위반 평가가 재개됩니다. 해당 날짜부터 대출이 다시 평가됩니다."
     },
     "text": {
+      "Complete these steps to preview the product": "제품을 미리 보려면 이 단계를 완료하세요",
       "Agriculture Loan": "농업 대출",
       "Auto Loan": "자동차 대출",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "신차 또는 중고차 구매를 위한 금융으로, 선택한 기간 동안 매월 일정한 할부금을 상환합니다.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -4006,6 +4006,7 @@
       "Breach evaluation will resume": "Pažeidimų vertinimas atnaujinamas {{date}}. Nuo tos dienos paskola vėl vertinama."
     },
     "text": {
+      "Complete these steps to preview the product": "Atlikite šiuos veiksmus, kad peržiūrėtumėte produktą",
       "Agriculture Loan": "Žemės ūkio paskola",
       "Auto Loan": "Automobilio paskola",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finansavimas naujų ar naudotų automobilių pirkimui su fiksuotomis mėnesinėmis įmokomis pasirinktu laikotarpiu.",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -4006,6 +4006,7 @@
       "Breach evaluation will resume": "Pārkāpumu novērtēšana atsākas {{date}}. No šī datuma aizdevums tiek novērtēts atkārtoti."
     },
     "text": {
+      "Complete these steps to preview the product": "Izpildiet šīs darbības, lai priekšskatītu produktu",
       "Agriculture Loan": "Lauksaimniecības aizdevums",
       "Auto Loan": "Auto aizdevums",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finansējums jaunu vai lietotu automobiļu iegādei ar fiksētiem ikmēneša maksājumiem izvēlētajā termiņā.",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -4006,6 +4006,7 @@
       "Breach evaluation will resume": "{{date}} देखि उल्लंघन मूल्यांकन पुनः सुरु हुन्छ। त्यो मितिदेखि ऋणको पुनः मूल्यांकन गरिन्छ।"
     },
     "text": {
+      "Complete these steps to preview the product": "उत्पादनको पूर्वावलोकन गर्न यी चरणहरू पूरा गर्नुहोस्",
       "Agriculture Loan": "कृषि ऋण",
       "Auto Loan": "सवारी साधन ऋण",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "नयाँ वा प्रयोग भएका कार खरिदका लागि वित्तपोषण, छनोट गरिएको अवधिभर नियमित मासिक किस्तासहित।",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -4006,6 +4006,7 @@
       "Breach evaluation will resume": "A avaliação de violações recomeça em {{date}}. O empréstimo volta a ser avaliado a partir dessa data."
     },
     "text": {
+      "Complete these steps to preview the product": "Conclua estes passos para pré-visualizar o produto",
       "Agriculture Loan": "Empréstimo agrícola",
       "Auto Loan": "Crédito automóvel",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financiamento para a compra de automóveis novos ou usados com prestações mensais fixas durante o prazo escolhido.",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -4003,6 +4003,7 @@
       "Breach evaluation will resume": "Tathmini ya ukiukaji itaanza tena tarehe {{date}}. Mkopo utatathminiwa upya kuanzia tarehe hiyo."
     },
     "text": {
+      "Complete these steps to preview the product": "Kamilisha hatua hizi ili kuona onyesho la awali la bidhaa",
       "Agriculture Loan": "Mkopo wa Kilimo",
       "Auto Loan": "Mkopo wa Gari",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Ufadhili wa ununuzi wa magari mapya au yaliyotumika kwa malipo ya kila mwezi yaliyopangwa katika muda uliochaguliwa.",


### PR DESCRIPTION
## Description

Custom / Advanced had no component of its own: it was `LoanProductWizardComponent` with `profileMode = 'custom-advanced'`, the same config-driven engine that renders the 13 guided product templates. The wizard already reused six of Classic's nine step components verbatim; the remaining four — Details, Currency, Terms, Settings — were re-declared as config field entries and painted by a generic field loop. That re-declaration was the sole source of divergence from Classic, and every
known defect in this mode lived in it.

Custom / Advanced now hosts those four components too, so its field set, conditional visibility, validators and payload are Classic's by construction rather than by maintenance. `usesClassicSteps()` is the only seam, selecting three things: which template branch renders, where validity comes from, and how the payload is assembled. Guided profiles are untouched — they keep the field grid, which is the point of a curated template.

This closes the full parity gap in one change:

- The 13 missing Classic fields (Fund, the principal / repayment / interest min-max bands, the floating-rate family, Fixed Length, installment gaps, the Configurable Terms master switch) are rendered by the components that own them.
- Interest Refunds and Deferred Income Recognition now appear for any advanced-payment-allocation product, as in Classic, instead of being opted in per guided profile.
- Loan Cycle Variations works: Classic's Terms step owns the three variation FormArrays, which the wizard's flat FormGroup of scalars could not hold.
- Toggles no longer ship without their dependants, so the payloads Fineract rejected cannot be built.
- `useGlobalConfigForRepaymentEvent` was inert — stripped from the payload while the day values were always sent. Classic's Settings step owns the real Event Settings block, so the duplicate Advanced Configuration step is hidden here and Classic's actual rule applies: null both day values, then drop the UI-only key.

Payload assembly deliberately bypasses the config `buildPayload`: its hidden defaults and profile transforms exist to complete a curated guided form, and Classic's steps already emit a complete product. `buildClassicPayload` mirrors `CreateLoanProductClassicComponent` — the same spread order, the same advanced-allocation extras, the same two create-time fixups.

### Re-hosting a step component means adopting its host contract

Worth knowing before reviewing or extending this. The four components are reusable, but part of what makes them work lives in Classic's *host*, not in the components — and every bug found while verifying this change in a browser was a piece of that contract I had not reproduced:

| Classic's host does | Consequence when omitted |
|---|---|
| `@ViewChild(..., { static: true })`, so refs exist before children initialise | Charges was handed an unresolved ref: `TypeError` on `currencyCode.value`, blank stepper |
| passes its Terms control straight to Settings | Settings subscribes with `?.` in `ngOnInit` — it captured nothing and **failed silently**, so linking a floating rate never forced interest recalculation on |
| `@if (loanProductFormValid)` around the preview step | `<mat-step>` renders content eagerly, so the summary built itself from an empty product and threw |
| passes `[deferredIncomeRecognition]` to Accounting | four GL account fields (Income from Capitalization, Income from Buy Down, Buy Down Expense, Deferred Income Liability) never rendered, so a capitalized-income product could not supply its mappings |

The wizard's steps sit inside `*ngFor`/`*ngIf`, so `static: true` is not available. Three controls consumed by sibling steps are therefore bound to the wizard's own stable controls, with `wireClassicControlMirrors()` mirroring the hosted values into them once both sides exist: `currencyCode` and `multiDisburseLoan` for Charges, `isLinkedToFloatingInterestRates` for Settings.
The last row was found by auditing every `@Input`/`@Output` on all ten step components against what Classic's host binds; it is the only binding that was missing.

### Review

The Review step is always present. Only the summary waits for a complete product — Classic hides its whole preview step, which makes a step vanish from the stepper; here the step stays and names the steps still outstanding. The banner (name, chips, principal / schedule / interest tiles) is now shared by both modes, sourced through a small `reviewValue()` lookup that reads the flat form for guided profiles and the hosted forms for Custom / Advanced.

### Styling

Classic's per-step Previous/Next row is hidden — the wizard shell already renders unified step actions — and Classic's page-level headings are toned down to the shell's eyebrow treatment. Deliberately typography only: Classic's layout classes (`flex-48`, `layout-row-wrap`, …) are global utilities in `src/main.scss` and already lay these components out correctly. An earlier attempt to
re-flow them into the wizard's `.field-grid` broke section headings and checkbox rows; the reasoning is recorded in the stylesheet so it is not retried. All rules are scoped to the hosting wrappers, so the Classic and Edit flows are untouched.

**Tests.** Eleven specs used Custom / Advanced as the vehicle for flat-form *engine* behaviour. That engine still serves 13 profiles, so those tests were re-pointed at BNPL (the widest guided profile) rather than deleted; one was rewritten to set the strategy explicitly instead of relying on a profile's default. Two goldens that locked the config field grid for Custom / Advanced were removed — they still passed, which was the problem: they asserted a path the UI no longer takes. Eight new specs cover the seam, including one per row of the table above. 298 loan-product tests pass; typecheck, prettier, stylelint, eslint and htmlhint clean.

**i18n.** One new key, `labels.text.Complete these steps to preview the product`, added to all 13 locale files. Non-English files carry the English string, matching how every other wizard key in this repo starts life.

**Verified in the browser** against a live Fineract: the wizard renders, and a create request reaches the database (the only failure left was a duplicate external ID, reported by Fineract's catch-all as `error.msg.product.loan.duplicate.charge`).

## Related issues and discussion

# WEB-1190

## Screenshots, if any
<img width="1917" height="983" alt="image" src="https://github.com/user-attachments/assets/2a08603f-4df7-4d8e-9534-ef6a09dd6db5" />

<img width="1917" height="962" alt="image" src="https://github.com/user-attachments/assets/0853a847-7351-40ba-a1b5-c551d10320b8" />

<img width="1917" height="975" alt="image" src="https://github.com/user-attachments/assets/822bfd22-0c93-4636-b946-9444234b6235" />

<img width="1917" height="962" alt="image" src="https://github.com/user-attachments/assets/d81df064-b0e1-498c-9680-9904477acfdb" />

<img width="1916" height="971" alt="image" src="https://github.com/user-attachments/assets/848f613e-9c94-455d-bb78-870a763cf006" />

<img width="1916" height="975" alt="image" src="https://github.com/user-attachments/assets/f80277c3-af61-4ded-824c-06ababb46a86" />

<img width="1917" height="967" alt="image" src="https://github.com/user-attachments/assets/321a8cf0-ae2b-4e5a-b4a1-349c2304c986" />

<img width="1917" height="975" alt="image" src="https://github.com/user-attachments/assets/a63528da-536c-4658-9abd-11d848d63bf6" />

<img width="1916" height="976" alt="image" src="https://github.com/user-attachments/assets/3c9d1f90-da49-4f2c-9904-4084c111458d" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Classic mode for Custom/Advanced loan product setup with dedicated forms, validation, navigation, and previews.
  - Added profile-specific defaults, controls, and payment allocation options.
  - Guided workflows remain available for other loan product profiles.
  - Added localized recovery-payment labels, guidance, and validation messages.

- **Bug Fixes**
  - Improved review summaries and submission handling.
  - Added messaging for incomplete steps before preview.

- **Documentation**
  - Added product-preview instructions across supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->