### PR TITLE
WEB-657: Working Capital - Transaction type issue

### DIFF
--- a/src/app/loans/loans-view/_loan-tab-shared.scss
+++ b/src/app/loans/loans-view/_loan-tab-shared.scss
@@ -80,6 +80,11 @@
     --tx-linked-bg: var(--ch-paid-bg);
     --tx-recovery: #00838f;
     --tx-recovery-bg: #e0f7fa;
+
+    /* Neutral fallback for transaction types without a dedicated badge class.
+       Built on the secondary text/surface tokens so it follows both themes. */
+    --tx-default: var(--ch-text-2);
+    --tx-default-bg: var(--ch-surface-h);
   }
 
   :host-context(.dark-theme) {
@@ -99,7 +104,7 @@
 /* ── Transaction-type badges (same system as charges-tab) ──── */
 $transaction-type-keys:
   'repayment', 'disbursement', 'accrual', 'reversed', 'downpayment', 'chargeoff', 'reage', 'reamortize', 'discount',
-  'linked';
+  'linked', 'recovery';
 
 @mixin transaction-badges {
   .badge {
@@ -110,14 +115,20 @@ $transaction-type-keys:
     border-radius: 20px;
     font-size: 11px;
     font-weight: 600;
-    border: 1px solid transparent;
     white-space: nowrap;
+
+    /* Neutral default so a type without a generated badge-* class still
+       renders as an intentional pill instead of unstyled text. */
+    background: var(--tx-default-bg);
+    color: var(--tx-default);
+    border: 1px solid var(--tx-default);
 
     .badge-dot {
       width: 6px;
       height: 6px;
       border-radius: 50%;
       flex-shrink: 0;
+      background: var(--tx-default);
     }
   }
 

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3961,6 +3961,7 @@
       "Transfer in progress": "Převod",
       "Transfer on hold": "Přenesejte na pozastavení",
       "Withdrawn": "Stažený",
+      "Withdrawn by applicant": "Staženo žadatelem",
       "Written Off": "Odepsáno"
     },
     "dialogContext": {

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3962,6 +3962,7 @@
       "Transfer in progress": "Übertragung in Arbeit",
       "Transfer on hold": "Übertragen",
       "Withdrawn": "Zurückgezogen",
+      "Withdrawn by applicant": "Vom Antragsteller zurückgezogen",
       "Written Off": "Abgeschrieben"
     },
     "dialogContext": {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3984,6 +3984,7 @@
       "Transfer in progress": "Transfer in progress",
       "Transfer on hold": "Transfer on hold",
       "Withdrawn": "Withdrawn",
+      "Withdrawn by applicant": "Withdrawn by applicant",
       "Written Off": "Written Off"
     },
     "dialogContext": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3961,6 +3961,7 @@
       "Transfer in progress": "Transferencia en progreso",
       "Transfer on hold": "Transferencia en pausa",
       "Withdrawn": "Retirado",
+      "Withdrawn by applicant": "Retirado por el solicitante",
       "Written Off": "Castigado"
     },
     "dialogContext": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3965,6 +3965,7 @@
       "Transfer in progress": "Transferencia en progreso",
       "Transfer on hold": "Transferencia en pausa",
       "Withdrawn": "Retirado",
+      "Withdrawn by applicant": "Retirado por el solicitante",
       "Written Off": "Castigado"
     },
     "dialogContext": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3963,6 +3963,7 @@
       "Transfer in progress": "Transfert en cours",
       "Transfer on hold": "Transfert en attente",
       "Withdrawn": "Retiré",
+      "Withdrawn by applicant": "Retiré par le demandeur",
       "Written Off": "Passé en perte"
     },
     "dialogContext": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3959,6 +3959,7 @@
       "Transfer in progress": "Trasferimento in corso",
       "Transfer on hold": "Trasferimento in attesa",
       "Withdrawn": "Ritirato",
+      "Withdrawn by applicant": "Ritirato dal richiedente",
       "Written Off": "Stralciato"
     },
     "dialogContext": {

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3959,6 +3959,7 @@
       "Transfer in progress": "진행중인 양도",
       "Transfer on hold": "보류에 이체하십시오",
       "Withdrawn": "빼는",
+      "Withdrawn by applicant": "신청자에 의해 철회됨",
       "Written Off": "상각됨"
     },
     "dialogContext": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3959,6 +3959,7 @@
       "Transfer in progress": "Vykdomas perkėlimas",
       "Transfer on hold": "Perkelti sustabdytas",
       "Withdrawn": "Pasitraukė",
+      "Withdrawn by applicant": "Pareiškėjo atsiimta",
       "Written Off": "Nurašyta"
     },
     "dialogContext": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3959,6 +3959,7 @@
       "Transfer in progress": "Iepriekšējā pārnešana",
       "Transfer on hold": "Pārnešana aizturēta",
       "Withdrawn": "Atsaukts",
+      "Withdrawn by applicant": "Pieteikuma iesniedzēja atsaukts",
       "Written Off": "Norakstīts"
     },
     "dialogContext": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3959,6 +3959,7 @@
       "Transfer in progress": "प्रगतिमा स्थानान्तरण",
       "Transfer on hold": "होल्डमा स्थानान्तरण गर्नुहोस्",
       "Withdrawn": "फिर्ता लिन",
+      "Withdrawn by applicant": "आवेदकद्वारा फिर्ता लिइएको",
       "Written Off": "राइट अफ"
     },
     "dialogContext": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3959,6 +3959,7 @@
       "Transfer in progress": "Transferência em andamento",
       "Transfer on hold": "Transferência em espera",
       "Withdrawn": "Retirado",
+      "Withdrawn by applicant": "Retirado pelo requerente",
       "Written Off": "Baixado"
     },
     "dialogContext": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3956,6 +3956,7 @@
       "Transfer in progress": "Uhamisho unaendelea",
       "Transfer on hold": "Uhamisho juu ya kushikilia",
       "Withdrawn": "Kutolewa",
+      "Withdrawn by applicant": "Imeondolewa na mwombaji",
       "Written Off": "Imefutwa"
     },
     "dialogContext": {


### PR DESCRIPTION
## Description

The transaction type for Recovery Payment was not colored properly

<img width="1228" height="756" alt="image" src="https://github.com/user-attachments/assets/a1f37a73-6b87-4211-ac29-66907ce5ecca" />

## Related issues and discussion

[WEB-657](WEB-657)

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] If you have multiple commits please combine them into one commit by squashing them.

- [ ] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-657]: https://mifosforge.jira.com/browse/WEB-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a distinct “Withdrawn by applicant” status label, with translations across supported languages.
  * Added localized messaging for cases where a currency has already been added.
  * Added neutral default styling for transaction badges, including recovery transactions, for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->