### PR TITLE
WEB-1204: Show a message when a currency is already in the list

### DIFF
--- a/src/app/organization/currencies/manage-currencies/manage-currencies.component.ts
+++ b/src/app/organization/currencies/manage-currencies/manage-currencies.component.ts
@@ -31,6 +31,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { DeleteDialogComponent } from '../../../shared/delete-dialog/delete-dialog.component';
 
 /** Custom Services */
+import { AlertService } from 'app/core/alert/alert.service';
 import { OrganizationService } from '../../organization.service';
 import { PopoverService } from '../../../configuration-wizard/popover/popover.service';
 import { ConfigurationWizardService } from '../../../configuration-wizard/configuration-wizard.service';
@@ -66,6 +67,7 @@ export class ManageCurrenciesComponent implements OnInit, AfterViewInit, OnChang
   private route = inject(ActivatedRoute);
   private formBuilder = inject(FormBuilder);
   private organizationservice = inject(OrganizationService);
+  private alertService = inject(AlertService);
   dialog = inject(MatDialog);
   private router = inject(Router);
   private translateService = inject(TranslateService);
@@ -157,20 +159,26 @@ export class ManageCurrenciesComponent implements OnInit, AfterViewInit, OnChang
   addCurrency() {
     const newCurrency = this.currencyForm.value.currency;
     const selectedCurrencyCodes: any[] = this.selectedCurrencies.map((currency) => currency.code);
-    if (!selectedCurrencyCodes.includes(newCurrency.code)) {
-      selectedCurrencyCodes.push(newCurrency.code);
-      this.organizationservice
-        .updateCurrencies(selectedCurrencyCodes)
-        .pipe(take(1))
-        .subscribe((response: any) => {
-          this.selectedCurrencies.push(newCurrency);
-          this.formRef.resetForm();
-          if (this.configurationWizardService.showCurrencyForm) {
-            this.configurationWizardService.showCurrencyForm = false;
-            this.openDialog();
-          }
-        });
+    if (selectedCurrencyCodes.includes(newCurrency.code)) {
+      this.alertService.alert({
+        type: 'error',
+        message: this.translateService.instant('labels.text.This currency has already been added')
+      });
+      this.formRef.resetForm();
+      return;
     }
+    selectedCurrencyCodes.push(newCurrency.code);
+    this.organizationservice
+      .updateCurrencies(selectedCurrencyCodes)
+      .pipe(take(1))
+      .subscribe((response: any) => {
+        this.selectedCurrencies.push(newCurrency);
+        this.formRef.resetForm();
+        if (this.configurationWizardService.showCurrencyForm) {
+          this.configurationWizardService.showCurrencyForm = false;
+          this.openDialog();
+        }
+      });
   }
 
   /**

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -4695,6 +4695,7 @@
       "The usage of stronger passwords": "Definujte standardy pro vynucení používání silnějších hesel",
       "These are predefined postings": "Jedná se o předdefinované příspěvky",
       "This allows you to manage funds associated with loans.": "To vám umožní spravovat finanční prostředky spojené s půjčkami.",
+      "This currency has already been added": "Tato měna již byla přidána",
       "This option allows you to create new loan product.": "Tato možnost umožňuje vytvořit nový úvěrový produkt.",
       "This option allows you to create new recurring product.": "Tato možnost umožňuje vytvořit nový opakující se produkt.",
       "This option allows you to create new savings product.": "Tato možnost umožňuje vytvořit nový spořicí produkt.",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -4695,6 +4695,7 @@
       "The usage of stronger passwords": "Definieren Sie Standards zur Durchsetzung der Verwendung stärkerer Passwörter",
       "These are predefined postings": "Dabei handelt es sich um vordefinierte Buchungen",
       "This allows you to manage funds associated with loans.": "Auf diese Weise können Sie die mit Krediten verbundenen Mittel verwalten.",
+      "This currency has already been added": "Diese Währung wurde bereits hinzugefügt",
       "This option allows you to create new loan product.": "Mit dieser Option können Sie ein neues Kreditprodukt erstellen.",
       "This option allows you to create new recurring product.": "Mit dieser Option können Sie ein neues wiederkehrendes Produkt erstellen.",
       "This option allows you to create new savings product.": "Mit dieser Option können Sie ein neues Sparprodukt erstellen.",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -4896,6 +4896,7 @@
       "The usage of stronger passwords": "Define standards for enforcing the usage of stronger passwords",
       "These are predefined postings": "These are predefined postings",
       "This allows you to manage funds associated with loans.": "This allows you to manage funds associated with loans.",
+      "This currency has already been added": "This currency has already been added",
       "This option allows you to create new loan product.": "This option allows you to create a new loan product.",
       "This option allows you to create new recurring product.": "This option allows you to create a new recurring product.",
       "This option allows you to create new savings product.": "This option allows you to create a new savings product.",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -4710,6 +4710,7 @@
       "The usage of stronger passwords": "Definir estándares para hacer cumplir el uso de contraseñas más seguras",
       "These are predefined postings": "Estas son publicaciones predefinidas",
       "This allows you to manage funds associated with loans.": "Esto le permite administrar fondos asociados con Créditos.",
+      "This currency has already been added": "Esta moneda ya fue agregada",
       "This option allows you to create new loan product.": "Esta opción le permite crear un nuevo producto de Crédito.",
       "This option allows you to create new recurring product.": "Esta opción le permite crear un nuevo producto recurrente.",
       "This option allows you to create new savings product.": "Esta opción le permite crear un nuevo producto de ahorro.",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -4734,6 +4734,7 @@
       "The usage of stronger passwords": "Definir estándares para hacer cumplir el uso de contraseñas más seguras",
       "These are predefined postings": "Estas son publicaciones predefinidas",
       "This allows you to manage funds associated with loans.": "Esto le permite administrar fondos asociados con Créditos.",
+      "This currency has already been added": "Esta moneda ya ha sido agregada",
       "This option allows you to create new loan product.": "Esta opción le permite crear un nuevo producto de Crédito.",
       "This option allows you to create new recurring product.": "Esta opción le permite crear un nuevo producto recurrente.",
       "This option allows you to create new savings product.": "Esta opción le permite crear un nuevo producto de ahorro.",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -4697,6 +4697,7 @@
       "The usage of stronger passwords": "Définir des normes pour imposer l'utilisation de mots de passe plus forts",
       "These are predefined postings": "Ce sont des publications prédéfinies",
       "This allows you to manage funds associated with loans.": "Cela vous permet de gérer les fonds associés aux prêts.",
+      "This currency has already been added": "Cette devise a déjà été ajoutée",
       "This option allows you to create new loan product.": "Cette option vous permet de créer un nouveau produit de prêt.",
       "This option allows you to create new recurring product.": "Cette option vous permet de créer un nouveau produit récurrent.",
       "This option allows you to create new savings product.": "Cette option vous permet de créer un nouveau produit d'épargne.",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -4693,6 +4693,7 @@
       "The usage of stronger passwords": "Definire standard per imporre l'uso di password più forti",
       "These are predefined postings": "Questi sono messaggi predefiniti",
       "This allows you to manage funds associated with loans.": "Ciò consente di gestire i fondi associati ai prestiti.",
+      "This currency has already been added": "Questa valuta è già stata aggiunta",
       "This option allows you to create new loan product.": "Questa opzione ti consente di creare un nuovo prodotto di prestito.",
       "This option allows you to create new recurring product.": "Questa opzione ti consente di creare un nuovo prodotto ricorrente.",
       "This option allows you to create new savings product.": "Questa opzione ti consente di creare un nuovo prodotto di risparmio.",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -4693,6 +4693,7 @@
       "The usage of stronger passwords": "더 강력한 비밀번호 사용을 시행하기 위한 표준 정의",
       "These are predefined postings": "사전 정의된 게시물입니다.",
       "This allows you to manage funds associated with loans.": "이를 통해 대출과 관련된 자금을 관리할 수 있습니다.",
+      "This currency has already been added": "이 통화는 이미 추가되었습니다",
       "This option allows you to create new loan product.": "이 옵션을 사용하면 새로운 대출 상품을 생성할 수 있습니다.",
       "This option allows you to create new recurring product.": "이 옵션을 사용하면 새로운 반복 제품을 생성할 수 있습니다.",
       "This option allows you to create new savings product.": "이 옵션을 사용하면 새로운 저축 상품을 만들 수 있습니다.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -4693,6 +4693,7 @@
       "The usage of stronger passwords": "Apibrėžkite stipresnių slaptažodžių naudojimo standartus",
       "These are predefined postings": "Tai yra iš anksto nustatyti skelbimai",
       "This allows you to manage funds associated with loans.": "Tai leidžia valdyti su paskolomis susijusias lėšas.",
+      "This currency has already been added": "Ši valiuta jau pridėta",
       "This option allows you to create new loan product.": "Ši parinktis leidžia sukurti naują paskolos produktą.",
       "This option allows you to create new recurring product.": "Ši parinktis leidžia sukurti naują pasikartojantį produktą.",
       "This option allows you to create new savings product.": "Ši parinktis leidžia sukurti naują taupymo produktą.",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -4693,6 +4693,7 @@
       "The usage of stronger passwords": "Definējiet standartus spēcīgāku paroļu izmantošanai",
       "These are predefined postings": "Tie ir iepriekš noteikti ziņojumi",
       "This allows you to manage funds associated with loans.": "Tas ļauj pārvaldīt ar aizdevumiem saistītos līdzekļus.",
+      "This currency has already been added": "Šī valūta jau ir pievienota",
       "This option allows you to create new loan product.": "Šī opcija ļauj izveidot jaunu aizdevuma produktu.",
       "This option allows you to create new recurring product.": "Šī opcija ļauj izveidot jaunu periodisku produktu.",
       "This option allows you to create new savings product.": "Šī opcija ļauj izveidot jaunu uzkrājumu produktu.",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -4693,6 +4693,7 @@
       "The usage of stronger passwords": "बलियो पासवर्डहरूको प्रयोग लागू गर्न मापदण्डहरू परिभाषित गर्नुहोस्",
       "These are predefined postings": "यी पूर्वनिर्धारित पोस्टहरू हुन्",
       "This allows you to manage funds associated with loans.": "यसले तपाईंलाई ऋणसँग सम्बन्धित कोषहरू व्यवस्थापन गर्न अनुमति दिन्छ।",
+      "This currency has already been added": "यो मुद्रा पहिले नै थपिएको छ",
       "This option allows you to create new loan product.": "यो विकल्पले तपाईंलाई नयाँ ऋण उत्पादन सिर्जना गर्न अनुमति दिन्छ।",
       "This option allows you to create new recurring product.": "यो विकल्पले तपाईंलाई नयाँ पुनरावर्ती उत्पादन सिर्जना गर्न अनुमति दिन्छ।",
       "This option allows you to create new savings product.": "यो विकल्पले तपाईंलाई नयाँ बचत उत्पादन सिर्जना गर्न अनुमति दिन्छ।",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -4693,6 +4693,7 @@
       "The usage of stronger passwords": "Defina padrões para impor o uso de senhas mais fortes",
       "These are predefined postings": "Estas são postagens predefinidas",
       "This allows you to manage funds associated with loans.": "Isso permite que você gerencie fundos associados a empréstimos.",
+      "This currency has already been added": "Esta moeda já foi adicionada",
       "This option allows you to create new loan product.": "Esta opção permite criar um novo produto de empréstimo.",
       "This option allows you to create new recurring product.": "Esta opção permite criar novos produtos recorrentes.",
       "This option allows you to create new savings product.": "Esta opção permite criar um novo produto de poupança.",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -4690,6 +4690,7 @@
       "The usage of stronger passwords": "Bainisha viwango vya kutekeleza utumiaji wa manenosiri yenye nguvu zaidi",
       "These are predefined postings": "Haya ni machapisho yaliyofafanuliwa awali",
       "This allows you to manage funds associated with loans.": "Hii inakuwezesha kudhibiti fedha zinazohusiana na mikopo.",
+      "This currency has already been added": "Sarafu hii tayari imeongezwa",
       "This option allows you to create new loan product.": "Chaguo hili hukuruhusu kuunda bidhaa mpya ya mkopo.",
       "This option allows you to create new recurring product.": "Chaguo hili hukuruhusu kuunda bidhaa mpya ya mara kwa mara.",
       "This option allows you to create new savings product.": "Chaguo hili hukuruhusu kuunda bidhaa mpya ya akiba.",


### PR DESCRIPTION

## Description
On the Manage Currencies page, if a currency that is already present in the list is selected and the add button is clicked, nothing happens. No message is displayed and the form is not cleared, so it appears to the user that the page is not working.

I have updated the add method so that it now displays a message and clears the form when the selected currency is already in the list, instead of doing nothing.

The new message has also been added to all thirteen translation files, as the application does not have a fallback language and would otherwise show the translation key on screen.

## Related issues and discussion

https://mifosforge.jira.com/browse/WEB-1204

## Screenshots, if any


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate currencies are now rejected when managing currencies.
  * A clear error alert is shown, and the form resets so another currency can be selected.

* **Localization**
  * Added the duplicate-currency message in English, Czech, German, Spanish, French, Italian, Korean, Lithuanian, Latvian, Nepali, Portuguese, and Swahili.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->