### PR TITLE
WEB-1198: Source delinquency bucket options from the tenant template

### DIFF
--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
@@ -374,11 +374,148 @@ describe('LoanProductWizardComponent', () => {
     expect(component.currencySymbol).toBe('KSh');
   });
 
+  describe('delinquency bucket options come from the tenant template', () => {
+    // Two Wheeler is one of the profiles that drops `delinquencyBucketId` from its hidden defaults, so
+    // the select is a visible, editable control there. Bucket ids are deliberately NOT 1 or 2: the
+    // select used to offer a hardcoded `'1' -> 'Bucket 1 – Standard'` / `'2' -> 'Bucket 2 – Aggressive'`
+    // pair, so a fixture using those ids would pass against the old fabricated list too.
+    const templateWithBuckets = {
+      currencyOptions: [{ code: 'KES', name: 'Kenyan Shilling' }],
+      delinquencyBucketOptions: [
+        { id: 7, name: 'Retail 30/60/90' },
+        { id: 9, name: 'SME 15/30/60' }
+      ]
+    };
+
+    function bucketField(component: LoanProductWizardComponent) {
+      const settingsStep = component.steps.find((step) =>
+        step.fields.some((field) => field.key === 'delinquencyBucketId')
+      )!;
+      return component.visibleFields(settingsStep).find((field) => field.key === 'delinquencyBucketId');
+    }
+
+    it("offers the tenant's own buckets, led by None", () => {
+      const component = createComponent();
+      component.profileMode = 'two-wheeler';
+      component.loanProductsTemplate = templateWithBuckets;
+
+      component.ngOnInit();
+
+      expect(bucketField(component)!.options).toEqual([
+        { value: '', label: 'None' },
+        { value: 7, label: 'Retail 30/60/90' },
+        { value: 9, label: 'SME 15/30/60' }
+      ]);
+    });
+
+    it('submits the selected bucket id as the number the backend issued', () => {
+      const component = createComponent();
+      component.profileMode = 'two-wheeler';
+      component.loanProductsTemplate = templateWithBuckets;
+
+      component.ngOnInit();
+      component.form.patchValue({ delinquencyBucketId: 7 });
+
+      // Not the string '7': the select binds the template's numeric `id`, exactly as Classic's
+      // `[value]="delinquencyBucket.id"` does.
+      expect(component.buildPayloadForSubmit().delinquencyBucketId).toBe(7);
+    });
+
+    it('keeps None selectable, and clears installment-level delinquency with it', () => {
+      const component = createComponent();
+      component.profileMode = 'two-wheeler';
+      component.loanProductsTemplate = templateWithBuckets;
+
+      component.ngOnInit();
+      component.form.patchValue({ delinquencyBucketId: '', enableInstallmentLevelDelinquency: true });
+
+      const payload = component.buildPayloadForSubmit();
+
+      // buildPayload normalizes the None option to null and resets the dependent flag, mirroring
+      // Classic's clear button.
+      expect(payload.delinquencyBucketId).toBeNull();
+      expect(payload.enableInstallmentLevelDelinquency).toBe(false);
+    });
+
+    it('falls back to None alone when the template carries no buckets', () => {
+      const component = createComponent();
+      component.profileMode = 'two-wheeler';
+      component.loanProductsTemplate = { currencyOptions: [{ code: 'KES', name: 'Kenyan Shilling' }] };
+
+      component.ngOnInit();
+
+      // No invented buckets: a tenant with none configured is offered none.
+      expect(bucketField(component)!.options).toEqual([{ value: '', label: 'None' }]);
+    });
+
+    it('seeds the currently-assigned bucket from the template, like Classic', () => {
+      // The template nests the assigned bucket under `delinquencyBucket` (`{ id, name, ranges }`),
+      // not a flat `delinquencyBucketId` — `loanProductSettingsForm` seeds from
+      // `this.loanProductsTemplate.delinquencyBucket.id` (loan-product-settings-step.component.ts).
+      // Reading a flat key here previously left the control at '' even when the template carried a
+      // bucket, silently resetting it to None on every load.
+      const component = createComponent();
+      component.profileMode = 'two-wheeler';
+      component.loanProductsTemplate = {
+        ...templateWithBuckets,
+        delinquencyBucket: { id: 7, name: 'Retail 30/60/90' }
+      };
+
+      component.ngOnInit();
+
+      expect(component.form.get('delinquencyBucketId')!.value).toBe(7);
+      expect(component.buildPayloadForSubmit().delinquencyBucketId).toBe(7);
+    });
+
+    it('seeds null, not None-as-empty-string, for a non-positive assigned bucket id', () => {
+      // Mirrors Classic's `delinquencyBucket.id > 0 ? ... : null` exactly: an assigned-but-invalid id
+      // (Fineract's sentinel for "no bucket") maps to null, not to the wizard's own '' None value.
+      const component = createComponent();
+      component.profileMode = 'two-wheeler';
+      component.loanProductsTemplate = { ...templateWithBuckets, delinquencyBucket: { id: 0, name: 'None' } };
+
+      component.ngOnInit();
+
+      expect(component.form.get('delinquencyBucketId')!.value).toBeNull();
+    });
+
+    it('falls back to the initial None default when the template carries no assigned bucket', () => {
+      const component = createComponent();
+      component.profileMode = 'two-wheeler';
+      component.loanProductsTemplate = templateWithBuckets;
+
+      component.ngOnInit();
+
+      expect(component.form.get('delinquencyBucketId')!.value).toBe('');
+    });
+  });
+
   it('exposes deferredIncomeRecognition so the Accounting step can reveal its GL accounts', () => {
     // The Accounting step gates four GL account fields on this input — Income from Capitalization,
     // Income from Buy Down, Buy Down Expense and Deferred Income Liability. Classic's host passes it;
     // the wizard did not, so those accounts never appeared and a capitalized-income product could not
     // supply the mappings Fineract requires.
+    const component = createComponent();
+    component.profileMode = 'custom-advanced';
+    component.loanProductsTemplate = {
+      currencyOptions: [{ code: 'INR' }],
+      enableIncomeCapitalization: true,
+      capitalizedIncomeCalculationTypeOptions: [{ id: 'FLAT' }],
+      capitalizedIncomeStrategyOptions: [{ id: 'EQUAL_AMORTIZATION' }],
+      capitalizedIncomeTypeOptions: [{ id: 'FEE' }],
+      enableBuyDownFee: false
+    };
+    component.ngOnInit();
+
+    component.onClassicAdvancePaymentStrategy(LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY);
+
+    expect(component.deferredIncomeRecognition?.capitalizedIncome?.enableIncomeCapitalization).toBe(true);
+    expect(component.deferredIncomeRecognition?.capitalizedIncome?.capitalizedIncomeCalculationType).toEqual({
+      id: 'FLAT'
+    });
+  });
+
+  it('produces a Classic-equivalent payload for Custom/Advanced once the advanced strategy is selected', () => {
     const component = createComponent();
     component.profileMode = 'custom-advanced';
     component.loanProductsTemplate = {

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
@@ -40,6 +40,7 @@ import {
   TEMPLATE_OPTION_SOURCES,
   NTH_DAY_ON_DAY_OPTION,
   ON_DAY_OF_MONTH_OPTIONS,
+  DELINQUENCY_BUCKET_NONE_OPTION,
   VALUE_MAP,
   SelectOption,
   LoanWizardProfileMode,
@@ -47,6 +48,7 @@ import {
   FormStep
 } from './loan-product.config';
 import { ProductsService } from '../../products.service';
+import { DelinquencyBucket } from '../models/loan-product.model';
 import { LoanProducts } from '../loan-products';
 import {
   AdvancedCreditAllocation,
@@ -871,6 +873,19 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
         value: option.code,
         label: option.name ?? option.displayLabel ?? option.code
       }));
+    }
+    // `delinquencyBucketOptions` is keyed `id`/`name` (DelinquencyBucket in models/loan-product.model.ts),
+    // so the generic `option.value ?? option.code` mapping below would label every bucket `undefined`.
+    // Classic binds `[value]="delinquencyBucket.id"` and renders `delinquencyBucket.name`. The "None"
+    // choice leads the list because the wizard renders it as an option where Classic uses a clear button.
+    if (key === 'delinquencyBucketId') {
+      return [
+        DELINQUENCY_BUCKET_NONE_OPTION,
+        ...(rawOptions as DelinquencyBucket[]).map((bucket) => ({
+          value: bucket.id,
+          label: bucket.name ?? String(bucket.id)
+        }))
+      ];
     }
     // Classic's reschedule strategy list is filtered by schedule type in `setRescheduleStrategies`,
     // keyed off `advancedTransactionProcessingStrategyDisabled` — which its `loanScheduleType`
@@ -2015,7 +2030,7 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
         canUseForTopup: this.loanProductsTemplate.canUseForTopup ?? INITIAL_FORM_STATE.canUseForTopup,
         isInterestRecalculationEnabled:
           this.loanProductsTemplate.isInterestRecalculationEnabled ?? INITIAL_FORM_STATE.isInterestRecalculationEnabled,
-        delinquencyBucketId: this.loanProductsTemplate.delinquencyBucketId ?? INITIAL_FORM_STATE.delinquencyBucketId,
+        delinquencyBucketId: this.getDefaultDelinquencyBucketId(),
         canDefineInstallmentAmount:
           this.loanProductsTemplate.canDefineInstallmentAmount ?? INITIAL_FORM_STATE.canDefineInstallmentAmount,
         // Fineract rejects multiDisburseLoan/allowVariableInstallments unless the product uses daily
@@ -2100,5 +2115,22 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
 
   private getDefaultCurrencyCode(): string {
     return this.loanProductsTemplate?.currencyOptions?.[0]?.code || INITIAL_FORM_STATE.currencyCode;
+  }
+
+  /**
+   * The bucket currently assigned on the template, mirroring Classic's own seed
+   * (`this.loanProductsTemplate.delinquencyBucket.id > 0 ? ... : null` in
+   * loan-product-settings-step.component.ts). The template nests the assigned bucket under
+   * `delinquencyBucket` — not a flat `delinquencyBucketId` — so reading the flat key here (as this
+   * used to) always missed it and reset the select to None even when the template had a bucket
+   * assigned. `delinquencyBucketId` is kept as a fallback for a template shape that does carry the
+   * flat key; on the real API response it never does, so this degrades to the previous behaviour.
+   */
+  private getDefaultDelinquencyBucketId(): number | string | null {
+    const delinquencyBucket = this.loanProductsTemplate?.delinquencyBucket;
+    if (delinquencyBucket) {
+      return delinquencyBucket.id > 0 ? delinquencyBucket.id : null;
+    }
+    return this.loanProductsTemplate?.delinquencyBucketId ?? INITIAL_FORM_STATE.delinquencyBucketId;
   }
 }

--- a/src/app/products/loan-products/wizard/loan-product.config.ts
+++ b/src/app/products/loan-products/wizard/loan-product.config.ts
@@ -339,7 +339,11 @@ export const VALUE_MAP: Record<string, Record<string, string>> = {
   isInterestRecalculationEnabled: { true: 'Enabled', false: 'Disabled' },
   allowPartialPeriodInterestCalculation: { true: 'Yes', false: 'No' },
   isEqualAmortization: { true: 'Yes', false: 'No' },
-  delinquencyBucketId: { '': 'None', '1': 'Bucket 1 – Standard', '2': 'Bucket 2 – Aggressive' },
+  // Only the "None" choice: every real bucket is named by the tenant, so the Review resolves its
+  // label from the field's template-sourced options (`formatFieldValue`) rather than from a static
+  // map that could only ever guess. The two invented entries that used to live here
+  // ('Bucket 1 – Standard', 'Bucket 2 – Aggressive') named buckets that exist on no tenant.
+  delinquencyBucketId: { '': 'None' },
   canDefineInstallmentAmount: { true: 'Yes', false: 'No' },
   allowVariableInstallments: { true: 'Yes', false: 'No' },
   multiDisburseLoan: { true: 'Yes', false: 'No' },
@@ -370,6 +374,18 @@ export const VALUE_MAP: Record<string, Record<string, string>> = {
   enableBuydownFees: { true: 'Yes', false: 'No' },
   overAppliedCalculationType: { '': 'None', Percentage: 'Percentage', Amount: 'Amount' }
 };
+
+/**
+ * The "no bucket" choice on the delinquency bucket select. Classic offers this as a clear button next
+ * to its dropdown (`clearProperty('delinquencyBucketId')` in loan-product-settings-step.component.ts,
+ * which also resets `enableInstallmentLevelDelinquency`); the wizard renders it as an option instead,
+ * so the empty value has to be declared rather than sourced from the template. `buildPayload`
+ * normalizes '' to null, and the same guard clears the installment-level flag.
+ *
+ * Declared above {@link FORM_STEPS} because that array literal references it at module-evaluation
+ * time — moving it down beside NTH_DAY_ON_DAY_OPTION would put it in the temporal dead zone.
+ */
+export const DELINQUENCY_BUCKET_NONE_OPTION: SelectOption = { value: '', label: 'None' };
 
 export const FORM_STEPS: FormStep[] = [
   {
@@ -816,14 +832,14 @@ export const FORM_STEPS: FormStep[] = [
         type: 'checkbox'
       },
       {
+        // The tenant's own delinquency buckets, sourced from the backend template at render time
+        // exactly like Classic, via TEMPLATE_OPTION_SOURCES. Only the "None" choice is declared here:
+        // it is the wizard's equivalent of Classic's clear button, not a bucket, so it has no template
+        // counterpart and must survive a template-less render.
         label: 'labels.inputs.Delinquency Bucket',
         key: 'delinquencyBucketId',
         type: 'select',
-        options: [
-          { value: '', label: 'None' },
-          { value: '1', label: 'Bucket 1 – Standard' },
-          { value: '2', label: 'Bucket 2 – Aggressive' }
-        ]
+        options: [DELINQUENCY_BUCKET_NONE_OPTION]
       },
       { label: 'labels.inputs.Define installment amount', key: 'canDefineInstallmentAmount', type: 'checkbox' },
       { label: 'labels.inputs.Allow variable installments', key: 'allowVariableInstallments', type: 'checkbox' },
@@ -1347,6 +1363,9 @@ export const TEMPLATE_OPTION_SOURCES: Record<string, string> = {
   // Classic's currency step fills its dropdown from `loanProductsTemplate.currencyOptions`
   // (loan-product-currency-step.component.ts), i.e. the currencies actually configured on the tenant.
   currencyCode: 'currencyOptions',
+  // Classic's settings step fills its bucket dropdown from `loanProductsTemplate.delinquencyBucketOptions`
+  // (loan-product-settings-step.component.ts), i.e. the buckets actually configured on the tenant.
+  delinquencyBucketId: 'delinquencyBucketOptions',
   preClosureInterestCalculationStrategy: 'preClosureInterestCalculationStrategyOptions',
   rescheduleStrategyMethod: 'rescheduleStrategyTypeOptions',
   interestRecalculationCompoundingMethod: 'interestRecalculationCompoundingTypeOptions',


### PR DESCRIPTION
## Description
The guided loan product wizard's Delinquency Bucket select (editable in Two Wheeler, Education, Agriculture, BNPL, Credit Card EMI, Home, Mortgage, Gold, Auto, JLG, Consumer Durable and LAS) offered two hardcoded options — 'Bucket 1 – Standard' and 'Bucket 2 – Aggressive' — with guessed ids that name no real bucket on any tenant. Classic sources this list from `loanProductsTemplate.delinquencyBucketOptions`.

Selecting either fabricated option attached whichever bucket actually holds id 1 or 2 on the tenant — a different delinquency classification than the label promised — or produced a raw 400 if no such bucket existed at all.

Fixed by wiring `delinquencyBucketId` into the existing `TEMPLATE_OPTION_SOURCES` mechanism (the same one the currency field already uses), with a small shape hook since `delinquencyBucketOptions` is keyed `id`/`name` rather than `id`/`value`. The "None" choice stays a static option — it's the wizard's equivalent of Classic's clear button, not a bucket, so it has no template counterpart and needs to survive a template-less render; it now also resets `enableInstallmentLevelDelinquency`, matching Classic's `clearProperty`.

## Related issues and discussion
# WEB-1198

## Screenshots, if any
<img width="1600" height="850" alt="WhatsApp Image 2026-09-01 at 2 37 11 AM" src="https://github.com/user-attachments/assets/c78d26d8-5b94-4af1-90d3-4d181f285f0d" />



## Checklist
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom and Advanced loan product profiles now support Classic Details, Currency, Terms, Settings, and Preview steps.
  * Advanced payment strategy selections populate deferred income recognition from the tenant template.
  * Loan product settings display delinquency buckets provided by the tenant template.
  * Added a clear “None” option; selections use backend-issued IDs.

* **Bug Fixes**
  * Selecting “None” clears the bucket and disables installment-level delinquency.
  * Added fallback behavior showing only “None” when no buckets are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->