### PR TITLE
WEB-1196: Source loan product template currency options from the tenant template

### DIFF
--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
@@ -330,6 +330,47 @@ describe('LoanProductWizardComponent', () => {
     ).toBe(true);
   });
 
+  it('sources the guided currency dropdown from the tenant template, like Classic', () => {
+    // Classic's currency step fills its dropdown from `loanProductsTemplate.currencyOptions` and binds
+    // `code` -> `name`. The guided templates used to carry a hardcoded INR/USD/EUR/GBP list, so a tenant
+    // configured on any other currency could not pick it — and was offered three it does not have.
+    const component = createComponent();
+    component.profileMode = 'personal';
+    component.loanProductsTemplate = {
+      currencyOptions: [
+        { code: 'KES', name: 'Kenyan Shilling', displaySymbol: 'KSh' },
+        { code: 'UGX', name: 'Uganda Shilling', displaySymbol: 'USh' }
+      ]
+    };
+
+    component.ngOnInit();
+
+    const currencyStep = component.steps.find((step) => step.fields.some((field) => field.key === 'currencyCode'))!;
+    const currencyField = component.visibleFields(currencyStep).find((field) => field.key === 'currencyCode')!;
+
+    expect(currencyField.options).toEqual([
+      { value: 'KES', label: 'Kenyan Shilling' },
+      { value: 'UGX', label: 'Uganda Shilling' }
+    ]);
+    // ...and the first template currency is the seeded default, exactly as Classic patches it.
+    expect(component.form.get('currencyCode')!.value).toBe('KES');
+  });
+
+  it('names the Review currency and its symbol from the tenant template', () => {
+    const component = createComponent();
+    component.profileMode = 'personal';
+    component.loanProductsTemplate = {
+      currencyOptions: [{ code: 'KES', name: 'Kenyan Shilling', displaySymbol: 'KSh' }]
+    };
+
+    component.ngOnInit();
+
+    // The banner chip and the principal symbol must follow the same tenant list the dropdown offers;
+    // the static four-code maps only ever covered INR/USD/EUR/GBP.
+    expect(component.formatValue('currencyCode', 'KES')).toBe('Kenyan Shilling');
+    expect(component.currencySymbol).toBe('KSh');
+  });
+
   it('produces a Classic-equivalent payload for Custom/Advanced once the advanced strategy is selected', () => {
     const component = createComponent();
     component.profileMode = 'custom-advanced';

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
@@ -66,7 +66,10 @@ import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
 import { rangeValidator } from 'app/shared/validators/percentage.validator';
 
-/** Currency symbols rendered in the Review banner, keyed by ISO currency code. */
+/**
+ * Fallback currency symbols for the Review banner, keyed by ISO currency code. Used only when the
+ * backend template has no `displaySymbol` for the selected currency (or has not loaded yet).
+ */
 const CURRENCY_SYMBOLS: Record<string, string> = { INR: '₹', USD: '$', EUR: '€', GBP: '£' };
 
 /**
@@ -629,6 +632,15 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
     if (!Array.isArray(rawOptions)) {
       return undefined;
     }
+    // `currencyOptions` is the one template list keyed by ISO `code`/`name` instead of `id`/`value`:
+    // Classic binds `[value]="currency.code"` and renders `currency.name`
+    // (loan-product-currency-step.component.html), so the wizard maps the same pair.
+    if (key === 'currencyCode') {
+      return rawOptions.map((option: any) => ({
+        value: option.code,
+        label: option.name ?? option.displayLabel ?? option.code
+      }));
+    }
     // Classic's reschedule strategy list is filtered by schedule type in `setRescheduleStrategies`,
     // keyed off `advancedTransactionProcessingStrategyDisabled` — which its `loanScheduleType`
     // handler sets to TRUE on Progressive and FALSE on Cumulative. So Progressive keeps ids > 3 and
@@ -972,6 +984,17 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
       return this.getTransactionProcessingStrategyLabel(String(normalizedValue));
     }
 
+    // The Review chip names the currency the way Classic's dropdown does — from the tenant's own
+    // `currencyOptions` — falling through to VALUE_MAP for a template-less render.
+    if (key === 'currencyCode') {
+      const currencyLabel = this.getTemplateSourcedOptions('currencyCode')?.find(
+        (option) => String(option.value) === String(normalizedValue)
+      )?.label;
+      if (currencyLabel) {
+        return String(currencyLabel);
+      }
+    }
+
     const map = this.valueMap[key];
     if (map) {
       const result = map[String(normalizedValue)];
@@ -1172,7 +1195,12 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, OnDestroy 
   }
 
   get currencySymbol(): string {
-    return CURRENCY_SYMBOLS[this.reviewCurrencyCode] || '';
+    // The tenant's own symbol for the selected currency first (`displaySymbol`, e.g. 'KSh'); the
+    // static map only covers four codes and cannot cover every currency Fineract may be configured with.
+    const templateSymbol = (this.loanProductsTemplate?.currencyOptions ?? []).find(
+      (option: any) => option.code === this.reviewCurrencyCode
+    )?.displaySymbol;
+    return templateSymbol || CURRENCY_SYMBOLS[this.reviewCurrencyCode] || '';
   }
 
   get formattedPrincipal(): string {

--- a/src/app/products/loan-products/wizard/loan-product.config.ts
+++ b/src/app/products/loan-products/wizard/loan-product.config.ts
@@ -395,17 +395,15 @@ export const FORM_STEPS: FormStep[] = [
     title: 'Currency',
     icon: 'ti-currency-dollar',
     fields: [
+      // The tenant's configured currencies, sourced from the backend template at render time exactly
+      // like Classic, via TEMPLATE_OPTION_SOURCES. Left empty here rather than carrying a hardcoded
+      // four-currency list, which offered choices the tenant may not have and hid the ones it does.
       {
         label: 'labels.inputs.CURRENCY',
         key: 'currencyCode',
         type: 'select',
         required: true,
-        options: [
-          { value: 'INR', label: 'INR – Indian Rupee' },
-          { value: 'USD', label: 'USD – US Dollar' },
-          { value: 'EUR', label: 'EUR – Euro' },
-          { value: 'GBP', label: 'GBP – British Pound' }
-        ]
+        options: []
       },
       {
         label: 'labels.inputs.Decimal Places',
@@ -1312,6 +1310,9 @@ export const INTEREST_RECALCULATION_FIELDS: readonly string[] = [
  * `visibleFields`, so the wizard and Classic always offer the identical choices.
  */
 export const TEMPLATE_OPTION_SOURCES: Record<string, string> = {
+  // Classic's currency step fills its dropdown from `loanProductsTemplate.currencyOptions`
+  // (loan-product-currency-step.component.ts), i.e. the currencies actually configured on the tenant.
+  currencyCode: 'currencyOptions',
   preClosureInterestCalculationStrategy: 'preClosureInterestCalculationStrategyOptions',
   rescheduleStrategyMethod: 'rescheduleStrategyTypeOptions',
   interestRecalculationCompoundingMethod: 'interestRecalculationCompoundingTypeOptions',


### PR DESCRIPTION
## Description

The guided loan product templates rendered a hardcoded four-currency dropdown (INR, USD, EUR, GBP) rather than the currencies configured on the tenant. A tenant operating in any other currency could not select it, and was shown three it does not have. The Classic flow sources this list from `loanProductsTemplate.currencyOptions` (`loan-product-currency-step.component.ts`), so the two flows disagreed.

The wizard already resolves several selects from the backend template at render time via `TEMPLATE_OPTION_SOURCES`. `currencyCode` is registered with that same mechanism instead of introducing a parallel path:

- `TEMPLATE_OPTION_SOURCES` gains `currencyCode: 'currencyOptions'`, and the Currency step field drops its static list.
- `getTemplateSourcedOptions` special-cases `currencyCode`: `currencyOptions` is the one template list keyed by `code`/`name`  rather than `id`/`value`, so it maps the same pair Classic binds.
- The Review banner had the same stale maps in two more places — the currency chip (`VALUE_MAP.currencyCode`) and the symbol prefixed to the principal (`CURRENCY_SYMBOLS`). Both now resolve from the template (`name` / `displaySymbol`), keeping the static maps only as fallbacks for a template-less render.

The default selection already came from the template (`getDefaultCurrencyCode` → `currencyOptions[0].code`) and is unchanged.

Custom/Advanced is unaffected: it hosts the real Classic currency component, so it already had this behaviour. The guided templates continue to expose only the Currency field — Decimal Places, Currency in multiples of and Installment in multiples of remain Custom/Advanced-only by design.

## Related issues and discussion

# WEB-1196

## Screenshots, if any
<img width="1600" height="850" alt="WhatsApp Image 2026-08-31 at 9 40 16 PM" src="https://github.com/user-attachments/assets/55e21f4a-12ea-4a2b-bb32-8ffac11a6bc0" />

<img width="1600" height="850" alt="WhatsApp Image 2026-08-31 at 9 40 32 PM" src="https://github.com/user-attachments/assets/b90c7fb6-3ea9-4078-b73b-3d81aa62c9f3" />


## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Currency options in the loan product wizard are now loaded from configured tenant currencies.
  * The first configured currency is selected by default.
  * Review screens display the configured currency name and symbol, including custom symbols when available.

* **Bug Fixes**
  * Removed reliance on a fixed list of currency options, ensuring currency selections reflect current configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->