### PR TITLE
WEB-1202: Prevent invalid deposit account actions

### DIFF
--- a/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/approve-fixed-deposits-account/approve-fixed-deposits-account.component.html
+++ b/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/approve-fixed-deposits-account/approve-fixed-deposits-account.component.html
@@ -42,7 +42,7 @@
         <button type="button" mat-raised-button [routerLink]="['../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
-        <button mat-raised-button color="primary" [disabled]="!approveFixedDepositsAccountForm">
+        <button mat-raised-button color="primary" [disabled]="approveFixedDepositsAccountForm.invalid">
           {{ 'labels.buttons.Confirm' | translate }}
         </button>
       </mat-card-actions>

--- a/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/approve-fixed-deposits-account/approve-fixed-deposits-account.component.spec.ts
+++ b/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/approve-fixed-deposits-account/approve-fixed-deposits-account.component.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+import { FixedDepositsService } from '../../fixed-deposits.service';
+import { ApproveFixedDepositsAccountComponent } from './approve-fixed-deposits-account.component';
+
+describe('ApproveFixedDepositsAccountComponent', () => {
+  let component: ApproveFixedDepositsAccountComponent;
+  let fixture: ComponentFixture<ApproveFixedDepositsAccountComponent>;
+  let fixedDepositsService: jest.Mocked<FixedDepositsService>;
+  let router: jest.Mocked<Router>;
+
+  const accountId = '123';
+  const approvedOnDate = new Date(2026, 8, 1);
+
+  beforeEach(async () => {
+    fixedDepositsService = {
+      executeFixedDepositsAccountCommand: jest.fn(() => of({}))
+    } as any;
+    router = {
+      navigate: jest.fn(() => Promise.resolve(true))
+    } as any;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ApproveFixedDepositsAccountComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { parent: { snapshot: { params: { fixedDepositAccountId: accountId } } } }
+        },
+        { provide: Router, useValue: router },
+        { provide: FixedDepositsService, useValue: fixedDepositsService },
+        {
+          provide: SettingsService,
+          useValue: { businessDate: approvedOnDate, language: { code: 'en' }, dateFormat: 'dd MMMM yyyy' }
+        },
+        { provide: Dates, useValue: { formatDate: jest.fn(() => '01 September 2026') } },
+        provideNativeDateAdapter(),
+        provideNoopAnimations()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApproveFixedDepositsAccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const confirmButton = (): HTMLButtonElement =>
+    fixture.nativeElement.querySelector('mat-card-actions button:last-child');
+
+  it('should disable Confirm when Approved On Date is empty', () => {
+    expect(confirmButton().disabled).toBe(true);
+  });
+
+  it('should enable Confirm when the form is valid', () => {
+    component.approveFixedDepositsAccountForm.patchValue({ approvedOnDate });
+    fixture.detectChanges();
+
+    expect(confirmButton().disabled).toBe(false);
+  });
+
+  it('should not submit an invalid form', () => {
+    component.submit();
+
+    expect(fixedDepositsService.executeFixedDepositsAccountCommand).not.toHaveBeenCalled();
+  });
+
+  it('should submit a valid form and navigate to the account', () => {
+    component.approveFixedDepositsAccountForm.patchValue({ approvedOnDate, note: 'Approved' });
+
+    component.submit();
+
+    expect(fixedDepositsService.executeFixedDepositsAccountCommand).toHaveBeenCalledWith(accountId, 'approve', {
+      approvedOnDate: '01 September 2026',
+      note: 'Approved',
+      dateFormat: 'dd MMMM yyyy',
+      locale: 'en'
+    });
+    expect(router.navigate).toHaveBeenCalledWith(['../../'], { relativeTo: TestBed.inject(ActivatedRoute) });
+  });
+});

--- a/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/approve-fixed-deposits-account/approve-fixed-deposits-account.component.ts
+++ b/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/approve-fixed-deposits-account/approve-fixed-deposits-account.component.ts
@@ -86,6 +86,9 @@ export class ApproveFixedDepositsAccountComponent implements OnInit {
    * if successful redirects to the fixed deposit account.
    */
   submit() {
+    if (this.approveFixedDepositsAccountForm.invalid) {
+      return;
+    }
     const approveFixedDepositsAccountFormData = this.approveFixedDepositsAccountForm.value;
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/premature-close-recurring-deposit-account/premature-close-recurring-deposit-account.component.html
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/premature-close-recurring-deposit-account/premature-close-recurring-deposit-account.component.html
@@ -37,7 +37,7 @@
         <button type="button" mat-raised-button [routerLink]="['../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
-        <button mat-raised-button color="primary" [disabled]="!prematureCloseRecurringDepositsAccountForm">
+        <button mat-raised-button color="primary" [disabled]="prematureCloseRecurringDepositsAccountForm.invalid">
           {{ 'labels.buttons.Confirm' | translate }}
         </button>
       </mat-card-actions>

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/premature-close-recurring-deposit-account/premature-close-recurring-deposit-account.component.spec.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/premature-close-recurring-deposit-account/premature-close-recurring-deposit-account.component.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+import { RecurringDepositsService } from '../../recurring-deposits.service';
+import { PrematureCloseRecurringDepositAccountComponent } from './premature-close-recurring-deposit-account.component';
+
+describe('PrematureCloseRecurringDepositAccountComponent', () => {
+  let component: PrematureCloseRecurringDepositAccountComponent;
+  let fixture: ComponentFixture<PrematureCloseRecurringDepositAccountComponent>;
+  let recurringDepositsService: jest.Mocked<RecurringDepositsService>;
+  let router: jest.Mocked<Router>;
+
+  const accountId = '789';
+  const closedOnDate = new Date(2026, 8, 1);
+
+  beforeEach(async () => {
+    recurringDepositsService = {
+      executeRecurringDepositsAccountCommand: jest.fn(() => of({}))
+    } as any;
+    router = {
+      navigate: jest.fn(() => Promise.resolve(true))
+    } as any;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        PrematureCloseRecurringDepositAccountComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { parent: { snapshot: { params: { recurringDepositAccountId: accountId } } } }
+        },
+        { provide: Router, useValue: router },
+        { provide: RecurringDepositsService, useValue: recurringDepositsService },
+        {
+          provide: SettingsService,
+          useValue: { businessDate: closedOnDate, language: { code: 'en' }, dateFormat: 'dd MMMM yyyy' }
+        },
+        { provide: Dates, useValue: { formatDate: jest.fn(() => '01 September 2026') } },
+        provideNativeDateAdapter(),
+        provideNoopAnimations()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PrematureCloseRecurringDepositAccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const confirmButton = (): HTMLButtonElement =>
+    fixture.nativeElement.querySelector('mat-card-actions button:last-child');
+
+  it('should disable Confirm when Closed On Date is empty', () => {
+    expect(confirmButton().disabled).toBe(true);
+  });
+
+  it('should enable Confirm when the form is valid', () => {
+    component.prematureCloseRecurringDepositsAccountForm.patchValue({ closedOnDate });
+    fixture.detectChanges();
+
+    expect(confirmButton().disabled).toBe(false);
+  });
+
+  it('should not submit an invalid form', () => {
+    component.submit();
+
+    expect(recurringDepositsService.executeRecurringDepositsAccountCommand).not.toHaveBeenCalled();
+  });
+
+  it('should submit a valid form and navigate to the account', () => {
+    component.prematureCloseRecurringDepositsAccountForm.patchValue({ closedOnDate });
+
+    component.submit();
+
+    expect(recurringDepositsService.executeRecurringDepositsAccountCommand).toHaveBeenCalledWith(
+      accountId,
+      'prematureClose',
+      {
+        closedOnDate: '01 September 2026',
+        dateFormat: 'dd MMMM yyyy',
+        locale: 'en'
+      }
+    );
+    expect(router.navigate).toHaveBeenCalledWith(['../../'], { relativeTo: TestBed.inject(ActivatedRoute) });
+  });
+});

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/premature-close-recurring-deposit-account/premature-close-recurring-deposit-account.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/premature-close-recurring-deposit-account/premature-close-recurring-deposit-account.component.ts
@@ -84,6 +84,9 @@ export class PrematureCloseRecurringDepositAccountComponent implements OnInit {
    * if successful redirects to the recurring deposit account.
    */
   submit() {
+    if (this.prematureCloseRecurringDepositsAccountForm.invalid) {
+      return;
+    }
     const prematureCloseRecurringDepositsAccountFormData = this.prematureCloseRecurringDepositsAccountForm.value;
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/reject-recurring-deposits-account/reject-recurring-deposits-account.component.html
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/reject-recurring-deposits-account/reject-recurring-deposits-account.component.html
@@ -42,7 +42,7 @@
         <button type="button" mat-raised-button [routerLink]="['../../']">
           {{ 'labels.buttons.Cancel' | translate }}
         </button>
-        <button mat-raised-button color="primary" [disabled]="!rejectRecurringDepositsAccountForm">
+        <button mat-raised-button color="primary" [disabled]="rejectRecurringDepositsAccountForm.invalid">
           {{ 'labels.buttons.Confirm' | translate }}
         </button>
       </mat-card-actions>

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/reject-recurring-deposits-account/reject-recurring-deposits-account.component.spec.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/reject-recurring-deposits-account/reject-recurring-deposits-account.component.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+import { RecurringDepositsService } from '../../recurring-deposits.service';
+import { RejectRecurringDepositsAccountComponent } from './reject-recurring-deposits-account.component';
+
+describe('RejectRecurringDepositsAccountComponent', () => {
+  let component: RejectRecurringDepositsAccountComponent;
+  let fixture: ComponentFixture<RejectRecurringDepositsAccountComponent>;
+  let recurringDepositsService: jest.Mocked<RecurringDepositsService>;
+  let router: jest.Mocked<Router>;
+
+  const accountId = '456';
+  const rejectedOnDate = new Date(2026, 8, 1);
+
+  beforeEach(async () => {
+    recurringDepositsService = {
+      executeRecurringDepositsAccountCommand: jest.fn(() => of({}))
+    } as any;
+    router = {
+      navigate: jest.fn(() => Promise.resolve(true))
+    } as any;
+
+    await TestBed.configureTestingModule({
+      imports: [
+        RejectRecurringDepositsAccountComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { parent: { snapshot: { params: { recurringDepositAccountId: accountId } } } }
+        },
+        { provide: Router, useValue: router },
+        { provide: RecurringDepositsService, useValue: recurringDepositsService },
+        {
+          provide: SettingsService,
+          useValue: { businessDate: rejectedOnDate, language: { code: 'en' }, dateFormat: 'dd MMMM yyyy' }
+        },
+        { provide: Dates, useValue: { formatDate: jest.fn(() => '01 September 2026') } },
+        provideNativeDateAdapter(),
+        provideNoopAnimations()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RejectRecurringDepositsAccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const confirmButton = (): HTMLButtonElement =>
+    fixture.nativeElement.querySelector('mat-card-actions button:last-child');
+
+  it('should disable Confirm when Rejected On Date is empty', () => {
+    expect(confirmButton().disabled).toBe(true);
+  });
+
+  it('should enable Confirm when the form is valid', () => {
+    component.rejectRecurringDepositsAccountForm.patchValue({ rejectedOnDate });
+    fixture.detectChanges();
+
+    expect(confirmButton().disabled).toBe(false);
+  });
+
+  it('should not submit an invalid form', () => {
+    component.submit();
+
+    expect(recurringDepositsService.executeRecurringDepositsAccountCommand).not.toHaveBeenCalled();
+  });
+
+  it('should submit a valid form and navigate to the account', () => {
+    component.rejectRecurringDepositsAccountForm.patchValue({ rejectedOnDate, note: 'Rejected' });
+
+    component.submit();
+
+    expect(recurringDepositsService.executeRecurringDepositsAccountCommand).toHaveBeenCalledWith(accountId, 'reject', {
+      rejectedOnDate: '01 September 2026',
+      note: 'Rejected',
+      dateFormat: 'dd MMMM yyyy',
+      locale: 'en'
+    });
+    expect(router.navigate).toHaveBeenCalledWith(['../../'], { relativeTo: TestBed.inject(ActivatedRoute) });
+  });
+});

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/reject-recurring-deposits-account/reject-recurring-deposits-account.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/reject-recurring-deposits-account/reject-recurring-deposits-account.component.ts
@@ -86,6 +86,9 @@ export class RejectRecurringDepositsAccountComponent implements OnInit {
    * if successful redirects to the recurring deposit account.
    */
   submit() {
+    if (this.rejectRecurringDepositsAccountForm.invalid) {
+      return;
+    }
     const rejectRecurringDepositsAccountFormData = this.rejectRecurringDepositsAccountForm.value;
     const locale = this.settingsService.language.code;
     const dateFormat = this.settingsService.dateFormat;


### PR DESCRIPTION
## Description

Prevents invalid Fixed and Recurring Deposit account actions by disabling Confirm when required forms are invalid and blocking invalid submissions from reaching the backend.

Covers Fixed Deposit approval, Recurring Deposit rejection, and Recurring Deposit premature closure.

## Related issues and discussion

WEB-1202


