### PR TITLE
WEB-1201: Improve Copilot reasoning and response UX

### DIFF
--- a/src/app/copilot/components/action-card/action-card.component.ts
+++ b/src/app/copilot/components/action-card/action-card.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ActionCard, ActionCardType } from '../../core/models/action-card.model';
@@ -20,7 +20,8 @@ import { translateCardLabel } from '../../core/card-label';
     TranslateModule
   ],
   templateUrl: './action-card.component.html',
-  styleUrls: ['./action-card.component.scss']
+  styleUrls: ['./action-card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ActionCardComponent {
   private readonly translate = inject(TranslateService);

--- a/src/app/copilot/components/briefing-area/briefing-area.component.ts
+++ b/src/app/copilot/components/briefing-area/briefing-area.component.ts
@@ -6,12 +6,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 /** Proactive briefing: auto-surfaced insight cards (urgent / opportunity / info). */
 @Component({
   selector: 'mifosx-briefing-area',
   templateUrl: './briefing-area.component.html',
-  styleUrls: ['./briefing-area.component.scss']
+  styleUrls: ['./briefing-area.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class BriefingAreaComponent {}

--- a/src/app/copilot/components/chat-area/chat-area.component.html
+++ b/src/app/copilot/components/chat-area/chat-area.component.html
@@ -5,7 +5,7 @@
   License, v. 2.0. If a copy of the MPL was not distributed with this
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
-<div class="chat-body" #messageContainer>
+<div class="chat-body" #messageContainer (click)="onBodyClick($event)" (scroll)="onScroll()">
   <!-- Empty / welcome state -->
   <div *ngIf="messages.length === 0" class="welcome">
     <span class="welcome__badge">{{ greetingTime | translate }}</span>
@@ -19,16 +19,32 @@
     </mifosx-quick-chips>
   </div>
 
+  <!-- Older messages are held back rather than rendered and hidden, so a long conversation
+       does not cost DOM that is re-checked on every token of the reply at the bottom. -->
+  <button type="button" class="show-earlier" *ngIf="hiddenCount > 0" (click)="revealEarlier()">
+    {{ 'copilot.showEarlier' | translate: { count: hiddenCount } }}
+  </button>
+
   <!-- Message list -->
-  <ng-container *ngFor="let msg of messages; trackBy: trackByMessageId">
-    <div class="msg" [class.msg--user]="msg.role === 'user'" [class.msg--ai]="msg.role === 'assistant'">
+  <ng-container *ngFor="let msg of visibleMessages; trackBy: trackByMessageId">
+    <div
+      class="msg"
+      [class.msg--user]="msg.role === 'user'"
+      [class.msg--ai]="msg.role === 'assistant'"
+      [attr.data-message-id]="msg.role === 'user' ? msg.id : null"
+    >
       <div *ngIf="msg.role === 'assistant' && !(msg.isStreaming && !msg.content?.trim())" class="msg__avatar">
         <img src="assets/images/MifosX_logo.png" [alt]="'copilot.assistantAvatarAlt' | translate" />
       </div>
       <div class="msg__content">
         <div class="msg__bubble" *ngIf="msg.content?.trim() || msg.role === 'user'">
           <span *ngIf="msg.role === 'user'">{{ msg.content }}</span>
-          <span *ngIf="msg.role === 'assistant'" [innerHTML]="msg.content | markdown"></span>
+          <span
+            *ngIf="msg.role === 'assistant'"
+            class="msg__text"
+            [class.msg__text--streaming]="msg.isStreaming"
+            [innerHTML]="msg.content | markdown: !!msg.isStreaming"
+          ></span>
         </div>
         <span class="msg__time">{{ relativeTime(msg.timestamp) }}</span>
 
@@ -62,7 +78,15 @@
 
         <!-- How the answer was reached, below it rather than above: a preamble frames an
              answer before it is read, and this is meant to be scrutiny, not framing. -->
-        <mifosx-thinking-trail *ngIf="msg.role === 'assistant'" [message]="msg" [isStreaming]="!!msg.isStreaming">
+        <mifosx-thinking-trail
+          *ngIf="msg.role === 'assistant'"
+          [messageId]="msg.id"
+          [steps]="msg.steps"
+          [workingNotes]="msg.workingNotes"
+          [turnMs]="msg.turnMs"
+          [notesElapsedMs]="msg.notesElapsedMs"
+          [isStreaming]="!!msg.isStreaming"
+        >
         </mifosx-thinking-trail>
 
         <!-- What can be done with a finished reply: take it, ask again, rate it.
@@ -113,6 +137,14 @@
       </div>
     </div>
   </div>
+
+  <!-- What a screen reader is told about the reply.
+       Announcing the answer as it streams would read it a word at a time and repeat every
+       partial sentence, so only the state is announced live; the finished answer is read from
+       the bubble itself, which is ordinary document text. -->
+  <p class="sr-only" role="status" aria-live="polite">
+    {{ (isStreaming ? 'copilot.a11y.working' : lastReplyDone ? 'copilot.a11y.replyReady' : '') | translate }}
+  </p>
 
   <!-- Typing indicator, only until the reply starts arriving. Once there are words on screen
        the message is its own progress, and a second avatar with dots underneath reads as a

--- a/src/app/copilot/components/chat-area/chat-area.component.spec.ts
+++ b/src/app/copilot/components/chat-area/chat-area.component.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { ChatAreaComponent } from './chat-area.component';
+import { ChatMessage } from '../../core/models/chat-message.model';
+import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
+
+/** A conversation of `pairs` question-and-answer exchanges, oldest first. */
+function conversation(pairs: number): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  for (let i = 0; i < pairs; i++) {
+    messages.push({ id: `u-${i}`, role: 'user', content: `Question ${i}`, timestamp: 0 });
+    messages.push({ id: `a-${i}`, role: 'assistant', content: `Answer ${i}`, timestamp: 0 });
+  }
+  return messages;
+}
+
+describe('ChatAreaComponent', () => {
+  let fixture: ComponentFixture<ChatAreaComponent>;
+  let component: ChatAreaComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ChatAreaComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: SettingsService, useValue: { language: { code: 'en-US' } } },
+        { provide: Dates, useValue: { getMomentLocale: () => 'en' } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ChatAreaComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('windowing a long conversation', () => {
+    it('renders a short conversation whole, with nothing held back', () => {
+      fixture.componentRef.setInput('messages', conversation(3));
+      fixture.detectChanges();
+
+      expect(component.hiddenCount).toBe(0);
+      expect(component.visibleMessages.length).toBe(6);
+      expect(fixture.nativeElement.querySelector('.show-earlier')).toBeNull();
+    });
+
+    it('holds back the oldest messages once the conversation is long', () => {
+      fixture.componentRef.setInput('messages', conversation(40));
+      fixture.detectChanges();
+
+      expect(component.hiddenCount).toBeGreaterThan(0);
+      expect(component.visibleMessages.length).toBeLessThan(80);
+      expect(fixture.nativeElement.querySelector('.show-earlier')).not.toBeNull();
+    });
+
+    /** Starting the window on a reply orphans it, which reads as the assistant speaking first. */
+    it('never starts the window on an answer', () => {
+      fixture.componentRef.setInput('messages', conversation(40));
+      fixture.detectChanges();
+      expect(component.visibleMessages[0].role).toBe('user');
+    });
+
+    it('always keeps the newest exchange', () => {
+      const messages = conversation(40);
+      fixture.componentRef.setInput('messages', messages);
+      fixture.detectChanges();
+      expect(component.visibleMessages[component.visibleMessages.length - 1].id).toBe(messages[79].id);
+    });
+
+    it('reveals the rest when asked, and says it did', () => {
+      fixture.componentRef.setInput('messages', conversation(40));
+      fixture.detectChanges();
+      expect(component.revealEarlier()).toBe(true);
+
+      expect(component.hiddenCount).toBe(0);
+      expect(component.visibleMessages.length).toBe(80);
+    });
+
+    it('has nothing to reveal in a short conversation', () => {
+      fixture.componentRef.setInput('messages', conversation(2));
+      fixture.detectChanges();
+      expect(component.revealEarlier()).toBe(false);
+    });
+
+    it('windows again for a new, shorter conversation', () => {
+      fixture.componentRef.setInput('messages', conversation(40));
+      fixture.detectChanges();
+      component.revealEarlier();
+      // Starting a new chat replaces the list with a shorter one.
+      fixture.componentRef.setInput('messages', conversation(1));
+      fixture.detectChanges();
+      expect(component.hiddenCount).toBe(0);
+
+      fixture.componentRef.setInput('messages', conversation(40));
+      fixture.detectChanges();
+      expect(component.hiddenCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe('what a screen reader is told', () => {
+    it('says it is working while the reply streams', () => {
+      fixture.componentRef.setInput('messages', conversation(1));
+      fixture.detectChanges();
+      fixture.componentRef.setInput('isStreaming', true);
+      fixture.detectChanges();
+
+      const status = fixture.nativeElement.querySelector('[role="status"]');
+      expect(status.textContent).toContain('copilot.a11y.working');
+    });
+
+    it('says the reply is ready once it has finished', () => {
+      fixture.componentRef.setInput('messages', conversation(1));
+      fixture.detectChanges();
+      fixture.componentRef.setInput('isStreaming', false);
+      fixture.detectChanges();
+
+      expect(component.lastReplyDone).toBe(true);
+      expect(fixture.nativeElement.querySelector('[role="status"]').textContent).toContain('copilot.a11y.replyReady');
+    });
+
+    it('says nothing when the assistant has not answered yet', () => {
+      fixture.componentRef.setInput('messages', [
+        { id: 'u-1', role: 'user', content: 'Hello', timestamp: 0 } as ChatMessage
+      ]);
+      expect(component.lastReplyDone).toBe(false);
+    });
+  });
+});

--- a/src/app/copilot/components/chat-area/chat-area.component.ts
+++ b/src/app/copilot/components/chat-area/chat-area.component.ts
@@ -8,18 +8,22 @@
 
 import {
   AfterViewChecked,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
   Input,
   OnChanges,
+  OnDestroy,
   Output,
   SimpleChanges,
   ViewChild,
   inject
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TranslateModule } from '@ngx-translate/core';
+import { Clipboard } from '@angular/cdk/clipboard';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { SettingsService } from 'app/settings/settings.service';
 import { Dates } from 'app/core/utils/dates';
 import { relativeTime } from '../../core/relative-time';
@@ -35,6 +39,23 @@ import { ThinkingTrailComponent } from '../thinking-trail/thinking-trail.compone
 /** Breathing room left above a confirmation card once it is scrolled into view. */
 const CARD_TOP_GAP_PX = 12;
 
+/** How long a copy button stays in its confirmed state. */
+const COPY_CONFIRM_MS = 1600;
+
+/**
+ * How many messages are rendered before the conversation is windowed.
+ *
+ * <p>Chosen to be comfortably more than fits on a tall screen, so the window is never the
+ * reason an officer has to click something. Beyond it, every extra exchange is DOM that is
+ * re-checked on every token of the reply being streamed at the bottom.
+ *
+ * <p>Windowing rather than virtual scrolling on purpose. CdkVirtualScrollViewport only
+ * measures fixed-height rows; chat messages are not, and the autosize strategy that handles
+ * them lives in cdk-experimental, which this project does not depend on and which would take
+ * the anchors that the prompt rail and the auto-follow both scroll to out of the DOM.
+ */
+const WINDOW_SIZE = 40;
+
 /** Scrollable chat body: welcome state, message bubbles, cards, typing indicator. */
 @Component({
   selector: 'mifosx-chat-area',
@@ -49,9 +70,10 @@ const CARD_TOP_GAP_PX = 12;
     ThinkingTrailComponent
   ],
   templateUrl: './chat-area.component.html',
-  styleUrls: ['./chat-area.component.scss']
+  styleUrls: ['./chat-area.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ChatAreaComponent implements OnChanges, AfterViewChecked {
+export class ChatAreaComponent implements OnChanges, AfterViewChecked, OnDestroy {
   @Input() messages: ChatMessage[] = [];
   @Input() isStreaming = false;
   @Input() greetingTime = '';
@@ -75,6 +97,8 @@ export class ChatAreaComponent implements OnChanges, AfterViewChecked {
   @Output() cardRoute = new EventEmitter<string | undefined>();
   @Output() confirmPending = new EventEmitter<void>();
   @Output() cancelPending = new EventEmitter<void>();
+  /** Which question's answer is on screen, so the rail can say where the officer is. */
+  @Output() visibleQuestionChanged = new EventEmitter<string>();
 
   @ViewChild('messageContainer') private messageContainer?: ElementRef<HTMLElement>;
   /** The confirmation card, so it can be shown from its top rather than from its buttons. */
@@ -83,6 +107,37 @@ export class ChatAreaComponent implements OnChanges, AfterViewChecked {
   /** How close to the bottom (px) still counts as "following the conversation". */
   private static readonly STICK_THRESHOLD_PX = 160;
   private pendingScroll = false;
+  /** Last question reported as on screen, so the rail is only told when it changes. */
+  private lastVisibleQuestion: string | null = null;
+  private scrollFrame = 0;
+  /** How many of the most recent messages are rendered. Grows when the officer asks. */
+  private revealed = WINDOW_SIZE;
+  /** The windowed slice, recomputed when the conversation changes rather than per check. */
+  visibleMessages: ChatMessage[] = [];
+  /** How many older messages are being held back, for the control that reveals them. */
+  hiddenCount = 0;
+
+  /** Render the whole conversation from here on, and say whether anything changed. */
+  revealEarlier(): boolean {
+    if (this.hiddenCount === 0) {
+      return false;
+    }
+    this.revealed = this.messages.length;
+    this.applyWindow();
+    return true;
+  }
+
+  private applyWindow(): void {
+    const total = this.messages.length;
+    // Always keep whole exchanges: starting the window on a reply orphans it from its
+    // question, which reads as the assistant having spoken unprompted.
+    let start = Math.max(0, total - Math.max(this.revealed, WINDOW_SIZE));
+    if (start > 0 && this.messages[start]?.role !== 'user') {
+      start -= 1;
+    }
+    this.hiddenCount = Math.max(0, start);
+    this.visibleMessages = start === 0 ? this.messages : this.messages.slice(start);
+  }
 
   /**
    * Auto-follow new content: stick to the bottom while the user is already there
@@ -90,6 +145,13 @@ export class ChatAreaComponent implements OnChanges, AfterViewChecked {
    * up to read history mid-stream.
    */
   ngOnChanges(changes: SimpleChanges): void {
+    if (changes['messages']) {
+      // A new conversation starts windowed again; a growing one keeps what was revealed.
+      if (this.messages.length < this.revealed) {
+        this.revealed = WINDOW_SIZE;
+      }
+      this.applyWindow();
+    }
     if (!changes['messages'] && !changes['isStreaming'] && !changes['pendingCard']) {
       return;
     }
@@ -103,6 +165,12 @@ export class ChatAreaComponent implements OnChanges, AfterViewChecked {
       ? true
       : container.scrollHeight - container.scrollTop - container.clientHeight < ChatAreaComponent.STICK_THRESHOLD_PX;
     this.pendingScroll = nearBottom || lastIsUser;
+  }
+
+  ngOnDestroy(): void {
+    if (this.scrollFrame) {
+      cancelAnimationFrame(this.scrollFrame);
+    }
   }
 
   ngAfterViewChecked(): void {
@@ -135,12 +203,116 @@ export class ChatAreaComponent implements OnChanges, AfterViewChecked {
     return !!last && last.role === 'assistant' && !!last.content?.trim();
   }
 
+  /**
+   * True once a reply has finished, so the live region can say so exactly once.
+   *
+   * <p>Paired with the streaming state rather than announced on its own: a region that only
+   * ever gains text is re-read by some screen readers, and "reply ready" repeated after every
+   * token would be worse than silence.
+   */
+  get lastReplyDone(): boolean {
+    const last = this.messages[this.messages.length - 1];
+    return !!last && last.role === 'assistant' && !last.isStreaming && !!last.content?.trim();
+  }
+
   trackByMessageId(_index: number, msg: ChatMessage): string {
     return msg.id;
   }
 
   private readonly settingsService = inject(SettingsService);
   private readonly dateUtils = inject(Dates);
+  private readonly clipboard = inject(Clipboard);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly translate = inject(TranslateService);
+
+  /**
+   * Take the code out of a fenced block.
+   *
+   * <p>Delegated from the scroll container rather than bound per button, because the blocks are
+   * markup built by the markdown renderer and have no template of their own to bind in. One
+   * listener also survives a reply being rewritten mid-stream, which per-button listeners
+   * would not.
+   */
+  /**
+   * Put a question back on screen, from its top edge.
+   *
+   * <p>Scrolling it to the middle would be prettier and less useful: what the officer came
+   * back for is the answer, and the answer is underneath.
+   */
+  scrollToQuestion(id: string): void {
+    const container = this.messageContainer?.nativeElement;
+    if (!container) {
+      return;
+    }
+    let target = container.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(id)}"]`);
+    if (!target) {
+      // The question is older than the window. Reveal the rest before going to it, rather
+      // than doing nothing and looking broken.
+      if (!this.revealEarlier()) {
+        return;
+      }
+      this.cdr.detectChanges();
+      target = container.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(id)}"]`);
+    }
+    if (!target) {
+      return;
+    }
+    const offset = target.getBoundingClientRect().top - container.getBoundingClientRect().top;
+    container.scrollTo({ top: Math.max(0, container.scrollTop + offset - CARD_TOP_GAP_PX), behavior: 'smooth' });
+  }
+
+  /**
+   * Report which question is on screen as the officer scrolls.
+   *
+   * <p>Coalesced onto an animation frame: a scroll fires far more often than the answer to it
+   * can change, and doing this work per event is what makes a long conversation feel heavy.
+   */
+  onScroll(): void {
+    if (this.scrollFrame) {
+      return;
+    }
+    this.scrollFrame = requestAnimationFrame(() => {
+      this.scrollFrame = 0;
+      const container = this.messageContainer?.nativeElement;
+      if (!container) {
+        return;
+      }
+      const top = container.getBoundingClientRect().top;
+      let current: string | null = null;
+      for (const node of Array.from(container.querySelectorAll<HTMLElement>('[data-message-id]'))) {
+        // The last question whose top has passed the fold is the one being read.
+        if (node.getBoundingClientRect().top - top <= ChatAreaComponent.STICK_THRESHOLD_PX) {
+          current = node.dataset['messageId'] ?? null;
+        }
+      }
+      if (current && current !== this.lastVisibleQuestion) {
+        this.lastVisibleQuestion = current;
+        this.visibleQuestionChanged.emit(current);
+      }
+    });
+  }
+
+  onBodyClick(event: MouseEvent): void {
+    const button = (event.target as HTMLElement | null)?.closest?.('[data-copy]') as HTMLElement | null;
+    if (!button) {
+      return;
+    }
+    const code = button.closest('.md-code-wrap')?.querySelector('code')?.textContent ?? '';
+    if (!code || !this.clipboard.copy(code)) {
+      return;
+    }
+    // Confirm on the button itself. A snackbar for copying two lines of code is more
+    // interruption than the act deserves.
+    button.classList.add('md-code__copy--done');
+    const label = button.getAttribute('aria-label');
+    button.setAttribute('aria-label', this.translate.instant('copilot.actions.copied'));
+    setTimeout(() => {
+      button.classList.remove('md-code__copy--done');
+      if (label) {
+        button.setAttribute('aria-label', label);
+      }
+    }, COPY_CONFIRM_MS);
+  }
 
   /** "3 minutes ago", in the language the officer chose. See core/relative-time.ts. */
   relativeTime(timestamp: number): string {

--- a/src/app/copilot/components/confirmation-card/confirmation-card.component.ts
+++ b/src/app/copilot/components/confirmation-card/confirmation-card.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ActionCard } from '../../core/models/action-card.model';
@@ -20,7 +20,8 @@ import { translateCardLabel } from '../../core/card-label';
     TranslateModule
   ],
   templateUrl: './confirmation-card.component.html',
-  styleUrls: ['./confirmation-card.component.scss']
+  styleUrls: ['./confirmation-card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ConfirmationCardComponent {
   private readonly translate = inject(TranslateService);

--- a/src/app/copilot/components/copilot-header/copilot-header.component.ts
+++ b/src/app/copilot/components/copilot-header/copilot-header.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -18,7 +18,8 @@ import { TranslateModule } from '@ngx-translate/core';
     TranslateModule
   ],
   templateUrl: './copilot-header.component.html',
-  styleUrls: ['./copilot-header.component.scss']
+  styleUrls: ['./copilot-header.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CopilotHeaderComponent {
   @Input() contextLabel: string | null = null;

--- a/src/app/copilot/components/copilot-panel/copilot-panel.component.html
+++ b/src/app/copilot/components/copilot-panel/copilot-panel.component.html
@@ -53,8 +53,20 @@
       (cardRoute)="onRouteClick($event)"
       (confirmPending)="confirmPendingAction()"
       (cancelPending)="cancelPendingAction()"
+      (visibleQuestionChanged)="activeQuestionId = $event"
     >
     </mifosx-chat-area>
+
+    <!-- The questions asked this session, for getting back to one. Appears at the second
+         question and hides itself on a narrow panel, where a column of its own would take
+         the space the conversation needs. -->
+    <mifosx-prompt-nav
+      *ngIf="activeTab === 'chat'"
+      [messages]="messages"
+      [activeId]="activeQuestionId"
+      (jumpTo)="jumpToQuestion($event)"
+    >
+    </mifosx-prompt-nav>
 
     <!-- Recent Chats tab -->
     <mifosx-recent-chats
@@ -185,6 +197,7 @@
       [(text)]="composerText"
       (send)="sendMessage($event)"
       (stop)="stopStreaming()"
+      (editLast)="editLastQuestion()"
     >
     </mifosx-input-bar>
 

--- a/src/app/copilot/components/copilot-panel/copilot-panel.component.scss
+++ b/src/app/copilot/components/copilot-panel/copilot-panel.component.scss
@@ -418,6 +418,46 @@ $content-width-full: 1440px;
         }
       }
 
+      .md-list--numbered {
+        list-style: decimal;
+      }
+
+      /* Headings inside a bubble. Sized by weight and spacing rather than by growing the type:
+         a reply is a paragraph or two, and 24px text in a chat bubble reads as shouting. */
+      .md-heading {
+        margin: ($u * 2) 0 ($u);
+        font-weight: 700;
+        line-height: 1.35;
+
+        &:first-child {
+          margin-top: 0;
+        }
+      }
+
+      .md-heading--1 {
+        font-size: 15.5px;
+      }
+
+      .md-heading--2 {
+        font-size: 14.5px;
+      }
+
+      .md-heading--3 {
+        font-size: 13.5px;
+      }
+
+      .md-quote {
+        margin: ($u) 0;
+        padding: ($u - 2px) 0 ($u - 2px) ($u * 2);
+        border-left: 2px solid;
+        font-style: italic;
+      }
+
+      .md-link {
+        text-decoration: underline;
+        overflow-wrap: anywhere;
+      }
+
       // Markdown tables (e.g. client lists): real rows and columns, scrolling
       // horizontally inside their own box when narrow.
       .md-table-wrap {
@@ -445,11 +485,65 @@ $content-width-full: 1440px;
         }
       }
 
+      /* A fenced block and the bar that names it are one object, so the corners are rounded
+         on the wrapper and the block itself is left square inside it. */
+      .md-code-wrap {
+        margin: $u 0;
+        border-radius: $r-sm;
+        overflow: hidden;
+        max-width: 100%;
+      }
+
+      .md-code__bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: $u;
+        padding: (0.5 * $u) ($u * 2);
+        font-size: 11px;
+      }
+
+      .md-code__lang {
+        font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+        text-transform: lowercase;
+        letter-spacing: 0.02em;
+      }
+
+      /* Reveals itself on hover or focus, but never disappears for keyboards or touch, where
+         hover does not exist and a control that only appears on hover cannot be reached. */
+      .md-code__copy {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 24px;
+        height: 24px;
+        padding: 0;
+        border: none;
+        border-radius: $r-xs;
+        background: transparent;
+        cursor: pointer;
+        opacity: 0.55;
+        transition: opacity 0.15s $ease;
+
+        svg {
+          width: 13px;
+          height: 13px;
+        }
+      }
+
+      .md-code-wrap:hover .md-code__copy,
+      .md-code__copy:focus-visible {
+        opacity: 1;
+      }
+
+      .md-code__copy--done {
+        opacity: 1;
+      }
+
       // Fenced code blocks: scroll inside their own box, never widen the bubble.
       .md-code {
-        margin: $u 0;
+        margin: 0;
         padding: $u ($u * 2);
-        border-radius: $r-sm;
         max-width: 100%;
         overflow-x: auto;
         font-size: 12.5px;
@@ -835,6 +929,186 @@ $content-width-full: 1440px;
     }
   }
 
+  /* Announced but not drawn: the live region tells a screen reader the state of the reply,
+     which sighted officers read from the indicator and the words appearing instead.
+     Not `display: none`, which would take it out of the accessibility tree as well. */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  /* Each token fades in as it lands. Short, and opacity only: at streaming speed anything
+     longer overlaps the next word, and anything that moves makes the line jitter as it grows. */
+  .md-token {
+    animation: copilot-token-in 0.18s ease-out;
+  }
+
+  /* A caret at the tail of the reply, so the answer looks like it is being written rather
+     than having stopped. Drawn with a border on ::after, so it needs no element of its own
+     inside markup that is rebuilt every token. */
+  .msg__text--streaming::after {
+    content: '';
+    display: inline-block;
+    width: 2px;
+    height: 1em;
+    margin-left: 2px;
+    vertical-align: text-bottom;
+    animation: copilot-caret 1s step-end infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .md-token {
+      animation: none;
+    }
+
+    .msg__text--streaming::after {
+      animation: none;
+      opacity: 1;
+    }
+  }
+
+  .show-earlier {
+    align-self: center;
+    margin: 0 auto ($u);
+    padding: (0.5 * $u) ($u * 2);
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    cursor: pointer;
+    font: inherit;
+    font-size: 11.5px;
+  }
+
+  /* ── The questions asked this session ── */
+
+  /* Sits over the conversation rather than beside it: taking a column would narrow the
+     answers, and the answers are what the panel is for. Pinned to the right edge, out of the
+     way of the text, which is set left. */
+  .prompt-nav {
+    position: absolute;
+    top: 88px;
+    right: $u;
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+    max-height: 46%;
+    padding: ($u - 2px);
+    border-radius: $r-sm;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .prompt-nav__toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: $r-xs;
+    background: transparent;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: opacity 0.15s $ease;
+
+    svg {
+      width: 13px;
+      height: 13px;
+    }
+
+    &:hover,
+    &:focus-visible {
+      opacity: 1;
+    }
+  }
+
+  .prompt-nav__list {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .prompt-nav__item {
+    display: flex;
+    align-items: center;
+    gap: $u - 2px;
+    width: 100%;
+    padding: 3px ($u - 2px);
+    border: none;
+    border-radius: $r-xs;
+    background: transparent;
+    cursor: pointer;
+    font: inherit;
+    font-size: 11.5px;
+    text-align: left;
+    transition:
+      background 0.15s $ease,
+      color 0.15s $ease;
+  }
+
+  /* The rule is what a collapsed rail is made of, and what marks position in an expanded one. */
+  .prompt-nav__rule {
+    width: 12px;
+    height: 2px;
+    flex-shrink: 0;
+    border-radius: 1px;
+  }
+
+  .prompt-nav__index {
+    min-width: 12px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .prompt-nav__label {
+    overflow: hidden;
+    max-width: 168px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  /* Collapsed, it is a strip of rules: still enough to see how far through the conversation
+     the officer is, and to click back to a point in it. */
+  .prompt-nav--collapsed {
+    .prompt-nav__index,
+    .prompt-nav__label {
+      display: none;
+    }
+
+    .prompt-nav__item {
+      width: auto;
+      padding: 3px;
+    }
+  }
+
+  /* On a narrow panel the rail would sit on top of the answers, so it goes away entirely.
+     Recent Chats still reaches every conversation, and the questions are still on screen. */
+  @media (width <= 620px) {
+    .prompt-nav {
+      display: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .prompt-nav__item,
+    .prompt-nav__toggle {
+      transition: none;
+    }
+  }
+
   /* ── How the answer was reached ── */
   .trail {
     margin-top: $u + 2px;
@@ -850,19 +1124,47 @@ $content-width-full: 1440px;
     font-size: 12.5px;
   }
 
-  .trail__spinner {
-    width: 11px;
-    height: 11px;
-    border: 2px solid transparent;
+  /* A dot that breathes rather than a spinner that races. A spinner claims the wait is
+     indeterminate and demands the eye; the label beside it is the part worth reading, so the
+     motion is kept quiet enough to sit under it. */
+  .trail__live-dot {
+    width: 7px;
+    height: 7px;
     border-radius: 50%;
     flex-shrink: 0;
-    animation: trail-spin 0.7s linear infinite;
+    animation: copilot-trail-pulse 1.6s ease-in-out infinite;
   }
 
-  @keyframes trail-spin {
-    to {
-      transform: rotate(360deg);
+  /* The label pulses with the dot, on opacity only: no transform, so text never reflows and
+     sub-pixel shifts never blur it mid-animation. */
+  .trail__live-label {
+    animation: copilot-trail-pulse 1.6s ease-in-out infinite;
+  }
+
+  .trail__live-time {
+    margin-left: auto;
+    font-size: 11.5px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Motion is the whole point of this line, so when it is unwanted the line still has to say
+     the same thing. The label and the counter stay; only the breathing stops. */
+  @media (prefers-reduced-motion: reduce) {
+    .trail__live-dot,
+    .trail__live-label {
+      animation: none;
+      opacity: 1;
     }
+
+    .trail__chevron {
+      transition: none;
+    }
+  }
+
+  /* The animated body needs its padding on an inner element: animating height on a padded box
+     leaves the padding visible at the collapsed keyframe, so the closed panel keeps a stripe. */
+  .trail__body-inner {
+    padding: 0 ($u) ($u) ($u * 3);
   }
 
   .trail__section {
@@ -903,7 +1205,7 @@ $content-width-full: 1440px;
   }
 
   .trail__body {
-    padding: 0 ($u) ($u) ($u * 3);
+    overflow: hidden;
   }
 
   .trail__steps {
@@ -1417,6 +1719,38 @@ $content-width-full: 1440px;
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes copilot-token-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes copilot-caret {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0;
+  }
+}
+
+@keyframes copilot-trail-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.45;
   }
 }
 

--- a/src/app/copilot/components/copilot-panel/copilot-panel.component.spec.ts
+++ b/src/app/copilot/components/copilot-panel/copilot-panel.component.spec.ts
@@ -50,7 +50,7 @@ describe('CopilotPanelComponent', () => {
   function build(): void {
     fixture = TestBed.createComponent(CopilotPanelComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    fixture.autoDetectChanges(true);
   }
 
   beforeEach(() => {
@@ -113,10 +113,13 @@ describe('CopilotPanelComponent', () => {
       expect(component.isFullScreen).toBe(false);
     });
 
-    it('fills the window when asked, and drops the frame that was in the way', () => {
-      component.togglePanel();
-      component.toggleFullScreen();
-      fixture.detectChanges();
+    it('fills the window when asked, and drops the frame that was in the way', async () => {
+      // Driven through the controls an officer actually uses. The panel is OnPush, and a
+      // template event is what marks it dirty; state poked in from a test never repaints.
+      fixture.nativeElement.querySelector('.ai-fab').click();
+      await fixture.whenStable();
+      fixture.nativeElement.querySelectorAll('.topbar__btn')[0].click();
+      await fixture.whenStable();
 
       const page = fixture.nativeElement.querySelector('.chat-page');
       expect(page.classList).toContain('chat-page--full');
@@ -175,10 +178,12 @@ describe('CopilotPanelComponent', () => {
   });
 
   describe('preferences', () => {
-    it('renders the tab as settings rather than a heading with nothing under it', () => {
-      component.togglePanel();
-      component.switchTab('preferences');
-      fixture.detectChanges();
+    it('renders the tab as settings rather than a heading with nothing under it', async () => {
+      fixture.nativeElement.querySelector('.ai-fab').click();
+      await fixture.whenStable();
+      const tabs = Array.from(fixture.nativeElement.querySelectorAll('.bottom-nav__item') as NodeListOf<HTMLElement>);
+      tabs.find((tab) => tab.textContent?.includes('preferences'))?.click();
+      await fixture.whenStable();
 
       const switches = fixture.nativeElement.querySelectorAll('.prefs__switch[role="switch"]');
       expect(switches.length).toBeGreaterThan(0);

--- a/src/app/copilot/components/copilot-panel/copilot-panel.component.ts
+++ b/src/app/copilot/components/copilot-panel/copilot-panel.component.ts
@@ -7,7 +7,16 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectorRef, Component, Input, ViewEncapsulation, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  HostListener,
+  Input,
+  ViewChild,
+  ViewEncapsulation,
+  inject
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -33,6 +42,8 @@ import { ChatAreaComponent } from '../chat-area/chat-area.component';
 import { RecentChatsComponent } from '../recent-chats/recent-chats.component';
 import { InputBarComponent } from '../input-bar/input-bar.component';
 import { CopilotPreferencesComponent } from '../copilot-preferences/copilot-preferences.component';
+import { PromptNavComponent } from '../prompt-nav/prompt-nav.component';
+import { InputBarComponent as InputBar } from '../input-bar/input-bar.component';
 
 export type CopilotTab = 'chat' | 'recent' | 'preferences' | 'help';
 
@@ -54,11 +65,13 @@ export type CopilotTab = 'chat' | 'recent' | 'preferences' | 'help';
     ChatAreaComponent,
     RecentChatsComponent,
     InputBarComponent,
-    CopilotPreferencesComponent
+    CopilotPreferencesComponent,
+    PromptNavComponent
   ],
   templateUrl: './copilot-panel.component.html',
   styleUrls: ['./copilot-panel.component.scss'],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 // Deliberately no ngOnInit. The shell creates this panel as soon as the feature is on,
 // which can be before the officer's credentials are written, and reading the transcript
@@ -106,6 +119,11 @@ export class CopilotPanelComponent {
 
   /** Conversation state, mirrored from ChatService. */
   messages: ChatMessage[] = [];
+  /** The question whose answer is on screen, mirrored for the prompt rail. */
+  activeQuestionId: string | null = null;
+
+  @ViewChild(ChatAreaComponent) private chatArea?: ChatAreaComponent;
+  @ViewChild(InputBar) private inputBar?: InputBar;
   conversations: Conversation[] = [];
   isStreaming = false;
   /** Write action awaiting confirmation, rendered as a confirmation card. */
@@ -195,6 +213,72 @@ export class CopilotPanelComponent {
       return 'copilot.greeting.afternoon';
     }
     return 'copilot.greeting.evening';
+  }
+
+  /**
+   * Keyboard shortcuts, active only while the panel is open.
+   *
+   * <p>Bound on the document because the panel is an overlay the officer may not have focused,
+   * and every branch of this returns early unless the panel is open, so nothing here changes
+   * how the rest of the application behaves.
+   */
+  @HostListener('document:keydown', ['$event'])
+  onShortcut(event: KeyboardEvent): void {
+    if (!this.isEnabled || !this.isOpen || this.activeTab !== 'chat') {
+      return;
+    }
+    const target = event.target as HTMLElement | null;
+    const typing =
+      !!target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable === true);
+
+    // "/" jumps to the composer, the convention almost every chat application uses. Never
+    // while the officer is typing, where it is just a slash.
+    if (event.key === '/' && !typing) {
+      event.preventDefault();
+      this.inputBar?.focusInput();
+      return;
+    }
+    // Alt+Up / Alt+Down move between the questions asked this session. Alt, because the
+    // arrows alone belong to the composer and to the scroll container.
+    if (event.altKey && (event.key === 'ArrowUp' || event.key === 'ArrowDown')) {
+      event.preventDefault();
+      this.stepThroughQuestions(event.key === 'ArrowUp' ? -1 : 1);
+      return;
+    }
+    // Escape closes the panel, but only from outside the composer, where it stops the reply.
+    if (event.key === 'Escape' && !typing && !this.isStreaming) {
+      event.preventDefault();
+      this.togglePanel();
+    }
+  }
+
+  /** Move to the question before or after the one on screen, and stop at the ends. */
+  private stepThroughQuestions(direction: -1 | 1): void {
+    const questions = this.messages.filter((message) => message.role === 'user');
+    if (questions.length === 0) {
+      return;
+    }
+    const current = questions.findIndex((message) => message.id === this.activeQuestionId);
+    // From nowhere in particular, Up goes to the last question and Down to the first.
+    const from = current < 0 ? (direction === -1 ? questions.length : -1) : current;
+    const next = Math.min(Math.max(from + direction, 0), questions.length - 1);
+    this.jumpToQuestion(questions[next].id);
+  }
+
+  /** Put the last question back in the composer to be reworded. */
+  editLastQuestion(): void {
+    const question = this.chatService.editLastQuestion();
+    if (question === null) {
+      return;
+    }
+    this.composerText = question;
+    this.inputBar?.focusInput();
+  }
+
+  /** The rail asked to go back to a question. */
+  jumpToQuestion(id: string): void {
+    this.activeQuestionId = id;
+    this.chatArea?.scrollToQuestion(id);
   }
 
   togglePanel(): void {

--- a/src/app/copilot/components/copilot-preferences/copilot-preferences.component.spec.ts
+++ b/src/app/copilot/components/copilot-preferences/copilot-preferences.component.spec.ts
@@ -26,7 +26,7 @@ describe('CopilotPreferencesComponent', () => {
 
     fixture = TestBed.createComponent(CopilotPreferencesComponent);
     component = fixture.componentInstance;
-    component.savedConversations = 3;
+    fixture.componentRef.setInput('savedConversations', 3);
     fixture.detectChanges();
   });
 
@@ -38,8 +38,8 @@ describe('CopilotPreferencesComponent', () => {
   });
 
   it('reports the switches as on or off for a screen reader', () => {
-    component.isFullScreen = true;
-    component.historyEnabled = false;
+    fixture.componentRef.setInput('isFullScreen', true);
+    fixture.componentRef.setInput('historyEnabled', false);
     fixture.detectChanges();
 
     const switches = fixture.nativeElement.querySelectorAll('.prefs__switch');
@@ -91,7 +91,7 @@ describe('CopilotPreferencesComponent', () => {
     });
 
     it('offers nothing to erase when nothing is saved', () => {
-      component.savedConversations = 0;
+      fixture.componentRef.setInput('savedConversations', 0);
       fixture.detectChanges();
 
       const button = fixture.nativeElement.querySelector('.prefs__button--danger');

--- a/src/app/copilot/components/copilot-preferences/copilot-preferences.component.ts
+++ b/src/app/copilot/components/copilot-preferences/copilot-preferences.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -24,7 +24,8 @@ import { TranslateModule } from '@ngx-translate/core';
     TranslateModule
   ],
   templateUrl: './copilot-preferences.component.html',
-  styleUrls: ['./copilot-preferences.component.scss']
+  styleUrls: ['./copilot-preferences.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class CopilotPreferencesComponent {
   /** Whether the panel opens filling the window. */

--- a/src/app/copilot/components/input-bar/input-bar.component.ts
+++ b/src/app/copilot/components/input-bar/input-bar.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -20,7 +20,8 @@ import { TranslateModule } from '@ngx-translate/core';
     TranslateModule
   ],
   templateUrl: './input-bar.component.html',
-  styleUrls: ['./input-bar.component.scss']
+  styleUrls: ['./input-bar.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class InputBarComponent {
   @Input() isStreaming = false;
@@ -36,11 +37,33 @@ export class InputBarComponent {
   @Output() textChange = new EventEmitter<string>();
   @Output() send = new EventEmitter<string>();
   @Output() stop = new EventEmitter<void>();
+  /** Up arrow in an empty composer: put the last question back to be reworded. */
+  @Output() editLast = new EventEmitter<void>();
+
+  @ViewChild('messageInput') private messageInput?: ElementRef<HTMLInputElement>;
+
+  /** Put the caret in the composer, for the panel's keyboard shortcuts. */
+  focusInput(): void {
+    this.messageInput?.nativeElement.focus();
+  }
 
   onKeyDown(event: KeyboardEvent): void {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       this.submit();
+      return;
+    }
+    // Only from an empty composer, so it can never eat a caret movement in text the officer
+    // is still writing. This is the shell convention, and the one people try first.
+    if (event.key === 'ArrowUp' && !this.text && !this.isStreaming) {
+      event.preventDefault();
+      this.editLast.emit();
+      return;
+    }
+    // Escape stops a reply that is going the wrong way, without reaching for the button.
+    if (event.key === 'Escape' && this.isStreaming) {
+      event.preventDefault();
+      this.stop.emit();
     }
   }
 

--- a/src/app/copilot/components/message-actions/message-actions.component.ts
+++ b/src/app/copilot/components/message-actions/message-actions.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, OnDestroy, Output, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, Output, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { TranslateModule } from '@ngx-translate/core';
@@ -31,7 +31,8 @@ import { toPlainText } from '../../core/plain-text';
     TranslateModule
   ],
   templateUrl: './message-actions.component.html',
-  styleUrls: ['./message-actions.component.scss']
+  styleUrls: ['./message-actions.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MessageActionsComponent implements OnDestroy {
   @Input({ required: true }) message!: ChatMessage;

--- a/src/app/copilot/components/prompt-nav/prompt-nav.component.html
+++ b/src/app/copilot/components/prompt-nav/prompt-nav.component.html
@@ -1,0 +1,46 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+<nav
+  class="prompt-nav"
+  [class.prompt-nav--collapsed]="collapsed"
+  *ngIf="hasEntries"
+  [attr.aria-label]="'copilot.promptNav.label' | translate"
+>
+  <button
+    type="button"
+    class="prompt-nav__toggle"
+    (click)="toggle()"
+    [attr.aria-expanded]="!collapsed"
+    [attr.aria-label]="(collapsed ? 'copilot.promptNav.expand' : 'copilot.promptNav.collapse') | translate"
+    [title]="(collapsed ? 'copilot.promptNav.expand' : 'copilot.promptNav.collapse') | translate"
+  >
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
+    </svg>
+  </button>
+
+  <!-- The list is always in the DOM: collapsing shrinks each row to a rule, so the officer
+       keeps the sense of how far through the conversation they are. Labels are hidden from
+       assistive technology only while collapsed, where they are not readable anyway. -->
+  <ol class="prompt-nav__list">
+    <li *ngFor="let entry of entries; trackBy: trackById">
+      <button
+        type="button"
+        class="prompt-nav__item"
+        [class.prompt-nav__item--active]="entry.id === activeId"
+        [attr.aria-current]="entry.id === activeId ? 'true' : null"
+        (click)="jumpTo.emit(entry.id)"
+        [title]="entry.label"
+      >
+        <span class="prompt-nav__rule" aria-hidden="true"></span>
+        <span class="prompt-nav__index" aria-hidden="true">{{ entry.index }}</span>
+        <span class="prompt-nav__label">{{ entry.label }}</span>
+      </button>
+    </li>
+  </ol>
+</nav>

--- a/src/app/copilot/components/prompt-nav/prompt-nav.component.scss
+++ b/src/app/copilot/components/prompt-nav/prompt-nav.component.scss
@@ -1,0 +1,10 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/* Structure lives in copilot-panel.component.scss, colour in copilot.component-theme.scss,
+   matching how every other component in this feature is styled. */

--- a/src/app/copilot/components/prompt-nav/prompt-nav.component.spec.ts
+++ b/src/app/copilot/components/prompt-nav/prompt-nav.component.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { PromptNavComponent } from './prompt-nav.component';
+import { ChatMessage } from '../../core/models/chat-message.model';
+
+function ask(id: string, content: string): ChatMessage {
+  return { id, role: 'user', content, timestamp: 0 };
+}
+
+function reply(id: string): ChatMessage {
+  return { id, role: 'assistant', content: 'One active loan.', timestamp: 0 };
+}
+
+describe('PromptNavComponent', () => {
+  let fixture: ComponentFixture<PromptNavComponent>;
+  let component: PromptNavComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        PromptNavComponent,
+        TranslateModule.forRoot()
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PromptNavComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  /** With one question there is nowhere to move between, so the rail is only furniture. */
+  it('stays away until there is a second question', () => {
+    fixture.componentRef.setInput('messages', [
+      ask('u-1', 'Show me the loan'),
+      reply('a-1')
+    ]);
+    fixture.detectChanges();
+
+    expect(component.hasEntries).toBe(false);
+    expect(fixture.nativeElement.querySelector('.prompt-nav')).toBeNull();
+  });
+
+  it('lists the questions once there are two', () => {
+    fixture.componentRef.setInput('messages', [
+      ask('u-1', 'Show me the loan'),
+      reply('a-1'),
+      ask('u-2', 'Who is this client'),
+      reply('a-2')
+    ]);
+    fixture.detectChanges();
+
+    const labels = Array.from(
+      fixture.nativeElement.querySelectorAll('.prompt-nav__label') as NodeListOf<HTMLElement>
+    ).map((node) => node.textContent?.trim());
+    expect(labels).toEqual([
+      'Show me the loan',
+      'Who is this client'
+    ]);
+  });
+
+  it('lists only what the officer asked, never the answers', () => {
+    fixture.componentRef.setInput('messages', [
+      ask('u-1', 'One'),
+      reply('a-1'),
+      ask('u-2', 'Two'),
+      reply('a-2')
+    ]);
+    expect(component.entries.map((entry) => entry.id)).toEqual([
+      'u-1',
+      'u-2'
+    ]);
+  });
+
+  it('numbers the questions in the order they were asked', () => {
+    fixture.componentRef.setInput('messages', [
+      ask('u-1', 'One'),
+      ask('u-2', 'Two'),
+      ask('u-3', 'Three')
+    ]);
+    expect(component.entries.map((entry) => entry.index)).toEqual([
+      1,
+      2,
+      3
+    ]);
+  });
+
+  it('trims a long question on a word boundary', () => {
+    const long = 'Show me the repayment schedule for the loan belonging to this particular client';
+    fixture.componentRef.setInput('messages', [
+      ask('u-1', long),
+      ask('u-2', 'Short')
+    ]);
+
+    const label = component.entries[0].label;
+    expect(label.endsWith('…')).toBe(true);
+    expect(label.length).toBeLessThanOrEqual(49);
+    expect(label).not.toContain('  ');
+    // Cut between words, so the tail is a whole word rather than half of one.
+    expect(long).toContain(label.slice(0, -1).trim());
+  });
+
+  it('collapses whitespace so a pasted question stays on one line', () => {
+    fixture.componentRef.setInput('messages', [
+      ask('u-1', 'Show me\n\n  the loan'),
+      ask('u-2', 'Short')
+    ]);
+    expect(component.entries[0].label).toBe('Show me the loan');
+  });
+
+  it('marks the question whose answer is on screen', () => {
+    fixture.componentRef.setInput('messages', [
+      ask('u-1', 'One'),
+      ask('u-2', 'Two')
+    ]);
+    fixture.componentRef.setInput('activeId', 'u-2');
+    fixture.detectChanges();
+
+    const items = fixture.nativeElement.querySelectorAll('.prompt-nav__item');
+    expect(items[0].getAttribute('aria-current')).toBeNull();
+    expect(items[1].getAttribute('aria-current')).toBe('true');
+    expect(items[1].classList).toContain('prompt-nav__item--active');
+  });
+
+  it('asks to go back to a question when one is clicked', () => {
+    fixture.componentRef.setInput('messages', [
+      ask('u-1', 'One'),
+      ask('u-2', 'Two')
+    ]);
+    fixture.detectChanges();
+
+    let jumped: string | undefined;
+    component.jumpTo.subscribe((id: string) => (jumped = id));
+    fixture.nativeElement.querySelectorAll('.prompt-nav__item')[1].click();
+    expect(jumped).toBe('u-2');
+  });
+
+  it('collapses to a strip of rules and back', () => {
+    fixture.componentRef.setInput('messages', [
+      ask('u-1', 'One'),
+      ask('u-2', 'Two')
+    ]);
+    fixture.detectChanges();
+
+    const toggle = fixture.nativeElement.querySelector('.prompt-nav__toggle');
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+
+    toggle.click();
+    fixture.detectChanges();
+    expect(component.collapsed).toBe(true);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(fixture.nativeElement.querySelector('.prompt-nav').classList).toContain('prompt-nav--collapsed');
+  });
+
+  /** Collapsing must not drop the list: it is what the officer clicks to move about. */
+  it('keeps the questions reachable while collapsed', () => {
+    fixture.componentRef.setInput('messages', [
+      ask('u-1', 'One'),
+      ask('u-2', 'Two')
+    ]);
+    fixture.detectChanges();
+    fixture.nativeElement.querySelector('.prompt-nav__toggle').click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelectorAll('.prompt-nav__item').length).toBe(2);
+  });
+
+  it('treats an absent conversation as the same empty list every time', () => {
+    fixture.componentRef.setInput('messages', null);
+    const first = component.entries;
+    fixture.componentRef.setInput('messages', undefined);
+    expect(component.entries).toBe(first);
+  });
+});

--- a/src/app/copilot/components/prompt-nav/prompt-nav.component.ts
+++ b/src/app/copilot/components/prompt-nav/prompt-nav.component.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import { ChatMessage } from '../../core/models/chat-message.model';
+
+/** Below this many questions the list is more furniture than help. */
+export const PROMPT_NAV_MIN_QUESTIONS = 2;
+
+/** How much of a question the rail shows before trimming it. */
+const MAX_LABEL_CHARS = 48;
+
+/** One question, as the rail lists it. */
+export interface PromptEntry {
+  id: string;
+  label: string;
+  index: number;
+}
+
+/**
+ * A rail of the questions asked in this session, for getting back to one.
+ *
+ * <p>A long exchange scrolls past what an officer wants to re-read, and scrolling back through
+ * an assistant's paragraphs to find the question that produced them is the tedious part. The
+ * rail lists the questions only: they are short, the officer wrote them, and they are what is
+ * actually remembered about a conversation.
+ *
+ * <p>It appears at the second question, because with one there is nothing to move between, and
+ * hides itself entirely on a narrow panel where a column of its own would take the space the
+ * conversation needs.
+ */
+@Component({
+  selector: 'mifosx-prompt-nav',
+  imports: [
+    CommonModule,
+    TranslateModule
+  ],
+  templateUrl: './prompt-nav.component.html',
+  styleUrls: ['./prompt-nav.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PromptNavComponent {
+  /**
+   * Built from the message list rather than taking it raw, so that a token arriving for the
+   * answer does not change anything this component reads.
+   */
+  @Input() set messages(value: ChatMessage[] | null | undefined) {
+    const questions = (value ?? []).filter((message) => message.role === 'user');
+    this.entries =
+      questions.length < PROMPT_NAV_MIN_QUESTIONS
+        ? NO_ENTRIES
+        : questions.map((message, index) => ({
+            id: message.id,
+            label: trim(message.content),
+            index: index + 1
+          }));
+  }
+
+  /** The question whose answer is on screen, so the rail says where the officer is. */
+  @Input() activeId: string | null = null;
+
+  @Output() jumpTo = new EventEmitter<string>();
+
+  entries: PromptEntry[] = NO_ENTRIES;
+
+  /** Collapsed to a strip of rules, which keeps the position readable at a glance. */
+  collapsed = false;
+
+  get hasEntries(): boolean {
+    return this.entries.length > 0;
+  }
+
+  toggle(): void {
+    this.collapsed = !this.collapsed;
+  }
+
+  trackById(_index: number, entry: PromptEntry): string {
+    return entry.id;
+  }
+}
+
+/** One shared empty array, so "nothing to list" is a stable reference for OnPush. */
+const NO_ENTRIES: PromptEntry[] = [];
+
+/**
+ * A question, short enough to scan.
+ *
+ * <p>Cut on a word boundary where there is one within reach of the limit: "Show me the repayme"
+ * is harder to recognise than "Show me the…", and recognising it is the whole job.
+ */
+function trim(text: string): string {
+  const clean = (text ?? '').replace(/\s+/g, ' ').trim();
+  if (clean.length <= MAX_LABEL_CHARS) {
+    return clean;
+  }
+  const cut = clean.slice(0, MAX_LABEL_CHARS);
+  const lastSpace = cut.lastIndexOf(' ');
+  return `${(lastSpace > MAX_LABEL_CHARS - 12 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+}

--- a/src/app/copilot/components/quick-chips/quick-chips.component.ts
+++ b/src/app/copilot/components/quick-chips/quick-chips.component.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { TranslateModule } from '@ngx-translate/core';
@@ -24,7 +24,8 @@ import { TranslateModule } from '@ngx-translate/core';
     TranslateModule
   ],
   templateUrl: './quick-chips.component.html',
-  styleUrls: ['./quick-chips.component.scss']
+  styleUrls: ['./quick-chips.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class QuickChipsComponent {
   @Input() prompts: string[] = [];

--- a/src/app/copilot/components/recent-chats/recent-chats.component.html
+++ b/src/app/copilot/components/recent-chats/recent-chats.component.html
@@ -6,6 +6,45 @@
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 <div class="chat-body recent-chats">
+  <!-- Shown once there are enough conversations that scanning them stops being quicker
+       than typing. Below that the box is another thing to look past. -->
+  <div class="recent-chats__search" *ngIf="conversations.length > 4">
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M15.5 14h-.79l-.28-.27A6.47 6.47 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+      />
+    </svg>
+    <input
+      type="search"
+      class="recent-chats__search-input"
+      [ngModel]="query"
+      (ngModelChange)="onSearch($event)"
+      [placeholder]="'copilot.recent.searchPlaceholder' | translate"
+      [attr.aria-label]="'copilot.recent.searchPlaceholder' | translate"
+    />
+    <button
+      type="button"
+      class="recent-chats__search-clear"
+      *ngIf="hasQuery"
+      (click)="clearSearch()"
+      [attr.aria-label]="'copilot.recent.searchClear' | translate"
+    >
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path
+          d="M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+        />
+      </svg>
+    </button>
+  </div>
+
+  <!-- Nothing matched, which is not the same as nothing saved and does not say so. -->
+  <div *ngIf="conversations.length > 0 && visible.length === 0" class="recent-chats__empty">
+    <p class="recent-chats__empty-title">{{ 'copilot.recent.noMatchTitle' | translate }}</p>
+    <p class="recent-chats__empty-subtitle">
+      {{ 'copilot.recent.noMatchSubtitle' | translate: { query: query } }}
+    </p>
+  </div>
+
   <div *ngIf="conversations.length === 0" class="recent-chats__empty">
     <svg viewBox="0 0 24 24" class="recent-chats__empty-icon">
       <path
@@ -15,8 +54,8 @@
     <p class="recent-chats__empty-title">{{ 'copilot.recent.emptyTitle' | translate }}</p>
     <p class="recent-chats__empty-subtitle">{{ 'copilot.recent.emptySubtitle' | translate }}</p>
   </div>
-  <div *ngIf="conversations.length > 0" class="recent-chats__list">
-    <div *ngFor="let conv of conversations; trackBy: trackByConversationId" class="recent-chats__item">
+  <div *ngIf="visible.length > 0" class="recent-chats__list">
+    <div *ngFor="let conv of visible; trackBy: trackByConversationId" class="recent-chats__item">
       <button type="button" class="recent-chats__item-main" (click)="open.emit(conv)">
         <span class="recent-chats__item-icon">
           <svg viewBox="0 0 24 24">

--- a/src/app/copilot/components/recent-chats/recent-chats.component.spec.ts
+++ b/src/app/copilot/components/recent-chats/recent-chats.component.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { RecentChatsComponent } from './recent-chats.component';
+import { Conversation } from '../../core/models/chat-message.model';
+import { SettingsService } from 'app/settings/settings.service';
+import { Dates } from 'app/core/utils/dates';
+
+function conversation(id: string, title: string, preview = ''): Conversation {
+  return { id, title, preview, timestamp: 0, messageCount: 2 };
+}
+
+/** Enough conversations that the search box is worth showing. */
+const MANY: Conversation[] = [
+  conversation('c-1', 'Préstamo de Rajesh', 'Show me the loan'),
+  conversation('c-2', 'Client lookup', 'Who is this client'),
+  conversation('c-3', 'Savings balance', 'What is the balance'),
+  conversation('c-4', 'Overdue report', 'Which loans are overdue'),
+  conversation('c-5', 'Repayment schedule', 'Show the schedule')
+];
+
+describe('RecentChatsComponent', () => {
+  let fixture: ComponentFixture<RecentChatsComponent>;
+  let component: RecentChatsComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        RecentChatsComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        { provide: SettingsService, useValue: { language: { code: 'en-US' } } },
+        { provide: Dates, useValue: { getMomentLocale: () => 'en' } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RecentChatsComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('conversations', MANY);
+    fixture.detectChanges();
+  });
+
+  it('lists everything saved until something is searched for', () => {
+    expect(component.visible.length).toBe(5);
+  });
+
+  it('narrows the list to what matches', () => {
+    component.onSearch('overdue');
+    fixture.detectChanges();
+
+    expect(component.visible.map((conversation) => conversation.id)).toEqual(['c-4']);
+  });
+
+  it('searches the preview as well as the title', () => {
+    component.onSearch('who is this');
+    expect(component.visible.map((conversation) => conversation.id)).toEqual(['c-2']);
+  });
+
+  /**
+   * An officer typing "prestamo" on a keyboard without accents should still find "Préstamo".
+   * A search that only matches perfectly typed accents is one most people conclude is broken.
+   */
+  it('ignores accents in both the query and the conversation', () => {
+    component.onSearch('prestamo');
+    expect(component.visible.map((conversation) => conversation.id)).toEqual(['c-1']);
+  });
+
+  it('ignores case', () => {
+    component.onSearch('CLIENT LOOKUP');
+    expect(component.visible.map((conversation) => conversation.id)).toEqual(['c-2']);
+  });
+
+  it('says nothing matched, which is not the same as nothing saved', () => {
+    component.onSearch('mortgage');
+    fixture.detectChanges();
+
+    expect(component.visible.length).toBe(0);
+    expect(fixture.nativeElement.querySelector('.recent-chats__empty-title').textContent).toContain(
+      'copilot.recent.noMatchTitle'
+    );
+  });
+
+  it('gives the whole list back when the search is cleared', () => {
+    component.onSearch('overdue');
+    component.clearSearch();
+
+    expect(component.query).toBe('');
+    expect(component.visible.length).toBe(5);
+  });
+
+  it('keeps the box away until there are enough chats to be worth searching', () => {
+    fixture.componentRef.setInput('conversations', [conversation('c-1', 'Only one')]);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.recent-chats__search')).toBeNull();
+  });
+
+  it('treats an absent list as the same empty array every time', () => {
+    fixture.componentRef.setInput('conversations', null);
+    const first = component.conversations;
+    fixture.componentRef.setInput('conversations', undefined);
+    expect(component.conversations).toBe(first);
+  });
+});

--- a/src/app/copilot/components/recent-chats/recent-chats.component.ts
+++ b/src/app/copilot/components/recent-chats/recent-chats.component.ts
@@ -6,28 +6,95 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
 import { SettingsService } from 'app/settings/settings.service';
 import { Dates } from 'app/core/utils/dates';
 import { Conversation } from '../../core/models/chat-message.model';
 import { relativeTime } from '../../core/relative-time';
 
+/** One shared empty array, so "nothing saved" is a stable reference for OnPush. */
+const NO_CONVERSATIONS: Conversation[] = [];
+
+/**
+ * Lowercased and stripped of accents, so a search matches what was meant rather than what was
+ * typed. NFD splits an accented letter into the letter and its mark; the mark is then dropped.
+ */
+function fold(text: string): string {
+  return (text ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim();
+}
+
 /** Recent Chats tab: list of saved conversations with preview, meta and delete. */
 @Component({
   selector: 'mifosx-recent-chats',
   imports: [
     CommonModule,
+    FormsModule,
     TranslateModule
   ],
   templateUrl: './recent-chats.component.html',
-  styleUrls: ['./recent-chats.component.scss']
+  styleUrls: ['./recent-chats.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RecentChatsComponent {
-  @Input() conversations: Conversation[] = [];
+  /**
+   * Saved conversations, kept in a field so the filter has something to filter.
+   *
+   * <p>Held rather than piped through a template expression, because a filter recomputed on
+   * every check is exactly the kind of work an OnPush component is here to avoid.
+   */
+  @Input()
+  set conversations(value: Conversation[] | null | undefined) {
+    this.all = value ?? NO_CONVERSATIONS;
+    this.applyFilter();
+  }
+  get conversations(): Conversation[] {
+    return this.all;
+  }
+  private all: Conversation[] = NO_CONVERSATIONS;
   @Output() open = new EventEmitter<Conversation>();
   @Output() remove = new EventEmitter<{ event: Event; id: string }>();
+
+  /** What the officer typed into the search box. */
+  query = '';
+  /** The conversations that match it, which is all of them until something is typed. */
+  visible: Conversation[] = NO_CONVERSATIONS;
+
+  /**
+   * Search across the saved conversations.
+   *
+   * <p>Matches the title and the preview, which between them carry the question that opened
+   * the conversation. Case- and accent-insensitive, because an officer searching for "prestamo"
+   * should find "préstamo" — a search that only matches perfectly typed accents is a search
+   * most people conclude is broken.
+   */
+  onSearch(query: string): void {
+    this.query = query;
+    this.applyFilter();
+  }
+
+  clearSearch(): void {
+    this.onSearch('');
+  }
+
+  get hasQuery(): boolean {
+    return this.query.trim().length > 0;
+  }
+
+  private applyFilter(): void {
+    const needle = fold(this.query);
+    this.visible = needle
+      ? this.all.filter(
+          (conversation) => fold(conversation.title).includes(needle) || fold(conversation.preview).includes(needle)
+        )
+      : this.all;
+  }
 
   onDelete(event: Event, id: string): void {
     event.stopPropagation();

--- a/src/app/copilot/components/thinking-trail/thinking-trail.component.html
+++ b/src/app/copilot/components/thinking-trail/thinking-trail.component.html
@@ -7,10 +7,17 @@
 -->
 <div class="trail" *ngIf="hasAnything">
   <!-- While the turn runs, one line naming what is happening right now. An officer waiting on a
-       slow branch connection needs to tell working apart from hung, and this is what does it. -->
-  <div class="trail__live" *ngIf="isStreaming && currentStep as step">
-    <span class="trail__spinner" aria-hidden="true"></span>
-    <span>{{ step.label }}</span>
+       slow branch connection needs to tell working apart from hung, and this is what does it.
+       aria-live announces it, because a silent wait is the same wait for a screen reader. -->
+  <div class="trail__live" *ngIf="isStreaming" role="status" aria-live="polite">
+    <span class="trail__live-dot" aria-hidden="true"></span>
+    <span class="trail__live-label">
+      <ng-container *ngIf="currentStep as step">{{ step.label }}</ng-container>
+      <ng-container *ngIf="!currentStep">{{ liveLabelKey | translate }}</ng-container>
+    </span>
+    <!-- Written to directly by the component; never bound, so a tick costs no change
+         detection. Starts at 0s so the slot never reflows when the first second lands. -->
+    <span class="trail__live-time" #liveTimer aria-hidden="true">0s</span>
   </div>
 
   <!-- One disclosure, not two. What it did and what it wrote both belong to the same question,
@@ -26,33 +33,53 @@
       <svg class="trail__chevron" [class.trail__chevron--open]="open" viewBox="0 0 24 24" aria-hidden="true">
         <path d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6z" />
       </svg>
-      <span>{{ 'copilot.trail.thinking' | translate }}</span>
-      <span class="trail__count" *ngIf="elapsed">{{ elapsed }}</span>
+      <span *ngIf="elapsed">{{ 'copilot.trail.thoughtFor' | translate: { seconds: elapsed } }}</span>
+      <span *ngIf="!elapsed">{{ 'copilot.trail.thinking' | translate }}</span>
     </button>
 
-    <div class="trail__body" [id]="bodyId" *ngIf="open">
-      <!-- What it actually did. This is the part that is a record. -->
-      <ol class="trail__steps" *ngIf="steps.length">
-        <li *ngFor="let step of steps" class="trail__step">
-          <span class="trail__tick" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" /></svg>
-          </span>
-          <span class="trail__step-label">{{ step.label }}</span>
-          <span class="trail__step-time" *ngIf="step.durationMs !== null && step.durationMs !== undefined">{{
-            seconds(step.durationMs)
-          }}</span>
-        </li>
-      </ol>
+    <!-- Animated rather than removed, so opening it does not jump the conversation. The answer
+         above keeps its position either way: this block is the last thing in the bubble. -->
+    <div class="trail__body" [id]="bodyId" [@expandBody]="open ? 'expanded' : 'collapsed'">
+      <div class="trail__body-inner">
+        <!-- What it actually did. This is the part that is a record. -->
+        <ol class="trail__steps" *ngIf="steps.length">
+          <li *ngFor="let step of steps" class="trail__step" [class.trail__step--write]="isWrite(step)">
+            <!-- A step that changed a record is marked as one. Reading and writing are not the
+                 same act, and a log that renders them identically hides the difference that
+                 matters most when an officer is checking what was done. -->
+            <span class="trail__tick" aria-hidden="true">
+              <svg *ngIf="!isWrite(step)" viewBox="0 0 24 24">
+                <path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+              </svg>
+              <svg *ngIf="isWrite(step)" viewBox="0 0 24 24">
+                <path
+                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                />
+              </svg>
+            </span>
+            <span class="trail__step-kind" *ngIf="isWrite(step)">{{ 'copilot.trail.wrote' | translate }}</span>
+            <span class="trail__step-label">{{ step.label }}</span>
+            <span class="trail__step-time" *ngIf="step.durationMs !== null && step.durationMs !== undefined">{{
+              seconds(step.durationMs)
+            }}</span>
+          </li>
+        </ol>
 
-      <!-- What it wrote while doing it, which is not a record. The caution sits with it, read
-           at the moment the text is, rather than floating where it will be scrolled past. -->
-      <div class="trail__notes-block" *ngIf="notes">
-        <p class="trail__caution">{{ 'copilot.trail.notesCaution' | translate }}</p>
-        <div class="trail__notes">{{ notes }}</div>
+        <!-- What it wrote while doing it, which is not a record. The caution sits with it, read
+             at the moment the text is, rather than floating where it will be scrolled past. -->
+        <div class="trail__notes-block" *ngIf="notes">
+          <p class="trail__caution">
+            {{ 'copilot.trail.notesCaution' | translate }}
+            <span class="trail__notes-time" *ngIf="notesElapsed">{{
+              'copilot.trail.notesTook' | translate: { seconds: notesElapsed }
+            }}</span>
+          </p>
+          <div class="trail__notes">{{ notes }}</div>
+        </div>
+
+        <!-- Points at where the decision basis actually lives, so this is never mistaken for it. -->
+        <p class="trail__note">{{ 'copilot.trail.stepsNote' | translate }}</p>
       </div>
-
-      <!-- Points at where the decision basis actually lives, so this is never mistaken for it. -->
-      <p class="trail__note">{{ 'copilot.trail.stepsNote' | translate }}</p>
     </div>
   </div>
 </div>

--- a/src/app/copilot/components/thinking-trail/thinking-trail.component.spec.ts
+++ b/src/app/copilot/components/thinking-trail/thinking-trail.component.spec.ts
@@ -7,14 +7,15 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
-import { describe, it, expect, beforeEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals';
 
 import { ThinkingTrailComponent } from './thinking-trail.component';
-import { ChatMessage } from '../../core/models/chat-message.model';
+import { CopilotStep } from '../../core/models/chat-message.model';
 
-function reply(overrides: Partial<ChatMessage> = {}): ChatMessage {
-  return { id: 'm-1', role: 'assistant', content: 'One active loan.', timestamp: 0, ...overrides };
+function step(label: string, done = true, durationMs?: number): CopilotStep {
+  return { label, readOnly: true, done, durationMs };
 }
 
 describe('ThinkingTrailComponent', () => {
@@ -25,142 +26,214 @@ describe('ThinkingTrailComponent', () => {
     await TestBed.configureTestingModule({
       imports: [
         ThinkingTrailComponent,
-        TranslateModule.forRoot()
+        TranslateModule.forRoot(),
+        NoopAnimationsModule
       ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ThinkingTrailComponent);
     component = fixture.componentInstance;
-    component.message = reply();
+    fixture.componentRef.setInput('messageId', 'm-1');
     fixture.detectChanges();
   });
 
-  /** A reply that used no tools and produced no notes gets no panel at all. */
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** A finished reply that used no tools and produced no notes gets no panel at all. */
   it('shows nothing when there is nothing to show', () => {
     expect(component.hasAnything).toBe(false);
     expect(fixture.nativeElement.querySelector('.trail')).toBeNull();
   });
 
   it('lists the steps the assistant actually took', () => {
-    component.message = reply({
-      steps: [
-        { label: 'Looked up the client', readOnly: true, done: true, durationMs: 3079 },
-        { label: 'Read the loan account', readOnly: true, done: true, durationMs: 412 }
-      ]
-    });
+    fixture.componentRef.setInput('steps', [
+      step('Reading the loan account'),
+      step('Checking the repayment schedule')
+    ]);
     fixture.detectChanges();
-    component.toggle();
+    fixture.nativeElement.querySelector('.trail__summary').click();
     fixture.detectChanges();
 
-    const labels = Array.from(fixture.nativeElement.querySelectorAll('.trail__step-label')).map((n) =>
-      (n as HTMLElement).textContent?.trim()
-    );
+    const labels = Array.from(
+      fixture.nativeElement.querySelectorAll('.trail__step-label') as NodeListOf<HTMLElement>
+    ).map((node) => node.textContent?.trim());
     expect(labels).toEqual([
-      'Looked up the client',
-      'Read the loan account'
+      'Reading the loan account',
+      'Checking the repayment schedule'
     ]);
   });
 
-  /** One disclosure, so the officer is not asked to open two things to see one answer. */
-  it('puts what it did and what it wrote in the same panel', () => {
-    component.message = reply({
-      steps: [{ label: 'Looked up the client', readOnly: true, done: true }],
-      workingNotes: 'Deciding which tool to use.'
-    });
-    fixture.detectChanges();
-    expect(fixture.nativeElement.querySelectorAll('.trail__summary').length).toBe(1);
+  // ─── State transitions ─────────────────────────────────────────────────────
 
-    component.toggle();
+  it('shows the live line while streaming and the disclosure once complete', () => {
+    fixture.componentRef.setInput('isStreaming', true);
+    fixture.componentRef.setInput('steps', [step('Reading the loan account', false)]);
     fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('.trail__step-label')).not.toBeNull();
-    expect(fixture.nativeElement.querySelector('.trail__notes').textContent).toContain('Deciding which tool');
+
+    expect(fixture.nativeElement.querySelector('.trail__live')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.trail__summary')).toBeNull();
+
+    fixture.componentRef.setInput('isStreaming', false);
+    fixture.componentRef.setInput('turnMs', 3200);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.trail__live')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.trail__summary')).not.toBeNull();
   });
 
   /**
-   * Reading it has to be a choice. Detailed explanations increase reliance on a recommendation
-   * including when it is wrong, so the panel never opens itself.
+   * The gap before the first tool call is a wait like any other. It used to render nothing,
+   * which is the state an officer cannot tell apart from a hung panel.
    */
-  it('stays closed until the officer opens it', () => {
-    component.message = reply({ workingNotes: 'The officer wants the balance.' });
+  it('names the wait even before the first step arrives', () => {
+    fixture.componentRef.setInput('isStreaming', true);
+    fixture.detectChanges();
+
+    expect(component.currentStep).toBeNull();
+    expect(component.liveLabelKey).toBe('copilot.trail.live.reading');
+    expect(fixture.nativeElement.querySelector('.trail__live')).not.toBeNull();
+  });
+
+  it('says it is thinking once notes have started arriving', () => {
+    fixture.componentRef.setInput('isStreaming', true);
+    fixture.componentRef.setInput('workingNotes', 'Checking the schedule before quoting a figure.');
+    fixture.detectChanges();
+
+    expect(component.liveLabelKey).toBe('copilot.trail.live.thinking');
+  });
+
+  it('names the step in flight while streaming', () => {
+    fixture.componentRef.setInput('isStreaming', true);
+    fixture.componentRef.setInput('steps', [
+      step('Reading the loan account'),
+      step('Checking the repayment schedule', false)
+    ]);
+    fixture.detectChanges();
+
+    expect(component.currentStep?.label).toBe('Checking the repayment schedule');
+    expect(fixture.nativeElement.querySelector('.trail__live-label').textContent).toContain(
+      'Checking the repayment schedule'
+    );
+  });
+
+  // ─── Collapsed by default ──────────────────────────────────────────────────
+
+  it('is collapsed when the turn completes', () => {
+    fixture.componentRef.setInput('steps', [step('Reading the loan account')]);
+    fixture.componentRef.setInput('turnMs', 4100);
     fixture.detectChanges();
 
     expect(component.open).toBe(false);
-    expect(fixture.nativeElement.querySelector('.trail__notes')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.trail__summary').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('stays closed until the officer opens it', () => {
+    fixture.componentRef.setInput('steps', [step('Reading the loan account')]);
+    fixture.detectChanges();
+    expect(component.open).toBe(false);
+
+    fixture.nativeElement.querySelector('.trail__summary').click();
+    fixture.detectChanges();
+    expect(component.open).toBe(true);
   });
 
   it('reports its open state to a screen reader', () => {
-    component.message = reply({ steps: [{ label: 'Looked up the client', readOnly: true, done: true }] });
+    fixture.componentRef.setInput('steps', [step('Reading the loan account')]);
     fixture.detectChanges();
+    const button = fixture.nativeElement.querySelector('.trail__summary');
 
-    const summary = fixture.nativeElement.querySelector('.trail__summary');
-    expect(summary.getAttribute('aria-expanded')).toBe('false');
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(button.getAttribute('aria-controls')).toBe('copilot-thinking-m-1');
 
-    summary.click();
+    fixture.nativeElement.querySelector('.trail__summary').click();
     fixture.detectChanges();
-    expect(summary.getAttribute('aria-expanded')).toBe('true');
+    expect(button.getAttribute('aria-expanded')).toBe('true');
   });
 
-  /** The caution belongs with the text, read at the moment the text is. */
+  it('gives each reply its own disclosure id', () => {
+    fixture.componentRef.setInput('messageId', 'm-2');
+    expect(component.bodyId).toBe('copilot-thinking-m-2');
+  });
+
   it('carries its caution beside the notes', () => {
-    component.message = reply({ workingNotes: 'Deciding which tool to use.' });
+    fixture.componentRef.setInput('workingNotes', 'It looked overdue at first glance.');
     fixture.detectChanges();
-    component.toggle();
+    fixture.nativeElement.querySelector('.trail__summary').click();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('.trail__caution')).not.toBeNull();
-    expect(fixture.nativeElement.querySelector('.trail__note')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.trail__notes').textContent).toContain('overdue');
   });
 
-  /** While the turn runs, the officer needs to tell working apart from hung. */
-  it('names the step in flight while streaming', () => {
-    component.message = reply({
-      steps: [
-        { label: 'Looked up the client', readOnly: true, done: true },
-        { label: 'Fetching the repayment schedule', readOnly: true, done: false }
-      ]
-    });
-    component.isStreaming = true;
-    fixture.detectChanges();
-
-    expect(component.currentStep?.label).toBe('Fetching the repayment schedule');
-    expect(fixture.nativeElement.querySelector('.trail__live').textContent).toContain(
-      'Fetching the repayment schedule'
-    );
-    expect(fixture.nativeElement.querySelectorAll('.trail__summary').length).toBe(0);
-  });
-
-  /**
-   * Wall clock, not a sum of the parts. Thinking and a call can overlap, and the answer still
-   * has to stream after both, so adding them up is wrong in both directions at once.
-   */
-  it('shows the wait the officer actually sat through', () => {
-    component.message = reply({
-      turnMs: 15000,
-      notesElapsedMs: 4000,
-      steps: [{ label: 'Looked up the client', readOnly: true, done: true, durationMs: 11000 }]
-    });
-
-    expect(component.elapsed).toBe('15s');
-  });
-
-  /** One panel per reply, or aria-controls names several elements at once. */
-  it('gives each reply its own disclosure id', () => {
-    component.message = reply({ id: 'm-7', workingNotes: 'thought' });
-    expect(component.bodyId).toBe('copilot-thinking-m-7');
-
-    component.message = reply({ id: 'm-8', workingNotes: 'thought' });
-    expect(component.bodyId).toBe('copilot-thinking-m-8');
-  });
+  // ─── Elapsed-time formatting ───────────────────────────────────────────────
 
   it('says a duration in seconds', () => {
-    expect(component.seconds(3079)).toBe('3.1s');
-    expect(component.seconds(412)).toBe('0.4s');
-    expect(component.seconds(23400)).toBe('23s');
-    expect(component.seconds(undefined)).toBe('');
+    expect(component.seconds(3200)).toBe('3.2s');
+    expect(component.seconds(800)).toBe('0.8s');
+  });
+
+  it('drops the decimal once the wait passes ten seconds', () => {
+    expect(component.seconds(9900)).toBe('9.9s');
+    expect(component.seconds(10_000)).toBe('10s');
+    expect(component.seconds(64_400)).toBe('64s');
   });
 
   it('shows no duration when nothing was timed', () => {
-    component.message = reply({ workingNotes: 'thought' });
+    expect(component.seconds(undefined)).toBe('');
     expect(component.elapsed).toBe('');
+  });
+
+  it('shows the wait the officer actually sat through', () => {
+    fixture.componentRef.setInput('turnMs', 8567);
+    expect(component.elapsed).toBe('8.6s');
+  });
+
+  // ─── The live counter ──────────────────────────────────────────────────────
+
+  /**
+   * The counter is written to the text node rather than bound, so that a tick never runs
+   * change detection. This checks the writing actually happens.
+   */
+  it('counts the wait up without binding a ticking value', () => {
+    jest.useFakeTimers();
+    fixture.componentRef.setInput('isStreaming', true);
+    component.ngOnChanges({
+      isStreaming: { currentValue: true, previousValue: false, firstChange: false, isFirstChange: () => false }
+    });
+    fixture.detectChanges();
+
+    jest.advanceTimersByTime(3000);
+    expect(fixture.nativeElement.querySelector('.trail__live-time').textContent).toBe('3s');
+  });
+
+  it('stops counting when the turn ends', () => {
+    jest.useFakeTimers();
+    const cleared = jest.spyOn(globalThis, 'clearInterval');
+    fixture.componentRef.setInput('isStreaming', true);
+    fixture.detectChanges();
+    jest.advanceTimersByTime(2000);
+
+    fixture.componentRef.setInput('isStreaming', false);
+    fixture.detectChanges();
+
+    expect(cleared).toHaveBeenCalled();
+    cleared.mockRestore();
+  });
+
+  // ─── Input normalisation (what keeps OnPush from re-checking) ──────────────
+
+  it('treats an absent step list as the same empty array every time', () => {
+    fixture.componentRef.setInput('steps', undefined);
+    const first = component.steps;
+    fixture.componentRef.setInput('steps', undefined);
+    expect(component.steps).toBe(first);
+  });
+
+  it('treats absent notes as an empty string', () => {
+    fixture.componentRef.setInput('workingNotes', undefined);
+    expect(component.workingNotes).toBe('');
+    expect(component.notes).toBe('');
   });
 });

--- a/src/app/copilot/components/thinking-trail/thinking-trail.component.ts
+++ b/src/app/copilot/components/thinking-trail/thinking-trail.component.ts
@@ -6,10 +6,28 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import { Component, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Input,
+  NgZone,
+  OnChanges,
+  OnDestroy,
+  SimpleChanges,
+  ViewChild,
+  inject
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { animate, state, style, transition, trigger } from '@angular/animations';
 import { TranslateModule } from '@ngx-translate/core';
-import { ChatMessage, CopilotStep } from '../../core/models/chat-message.model';
+import { CopilotStep } from '../../core/models/chat-message.model';
+
+/** Below this many seconds the figure carries a decimal, above it does not. */
+const DECIMAL_BELOW_SECONDS = 10;
+
+/** One shared empty array, so "no steps" is a stable reference for OnPush. */
+const NO_STEPS: CopilotStep[] = [];
 
 /**
  * How the assistant reached an answer, in two parts that are not the same kind of thing.
@@ -28,6 +46,11 @@ import { ChatMessage, CopilotStep } from '../../core/models/chat-message.model';
  * before it is read, and detailed explanations are known to increase reliance on a
  * recommendation including when the recommendation is wrong. Below, opening one is an act of
  * scrutiny rather than a preamble.
+ *
+ * <p>Takes its parts as discrete inputs rather than the whole message, so that a token
+ * arriving for the answer does not change any input this component reads and OnPush can skip
+ * it entirely. The answer streams several times a second; the trail changes a handful of
+ * times per turn.
  */
 @Component({
   selector: 'mifosx-thinking-trail',
@@ -36,12 +59,65 @@ import { ChatMessage, CopilotStep } from '../../core/models/chat-message.model';
     TranslateModule
   ],
   templateUrl: './thinking-trail.component.html',
-  styleUrls: ['./thinking-trail.component.scss']
+  styleUrls: ['./thinking-trail.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [
+    // Mirrors `detailExpand` in organization/investors, the house pattern for a height
+    // collapse. mat-expansion-panel is deliberately not used: its chrome fights the bubble.
+    trigger('expandBody', [
+      state('collapsed', style({ height: '0px', minHeight: '0', opacity: 0 })),
+      state('expanded', style({ height: '*', opacity: 1 })),
+      transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)'))
+    ])
+  ]
 })
-export class ThinkingTrailComponent {
-  @Input({ required: true }) message!: ChatMessage;
+export class ThinkingTrailComponent implements OnChanges, OnDestroy {
+  /** Identifies the reply this trail belongs to; only used to build the disclosure id. */
+  @Input({ required: true }) messageId!: string;
+
+  /**
+   * Normalised through a setter so an absent value is always the SAME empty array.
+   *
+   * <p>OnPush compares input references. A `msg.steps || []` in the parent template would hand
+   * this a freshly built array on every check, which is a changed reference every token, which
+   * is exactly the re-render this component is shaped to avoid.
+   */
+  @Input()
+  set steps(value: CopilotStep[] | null | undefined) {
+    this.stepList = value ?? NO_STEPS;
+  }
+  get steps(): CopilotStep[] {
+    return this.stepList;
+  }
+  private stepList: CopilotStep[] = NO_STEPS;
+
+  @Input()
+  set workingNotes(value: string | null | undefined) {
+    this.notesText = value ?? '';
+  }
+  get workingNotes(): string {
+    return this.notesText;
+  }
+  private notesText = '';
+  /** Wall-clock duration of the whole turn, stamped once the turn ends. */
+  @Input() turnMs?: number;
+  /**
+   * How long the model spent writing its notes, which is not the same as the wait.
+   *
+   * <p>Shown beside the notes rather than in the header. The header figure is the wall clock
+   * the officer sat through; this one is a part of it, and putting two durations side by side
+   * in the same line would invite reading one as the other.
+   */
+  @Input() notesElapsedMs?: number;
   /** True while the turn is still running, which changes the wording from past to present. */
   @Input() isStreaming = false;
+
+  /** The live seconds counter, written to directly so a tick never runs change detection. */
+  @ViewChild('liveTimer') private liveTimer?: ElementRef<HTMLElement>;
+
+  private readonly zone = inject(NgZone);
+  private timerId?: ReturnType<typeof setInterval>;
+  private startedAt = 0;
 
   open = false;
 
@@ -53,19 +129,15 @@ export class ThinkingTrailComponent {
    * the situation the attribute exists to avoid.
    */
   get bodyId(): string {
-    return `copilot-thinking-${this.message.id}`;
-  }
-
-  get steps(): CopilotStep[] {
-    return this.message.steps ?? [];
+    return `copilot-thinking-${this.messageId}`;
   }
 
   get notes(): string {
-    return (this.message.workingNotes ?? '').trim();
+    return (this.workingNotes ?? '').trim();
   }
 
   get hasAnything(): boolean {
-    return this.steps.length > 0 || this.notes.length > 0;
+    return this.steps.length > 0 || this.notes.length > 0 || this.isStreaming;
   }
 
   /** The step in flight, which is what the officer wants to see while waiting. */
@@ -73,8 +145,19 @@ export class ThinkingTrailComponent {
     return this.steps.find((step) => !step.done) ?? null;
   }
 
-  get finishedCount(): number {
-    return this.steps.filter((step) => step.done).length;
+  /**
+   * What to call what is happening right now.
+   *
+   * <p>Before the first tool call there is still a wait, and it used to be shown by nothing at
+   * all: an officer on a slow branch connection saw three dots and no words. A named state is
+   * what separates working from hung, so the gap is filled with the one thing that is honestly
+   * known at that point — that the assistant is reading the question.
+   */
+  get liveLabelKey(): string {
+    if (this.currentStep) {
+      return '';
+    }
+    return this.notes ? 'copilot.trail.live.thinking' : 'copilot.trail.live.reading';
   }
 
   /**
@@ -86,7 +169,17 @@ export class ThinkingTrailComponent {
    * is wanted here is the wait, and the wait is from when the turn started to when it ended.
    */
   get elapsed(): string {
-    return this.message.turnMs ? this.seconds(this.message.turnMs) : '';
+    return this.turnMs ? this.seconds(this.turnMs) : '';
+  }
+
+  /** How long the model spent on its notes, for the line that carries them. */
+  get notesElapsed(): string {
+    return this.notesElapsedMs ? this.seconds(this.notesElapsedMs) : '';
+  }
+
+  /** A step that changes a record, which does not look like one that only read. */
+  isWrite(step: CopilotStep): boolean {
+    return step.readOnly === false;
   }
 
   /**
@@ -100,10 +193,51 @@ export class ThinkingTrailComponent {
       return '';
     }
     const value = ms / 1000;
-    return value < 10 ? `${value.toFixed(1)}s` : `${Math.round(value)}s`;
+    return value < DECIMAL_BELOW_SECONDS ? `${value.toFixed(1)}s` : `${Math.round(value)}s`;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['isStreaming']) {
+      this.isStreaming ? this.startTimer() : this.stopTimer();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.stopTimer();
   }
 
   toggle(): void {
     this.open = !this.open;
+  }
+
+  /**
+   * Count the wait up, without involving Angular.
+   *
+   * <p>A value that changes every second and is bound in the template would ask the framework
+   * to check this component, and every component above it, once a second for the whole turn —
+   * on top of the checks the answer's own tokens already cause. The interval runs outside the
+   * zone and writes to the text node itself, so a tick costs one assignment.
+   *
+   * <p>Held to whole seconds deliberately. A tenths-place digit changing ten times a second
+   * beside a pulsing label is motion for its own sake, and the officer is reading the label.
+   */
+  private startTimer(): void {
+    this.stopTimer();
+    this.startedAt = Date.now();
+    this.zone.runOutsideAngular(() => {
+      this.timerId = setInterval(() => {
+        const node = this.liveTimer?.nativeElement;
+        if (node) {
+          node.textContent = `${Math.floor((Date.now() - this.startedAt) / 1000)}s`;
+        }
+      }, 1000);
+    });
+  }
+
+  private stopTimer(): void {
+    if (this.timerId !== undefined) {
+      clearInterval(this.timerId);
+      this.timerId = undefined;
+    }
   }
 }

--- a/src/app/copilot/copilot.component-theme.scss
+++ b/src/app/copilot/copilot.component-theme.scss
@@ -179,7 +179,80 @@ $copilot-warning: #f59e0b;
 
       &__bubble .md-code {
         background: rgba(if($is-dark, #fff, #000), 0.06);
+      }
+
+      /* The border lives on the wrapper now, so the bar and the code read as one object. */
+      &__bubble .md-code-wrap {
         border: 1px solid $border;
+      }
+
+      &__bubble .md-code__bar {
+        background: rgba(if($is-dark, #fff, #000), 0.1);
+        border-bottom: 1px solid $border;
+        color: $text-3;
+      }
+
+      &__bubble .md-code__copy {
+        color: $text-2;
+
+        svg {
+          fill: currentcolor;
+        }
+
+        &:hover {
+          background: rgba(if($is-dark, #fff, #000), 0.08);
+        }
+
+        &:focus-visible {
+          outline: 2px solid $brand-ring;
+          outline-offset: -2px;
+        }
+      }
+
+      &__bubble .md-code__copy--done svg {
+        fill: $success-text;
+      }
+
+      &__text--streaming::after {
+        border-left: 2px solid $brand-text;
+      }
+
+      /* Syntax colour. Held to four roles: more than that in a chat bubble reads as noise,
+         and these four are what make a payload skimmable. Both sets are checked for contrast
+         against the code block's own ground, which is a tint of the bubble rather than white. */
+      &__bubble .hl-keyword {
+        color: if($is-dark, #c4a7fb, #6d28d9);
+      }
+
+      &__bubble .hl-string {
+        color: if($is-dark, #86efac, #047857);
+      }
+
+      &__bubble .hl-number {
+        color: if($is-dark, #fbbf24, #b45309);
+      }
+
+      &__bubble .hl-comment {
+        color: $text-3;
+        font-style: italic;
+      }
+
+      &__bubble .md-heading {
+        color: $text-1;
+      }
+
+      &__bubble .md-quote {
+        border-left-color: $border;
+        color: $text-2;
+      }
+
+      &__bubble .md-link {
+        color: $brand-text;
+
+        &:focus-visible {
+          outline: 2px solid $brand-ring;
+          outline-offset: 2px;
+        }
       }
 
       &__bubble .md-table {
@@ -369,13 +442,80 @@ $copilot-warning: #f59e0b;
     /* How the answer was reached. Quiet enough not to compete with the answer, legible
        enough to read on a branch monitor under fluorescent light: a real muted token rather
        than opacity, which compounds unpredictably with the theme. */
+
+    .show-earlier {
+      background: $muted;
+      color: $text-2;
+
+      &:hover {
+        background: $brand-tint;
+        color: $brand-text;
+      }
+
+      &:focus-visible {
+        outline: 2px solid $brand-ring;
+        outline-offset: 2px;
+      }
+    }
+
+    /* The questions asked this session. Reads as a quiet overlay: it sits above the
+       conversation, so it needs its own ground to stay legible over text. */
+    .prompt-nav {
+      background: $surface;
+      border: 1px solid $border;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, if($is-dark, 0.4, 0.08));
+    }
+
+    .prompt-nav__toggle {
+      color: $text-2;
+
+      svg {
+        fill: currentcolor;
+      }
+
+      &:focus-visible {
+        outline: 2px solid $brand-ring;
+        outline-offset: -2px;
+      }
+    }
+
+    .prompt-nav__item {
+      color: $text-2;
+
+      .prompt-nav__rule {
+        background: $border;
+      }
+
+      &:hover {
+        background: $brand-tint;
+        color: $brand-text;
+      }
+
+      &:focus-visible {
+        outline: 2px solid $brand-ring;
+        outline-offset: -2px;
+      }
+    }
+
+    .prompt-nav__item--active {
+      color: $brand-text;
+      font-weight: 600;
+
+      .prompt-nav__rule {
+        background: $brand-text;
+      }
+    }
+
     .trail__live {
       color: $text-2;
     }
 
-    .trail__spinner {
-      border-color: $border;
-      border-top-color: $brand-text;
+    .trail__live-dot {
+      background: $brand-text;
+    }
+
+    .trail__live-time {
+      color: $text-3;
     }
 
     .trail__section {

--- a/src/app/copilot/core/highlight.spec.ts
+++ b/src/app/copilot/core/highlight.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { highlightCode, highlightLanguage } from './highlight';
+
+describe('highlightLanguage', () => {
+  it('recognises the aliases a model actually writes', () => {
+    expect(highlightLanguage('ts')).toBe('js');
+    expect(highlightLanguage('TypeScript')).toBe('js');
+    expect(highlightLanguage('yml')).toBe('yaml');
+    expect(highlightLanguage('bash')).toBe('shell');
+  });
+
+  it('is null for a language it does not colour', () => {
+    expect(highlightLanguage('brainfuck')).toBeNull();
+    expect(highlightLanguage('')).toBeNull();
+  });
+});
+
+describe('highlightCode', () => {
+  it('leaves an unknown language exactly as it was', () => {
+    const code = 'some plain text 123';
+    expect(highlightCode(code, 'cobol')).toBe(code);
+  });
+
+  it('marks keywords, numbers and strings', () => {
+    const html = highlightCode("const x = 42; const s = 'hi';", 'js');
+    expect(html).toContain('<span class="hl-keyword">const</span>');
+    expect(html).toContain('<span class="hl-number">42</span>');
+    expect(html).toContain('<span class="hl-string">\'hi\'</span>');
+  });
+
+  it('marks a double-quoted string that arrived escaped', () => {
+    const html = highlightCode('{&quot;principal&quot;: 50000}', 'json');
+    expect(html).toContain('<span class="hl-string">&quot;principal&quot;</span>');
+    expect(html).toContain('<span class="hl-number">50000</span>');
+  });
+
+  /** A keyword inside a string is part of the string, not a keyword. */
+  it('does not colour a keyword that lives inside a string', () => {
+    const html = highlightCode("const a = 'const';", 'js');
+    expect(html).toContain('<span class="hl-string">\'const\'</span>');
+    expect(html.match(/hl-keyword/g)?.length).toBe(1);
+  });
+
+  it('does not colour anything inside a comment', () => {
+    const html = highlightCode('// const x = 1\nconst y = 2;', 'js');
+    expect(html).toContain('<span class="hl-comment">// const x = 1</span>');
+    // Only the second, real `const` is a keyword.
+    expect(html.match(/hl-keyword/g)?.length).toBe(1);
+  });
+
+  it('treats SQL keywords without caring about case', () => {
+    const html = highlightCode('select * from m_loan where id = 1', 'sql');
+    expect(html).toContain('<span class="hl-keyword">select</span>');
+    expect(html).toContain('<span class="hl-keyword">where</span>');
+  });
+
+  it('marks a SQL comment', () => {
+    expect(highlightCode('-- a note\nselect 1', 'sql')).toContain('<span class="hl-comment">-- a note</span>');
+  });
+
+  it('marks a yaml comment with a hash', () => {
+    expect(highlightCode('# a note\nkey: 1', 'yaml')).toContain('<span class="hl-comment"># a note</span>');
+  });
+
+  /**
+   * The input is already escaped upstream, and nothing here may introduce markup that could
+   * be read as a tag. Only the spans this module writes should appear.
+   */
+  it('adds no markup beyond its own spans', () => {
+    const html = highlightCode('&lt;script&gt;alert(1)&lt;/script&gt;', 'js');
+    expect(html).not.toContain('<script');
+    expect(html.replace(/<\/?span[^>]*>/g, '')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('keeps the text intact when the spans are stripped back off', () => {
+    const code = 'const total = 50000; // the principal\n';
+    expect(highlightCode(code, 'js').replace(/<\/?span[^>]*>/g, '')).toBe(code);
+  });
+});

--- a/src/app/copilot/core/highlight.ts
+++ b/src/app/copilot/core/highlight.ts
@@ -1,0 +1,202 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Colour for the few languages the assistant actually emits.
+ *
+ * <p>Deliberately not a highlighting library. The Copilot answers about loans and clients, and
+ * the code in a reply is a JSON payload, a SQL query or a snippet of configuration. A general
+ * highlighter is hundreds of kilobytes for grammars nobody here will hit, on a panel that is
+ * lazy-loaded precisely so it costs nothing until it is opened.
+ *
+ * <p>What this does instead is one pass per language over already-escaped text, marking
+ * strings, numbers, comments and keywords. It will not colour every construct correctly, and
+ * that is the accepted trade: the point is to make a payload skimmable, not to be an IDE. When
+ * a language is unknown the text is returned untouched, which is the honest outcome.
+ *
+ * <p>Input MUST already be HTML-escaped. Everything below inserts &lt;span&gt; wrappers into
+ * that text, so passing raw model output here would defeat the escaping done upstream.
+ */
+
+/** Languages worth a pass, mapped from the aliases a model actually writes. */
+const ALIASES: Record<string, string> = {
+  js: 'js',
+  javascript: 'js',
+  ts: 'js',
+  typescript: 'js',
+  json: 'json',
+  sql: 'sql',
+  yaml: 'yaml',
+  yml: 'yaml',
+  sh: 'shell',
+  bash: 'shell',
+  shell: 'shell'
+};
+
+const KEYWORDS: Record<string, string[]> = {
+  js: [
+    'const',
+    'let',
+    'var',
+    'function',
+    'return',
+    'if',
+    'else',
+    'for',
+    'while',
+    'class',
+    'new',
+    'await',
+    'async',
+    'import',
+    'export',
+    'from',
+    'try',
+    'catch',
+    'throw',
+    'typeof',
+    'interface',
+    'type',
+    'true',
+    'false',
+    'null',
+    'undefined'
+  ],
+  json: [
+    'true',
+    'false',
+    'null'
+  ],
+  sql: [
+    'SELECT',
+    'FROM',
+    'WHERE',
+    'JOIN',
+    'LEFT',
+    'RIGHT',
+    'INNER',
+    'OUTER',
+    'ON',
+    'GROUP',
+    'ORDER',
+    'BY',
+    'HAVING',
+    'LIMIT',
+    'INSERT',
+    'INTO',
+    'VALUES',
+    'UPDATE',
+    'SET',
+    'DELETE',
+    'CREATE',
+    'TABLE',
+    'ALTER',
+    'DROP',
+    'AND',
+    'OR',
+    'NOT',
+    'NULL',
+    'AS',
+    'DISTINCT',
+    'COUNT',
+    'SUM'
+  ],
+  yaml: [
+    'true',
+    'false',
+    'null'
+  ],
+  shell: [
+    'if',
+    'then',
+    'fi',
+    'for',
+    'in',
+    'do',
+    'done',
+    'echo',
+    'export',
+    'cd',
+    'sudo',
+    'curl',
+    'npm'
+  ]
+};
+
+/** Comment openers per language, as they appear once escaped. */
+const LINE_COMMENT: Record<string, RegExp | null> = {
+  js: /\/\/[^\n]*/g,
+  json: null,
+  sql: /--[^\n]*/g,
+  yaml: /#[^\n]*/g,
+  shell: /#[^\n]*/g
+};
+
+/** The language this block will be coloured as, or null to leave it alone. */
+export function highlightLanguage(language: string): string | null {
+  return ALIASES[(language ?? '').trim().toLowerCase()] ?? null;
+}
+
+/**
+ * Colour one block of ALREADY-ESCAPED code.
+ *
+ * <p>Runs as a single scan rather than a chain of replaces. Chained replaces re-enter text that
+ * earlier passes have already wrapped, so a keyword inside a string, or the word "span" inside
+ * a comment, ends up mangled. Scanning once and consuming each match whole avoids that.
+ */
+export function highlightCode(escaped: string, language: string): string {
+  const lang = highlightLanguage(language);
+  if (!lang) {
+    return escaped;
+  }
+  const keywords = new Set(KEYWORDS[lang]);
+  const caseInsensitive = lang === 'sql';
+  const comment = LINE_COMMENT[lang];
+
+  // One alternation, tried in order at each position: comments and strings first, because
+  // their contents must never be examined for anything else.
+  const parts: string[] = [
+    comment ? comment.source : null,
+    '&quot;(?:[^&\\\\]|\\\\.|&(?!quot;))*&quot;',
+    "'(?:[^'\\\\]|\\\\.)*'",
+    '\\b\\d+(?:\\.\\d+)?\\b',
+    '[A-Za-z_$][\\w$]*'
+  ].filter((part): part is string => part !== null);
+  const scanner = new RegExp(parts.join('|'), 'g');
+
+  let out = '';
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = scanner.exec(escaped)) !== null) {
+    const token = match[0];
+    out += escaped.slice(last, match.index);
+    last = match.index + token.length;
+
+    if (comment && token.startsWith(commentOpener(lang))) {
+      out += wrap('comment', token);
+    } else if (token.startsWith('&quot;') || token.startsWith("'")) {
+      out += wrap('string', token);
+    } else if (/^\d/.test(token)) {
+      out += wrap('number', token);
+    } else if (keywords.has(caseInsensitive ? token.toUpperCase() : token)) {
+      out += wrap('keyword', token);
+    } else {
+      out += token;
+    }
+  }
+  return out + escaped.slice(last);
+}
+
+function commentOpener(lang: string): string {
+  return lang === 'js' ? '//' : lang === 'sql' ? '--' : '#';
+}
+
+/** The token text is already escaped, so it is placed inside the span verbatim. */
+function wrap(kind: string, token: string): string {
+  return `<span class="hl-${kind}">${token}</span>`;
+}

--- a/src/app/copilot/core/markdown.spec.ts
+++ b/src/app/copilot/core/markdown.spec.ts
@@ -119,4 +119,98 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<li>item</li>');
     expect(html).toContain('md-code');
   });
+  // ─── Constructs a model reaches for constantly, which used to reach the screen raw ───
+
+  describe('headings', () => {
+    it('renders a heading rather than showing its hashes', () => {
+      const html = render('## Outstanding balance');
+      expect(html).toContain('<h2 class="md-heading md-heading--2">Outstanding balance</h2>');
+      expect(html).not.toContain('##');
+    });
+
+    it('flattens deeper levels, because a bubble has no room for six', () => {
+      expect(render('##### Deep')).toContain('<h3');
+    });
+
+    it('leaves a hash that is not a heading alone', () => {
+      expect(render('Account #4521 is active')).toContain('Account #4521 is active');
+    });
+  });
+
+  describe('numbered lists', () => {
+    it('renders "1." as a list rather than a literal digit', () => {
+      const html = render('1. Read the account\n2. Check the schedule');
+      expect(html).toContain('<ol class="md-list md-list--numbered">');
+      expect(html).toContain('<li>Read the account</li>');
+      expect(html).toContain('<li>Check the schedule</li>');
+    });
+
+    it('accepts "1)" as well', () => {
+      expect(render('1) First')).toContain('<li>First</li>');
+    });
+
+    it('closes a numbered list before a bulleted one starts', () => {
+      const html = render('1. First\n- Second');
+      expect(html).toContain('</ol>');
+      expect(html).toContain('<ul class="md-list">');
+    });
+  });
+
+  describe('links', () => {
+    it('renders an http link, opened safely', () => {
+      const html = render('See [the schedule](https://example.org/loans/1)');
+      expect(html).toContain('href="https://example.org/loans/1"');
+      expect(html).toContain('rel="noopener noreferrer"');
+      expect(html).toContain('>the schedule</a>');
+    });
+
+    /** A model writes the href, so a scheme that can act rather than navigate never renders. */
+    it('refuses a javascript: link', () => {
+      const html = render('[tap here](javascript:alert(1))');
+      // No anchor is built. The text itself stays on screen as escaped, inert prose.
+      expect(html).not.toContain('<a');
+      expect(html).not.toContain('href');
+    });
+
+    it('refuses a data: link', () => {
+      expect(render('[x](data:text/html;base64,PHN2Zz4=)')).not.toContain('<a');
+    });
+  });
+
+  describe('blockquotes', () => {
+    it('renders a quote', () => {
+      expect(render('> Verify before disbursing')).toContain('<blockquote class="md-quote">');
+    });
+
+    it('joins consecutive quote lines into one quote', () => {
+      const html = render('> One\n> Two');
+      expect(html.match(/<blockquote/g)?.length).toBe(1);
+      expect(html).toContain('One<br/>Two');
+    });
+  });
+
+  describe('code blocks', () => {
+    it('names the language of a fenced block', () => {
+      const html = render('```json\n{"a":1}\n```');
+      expect(html).toContain('<span class="md-code__lang">json</span>');
+      // The body is now syntax-coloured, so compare it with the colour spans taken back off.
+      expect(html.replace(/<\/?span[^>]*>/g, '')).toContain('{&quot;a&quot;:1}');
+    });
+
+    it('still renders a block with no language given', () => {
+      const html = render('```\nplain\n```');
+      expect(html).toContain('<pre class="md-code">');
+      expect(html).toContain('plain');
+    });
+
+    it("offers a control to take the code, labelled in the officer's language", () => {
+      const html = render('```\nx\n```', 'Copiar código');
+      expect(html).toContain('data-copy');
+      expect(html).toContain('aria-label="Copiar c\u00f3digo"');
+    });
+
+    it('keeps indentation inside a fenced block, which is meaningful in YAML', () => {
+      expect(render('```yaml\na:\n  b: 1\n```').replace(/<\/?span[^>]*>/g, '')).toContain('a:\n  b: 1');
+    });
+  });
 });

--- a/src/app/copilot/core/markdown.ts
+++ b/src/app/copilot/core/markdown.ts
@@ -6,6 +6,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { highlightCode } from './highlight';
+
 /**
  * The assistant's markdown, as the HTML the panel shows.
  *
@@ -18,8 +20,30 @@
  * PDF is built from: a filed document has to say what the officer read, and two renderers
  * would eventually disagree.
  */
-export function renderMarkdown(markdown: string | null | undefined): string {
-  return render(escapeHtml(withoutHalfWrittenMarkup(markdown ?? '')));
+export function renderMarkdown(markdown: string | null | undefined, copyLabel = '', streaming = false): string {
+  const html = render(escapeHtml(withoutHalfWrittenMarkup(markdown ?? '')), copyLabel);
+  return streaming ? markNewestWord(html) : html;
+}
+
+/**
+ * Wrap the word that has just arrived, so it can fade in rather than snap on.
+ *
+ * <p>The bubble is rebuilt from the whole reply on every token, so there is no diff to work
+ * from and no way to know which nodes are new. What is knowable is that the LAST word is the
+ * one that was not there a moment ago. Marking it means each token gets a fresh element with
+ * the animation on it, and the words before it are plain — which is exactly the effect wanted,
+ * for the cost of one regex per token.
+ *
+ * <p>Skipped when the reply currently ends inside a fenced block or a table: those are
+ * rebuilt wholesale as the rows arrive, and a word fading inside them flickers rather than
+ * settles.
+ */
+function markNewestWord(html: string): string {
+  if (/<\/(?:pre|table)>\s*(?:<\/[a-z]+>\s*)*$/i.test(html)) {
+    return html;
+  }
+  // The final run of non-space, non-markup characters, ignoring any tags that close after it.
+  return html.replace(/([^\s<>]+)((?:\s|<\/[a-z]+>|<br\/?>)*)$/i, '<span class="md-token">$1</span>$2');
 }
 
 /**
@@ -66,25 +90,60 @@ function escapeHtml(text: string): string {
  * Fenced ```code``` blocks first (content is already escaped, so it is inserted
  * verbatim inside <pre>), then line-based rendering for the prose between them.
  */
-function render(escaped: string): string {
-  const segments = escaped.split(/```[a-zA-Z0-9_-]*\n?([\s\S]*?)```/g);
+function render(escaped: string, copyLabel: string): string {
+  // Capture the language as well as the body: it is what labels the block on screen, and
+  // discarding it was why every block read as anonymous text.
+  const segments = escaped.split(/```([a-zA-Z0-9_-]*)\n?([\s\S]*?)```/g);
   const out: string[] = [];
-  segments.forEach((segment, index) => {
-    if (index % 2 === 1) {
+  for (let i = 0; i < segments.length; i++) {
+    // Each fence contributes two capture groups, so a matched block occupies i+1 and i+2.
+    if (i % 3 === 1) {
+      const language = segments[i] ?? '';
       // No trim: leading indentation and trailing blank lines are meaningful in
       // Python/YAML/nested JSON, so fenced content is rendered verbatim.
-      out.push(`<pre class="md-code"><code>${segment}</code></pre>`);
-    } else if (segment.trim().length > 0 || segments.length === 1) {
+      const body = segments[i + 1] ?? '';
+      out.push(renderCode(language, body, copyLabel));
+      i++;
+      continue;
+    }
+    const segment = segments[i];
+    if (segment.trim().length > 0 || segments.length === 1) {
       out.push(renderText(segment));
     }
-  });
+  }
   return out.join('\n');
+}
+
+/**
+ * A fenced block, with its language named and a control to take the code.
+ *
+ * <p>The language is shown because an officer pasting a snippet needs to know what it is, and
+ * the copy button exists because selecting many lines of pre-formatted text inside a scrolling
+ * chat panel is genuinely awkward. The body is already escaped, so it is inserted verbatim;
+ * the language is escaped again on its way into the attribute because it reaches here from the
+ * model and only the body has been through escapeHtml.
+ */
+function renderCode(language: string, body: string, copyLabel: string): string {
+  const safeLanguage = escapeHtml(language).slice(0, 24);
+  const label = safeLanguage
+    ? `<span class="md-code__lang">${safeLanguage}</span>`
+    : '<span class="md-code__lang md-code__lang--none"></span>';
+  return (
+    `<div class="md-code-wrap">` +
+    `<div class="md-code__bar">${label}` +
+    `<button type="button" class="md-code__copy" data-copy aria-label="${escapeHtml(copyLabel)}" title="${escapeHtml(copyLabel)}">` +
+    `<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 1H4a2 2 0 0 0-2 2v14h2V3h12V1zm3 4H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zm0 16H8V7h11v14z"/></svg>` +
+    `</button></div>` +
+    `<pre class="md-code"><code>${highlightCode(body, language)}</code></pre>` +
+    `</div>`
+  );
 }
 
 function renderText(escaped: string): string {
   const lines = escaped.split('\n');
   const out: string[] = [];
   let listOpen = false;
+  let numberedOpen = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -101,12 +160,20 @@ function renderText(escaped: string): string {
         out.push('</ul>');
         listOpen = false;
       }
+      if (numberedOpen) {
+        out.push('</ol>');
+        numberedOpen = false;
+      }
       out.push(renderTable(table));
       continue;
     }
 
     const bullet = /^\s*[-*]\s+(.*)$/.exec(line);
     if (bullet) {
+      if (numberedOpen) {
+        out.push('</ol>');
+        numberedOpen = false;
+      }
       if (!listOpen) {
         out.push('<ul class="md-list">');
         listOpen = true;
@@ -114,9 +181,54 @@ function renderText(escaped: string): string {
       out.push(`<li>${inline(bullet[1])}</li>`);
       continue;
     }
+
+    // "1." / "2)" — a model asked for steps answers with these constantly, and they were
+    // reaching the screen as literal digits followed by a full stop.
+    const numbered = /^\s*\d{1,3}[.)]\s+(.*)$/.exec(line);
+    if (numbered) {
+      if (listOpen) {
+        out.push('</ul>');
+        listOpen = false;
+      }
+      if (!numberedOpen) {
+        out.push('<ol class="md-list md-list--numbered">');
+        numberedOpen = true;
+      }
+      out.push(`<li>${inline(numbered[1])}</li>`);
+      continue;
+    }
+
     if (listOpen) {
       out.push('</ul>');
       listOpen = false;
+    }
+    if (numberedOpen) {
+      out.push('</ol>');
+      numberedOpen = false;
+    }
+
+    // Headings. Capped at three levels: a chat bubble has no room for a six-level hierarchy,
+    // and deeper hashes read better flattened than rendered as ever-smaller text.
+    const heading = /^\s*(#{1,6})\s+(.*)$/.exec(line);
+    if (heading) {
+      const level = Math.min(heading[1].length, 3);
+      out.push(`<h${level} class="md-heading md-heading--${level}">${inline(heading[2])}</h${level}>`);
+      continue;
+    }
+
+    // Blockquote. Consecutive lines join into one quote rather than stacking separate ones.
+    const quote = /^\s*&gt;\s?(.*)$/.exec(line);
+    if (quote) {
+      const quoted: string[] = [];
+      let next = /^\s*&gt;\s?(.*)$/.exec(lines[i]);
+      while (i < lines.length && next) {
+        quoted.push(inline(next[1]));
+        i++;
+        next = i < lines.length ? /^\s*&gt;\s?(.*)$/.exec(lines[i]) : null;
+      }
+      i--;
+      out.push(`<blockquote class="md-quote">${quoted.join('<br/>')}</blockquote>`);
+      continue;
     }
     if (line.trim().length === 0) {
       out.push('<br/>');
@@ -126,6 +238,9 @@ function renderText(escaped: string): string {
   }
   if (listOpen) {
     out.push('</ul>');
+  }
+  if (numberedOpen) {
+    out.push('</ol>');
   }
   return out.join('\n');
 }
@@ -164,8 +279,18 @@ function renderTable(rows: string[]): string {
 
 /** Inline markdown: **bold**, *italic*, `code`. Operates on already-escaped text. */
 function inline(text: string): string {
-  return text
-    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-    .replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>')
-    .replace(/`([^`]+)`/g, '<code class="md-inline-code">$1</code>');
+  return (
+    text
+      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+      .replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>')
+      .replace(/`([^`]+)`/g, '<code class="md-inline-code">$1</code>')
+      // [text](url). Only http(s) survives: the text arrives from a model, and javascript:
+      // or data: in an href is the one thing in a link that can act rather than navigate.
+      // rel="noopener" because target="_blank" without it hands the opener to the new page.
+      .replace(
+        /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+        (_match, label: string, href: string) =>
+          `<a class="md-link" href="${href}" target="_blank" rel="noopener noreferrer">${label}</a>`
+      )
+  );
 }

--- a/src/app/copilot/core/mcp-client.ts
+++ b/src/app/copilot/core/mcp-client.ts
@@ -81,7 +81,7 @@ export class McpClient {
 
   private async *singleErrorStream(
     code: McpErrorCode,
-    message: string,
+    message: string | undefined,
     retryable: boolean
   ): AsyncGenerator<McpStreamEvent> {
     yield this.errorEvent(code, message, retryable);
@@ -169,10 +169,16 @@ export class McpClient {
         return; // User pressed stop, so end silently.
       }
       if (timedOut) {
-        yield this.errorEvent('LLM_UNAVAILABLE', 'Timed out waiting for the assistant to respond.', true);
+        yield this.errorEvent('LLM_UNAVAILABLE', undefined, true);
         return;
       }
-      yield this.errorEvent('INTERNAL', error instanceof Error ? error.message : String(error), false);
+      // The detail goes to the console, not to the officer. A transport failure surfaces from
+      // the browser as "Failed to fetch", which is what a blocked CORS preflight, a DNS
+      // failure and an unreachable host all look like from here: it tells whoever is
+      // configuring the deployment something, and tells a loan officer nothing at all. The
+      // panel says it could not reach the assistant, which is the part that is true and useful.
+      console.error('Copilot transport failed', error);
+      yield this.errorEvent('INTERNAL', undefined, false);
     } finally {
       clearTimeout(timeout);
       signal?.removeEventListener('abort', onOuterAbort);
@@ -363,7 +369,7 @@ export class McpClient {
     return codes.includes(value as McpErrorCode) ? (value as McpErrorCode) : 'INTERNAL';
   }
 
-  private errorEvent(errorCode: McpErrorCode, message: string, retryable: boolean): McpStreamEvent {
+  private errorEvent(errorCode: McpErrorCode, message: string | undefined, retryable: boolean): McpStreamEvent {
     return { type: 'error', errorCode, message, retryable };
   }
 

--- a/src/app/copilot/core/step-label.spec.ts
+++ b/src/app/copilot/core/step-label.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { translateStepLabel } from './step-label';
+
+/** Stands in for TranslateService.instant: known keys resolve, unknown ones echo back. */
+function translator(known: Record<string, string>): (key: string) => string {
+  return (key: string) => known[key] ?? key;
+}
+
+describe('translateStepLabel', () => {
+  const dictionary = translator({
+    'copilot.trail.steps.loanDetails': 'Prêt consulté',
+    'copilot.trail.steps.clientSearch': 'Client recherché'
+  });
+
+  it('names a step from its machine name, dropping the vendor prefix', () => {
+    expect(translateStepLabel('mifos_loan_details', 'Reading the loan account', dictionary)).toBe('Prêt consulté');
+  });
+
+  it('falls back to the English label when the machine name is unknown', () => {
+    const known = translator({ 'copilot.trail.steps.clientSearch': 'Client recherché' });
+    expect(translateStepLabel('acme_lookup', 'Client search', known)).toBe('Client recherché');
+  });
+
+  /**
+   * A deployment can add its own tools to the manifest. An English row reads better than a
+   * missing-translation placeholder, so an unknown step keeps the gateway's own wording.
+   */
+  it("shows an unknown deployment's own label unchanged", () => {
+    expect(translateStepLabel('acme_credit_bureau', 'Checking the credit bureau', dictionary)).toBe(
+      'Checking the credit bureau'
+    );
+  });
+
+  it('still names a step when only the machine name arrives', () => {
+    expect(translateStepLabel('mifos_loan_details', undefined, dictionary)).toBe('Prêt consulté');
+  });
+
+  it('still names a step when only the label arrives', () => {
+    expect(translateStepLabel(undefined, 'Loan details', dictionary)).toBe('Prêt consulté');
+  });
+
+  it('is empty when the gateway named the step neither way', () => {
+    expect(translateStepLabel(undefined, undefined, dictionary)).toBe('');
+    expect(translateStepLabel('', '   ', dictionary)).toBe('');
+  });
+
+  it('prefers the machine name, which does not get reworded between releases', () => {
+    const both = translator({
+      'copilot.trail.steps.loanDetails': 'From the machine name',
+      'copilot.trail.steps.readingTheLoanAccount': 'From the English label'
+    });
+    expect(translateStepLabel('mifos_loan_details', 'Reading the loan account', both)).toBe('From the machine name');
+  });
+});

--- a/src/app/copilot/core/step-label.ts
+++ b/src/app/copilot/core/step-label.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Prefix for the step vocabulary in the translation files. */
+const STEP_PREFIX = 'copilot.trail.steps.';
+
+/**
+ * "mifos_loan_details" and "Reading the loan account" both become "loanDetails".
+ *
+ * <p>The gateway may name a step either way round: `toolName` is the manifest's machine name,
+ * `toolLabel` its English prose. Both reduce to the same key so a deployment that sends only
+ * one of them still resolves, and the vendor prefix is dropped because "mifos" is not part of
+ * what the step is.
+ */
+function slug(value: string): string {
+  const words = value
+    .trim()
+    .split(/[^A-Za-z0-9]+/)
+    .filter((word) => word.length > 0)
+    .filter((word, index) => !(index === 0 && word.toLowerCase() === 'mifos'));
+  if (words.length === 0) {
+    return '';
+  }
+  return words
+    .map((word, index) =>
+      index === 0 ? word.toLowerCase() : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+    )
+    .join('');
+}
+
+/**
+ * Name a step in the officer's language.
+ *
+ * <p>Steps arrive named by the gateway's tool manifest, which is written in English. Rather
+ * than teach the gateway thirteen languages, the vocabulary lives here and resolves through
+ * `copilot.trail.steps.*` — the same arrangement the card rows use.
+ *
+ * <p>Resolution order matters. The machine name is tried first because it is stable: a
+ * deployment can reword a label between releases, but `mifos_loan_details` is what the
+ * manifest calls the tool. The English label is the fallback, and if neither resolves the
+ * label is shown exactly as the gateway sent it — a deployment can add its own tools, and an
+ * English row reads better than a missing-translation placeholder.
+ */
+export function translateStepLabel(
+  toolName: string | undefined,
+  toolLabel: string | undefined,
+  translate: (key: string) => string
+): string {
+  for (const candidate of [
+    toolName,
+    toolLabel
+  ]) {
+    const key = candidate ? STEP_PREFIX + slug(candidate) : '';
+    if (!key || key === STEP_PREFIX) {
+      continue;
+    }
+    const translated = translate(key);
+    if (translated && translated !== key) {
+      return translated;
+    }
+  }
+  return (toolLabel ?? toolName ?? '').trim();
+}

--- a/src/app/copilot/pipes/markdown.pipe.ts
+++ b/src/app/copilot/pipes/markdown.pipe.ts
@@ -8,6 +8,7 @@
 
 import { Pipe, PipeTransform, inject } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { TranslateService } from '@ngx-translate/core';
 import { renderMarkdown } from '../core/markdown';
 
 /**
@@ -20,8 +21,13 @@ import { renderMarkdown } from '../core/markdown';
 @Pipe({ name: 'markdown' })
 export class MarkdownPipe implements PipeTransform {
   private readonly sanitizer = inject(DomSanitizer);
+  private readonly translate = inject(TranslateService);
 
-  transform(value: string | null | undefined): SafeHtml {
-    return this.sanitizer.bypassSecurityTrustHtml(renderMarkdown(value));
+  transform(value: string | null | undefined, streaming = false): SafeHtml {
+    // The copy control inside a fenced block is built as raw markup, so it cannot reach the
+    // translate pipe. Its label is resolved here instead, where a TranslateService is at hand.
+    return this.sanitizer.bypassSecurityTrustHtml(
+      renderMarkdown(value, this.translate.instant('copilot.actions.copyCode'), streaming)
+    );
   }
 }

--- a/src/app/copilot/services/chat.service.spec.ts
+++ b/src/app/copilot/services/chat.service.spec.ts
@@ -739,4 +739,59 @@ describe('ChatService', () => {
       expect(localStorage.getItem(keyFor('priya'))).not.toBeNull();
     });
   });
+  describe('taking back the last question', () => {
+    it('hands the question back and removes the exchange it belonged to', () => {
+      service.sendMessage('Show me the loan');
+      expect(service.messages$.value.some((message) => message.content === 'Show me the loan')).toBe(true);
+
+      const question = service.editLastQuestion();
+
+      expect(question).toBe('Show me the loan');
+      expect(service.messages$.value).toEqual([]);
+    });
+
+    /**
+     * Leaving the old exchange above the new one produces two answers to nearly the same
+     * question, which is a transcript that invites reading the wrong one.
+     */
+    it('leaves earlier exchanges alone', () => {
+      service.sendMessage('First question');
+      service.sendMessage('Second question');
+      const before = service.messages$.value.length;
+
+      const question = service.editLastQuestion();
+
+      expect(question).toBe('Second question');
+      expect(service.messages$.value.length).toBeLessThan(before);
+      expect(service.messages$.value[0].content).toBe('First question');
+      expect(service.messages$.value.some((message) => message.content === 'Second question')).toBe(false);
+    });
+
+    it('has nothing to take back in an empty conversation', () => {
+      expect(service.editLastQuestion()).toBeNull();
+    });
+
+    /** The reply being withdrawn is still arriving; stopping is a separate, visible act. */
+    it('refuses while a reply is still streaming', () => {
+      service.isStreaming$.next(true);
+      service.sendMessage('Show me the loan');
+
+      expect(service.editLastQuestion()).toBeNull();
+    });
+
+    it('drops any card that was waiting on the withdrawn question', () => {
+      service.sendMessage('Approve the loan');
+      service.pendingAction$.next({
+        cardId: 'card-1',
+        tool: 'mifos_loan_approve',
+        args: {},
+        display: [],
+        humanSummary: 'Approve'
+      });
+
+      service.editLastQuestion();
+
+      expect(service.pendingAction$.value).toBeNull();
+    });
+  });
 });

--- a/src/app/copilot/services/chat.service.ts
+++ b/src/app/copilot/services/chat.service.ts
@@ -22,6 +22,7 @@ import { environment } from '../../../environments/environment';
 import { ChatMessage, Conversation } from '../core/models/chat-message.model';
 import { McpStreamEvent, PendingAction } from '../core/models/mcp-response.model';
 import { ActionCard } from '../core/models/action-card.model';
+import { translateStepLabel } from '../core/step-label';
 import { InputSanitizer } from '../core/input-sanitizer';
 import { ResponseParser } from '../core/response-parser';
 import { COPILOT_CONFIG } from '../copilot.config';
@@ -219,6 +220,37 @@ export class ChatService {
   }
 
   /**
+   * Take back the last exchange and hand the question back for editing.
+   *
+   * <p>Rephrasing a question is the ordinary way out of a reply that missed the point, and
+   * doing it by hand means retyping. The exchange is removed rather than left above the new
+   * one, because two answers to nearly the same question is a transcript that invites reading
+   * the wrong one.
+   *
+   * <p>Refused mid-turn: the reply being withdrawn is still arriving, and stopping is a
+   * separate, visible act.
+   *
+   * @returns the question, for the composer; null when there is nothing to take back.
+   */
+  editLastQuestion(): string | null {
+    this.ensureCurrentUser();
+    if (this.isStreaming$.value) {
+      return null;
+    }
+    const messages = this.messages$.value;
+    const index = messages.map((message) => message.role).lastIndexOf('user');
+    if (index < 0) {
+      return null;
+    }
+    // Everything from the question onward goes: the question, its reply, and any card or
+    // follow-up that belonged to it.
+    this.messages$.next(messages.slice(0, index));
+    this.pendingAction$.next(null);
+    this.archiveCurrentConversation();
+    return messages[index].content;
+  }
+
+  /**
    * Send a question.
    *
    * @returns whether it was accepted, so the caller knows whether to empty the composer.
@@ -277,8 +309,31 @@ export class ChatService {
    * <p>Matched on the label rather than the tool name, because the same tool can legitimately
    * be called twice in one turn and each call is its own step in what the officer reads.
    */
+  /**
+   * What the officer reads when a turn fails.
+   *
+   * <p>The gateway's own message is preferred, because it knows what went wrong. When there is
+   * none the code is turned into copy from the translation files, rather than whatever string
+   * the transport happened to throw: "Failed to fetch" is what a blocked CORS preflight, a DNS
+   * failure and an unreachable host all look like from the browser, and it tells a loan officer
+   * nothing they can act on. The technical detail is logged for whoever is configuring the
+   * deployment.
+   */
+  private errorText(event: McpStreamEvent): string {
+    const fromGateway = event.message?.trim();
+    if (fromGateway) {
+      return fromGateway;
+    }
+    const key = event.errorCode === 'LLM_UNAVAILABLE' ? 'copilot.errors.timedOut' : 'copilot.errors.streamFailed';
+    return this.translate.instant(key);
+  }
+
   private recordStep(event: McpStreamEvent): void {
-    const label = event.toolLabel ?? event.toolName;
+    // Resolved here rather than in the template: a step log is part of the record of what was
+    // done on a client's account, so the wording is fixed at the moment the step happened.
+    // Unknown tools fall back to the gateway's own English, which reads better than a
+    // missing-translation placeholder (see core/step-label.ts).
+    const label = translateStepLabel(event.toolName, event.toolLabel, (key) => this.translate.instant(key));
     if (!label) {
       return;
     }
@@ -484,9 +539,7 @@ export class ChatService {
         this.decisionBackup = null;
         break;
       case 'error':
-        this.appendToDraft(
-          `${this.draftContent() ? '\n\n' : ''}${event.message ?? this.translate.instant('copilot.errors.streamFailed')}`
-        );
+        this.appendToDraft(`${this.draftContent() ? '\n\n' : ''}${this.errorText(event)}`);
         // The gateway has already worked out whether waiting will help. Offer the question
         // back when it will, so a rate limit costs a click instead of retyping.
         if (event.retryable && this.lastPrompt) {

--- a/src/app/copilot/services/mcp-fixtures.ts
+++ b/src/app/copilot/services/mcp-fixtures.ts
@@ -52,6 +52,51 @@ async function* tokens(text: string): AsyncGenerator<McpStreamEvent> {
   }
 }
 
+/**
+ * How long a demo tool call appears to take.
+ *
+ * <p>Long enough that the live line is legible rather than a flicker, short enough that the
+ * demo does not feel broken. The real gateway takes seconds on a tool call, so a demo that
+ * returns instantly misrepresents the wait the reasoning block exists to explain.
+ */
+const STEP_DELAY_MS = 900;
+
+/** Pause between working-note fragments as the model writes them. */
+const NOTE_DELAY_MS = 12;
+
+/**
+ * A 'thinking' start → delta* → end sequence, the shape chat.service.ts reduces into
+ * `workingNotes` + `notesElapsedMs`.
+ */
+async function* thinking(text: string): AsyncGenerator<McpStreamEvent> {
+  const startedAt = Date.now();
+  yield { type: 'thinking', thinkingPhase: 'start' };
+  for (const word of text.match(/\S+\s*|\s+/g) ?? []) {
+    await sleep(NOTE_DELAY_MS);
+    yield { type: 'thinking', thinkingPhase: 'delta', thinking: word };
+  }
+  yield { type: 'thinking', thinkingPhase: 'end', thinkingElapsedMs: Date.now() - startedAt };
+}
+
+/**
+ * One tool call, started → finished, carrying the banking `toolLabel` the manifest
+ * supplies. Awaits between the two phases, so only ever one step is in flight —
+ * which is what recordStep() in chat.service.ts assumes.
+ */
+async function* step(toolName: string, toolLabel: string, readOnly = true): AsyncGenerator<McpStreamEvent> {
+  const startedAt = Date.now();
+  yield { type: 'tool_call', toolName, toolLabel, toolPhase: 'started', readOnly };
+  await sleep(STEP_DELAY_MS);
+  yield {
+    type: 'tool_call',
+    toolName,
+    toolLabel,
+    toolPhase: 'finished',
+    readOnly,
+    durationMs: Date.now() - startedAt
+  };
+}
+
 /** One-line helper so suggestion lists read clearly at each call site. */
 function suggest(...items: string[]): McpStreamEvent {
   return { type: 'suggest', suggestions: items };
@@ -112,6 +157,12 @@ export async function* mockChatStream(
 
   if (/(approve|disburse|repay|repayment|record|transfer|waive)/.test(message)) {
     // Write intent, so the gateway pauses with an approval card and nothing executes yet.
+    yield* thinking(
+      `This asks me to change a record, so nothing executes without the officer approving it. ` +
+        `I will read the loan first so the card states the real figures rather than echoing ` +
+        `back what was typed.`
+    );
+    yield* step('mifos_loan_details', 'Reading the loan account');
     yield* tokens(t('copilot.demo.writeIntro'));
     await sleep(120);
     yield {
@@ -143,9 +194,14 @@ export async function* mockChatStream(
   }
 
   if (/loan/.test(message)) {
-    yield { type: 'tool_call', toolName: 'mifos_loan_details', toolPhase: 'started', readOnly: true };
-    await sleep(350);
-    yield { type: 'tool_call', toolName: 'mifos_loan_details', toolPhase: 'finished', readOnly: true };
+    yield* thinking(
+      `The officer is asking about ${client}'s loan. I should find the client record first, ` +
+        `then read the loan account itself, and check the repayment schedule before I say ` +
+        `anything about what is outstanding. I will not quote a figure I have not read.`
+    );
+    yield* step('mifos_client_search', 'Finding the client');
+    yield* step('mifos_loan_details', 'Reading the loan account');
+    yield* step('mifos_repayment_schedule', 'Checking the repayment schedule');
     yield* tokens(t('copilot.demo.loanIntro', { client }));
     yield {
       type: 'action_card',
@@ -172,9 +228,13 @@ export async function* mockChatStream(
   }
 
   if (/(client|search|who is)/.test(message)) {
-    yield { type: 'tool_call', toolName: 'mifos_client_search', toolPhase: 'started', readOnly: true };
-    await sleep(300);
-    yield { type: 'tool_call', toolName: 'mifos_client_search', toolPhase: 'finished', readOnly: true };
+    yield* thinking(
+      `A client lookup. I will search the client register, then read the profile and the ` +
+        `savings balance so the summary is complete rather than partly guessed.`
+    );
+    yield* step('mifos_client_search', 'Searching the client register');
+    yield* step('mifos_client_details', 'Reading the client profile');
+    yield* step('mifos_savings_balance', 'Reading the savings balance');
     yield* tokens(t('copilot.demo.clientIntro'));
     yield {
       type: 'action_card',
@@ -199,6 +259,14 @@ export async function* mockChatStream(
     return;
   }
 
+  // The fallback answers with a trail too. Without one, any prompt outside the three intents
+  // above showed no reasoning at all, which made the demo look like the feature was missing
+  // rather than like the question had no account to read.
+  yield* thinking(
+    `Nothing in this asks for a specific loan or client by name, so I have no account to ` +
+      `read. I will say what I can actually do rather than guess at what was meant.`
+  );
+  yield* step('mifos_client_search', 'Searching the client register');
   yield* tokens(t('copilot.demo.modeNotice'));
   yield suggest(
     t('copilot.demo.suggest.clientLoans'),
@@ -216,9 +284,7 @@ export async function* mockDecisionStream(
 ): AsyncGenerator<McpStreamEvent> {
   await sleep(250);
   if (decision === 'approve') {
-    yield { type: 'tool_call', toolName: 'mifos_loan_approve', toolPhase: 'started', readOnly: false };
-    await sleep(600);
-    yield { type: 'tool_call', toolName: 'mifos_loan_approve', toolPhase: 'finished', readOnly: false };
+    yield* step('mifos_loan_approve', 'Approving the loan', false);
     yield* tokens(t('copilot.demo.approved'));
     yield {
       type: 'action_card',

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -6108,6 +6108,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Show {{count}} earlier messages",
+    "a11y": {
+      "replyReady": "Reply ready",
+      "working": "Working on your question"
+    },
+    "promptNav": {
+      "label": "Questions in this chat",
+      "expand": "Show the questions",
+      "collapse": "Hide the questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Aktuální relace",
     "newChat": "Nový chat",
@@ -6158,6 +6168,10 @@
       "aboutStorage": "Vaše konverzace zůstávají v tomto prohlížeči a nikdy se neukládají na server asistenta."
     },
     "recent": {
+      "noMatchSubtitle": "Nothing saved matches \"{{query}}\".",
+      "noMatchTitle": "No chats found",
+      "searchClear": "Clear search",
+      "searchPlaceholder": "Search chats",
       "emptyTitle": "Žádné nedávné konverzace",
       "emptySubtitle": "Zde se zobrazí historie vašich chatů",
       "messages": "zpráv",
@@ -6191,6 +6205,7 @@
     "openAssistant": "Otevřít Mifos X Copilot",
     "newChatTitle": "Nová konverzace",
     "errors": {
+      "timedOut": "The assistant took too long to respond. Please try again.",
       "invalidLength": "Zpráva je prázdná nebo příliš dlouhá. Zkraťte ji prosím a zkuste to znovu.",
       "injectionBlocked": "Zpráva vypadá jako pokus o obejití pokynů, proto nebyla odeslána. Přeformulujte ji prosím.",
       "streamFailed": "Mifos X Copilot je nedostupný. Zkuste to prosím znovu."
@@ -6262,11 +6277,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "changed",
+      "thoughtFor": "Thought for {{seconds}}",
+      "live": {
+        "reading": "Reading your question",
+        "thinking": "Thinking"
+      },
+      "steps": {
+        "loanDetails": "Reading the loan account",
+        "clientSearch": "Searching the client register",
+        "clientDetails": "Reading the client profile",
+        "repaymentSchedule": "Checking the repayment schedule",
+        "savingsBalance": "Reading the savings balance",
+        "loanApprove": "Approving the loan"
+      },
       "stepsNote": "Toto jsou záznamy, které asistent přečetl. Podklad pro jakékoli rozhodnutí o tomto klientovi je ve Fineractu: pravidla úvěrového produktu, splátkový kalendář a úvěrová politika vaší instituce.",
       "thinking": "Přemýšlení",
       "notesCaution": "Vlastní pracovní text asistenta. Není to záznam o tom, jak odpověď vznikla, ani úvěrové hodnocení. Ověřte každou částku podle záznamu klienta."
     },
     "actions": {
+      "copyCode": "Copy code",
       "tryAgain": "Zkusit znovu",
       "groupLabel": "Akce k odpov\u011bdi",
       "copy": "Kop\u00edrovat",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -6107,6 +6107,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Show {{count}} earlier messages",
+    "a11y": {
+      "replyReady": "Reply ready",
+      "working": "Working on your question"
+    },
+    "promptNav": {
+      "label": "Questions in this chat",
+      "expand": "Show the questions",
+      "collapse": "Hide the questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Aktuelle Sitzung",
     "newChat": "Neuer Chat",
@@ -6157,6 +6167,10 @@
       "aboutStorage": "Ihre Unterhaltungen bleiben in diesem Browser und werden nie auf dem Assistenzserver gespeichert."
     },
     "recent": {
+      "noMatchSubtitle": "Nothing saved matches \"{{query}}\".",
+      "noMatchTitle": "No chats found",
+      "searchClear": "Clear search",
+      "searchPlaceholder": "Search chats",
       "emptyTitle": "Keine kürzlichen Unterhaltungen",
       "emptySubtitle": "Ihr Chatverlauf wird hier angezeigt",
       "messages": "Nachrichten",
@@ -6190,6 +6204,7 @@
     "openAssistant": "Mifos X Copilot öffnen",
     "newChatTitle": "Neue Unterhaltung",
     "errors": {
+      "timedOut": "The assistant took too long to respond. Please try again.",
       "invalidLength": "Die Nachricht ist leer oder zu lang. Bitte kürzen Sie sie und versuchen Sie es erneut.",
       "injectionBlocked": "Die Nachricht sieht wie ein Versuch aus, die Anweisungen zu umgehen, und wurde daher nicht gesendet. Bitte formulieren Sie sie um.",
       "streamFailed": "Mifos X Copilot ist nicht erreichbar. Bitte versuchen Sie es erneut."
@@ -6261,11 +6276,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "changed",
+      "thoughtFor": "Thought for {{seconds}}",
+      "live": {
+        "reading": "Reading your question",
+        "thinking": "Thinking"
+      },
+      "steps": {
+        "loanDetails": "Reading the loan account",
+        "clientSearch": "Searching the client register",
+        "clientDetails": "Reading the client profile",
+        "repaymentSchedule": "Checking the repayment schedule",
+        "savingsBalance": "Reading the savings balance",
+        "loanApprove": "Approving the loan"
+      },
       "stepsNote": "Dies sind die Datensätze, die der Assistent gelesen hat. Die Grundlage jeder Entscheidung zu diesem Kunden liegt in Fineract: die Regeln des Kreditprodukts, der Tilgungsplan und die Kreditrichtlinie Ihres Instituts.",
       "thinking": "Denkprozess",
       "notesCaution": "Der Arbeitstext des Assistenten. Kein Nachweis darüber, wie die Antwort entstanden ist, und keine Kreditbewertung. Prüfen Sie jede Zahl anhand der Kundenakte."
     },
     "actions": {
+      "copyCode": "Copy code",
       "tryAgain": "Erneut versuchen",
       "groupLabel": "Aktionen zur Antwort",
       "copy": "Kopieren",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -5971,6 +5971,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Show {{count}} earlier messages",
+    "a11y": {
+      "replyReady": "Reply ready",
+      "working": "Working on your question"
+    },
+    "promptNav": {
+      "label": "Questions in this chat",
+      "expand": "Show the questions",
+      "collapse": "Hide the questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Current session",
     "newChat": "New chat",
@@ -6021,6 +6031,10 @@
       "aboutStorage": "Your conversations stay in this browser and are never stored on the assistant server."
     },
     "recent": {
+      "noMatchSubtitle": "Nothing saved matches \"{{query}}\".",
+      "noMatchTitle": "No chats found",
+      "searchClear": "Clear search",
+      "searchPlaceholder": "Search chats",
       "emptyTitle": "No recent conversations",
       "emptySubtitle": "Your chat history will appear here",
       "messages": "messages",
@@ -6054,6 +6068,7 @@
     "openAssistant": "Open Mifos X Copilot",
     "newChatTitle": "New conversation",
     "errors": {
+      "timedOut": "The assistant took too long to respond. Please try again.",
       "invalidLength": "That message is empty or too long. Please shorten it and try again.",
       "injectionBlocked": "That message looks like an instruction-override attempt, so it was not sent. Please rephrase it.",
       "streamFailed": "Could not reach Mifos X Copilot. Please try again."
@@ -6125,11 +6140,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "changed",
+      "thoughtFor": "Thought for {{seconds}}",
+      "live": {
+        "reading": "Reading your question",
+        "thinking": "Thinking"
+      },
+      "steps": {
+        "loanDetails": "Reading the loan account",
+        "clientSearch": "Searching the client register",
+        "clientDetails": "Reading the client profile",
+        "repaymentSchedule": "Checking the repayment schedule",
+        "savingsBalance": "Reading the savings balance",
+        "loanApprove": "Approving the loan"
+      },
       "stepsNote": "These are the records the assistant read. The basis for any decision on this client is in Fineract: the loan product rules, the repayment schedule, and your institution's credit policy.",
       "thinking": "Thinking",
       "notesCaution": "The assistant's own working text. Not a record of how the answer was produced, and not a credit assessment. Check every figure against the client record."
     },
     "actions": {
+      "copyCode": "Copy code",
       "tryAgain": "Try again",
       "groupLabel": "Response actions",
       "copy": "Copy",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -5819,6 +5819,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Mostrar {{count}} mensajes anteriores",
+    "a11y": {
+      "replyReady": "Respuesta lista",
+      "working": "Trabajando en su pregunta"
+    },
+    "promptNav": {
+      "label": "Preguntas de este chat",
+      "expand": "Mostrar las preguntas",
+      "collapse": "Ocultar las preguntas"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Sesión actual",
     "newChat": "Nuevo chat",
@@ -5869,6 +5879,10 @@
       "aboutStorage": "Sus conversaciones quedan en este navegador y nunca se guardan en el servidor del asistente."
     },
     "recent": {
+      "noMatchSubtitle": "Nada de lo guardado coincide con \"{{query}}\".",
+      "noMatchTitle": "No se encontraron chats",
+      "searchClear": "Borrar búsqueda",
+      "searchPlaceholder": "Buscar chats",
       "emptyTitle": "No hay conversaciones recientes",
       "emptySubtitle": "Tu historial de chat aparecerá aquí",
       "messages": "mensajes",
@@ -5902,6 +5916,7 @@
     "openAssistant": "Abrir Mifos X Copilot",
     "newChatTitle": "Nueva conversación",
     "errors": {
+      "timedOut": "El asistente tardó demasiado en responder. Inténtelo de nuevo.",
       "invalidLength": "El mensaje está vacío o es demasiado largo. Por favor acórtalo e inténtalo de nuevo.",
       "injectionBlocked": "El mensaje parece un intento de anular las instrucciones, por lo que no se envió. Por favor reformúlalo.",
       "streamFailed": "No se pudo contactar con Mifos X Copilot. Inténtalo de nuevo."
@@ -5973,11 +5988,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "modificó",
+      "thoughtFor": "Pensó durante {{seconds}}",
+      "live": {
+        "reading": "Leyendo su pregunta",
+        "thinking": "Pensando"
+      },
+      "steps": {
+        "loanDetails": "Consultando la cuenta del préstamo",
+        "clientSearch": "Buscando en el registro de clientes",
+        "clientDetails": "Consultando el perfil del cliente",
+        "repaymentSchedule": "Revisando el plan de pagos",
+        "savingsBalance": "Consultando el saldo de ahorros",
+        "loanApprove": "Aprobando el préstamo"
+      },
       "stepsNote": "Estos son los registros que consultó el asistente. La base de cualquier decisión sobre este cliente está en Fineract: las reglas del producto de crédito, el calendario de pagos y la política crediticia de su institución.",
       "thinking": "Pensamiento",
       "notesCaution": "Texto de trabajo del propio asistente. No es un registro de cómo se produjo la respuesta, ni una evaluación crediticia. Verifique cada cifra con el expediente del cliente."
     },
     "actions": {
+      "copyCode": "Copiar código",
       "tryAgain": "Intentar de nuevo",
       "groupLabel": "Acciones de la respuesta",
       "copy": "Copiar",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -5841,6 +5841,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Mostrar {{count}} mensajes anteriores",
+    "a11y": {
+      "replyReady": "Respuesta lista",
+      "working": "Trabajando en su pregunta"
+    },
+    "promptNav": {
+      "label": "Preguntas de este chat",
+      "expand": "Mostrar las preguntas",
+      "collapse": "Ocultar las preguntas"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Sesión actual",
     "newChat": "Nuevo chat",
@@ -5891,6 +5901,10 @@
       "aboutStorage": "Sus conversaciones quedan en este navegador y nunca se guardan en el servidor del asistente."
     },
     "recent": {
+      "noMatchSubtitle": "Nada de lo guardado coincide con \"{{query}}\".",
+      "noMatchTitle": "No se encontraron chats",
+      "searchClear": "Borrar búsqueda",
+      "searchPlaceholder": "Buscar chats",
       "emptyTitle": "No hay conversaciones recientes",
       "emptySubtitle": "Tu historial de chat aparecerá aquí",
       "messages": "mensajes",
@@ -5924,6 +5938,7 @@
     "openAssistant": "Abrir Mifos X Copilot",
     "newChatTitle": "Nueva conversación",
     "errors": {
+      "timedOut": "El asistente tardó demasiado en responder. Inténtelo de nuevo.",
       "invalidLength": "El mensaje está vacío o es demasiado largo. Por favor acórtalo e inténtalo de nuevo.",
       "injectionBlocked": "El mensaje parece un intento de anular las instrucciones, por lo que no se envió. Por favor reformúlalo.",
       "streamFailed": "No se pudo contactar con Mifos X Copilot. Inténtalo de nuevo."
@@ -5995,11 +6010,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "modificó",
+      "thoughtFor": "Pensó durante {{seconds}}",
+      "live": {
+        "reading": "Leyendo su pregunta",
+        "thinking": "Pensando"
+      },
+      "steps": {
+        "loanDetails": "Consultando la cuenta del préstamo",
+        "clientSearch": "Buscando en el registro de clientes",
+        "clientDetails": "Consultando el perfil del cliente",
+        "repaymentSchedule": "Revisando el plan de pagos",
+        "savingsBalance": "Consultando el saldo de ahorros",
+        "loanApprove": "Aprobando el préstamo"
+      },
       "stepsNote": "Estos son los registros que consultó el asistente. La base de cualquier decisión sobre este cliente está en Fineract: las reglas del producto de crédito, el calendario de pagos y la política crediticia de su institución.",
       "thinking": "Pensamiento",
       "notesCaution": "Texto de trabajo del propio asistente. No es un registro de cómo se produjo la respuesta, ni una evaluación crediticia. Verifique cada cifra con el expediente del cliente."
     },
     "actions": {
+      "copyCode": "Copiar código",
       "tryAgain": "Intentar de nuevo",
       "groupLabel": "Acciones de la respuesta",
       "copy": "Copiar",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -5821,6 +5821,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Afficher {{count}} messages précédents",
+    "a11y": {
+      "replyReady": "Réponse prête",
+      "working": "Traitement de votre question"
+    },
+    "promptNav": {
+      "label": "Questions de cette conversation",
+      "expand": "Afficher les questions",
+      "collapse": "Masquer les questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Session actuelle",
     "newChat": "Nouvelle discussion",
@@ -5871,6 +5881,10 @@
       "aboutStorage": "Vos conversations restent dans ce navigateur et ne sont jamais stockées sur le serveur de l’assistant."
     },
     "recent": {
+      "noMatchSubtitle": "Rien d'enregistré ne correspond à \"{{query}}\".",
+      "noMatchTitle": "Aucune conversation trouvée",
+      "searchClear": "Effacer la recherche",
+      "searchPlaceholder": "Rechercher",
       "emptyTitle": "Aucune conversation récente",
       "emptySubtitle": "Votre historique de discussion apparaîtra ici",
       "messages": "messages",
@@ -5904,6 +5918,7 @@
     "openAssistant": "Ouvrir Mifos X Copilot",
     "newChatTitle": "Nouvelle conversation",
     "errors": {
+      "timedOut": "L'assistant a mis trop de temps à répondre. Veuillez réessayer.",
       "invalidLength": "Le message est vide ou trop long. Veuillez le raccourcir et réessayer.",
       "injectionBlocked": "Le message ressemble à une tentative de contournement des instructions, il n'a donc pas été envoyé. Veuillez le reformuler.",
       "streamFailed": "Mifos X Copilot est injoignable. Veuillez réessayer."
@@ -5975,11 +5990,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "a modifié",
+      "thoughtFor": "A réfléchi pendant {{seconds}}",
+      "live": {
+        "reading": "Lecture de votre question",
+        "thinking": "Réflexion"
+      },
+      "steps": {
+        "loanDetails": "Consultation du compte de prêt",
+        "clientSearch": "Recherche dans le registre des clients",
+        "clientDetails": "Consultation du profil client",
+        "repaymentSchedule": "Vérification de l'échéancier",
+        "savingsBalance": "Consultation du solde d'épargne",
+        "loanApprove": "Approbation du prêt"
+      },
       "stepsNote": "Voici les enregistrements consultés par l'assistant. La base de toute décision concernant ce client se trouve dans Fineract : les règles du produit de prêt, l'échéancier de remboursement et la politique de crédit de votre institution.",
       "thinking": "Réflexion",
       "notesCaution": "Texte de travail de l'assistant. Ce n'est ni un compte rendu de la manière dont la réponse a été produite, ni une évaluation de crédit. Vérifiez chaque chiffre dans la fiche du client."
     },
     "actions": {
+      "copyCode": "Copier le code",
       "tryAgain": "R\u00e9essayer",
       "groupLabel": "Actions sur la r\u00e9ponse",
       "copy": "Copier",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -5818,6 +5818,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Show {{count}} earlier messages",
+    "a11y": {
+      "replyReady": "Reply ready",
+      "working": "Working on your question"
+    },
+    "promptNav": {
+      "label": "Questions in this chat",
+      "expand": "Show the questions",
+      "collapse": "Hide the questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Sessione corrente",
     "newChat": "Nuova chat",
@@ -5868,6 +5878,10 @@
       "aboutStorage": "Le sue conversazioni restano in questo browser e non vengono mai salvate sul server dell’assistente."
     },
     "recent": {
+      "noMatchSubtitle": "Nothing saved matches \"{{query}}\".",
+      "noMatchTitle": "No chats found",
+      "searchClear": "Clear search",
+      "searchPlaceholder": "Search chats",
       "emptyTitle": "Nessuna conversazione recente",
       "emptySubtitle": "La cronologia delle chat apparirà qui",
       "messages": "messaggi",
@@ -5901,6 +5915,7 @@
     "openAssistant": "Apri Mifos X Copilot",
     "newChatTitle": "Nuova conversazione",
     "errors": {
+      "timedOut": "The assistant took too long to respond. Please try again.",
       "invalidLength": "Il messaggio è vuoto o troppo lungo. Per favore accorcialo e riprova.",
       "injectionBlocked": "Il messaggio sembra un tentativo di aggirare le istruzioni, quindi non è stato inviato. Per favore riformulalo.",
       "streamFailed": "Mifos X Copilot non è raggiungibile. Riprova."
@@ -5972,11 +5987,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "changed",
+      "thoughtFor": "Thought for {{seconds}}",
+      "live": {
+        "reading": "Reading your question",
+        "thinking": "Thinking"
+      },
+      "steps": {
+        "loanDetails": "Reading the loan account",
+        "clientSearch": "Searching the client register",
+        "clientDetails": "Reading the client profile",
+        "repaymentSchedule": "Checking the repayment schedule",
+        "savingsBalance": "Reading the savings balance",
+        "loanApprove": "Approving the loan"
+      },
       "stepsNote": "Questi sono i record che l'assistente ha letto. La base di qualsiasi decisione su questo cliente è in Fineract: le regole del prodotto di prestito, il piano di rimborso e la politica creditizia del suo istituto.",
       "thinking": "Pensiero",
       "notesCaution": "Testo di lavoro dell'assistente. Non è un resoconto di come è stata prodotta la risposta, né una valutazione del credito. Verifichi ogni importo sulla scheda del cliente."
     },
     "actions": {
+      "copyCode": "Copy code",
       "tryAgain": "Riprova",
       "groupLabel": "Azioni sulla risposta",
       "copy": "Copia",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -5817,6 +5817,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Show {{count}} earlier messages",
+    "a11y": {
+      "replyReady": "Reply ready",
+      "working": "Working on your question"
+    },
+    "promptNav": {
+      "label": "Questions in this chat",
+      "expand": "Show the questions",
+      "collapse": "Hide the questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "현재 세션",
     "newChat": "새 채팅",
@@ -5867,6 +5877,10 @@
       "aboutStorage": "대화는 이 브라우저에 남으며 어시스턴트 서버에 저장되지 않습니다."
     },
     "recent": {
+      "noMatchSubtitle": "Nothing saved matches \"{{query}}\".",
+      "noMatchTitle": "No chats found",
+      "searchClear": "Clear search",
+      "searchPlaceholder": "Search chats",
       "emptyTitle": "최근 대화 없음",
       "emptySubtitle": "채팅 기록이 여기에 표시됩니다",
       "messages": "개의 메시지",
@@ -5900,6 +5914,7 @@
     "openAssistant": "Mifos X Copilot 열기",
     "newChatTitle": "새 대화",
     "errors": {
+      "timedOut": "The assistant took too long to respond. Please try again.",
       "invalidLength": "메시지가 비어 있거나 너무 깁니다. 줄여서 다시 시도해 주세요.",
       "injectionBlocked": "메시지가 지시 무시 시도로 보여 전송되지 않았습니다. 다시 작성해 주세요.",
       "streamFailed": "Mifos X Copilot에 연결할 수 없습니다. 다시 시도해 주세요."
@@ -5971,11 +5986,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "changed",
+      "thoughtFor": "Thought for {{seconds}}",
+      "live": {
+        "reading": "Reading your question",
+        "thinking": "Thinking"
+      },
+      "steps": {
+        "loanDetails": "Reading the loan account",
+        "clientSearch": "Searching the client register",
+        "clientDetails": "Reading the client profile",
+        "repaymentSchedule": "Checking the repayment schedule",
+        "savingsBalance": "Reading the savings balance",
+        "loanApprove": "Approving the loan"
+      },
       "stepsNote": "어시스턴트가 읽은 기록입니다. 이 고객에 대한 결정의 근거는 Fineract에 있습니다. 대출 상품 규칙, 상환 일정, 그리고 기관의 여신 정책입니다.",
       "thinking": "생각 과정",
       "notesCaution": "어시스턴트가 작업 중 남긴 글입니다. 답변이 어떻게 만들어졌는지에 대한 기록이 아니며, 신용 평가도 아닙니다. 모든 수치는 고객 기록과 대조하십시오."
     },
     "actions": {
+      "copyCode": "Copy code",
       "tryAgain": "\ub2e4\uc2dc \uc2dc\ub3c4",
       "groupLabel": "\uc751\ub2f5 \uc791\uc5c5",
       "copy": "\ubcf5\uc0ac",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -5818,6 +5818,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Show {{count}} earlier messages",
+    "a11y": {
+      "replyReady": "Reply ready",
+      "working": "Working on your question"
+    },
+    "promptNav": {
+      "label": "Questions in this chat",
+      "expand": "Show the questions",
+      "collapse": "Hide the questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Dabartinė sesija",
     "newChat": "Naujas pokalbis",
@@ -5868,6 +5878,10 @@
       "aboutStorage": "Jūsų pokalbiai lieka šioje naršyklėje ir niekada nesaugomi asistento serveryje."
     },
     "recent": {
+      "noMatchSubtitle": "Nothing saved matches \"{{query}}\".",
+      "noMatchTitle": "No chats found",
+      "searchClear": "Clear search",
+      "searchPlaceholder": "Search chats",
       "emptyTitle": "Nėra naujausių pokalbių",
       "emptySubtitle": "Jūsų pokalbių istorija bus rodoma čia",
       "messages": "žinutės",
@@ -5901,6 +5915,7 @@
     "openAssistant": "Atidaryti Mifos X Copilot",
     "newChatTitle": "Naujas pokalbis",
     "errors": {
+      "timedOut": "The assistant took too long to respond. Please try again.",
       "invalidLength": "Žinutė tuščia arba per ilga. Sutrumpinkite ją ir bandykite dar kartą.",
       "injectionBlocked": "Žinutė atrodo kaip bandymas apeiti nurodymus, todėl nebuvo išsiųsta. Perfrazuokite ją.",
       "streamFailed": "Nepavyko pasiekti Mifos X Copilot. Bandykite dar kartą."
@@ -5972,11 +5987,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "changed",
+      "thoughtFor": "Thought for {{seconds}}",
+      "live": {
+        "reading": "Reading your question",
+        "thinking": "Thinking"
+      },
+      "steps": {
+        "loanDetails": "Reading the loan account",
+        "clientSearch": "Searching the client register",
+        "clientDetails": "Reading the client profile",
+        "repaymentSchedule": "Checking the repayment schedule",
+        "savingsBalance": "Reading the savings balance",
+        "loanApprove": "Approving the loan"
+      },
       "stepsNote": "Tai įrašai, kuriuos perskaitė asistentas. Bet kokio sprendimo dėl šio kliento pagrindas yra Fineract sistemoje: paskolos produkto taisyklės, grąžinimo grafikas ir jūsų įstaigos kreditavimo politika.",
       "thinking": "Mąstymas",
       "notesCaution": "Paties asistento darbinis tekstas. Tai nėra įrašas apie tai, kaip buvo gautas atsakymas, ir tai nėra kredito vertinimas. Patikrinkite kiekvieną skaičių kliento byloje."
     },
     "actions": {
+      "copyCode": "Copy code",
       "tryAgain": "Bandyti dar kart\u0105",
       "groupLabel": "Atsakymo veiksmai",
       "copy": "Kopijuoti",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -5817,6 +5817,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Show {{count}} earlier messages",
+    "a11y": {
+      "replyReady": "Reply ready",
+      "working": "Working on your question"
+    },
+    "promptNav": {
+      "label": "Questions in this chat",
+      "expand": "Show the questions",
+      "collapse": "Hide the questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Pašreizējā sesija",
     "newChat": "Jauna saruna",
@@ -5867,6 +5877,10 @@
       "aboutStorage": "Jūsu sarunas paliek šajā pārlūkā un nekad netiek glabātas asistenta serverī."
     },
     "recent": {
+      "noMatchSubtitle": "Nothing saved matches \"{{query}}\".",
+      "noMatchTitle": "No chats found",
+      "searchClear": "Clear search",
+      "searchPlaceholder": "Search chats",
       "emptyTitle": "Nav nesenu sarunu",
       "emptySubtitle": "Jūsu sarunu vēsture parādīsies šeit",
       "messages": "ziņojumi",
@@ -5900,6 +5914,7 @@
     "openAssistant": "Atvērt Mifos X Copilot",
     "newChatTitle": "Jauna saruna",
     "errors": {
+      "timedOut": "The assistant took too long to respond. Please try again.",
       "invalidLength": "Ziņojums ir tukšs vai pārāk garš. Lūdzu, saīsiniet to un mēģiniet vēlreiz.",
       "injectionBlocked": "Ziņojums izskatās pēc mēģinājuma apiet norādījumus, tāpēc tas netika nosūtīts. Lūdzu, pārformulējiet to.",
       "streamFailed": "Neizdevās sasniegt Mifos X Copilot. Lūdzu, mēģiniet vēlreiz."
@@ -5971,11 +5986,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "changed",
+      "thoughtFor": "Thought for {{seconds}}",
+      "live": {
+        "reading": "Reading your question",
+        "thinking": "Thinking"
+      },
+      "steps": {
+        "loanDetails": "Reading the loan account",
+        "clientSearch": "Searching the client register",
+        "clientDetails": "Reading the client profile",
+        "repaymentSchedule": "Checking the repayment schedule",
+        "savingsBalance": "Reading the savings balance",
+        "loanApprove": "Approving the loan"
+      },
       "stepsNote": "Šie ir ieraksti, ko asistents izlasīja. Jebkura lēmuma pamatojums par šo klientu ir Fineract sistēmā: aizdevuma produkta noteikumi, atmaksas grafiks un jūsu iestādes kredītpolitika.",
       "thinking": "Domāšana",
       "notesCaution": "Paša asistenta darba teksts. Tas nav ieraksts par to, kā atbilde tika iegūta, un tas nav kredīta novērtējums. Pārbaudiet katru skaitli klienta lietā."
     },
     "actions": {
+      "copyCode": "Copy code",
       "tryAgain": "M\u0113\u0123in\u0101t v\u0113lreiz",
       "groupLabel": "Darb\u012bbas ar atbildi",
       "copy": "Kop\u0113t",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -5817,6 +5817,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Show {{count}} earlier messages",
+    "a11y": {
+      "replyReady": "Reply ready",
+      "working": "Working on your question"
+    },
+    "promptNav": {
+      "label": "Questions in this chat",
+      "expand": "Show the questions",
+      "collapse": "Hide the questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "हालको सत्र",
     "newChat": "नयाँ कुराकानी",
@@ -5867,6 +5877,10 @@
       "aboutStorage": "तपाईंका कुराकानी यही ब्राउजरमा रहन्छन् र सहायक सर्भरमा कहिल्यै राखिँदैनन्।"
     },
     "recent": {
+      "noMatchSubtitle": "Nothing saved matches \"{{query}}\".",
+      "noMatchTitle": "No chats found",
+      "searchClear": "Clear search",
+      "searchPlaceholder": "Search chats",
       "emptyTitle": "कुनै हालैको कुराकानी छैन",
       "emptySubtitle": "तपाईंको कुराकानी इतिहास यहाँ देखिनेछ",
       "messages": "सन्देशहरू",
@@ -5900,6 +5914,7 @@
     "openAssistant": "Mifos X Copilot खोल्नुहोस्",
     "newChatTitle": "नयाँ कुराकानी",
     "errors": {
+      "timedOut": "The assistant took too long to respond. Please try again.",
       "invalidLength": "सन्देश खाली छ वा धेरै लामो छ। कृपया छोटो पारेर फेरि प्रयास गर्नुहोस्।",
       "injectionBlocked": "सन्देश निर्देशन उल्लंघन गर्ने प्रयास जस्तो देखिन्छ, त्यसैले पठाइएन। कृपया फरक तरिकाले लेख्नुहोस्।",
       "streamFailed": "Mifos X Copilot मा पुग्न सकिएन। कृपया फेरि प्रयास गर्नुहोस्।"
@@ -5971,11 +5986,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "changed",
+      "thoughtFor": "Thought for {{seconds}}",
+      "live": {
+        "reading": "Reading your question",
+        "thinking": "Thinking"
+      },
+      "steps": {
+        "loanDetails": "Reading the loan account",
+        "clientSearch": "Searching the client register",
+        "clientDetails": "Reading the client profile",
+        "repaymentSchedule": "Checking the repayment schedule",
+        "savingsBalance": "Reading the savings balance",
+        "loanApprove": "Approving the loan"
+      },
       "stepsNote": "यी सहायकले पढेका अभिलेखहरू हुन्। यस ग्राहकसम्बन्धी कुनै पनि निर्णयको आधार Fineract मा छ: ऋण उत्पादनका नियम, भुक्तानी तालिका, र तपाईंको संस्थाको ऋण नीति।",
       "thinking": "सोचाइ",
       "notesCaution": "सहायकले काम गर्दा लेखेको पाठ। जवाफ कसरी बन्यो भन्ने अभिलेख होइन, र ऋण मूल्याङ्कन पनि होइन। हरेक अङ्क ग्राहकको अभिलेखसँग मिलाएर हेर्नुहोस्।"
     },
     "actions": {
+      "copyCode": "Copy code",
       "tryAgain": "\u092b\u0947\u0930\u093f \u092a\u094d\u0930\u092f\u093e\u0938 \u0917\u0930\u094d\u0928\u0941\u0939\u094b\u0938\u094d",
       "groupLabel": "\u091c\u0935\u093e\u092b\u0915\u093e \u0915\u093e\u0930\u094d\u092f\u0939\u0930\u0942",
       "copy": "\u092a\u094d\u0930\u0924\u093f\u0932\u093f\u092a\u093f \u0917\u0930\u094d\u0928\u0941\u0939\u094b\u0938\u094d",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -5817,6 +5817,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Show {{count}} earlier messages",
+    "a11y": {
+      "replyReady": "Reply ready",
+      "working": "Working on your question"
+    },
+    "promptNav": {
+      "label": "Questions in this chat",
+      "expand": "Show the questions",
+      "collapse": "Hide the questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Sessão atual",
     "newChat": "Nova conversa",
@@ -5867,6 +5877,10 @@
       "aboutStorage": "As suas conversas ficam neste navegador e nunca são guardadas no servidor do assistente."
     },
     "recent": {
+      "noMatchSubtitle": "Nothing saved matches \"{{query}}\".",
+      "noMatchTitle": "No chats found",
+      "searchClear": "Clear search",
+      "searchPlaceholder": "Search chats",
       "emptyTitle": "Sem conversas recentes",
       "emptySubtitle": "O seu histórico de conversas aparecerá aqui",
       "messages": "mensagens",
@@ -5900,6 +5914,7 @@
     "openAssistant": "Abrir o Mifos X Copilot",
     "newChatTitle": "Nova conversa",
     "errors": {
+      "timedOut": "The assistant took too long to respond. Please try again.",
       "invalidLength": "A mensagem está vazia ou é demasiado longa. Por favor, encurte-a e tente novamente.",
       "injectionBlocked": "A mensagem parece uma tentativa de contornar as instruções, por isso não foi enviada. Por favor, reformule-a.",
       "streamFailed": "Não foi possível contactar o Mifos X Copilot. Tente novamente."
@@ -5971,11 +5986,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "changed",
+      "thoughtFor": "Thought for {{seconds}}",
+      "live": {
+        "reading": "Reading your question",
+        "thinking": "Thinking"
+      },
+      "steps": {
+        "loanDetails": "Reading the loan account",
+        "clientSearch": "Searching the client register",
+        "clientDetails": "Reading the client profile",
+        "repaymentSchedule": "Checking the repayment schedule",
+        "savingsBalance": "Reading the savings balance",
+        "loanApprove": "Approving the loan"
+      },
       "stepsNote": "Estes são os registos que o assistente consultou. A base de qualquer decisão sobre este cliente está no Fineract: as regras do produto de crédito, o plano de reembolso e a política de crédito da sua instituição.",
       "thinking": "Pensamento",
       "notesCaution": "Texto de trabalho do próprio assistente. Não é um registo de como a resposta foi produzida, nem uma avaliação de crédito. Verifique cada valor no processo do cliente."
     },
     "actions": {
+      "copyCode": "Copy code",
       "tryAgain": "Tentar novamente",
       "groupLabel": "A\u00e7\u00f5es da resposta",
       "copy": "Copiar",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -5814,6 +5814,16 @@
     }
   },
   "copilot": {
+    "showEarlier": "Show {{count}} earlier messages",
+    "a11y": {
+      "replyReady": "Reply ready",
+      "working": "Working on your question"
+    },
+    "promptNav": {
+      "label": "Questions in this chat",
+      "expand": "Show the questions",
+      "collapse": "Hide the questions"
+    },
     "brand": "Mifos X Copilot",
     "currentSession": "Kipindi cha sasa",
     "newChat": "Mazungumzo mapya",
@@ -5864,6 +5874,10 @@
       "aboutStorage": "Mazungumzo yako hubaki kwenye kivinjari hiki na hayahifadhiwi kamwe kwenye seva ya msaidizi."
     },
     "recent": {
+      "noMatchSubtitle": "Nothing saved matches \"{{query}}\".",
+      "noMatchTitle": "No chats found",
+      "searchClear": "Clear search",
+      "searchPlaceholder": "Search chats",
       "emptyTitle": "Hakuna mazungumzo ya hivi karibuni",
       "emptySubtitle": "Historia yako ya mazungumzo itaonekana hapa",
       "messages": "ujumbe",
@@ -5897,6 +5911,7 @@
     "openAssistant": "Fungua Mifos X Copilot",
     "newChatTitle": "Mazungumzo mapya",
     "errors": {
+      "timedOut": "The assistant took too long to respond. Please try again.",
       "invalidLength": "Ujumbe ni tupu au mrefu sana. Tafadhali ufupishe na ujaribu tena.",
       "injectionBlocked": "Ujumbe unaonekana kama jaribio la kukiuka maelekezo, hivyo haukutumwa. Tafadhali uandike upya.",
       "streamFailed": "Imeshindwa kufikia Mifos X Copilot. Tafadhali jaribu tena."
@@ -5968,11 +5983,27 @@
       }
     },
     "trail": {
+      "notesTook": "({{seconds}})",
+      "wrote": "changed",
+      "thoughtFor": "Thought for {{seconds}}",
+      "live": {
+        "reading": "Reading your question",
+        "thinking": "Thinking"
+      },
+      "steps": {
+        "loanDetails": "Reading the loan account",
+        "clientSearch": "Searching the client register",
+        "clientDetails": "Reading the client profile",
+        "repaymentSchedule": "Checking the repayment schedule",
+        "savingsBalance": "Reading the savings balance",
+        "loanApprove": "Approving the loan"
+      },
       "stepsNote": "Haya ni makumbukumbu ambayo msaidizi alisoma. Msingi wa uamuzi wowote kuhusu mteja huyu uko katika Fineract: kanuni za bidhaa ya mkopo, ratiba ya marejesho, na sera ya mikopo ya taasisi yako.",
       "thinking": "Kufikiri",
       "notesCaution": "Maandishi ya kazi ya msaidizi mwenyewe. Si kumbukumbu ya jinsi jibu lilivyopatikana, wala si tathmini ya mkopo. Hakiki kila takwimu dhidi ya kumbukumbu ya mteja."
     },
     "actions": {
+      "copyCode": "Copy code",
       "tryAgain": "Jaribu tena",
       "groupLabel": "Vitendo vya jibu",
       "copy": "Nakili",


### PR DESCRIPTION
## Description

While the Copilot prepared a response the officer had almost nothing to go on: a rotating spinner, no indication of what was happening, and no sense of how long it had been running. Before the first tool call there was no reasoning panel at all, so a slow branch connection was indistinguishable from a hung one. Once the answer arrived, the record of what the assistant had actually done named its steps with raw gateway strings such as `mifos_loan_details`.

This reworks that wait into something an officer can read and trust, following the pattern ChatGPT, Claude and Grok have converged on: a named, gently animated state with a live elapsed counter while the assistant works, collapsing on completion to "Thought for N seconds" that expands into the steps taken and the model's own working notes. Steps are now named in the officer's language, and a step that changed a record is marked apart from one that only read, because that is the distinction that matters when someone is checking what was done on a client's account.

The same review covered the rest of the response experience, where the gap between what the assistant could say and what the panel could render was causing visible breakage:

- Replies containing headings, numbered lists, links or quotes were rendered as literal `##` and `1.`, because the markdown renderer did not support them.
- Code blocks were anonymous and could only be copied by selecting the text by hand inside a scrolling panel.
- A transport failure put the browser's own wording, "Failed to fetch", in front of the officer. That is what a blocked CORS preflight, a DNS failure and an unreachable host all look like from the browser, and it tells a loan officer nothing they can act on. The detail is now logged for whoever configures the deployment, and the panel says it could not reach the assistant.
- A long session had no way back to an earlier question except scrolling, so there is now a rail of the questions asked, and search across saved chats.

Two constraints shaped the implementation. The panel is lazy-loaded so it costs nothing until it is opened, so syntax highlighting is a small pass over the few languages the assistant actually emits rather than a highlighting library. And the reply streams several times a second, so the whole feature was moved to OnPush and the reasoning block was given discrete, reference-stable inputs, so that a token arriving for the answer no longer re-renders the panel around it. The elapsed counter runs outside the Angular zone and writes to its text node directly, so a ticking value never triggers change detection.

Accessibility was treated as part of the work rather than a pass afterwards: motion is disabled under `prefers-reduced-motion` while every label and counter stays, the streaming state is announced to screen readers without re-reading the answer, and the panel is navigable from the keyboard.

All user-facing strings were added to all 13 locales.

**Dependencies:** none. No package was added, and no backend or gateway change is required.

**Out of scope:** server-side conversation history. The wire contract exposes only the chat and decision endpoints, so there is nothing to persist to; this needs a gateway ticket rather than a frontend one.

## Related issues and discussion

# WEB-1201

## Screenshots, if any

https://github.com/user-attachments/assets/93ea0967-5c8d-4fc1-9c7e-6655f3dacea9

https://github.com/user-attachments/assets/030fbc04-312e-4e1c-9bbb-ea61addbab2b

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigate questions within a conversation and reveal earlier messages.
  * Search saved conversations by title or preview, with clear and no-results states.
  * Copy fenced code blocks with syntax highlighting and language labels.
  * Use keyboard shortcuts to focus the composer, edit the last question, navigate prompts, or stop streaming.
  * View improved live streaming status, reasoning steps, elapsed times, and accessibility announcements.
* **Bug Fixes**
  * Error messages now avoid exposing technical details and provide clearer timeout feedback.
* **Translations**
  * Added Copilot labels and accessibility text across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->