### PR TITLE
WEB-1203: Show a message when the currency filter matches nothing

### DIFF
--- a/src/app/organization/currencies/currencies.component.html
+++ b/src/app/organization/currencies/currencies.component.html
@@ -37,6 +37,14 @@
 
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr *matNoDataRow>
+        <td class="no-data-cell" [attr.colspan]="displayedColumns.length">
+          {{
+            (filterValue ? 'labels.inputs.No records match the selected filter' : 'labels.text.No data found')
+              | translate
+          }}
+        </td>
+      </tr>
     </table>
 
     <mat-paginator [pageSizeOptions]="[10, 25, 50, 100]" showFirstLastButtons></mat-paginator>

--- a/src/app/organization/currencies/currencies.component.scss
+++ b/src/app/organization/currencies/currencies.component.scss
@@ -9,3 +9,13 @@
 table {
   width: 100%;
 }
+
+/* The empty-state row carries no mat-cell directive, so it gets none of the
+   table's cell padding. Dim it rather than naming a colour, so it follows
+   whichever text colour the active theme already gives the table. */
+.no-data-cell {
+  padding: 24px 16px;
+  text-align: center;
+  font-style: italic;
+  opacity: 0.75;
+}

--- a/src/app/organization/currencies/currencies.component.ts
+++ b/src/app/organization/currencies/currencies.component.ts
@@ -32,7 +32,8 @@ import {
   MatHeaderRowDef,
   MatHeaderRow,
   MatRowDef,
-  MatRow
+  MatRow,
+  MatNoDataRow
 } from '@angular/material/table';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
@@ -64,6 +65,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatHeaderRow,
     MatRowDef,
     MatRow,
+    MatNoDataRow,
     MatPaginator
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
@@ -84,6 +86,8 @@ export class CurrenciesComponent implements OnInit, AfterViewInit {
   ];
   /** Data source for currencies table. */
   dataSource: MatTableDataSource<any>;
+  /** Filter currently applied to the table, used to word the empty state. */
+  filterValue = '';
 
   /** Paginator for currencies table. */
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
@@ -117,7 +121,8 @@ export class CurrenciesComponent implements OnInit, AfterViewInit {
    * @param {string} filterValue Value to filter data.
    */
   applyFilter(filterValue: string) {
-    this.dataSource.filter = filterValue.trim().toLowerCase();
+    this.filterValue = filterValue.trim();
+    this.dataSource.filter = this.filterValue.toLowerCase();
   }
 
   /**


### PR DESCRIPTION

## Description
On the Currency Configuration page, typing a value in the Filter box that does not match any currency removed all the rows and left an empty area. There was no message, so the user could not tell whether the filter had no results or the page had failed to load.

I have added an empty state row to the table. It shows "No records match the selected filter" when a filter is applied, and "No data found" when the list is empty. Both strings already exist in all thirteen translation files, so no new translations were required.

A small style rule was also added, because the empty row does not use the mat-cell directive and so has no padding by default.


## Related issues and discussion

https://mifosforge.jira.com/browse/WEB-1203

## Screenshots, if any
before:
<img width="1920" height="1080" alt="currency issue" src="https://github.com/user-attachments/assets/c1f53324-1156-4c31-ad98-42ef6850d43e" />
after:
<img width="1920" height="1080" alt="{B07709BC-BE3E-48F5-9029-B52B75545CC6}" src="https://github.com/user-attachments/assets/811d9977-461b-47fd-8d35-baf7b8c61201" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear empty-state messages to the currencies table.
  * Displays different guidance when no records match an active filter versus when no currency data is available.

* **Style**
  * Improved empty-state presentation with centered, italic text, spacing, and reduced emphasis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->