### PR TITLE
WEB-1197: Prevent invalid recurring-deposit approval submission

### DIFF
--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/approve-recurring-deposits-account/approve-recurring-deposits-account.component.html
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/approve-recurring-deposits-account/approve-recurring-deposits-account.component.html
@@ -42,7 +42,7 @@
         <button type="button" mat-raised-button [routerLink]="['../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
-        <button mat-raised-button color="primary" [disabled]="!approveRecurringDepositsAccountForm">
+        <button mat-raised-button color="primary" [disabled]="approveRecurringDepositsAccountForm.invalid">
           {{ 'labels.buttons.Confirm' | translate }}
         </button>
       </mat-card-actions>

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/approve-recurring-deposits-account/approve-recurring-deposits-account.component.spec.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/approve-recurring-deposits-account/approve-recurring-deposits-account.component.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+import { RecurringDepositsService } from '../../recurring-deposits.service';
+import { ApproveRecurringDepositsAccountComponent } from './approve-recurring-deposits-account.component';
+
+describe('ApproveRecurringDepositsAccountComponent', () => {
+  let component: ApproveRecurringDepositsAccountComponent;
+  let fixture: ComponentFixture<ApproveRecurringDepositsAccountComponent>;
+  let recurringDepositsService: jest.Mocked<RecurringDepositsService>;
+  let router: jest.Mocked<Router>;
+
+  const accountId = '123';
+  const approvedOnDate = new Date(2026, 7, 31);
+
+  beforeEach(async () => {
+    recurringDepositsService = {
+      executeRecurringDepositsAccountCommand: jest.fn(() => of({}))
+    } as any;
+    router = {
+      navigate: jest.fn(() => Promise.resolve(true))
+    } as any;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ApproveRecurringDepositsAccountComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { parent: { snapshot: { params: { recurringDepositAccountId: accountId } } } }
+        },
+        { provide: Router, useValue: router },
+        { provide: RecurringDepositsService, useValue: recurringDepositsService },
+        {
+          provide: SettingsService,
+          useValue: { businessDate: approvedOnDate, language: { code: 'en' }, dateFormat: 'dd MMMM yyyy' }
+        },
+        { provide: Dates, useValue: { formatDate: jest.fn(() => '31 August 2026') } },
+        provideNativeDateAdapter(),
+        provideNoopAnimations()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApproveRecurringDepositsAccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const confirmButton = (): HTMLButtonElement =>
+    fixture.nativeElement.querySelector('mat-card-actions button:last-child');
+
+  it('should disable Confirm when Approved On Date is empty', () => {
+    expect(confirmButton().disabled).toBe(true);
+  });
+
+  it('should enable Confirm when the form is valid', () => {
+    component.approveRecurringDepositsAccountForm.patchValue({ approvedOnDate });
+    fixture.detectChanges();
+
+    expect(confirmButton().disabled).toBe(false);
+  });
+
+  it('should not submit an invalid form', () => {
+    component.submit();
+
+    expect(recurringDepositsService.executeRecurringDepositsAccountCommand).not.toHaveBeenCalled();
+  });
+
+  it('should submit a valid form and navigate to the account', () => {
+    component.approveRecurringDepositsAccountForm.patchValue({ approvedOnDate, note: 'Approved' });
+
+    component.submit();
+
+    expect(recurringDepositsService.executeRecurringDepositsAccountCommand).toHaveBeenCalledWith(accountId, 'approve', {
+      approvedOnDate: '31 August 2026',
+      note: 'Approved',
+      dateFormat: 'dd MMMM yyyy',
+      locale: 'en'
+    });
+    expect(router.navigate).toHaveBeenCalledWith(['../../'], { relativeTo: TestBed.inject(ActivatedRoute) });
+  });
+});

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/approve-recurring-deposits-account/approve-recurring-deposits-account.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/approve-recurring-deposits-account/approve-recurring-deposits-account.component.ts
@@ -86,6 +86,9 @@ export class ApproveRecurringDepositsAccountComponent implements OnInit {
    * if successful redirects to the recurring deposit account.
    */
   submit() {
+    if (this.approveRecurringDepositsAccountForm.invalid) {
+      return;
+    }
     const approveRecurringDepositsAccountFormData = this.approveRecurringDepositsAccountForm.value;
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;


### PR DESCRIPTION
 ## Description

Prevents invalid recurring-deposit approval submissions by disabling Confirm when the approval form is invalid and blocking invalid forms from invoking the approval API.

## Related issues and discussion

WEB-1197

## Screenshots, if any

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The Confirm button is now enabled only when all required approval details are valid.
  - Invalid approval forms can no longer be submitted.
  - Valid approvals continue to process the entered date and notes, then return to the account.

- **Tests**
  - Added coverage for button validation, blocked invalid submissions, and successful approval processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->