### PR TITLE
WEB-1209: Explain why the guided loan product wizard cannot submit

### DIFF
--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.html
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.html
@@ -326,9 +326,52 @@
           </div>
         </ng-container>
 
-        <p *ngIf="i === visibleSteps.length - 1 && borrowerCycleStepInvalid" class="step-actions__blocked">
+        <!--
+          Suppressed once the summary below is up: the loan-cycle step is one of the entries it lists,
+          and two messages stacked on the same problem read as two problems. This one stays for the
+          pre-attempt case, where it is the only warning the operator gets.
+        -->
+        <p
+          *ngIf="i === visibleSteps.length - 1 && borrowerCycleStepInvalid && !showGuidedIncompleteSummary"
+          class="step-actions__blocked"
+        >
           {{ 'labels.text.Fix the loan cycle variations before creating the product' | translate }}
         </p>
+
+        <!--
+          C4: the answer to a "Create Loan Product" click that cannot go through. `role="alert"` is not
+          decoration — `markAllAsTouched()` alone reveals field messages silently and only on the step
+          in view, so a screen-reader user got no signal at all. The live region announces the whole
+          list; the buttons make each named step reachable in one click, since `[linear]="false"` means
+          the offending control is usually not on the step being looked at.
+        -->
+        <div class="submit-blocked" role="alert" *ngIf="i === visibleSteps.length - 1 && showGuidedIncompleteSummary">
+          <p class="submit-blocked__title">
+            {{ 'labels.text.Complete these steps before creating the product' | translate }}
+          </p>
+          <ul class="submit-blocked__steps" *ngIf="incompleteGuidedSteps.length">
+            <!--
+              trackBy is not optional here: `incompleteGuidedSteps` is a getter that returns fresh
+              objects on every access, so identity diffing would destroy and recreate each button on
+              every change-detection pass — dropping focus out from under a keyboard user mid-list,
+              inside the very alert added to make this flow accessible.
+            -->
+            <li *ngFor="let incompleteStep of incompleteGuidedSteps; trackBy: trackByIncompleteStepTitle">
+              <!--
+                `step.title` unpiped, matching the stepper headers exactly — the operator has to be able
+                to find the step this names. Those headers are raw English today (review finding I1,
+                wizard chrome untranslated); translating them is one wholesale change across the chrome,
+                and half-translating it here would break the match that makes the list useful.
+              -->
+              <button type="button" class="submit-blocked__step" (click)="goToStep(incompleteStep.index)">
+                {{ incompleteStep.title }}
+              </button>
+            </li>
+          </ul>
+          <p class="submit-blocked__generic" *ngIf="guidedSubmitBlockedWithoutCause">
+            {{ 'labels.text.Check the highlighted fields before creating the product' | translate }}
+          </p>
+        </div>
 
         <div class="step-actions">
           <button mat-stroked-button matStepperPrevious *ngIf="i > 0">

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.scss
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.scss
@@ -300,6 +300,47 @@ mat-checkbox {
   font-size: 0.875rem;
 }
 
+// Guided mode's answer to a blocked "Create Loan Product" click: the steps that still hold something
+// invalid, each a button that jumps to it. Deliberately error-toned rather than the dashed neutral of
+// `.review-pending` below — that block explains a summary that is merely not ready yet, this one
+// explains a button the operator just pressed and that refused.
+.submit-blocked {
+  padding: var(--lp-space-16) var(--lp-space-24);
+  margin-bottom: var(--lp-space-16);
+  border: 1px solid var(--mat-sys-error, #b3261e);
+  border-radius: var(--lp-radius);
+
+  &__title {
+    margin: 0 0 var(--lp-space-8);
+    font-weight: 600;
+    color: var(--mat-sys-error, #b3261e);
+  }
+
+  &__steps {
+    margin: 0;
+    padding-left: var(--lp-space-24);
+    color: var(--lp-text);
+  }
+
+  // A link in a list, not a control in a toolbar: it names a step and takes you there. Underlined
+  // rather than coloured alone, so it does not rely on colour to read as actionable.
+  &__step {
+    padding: 0;
+    border: 0;
+    background: none;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  &__generic {
+    margin: 0;
+    color: var(--lp-text);
+  }
+}
+
 // Shown on the Review step while the hosted Classic steps are still incomplete, in place of the
 // product summary (which cannot render a partial product).
 .review-pending {

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
@@ -81,7 +81,7 @@ import { LoanProductPreviewStepComponent } from '../loan-product-stepper/loan-pr
 import { LoanProductService } from '../services/loan-product.service';
 import { Router } from '@angular/router';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
-import { MatStepperModule } from '@angular/material/stepper';
+import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import { MatButtonModule } from '@angular/material/button';
 import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
@@ -247,6 +247,21 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
   // reused Classic accounting step renders as radio options — resolved by the host from the shared
   // `Accounting` util, identical to Classic.
   @Input() accountingRuleData: any[] = [];
+
+  // The stepper itself, so a failed guided submit can send the operator to the step that blocked it.
+  // `[linear]="false"` lets them reach Review with an earlier step still incomplete, which is exactly
+  // when the offending control is on a step they are not looking at.
+  @ViewChild(MatStepper) stepper?: MatStepper;
+
+  /**
+   * Whether the operator has already pressed "Create Loan Product" on an invalid guided form.
+   *
+   * Gates the incomplete-steps summary so the wizard does not open by listing everything the operator
+   * has not filled in yet. Classic's `review-pending` block needs no such flag because it stands in
+   * for a summary that genuinely cannot render; this one answers a click that would otherwise do
+   * nothing, so it appears when — and only when — that click happens.
+   */
+  guidedSubmitAttempted = false;
 
   // Reused Classic Charges step. Rendered for the `kind: 'charges'` step; read at submit time to fold the
   // selected charge objects into the payload — mirrors Classic's `@ViewChild(LoanProductChargesStepComponent)`.
@@ -662,6 +677,17 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
   }
 
   /**
+   * Keyed on the title, NOT on the `index` the entry carries. That index is a position in
+   * {@link visibleSteps}, and the visible set changes under the operator — Payment Allocation and
+   * Deferred Income Recognition appear and disappear with the repayment strategy — so every later
+   * index shifts when one is inserted. Tracking on it would rebind a rendered row to a different
+   * step, which is the churn the trackBy exists to prevent. Step titles are unique and stable.
+   */
+  trackByIncompleteStepTitle(_index: number, step: { index: number; title: string }): string {
+    return step.title;
+  }
+
+  /**
    * The one message the field grid renders for a control, in the order the constraints are worth
    * reporting: a blank required field first, then its floor, its decimal places, its length.
    *
@@ -1047,6 +1073,94 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
       });
     }
     return steps.filter(({ form }) => !form || form.invalid).map(({ title }) => title);
+  }
+
+  /**
+   * Whether "Create Loan Product" is currently blocked in guided mode.
+   *
+   * The single source of truth for the guided submit gate: {@link submit} returns early on exactly
+   * this condition, and the template renders the incomplete-steps summary on exactly this condition.
+   * Keeping them one expression is the point — a summary that can disagree with the gate is the same
+   * dead button with extra steps.
+   */
+  get guidedSubmitBlocked(): boolean {
+    if (!this.form) {
+      return false;
+    }
+    const accountingForm = this.loanProductAccountingStep?.loanProductAccountingForm;
+    const deferredIncomeForm = this.loanProductDeferredIncomeRecognitionStep?.loanDeferredIncomeRecognitionForm;
+    return (
+      this.form.invalid || !!accountingForm?.invalid || !!deferredIncomeForm?.invalid || this.borrowerCycleStepInvalid
+    );
+  }
+
+  /**
+   * The visible guided steps that still hold something invalid, each with its index in
+   * {@link visibleSteps} so the summary can offer a jump straight to it.
+   *
+   * Guided mode's counterpart to {@link incompleteClassicSteps}, and it has to work differently.
+   * Classic hosts one FormGroup per step, so "which step is incomplete" is a property of the step.
+   * The guided flow holds every field in one flat FormGroup, so the mapping only exists via
+   * {@link visibleFields} — the same visibility source of truth the Review and the field grid use, so
+   * a control the operator was never shown can never be blamed here.
+   *
+   * The four reused Classic steps are checked the way {@link classicFormsValid} checks them: only
+   * Accounting and Deferred Income Recognition carry validators, and the borrower-cycle step reports
+   * its own rules through {@link borrowerCycleStepInvalid}. Charges, Payment Allocation and Interest
+   * Refunds have no validators in either flow, so they can never appear.
+   */
+  get incompleteGuidedSteps(): Array<{ index: number; title: string }> {
+    if (!this.form) {
+      return [];
+    }
+    const accountingForm = this.loanProductAccountingStep?.loanProductAccountingForm;
+    const deferredIncomeForm = this.loanProductDeferredIncomeRecognitionStep?.loanDeferredIncomeRecognitionForm;
+
+    return this.visibleSteps
+      .map((step, index) => ({ step, index }))
+      .filter(({ step }) => {
+        switch (step.kind ?? 'fields') {
+          case 'fields':
+            return this.visibleFields(step).some((field) => !!this.form.get(field.key)?.invalid);
+          case 'accounting':
+            return !!accountingForm?.invalid;
+          case 'deferred-income':
+            return !!deferredIncomeForm?.invalid;
+          case 'borrower-cycle':
+            return this.borrowerCycleStepInvalid;
+          default:
+            return false;
+        }
+      })
+      .map(({ step, index }) => ({ index, title: step.title }));
+  }
+
+  /**
+   * Whether the submit is blocked by something the step summary cannot name — an invalid control that
+   * no visible step owns (a conditional field whose gate closed while it held a bad value, say).
+   *
+   * Without this the summary would render empty and the operator would be back at C4's dead button,
+   * so the template falls back to a generic "check your entries" line. It should be unreachable in
+   * practice; it exists so that "blocked" and "explained" cannot come apart.
+   */
+  get guidedSubmitBlockedWithoutCause(): boolean {
+    return this.guidedSubmitBlocked && this.incompleteGuidedSteps.length === 0;
+  }
+
+  /**
+   * Whether the Review step should render the incomplete-steps summary: guided mode only, after a
+   * create attempt, and only while something still blocks it. It disappears on its own as the
+   * operator fixes the last offending control, so the page never claims a problem that is solved.
+   */
+  get showGuidedIncompleteSummary(): boolean {
+    return !this.usesClassicSteps && this.guidedSubmitAttempted && this.guidedSubmitBlocked;
+  }
+
+  /** Jumps the stepper to a step named in the incomplete-steps summary. */
+  goToStep(index: number): void {
+    if (this.stepper) {
+      this.stepper.selectedIndex = index;
+    }
   }
 
   /**
@@ -1960,19 +2074,26 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
       return;
     }
 
-    const accountingForm = this.loanProductAccountingStep?.loanProductAccountingForm;
     // Classic's `loanProductFormValid` additionally requires `loanIncomeCapitalizationForm.valid`
     // whenever the advanced payment allocation strategy is selected: the reused Deferred Income
     // Recognition step attaches `Validators.required` to each dependent it registers, so an
-    // incomplete capitalized-income / buydown-fee configuration must block submit here too.
-    const deferredIncomeForm = this.loanProductDeferredIncomeRecognitionStep?.loanDeferredIncomeRecognitionForm;
-    // The borrower-cycle step holds FormArrays of objects rather than a FormGroup, so its rules cannot
-    // ride on `form.invalid`. It renders inline messages on its own step, and the Review step shows a
-    // notice next to the button, so there is nothing extra to mark as touched here.
-    if (this.form.invalid || accountingForm?.invalid || deferredIncomeForm?.invalid || this.borrowerCycleStepInvalid) {
+    // incomplete capitalized-income / buydown-fee configuration must block submit here too. The
+    // borrower-cycle step holds FormArrays of objects rather than a FormGroup, so its rules cannot
+    // ride on `form.invalid`; it reports them through `borrowerCycleStepInvalid` instead. All of that
+    // is folded into `guidedSubmitBlocked`, which the template reads too.
+    if (this.guidedSubmitBlocked) {
+      const accountingForm = this.loanProductAccountingStep?.loanProductAccountingForm;
+      const deferredIncomeForm = this.loanProductDeferredIncomeRecognitionStep?.loanDeferredIncomeRecognitionForm;
       this.form.markAllAsTouched();
       accountingForm?.markAllAsTouched();
       deferredIncomeForm?.markAllAsTouched();
+      // Marking everything touched only reveals the field-level messages, and only on the step the
+      // operator happens to be looking at. This is what turns the click into an answer: the Review
+      // step renders `incompleteGuidedSteps` in a live region, naming each step that still blocks the
+      // create and offering a jump to it. The stepper is deliberately NOT moved for them — the
+      // summary they just asked for is on this step, and yanking them away from it before they can
+      // read it trades one confusing outcome for another.
+      this.guidedSubmitAttempted = true;
       return;
     }
     this.postLoanProduct(this.buildPayloadForSubmit());

--- a/src/app/products/loan-products/wizard/loan-product-wizard.render.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.render.spec.ts
@@ -219,4 +219,120 @@ describe('LoanProductWizardComponent (rendered)', () => {
     expect(control.errors).toBeNull();
     expect(fieldByLabel('labels.inputs.Annual interest rate').querySelectorAll('mat-error').length).toBe(0);
   });
+
+  /**
+   * C4: "Create Loan Product" used to be a silent dead button — the guided branch of `submit()` called
+   * `markAllAsTouched()` and returned, with no message, no stepper move and no disabled state. Since
+   * the stepper is `[linear]="false"`, the operator reaches Review with an earlier step incomplete and
+   * the offending control is usually not on screen, so the field-level messages that pass revealed
+   * were invisible to them. These tests are DOM-level on purpose: the defect was that nothing
+   * RENDERED, which the `new LoanProductWizardComponent()` specs in the sibling file cannot see.
+   */
+  describe('blocked submit on the guided Review step', () => {
+    function createButton(): HTMLButtonElement {
+      return Array.from(
+        fixture.nativeElement.querySelectorAll('.step-actions button') as NodeListOf<HTMLButtonElement>
+      ).find((button) => button.textContent?.trim() === 'labels.buttons.Create Loan Product')!;
+    }
+
+    function summary(): HTMLElement | null {
+      return fixture.nativeElement.querySelector('.submit-blocked');
+    }
+
+    function listedSteps(): string[] {
+      return Array.from(fixture.nativeElement.querySelectorAll('.submit-blocked__step') as NodeListOf<HTMLElement>).map(
+        (step) => step.textContent!.trim()
+      );
+    }
+
+    function clickCreate(): void {
+      createButton().click();
+      detect();
+    }
+
+    it('says nothing until the operator actually presses Create', () => {
+      // The form is invalid from the first render (`name` is required and empty). A wizard that opens
+      // by listing every step the operator has not reached yet is noise, not feedback.
+      expect(component.guidedSubmitBlocked).toBe(true);
+      expect(summary()).toBeNull();
+    });
+
+    it('names the steps that block the create instead of doing nothing', () => {
+      clickCreate();
+
+      expect(summary()).not.toBeNull();
+      // Details owns the required, empty `name`, so it must be named. The wording of the whole list is
+      // not pinned here — which other steps start incomplete is a property of the profile config.
+      expect(listedSteps()).toContain('Details');
+    });
+
+    it('announces the summary to a screen reader', () => {
+      // The accessibility face of C4: `markAllAsTouched()` reveals messages silently, so a
+      // screen-reader user got no signal at all that the click had been rejected.
+      clickCreate();
+
+      expect(summary()!.getAttribute('role')).toBe('alert');
+    });
+
+    it('does not attempt the create while blocked', () => {
+      const productsService = TestBed.inject(ProductsService);
+      clickCreate();
+
+      expect(productsService.createLoanProduct).not.toHaveBeenCalled();
+    });
+
+    it('jumps the stepper to a step named in the summary', () => {
+      clickCreate();
+
+      const details = component.incompleteGuidedSteps.find((step) => step.title === 'Details')!;
+      const detailsButton = Array.from(
+        fixture.nativeElement.querySelectorAll('.submit-blocked__step') as NodeListOf<HTMLButtonElement>
+      ).find((button) => button.textContent!.trim() === 'Details')!;
+
+      detailsButton.click();
+      detect();
+
+      expect(component.stepper!.selectedIndex).toBe(details.index);
+    });
+
+    it('keeps the step buttons across change detection so focus survives', () => {
+      // `incompleteGuidedSteps` is a getter returning fresh objects, so without a trackBy Angular's
+      // identity diffing rebuilds every button on each pass — and a button replaced under the
+      // operator's focus is the same class of defect as the dead button this whole block fixes.
+      clickCreate();
+      const before = fixture.nativeElement.querySelector('.submit-blocked__step') as HTMLButtonElement;
+      before.focus();
+
+      detect();
+      detect();
+
+      const after = fixture.nativeElement.querySelector('.submit-blocked__step') as HTMLButtonElement;
+      expect(after).toBe(before);
+      expect(document.activeElement).toBe(before);
+    });
+
+    it('drops a step from the list once its fields are filled', () => {
+      clickCreate();
+      expect(listedSteps()).toContain('Details');
+
+      // Every visible Details control that is currently invalid — the step is only listed because one
+      // of its own fields is, so satisfying them all must remove it and leave the rest of the list.
+      // Details is all text/date/checkbox, and its two required controls are `name` and `shortName`;
+      // the filler is kept inside `shortName`'s 4-character limit so it satisfies rather than trades
+      // one error for another.
+      const detailsStep = component.visibleSteps.find((step) => step.title === 'Details')!;
+      component.visibleFields(detailsStep).forEach((field) => {
+        const control = component.form.get(field.key)!;
+        if (control.invalid) {
+          control.setValue('ABCD');
+        }
+      });
+      detect();
+
+      expect(component.visibleFields(detailsStep).every((field) => component.form.get(field.key)!.valid)).toBe(true);
+
+      expect(listedSteps()).not.toContain('Details');
+      expect(summary()).not.toBeNull();
+    });
+  });
 });

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -4017,6 +4017,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Dokončete tyto kroky, abyste zobrazili náhled produktu",
+      "Complete these steps before creating the product": "Dokončete tyto kroky před vytvořením produktu",
+      "Check the highlighted fields before creating the product": "Zkontrolujte zvýrazněná pole před vytvořením produktu",
       "Agriculture Loan": "Zemědělský úvěr",
       "Auto Loan": "Úvěr na automobil",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financování nákupu nových i ojetých vozů s pevnými měsíčními splátkami po zvolenou dobu splatnosti.",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -4018,6 +4018,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Schließen Sie diese Schritte ab, um eine Vorschau des Produkts anzuzeigen",
+      "Complete these steps before creating the product": "Schließen Sie diese Schritte ab, bevor Sie das Produkt erstellen",
+      "Check the highlighted fields before creating the product": "Prüfen Sie die markierten Felder, bevor Sie das Produkt erstellen",
       "Agriculture Loan": "Agrarkredit",
       "Auto Loan": "Autokredit",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finanzierung für den Kauf von Neu- oder Gebrauchtwagen mit festen monatlichen Raten über eine gewählte Laufzeit.",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -4040,6 +4040,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Complete these steps to preview the product",
+      "Complete these steps before creating the product": "Complete these steps before creating the product",
+      "Check the highlighted fields before creating the product": "Check the highlighted fields before creating the product",
       "Country": "Country",
       "Agriculture Loan": "Agriculture Loan",
       "Auto Loan": "Auto Loan",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -4017,6 +4017,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Complete estos pasos para ver la vista previa del producto",
+      "Complete these steps before creating the product": "Complete estos pasos antes de crear el producto",
+      "Check the highlighted fields before creating the product": "Revise los campos resaltados antes de crear el producto",
       "Agriculture Loan": "Crédito Agrícola",
       "Auto Loan": "Crédito Automotriz",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financiamiento para la compra de autos nuevos o usados con cuotas mensuales fijas durante el plazo elegido.",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -4021,6 +4021,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Complete estos pasos para ver la vista previa del producto",
+      "Complete these steps before creating the product": "Complete estos pasos antes de crear el producto",
+      "Check the highlighted fields before creating the product": "Revise los campos resaltados antes de crear el producto",
       "Agriculture Loan": "Crédito Agrícola",
       "Auto Loan": "Crédito Automotriz",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financiamiento para la compra de autos nuevos o usados con cuotas mensuales fijas durante el plazo elegido.",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -4019,6 +4019,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Complétez ces étapes pour afficher l'aperçu du produit",
+      "Complete these steps before creating the product": "Complétez ces étapes avant de créer le produit",
+      "Check the highlighted fields before creating the product": "Vérifiez les champs en surbrillance avant de créer le produit",
       "Agriculture Loan": "Prêt agricole",
       "Auto Loan": "Prêt automobile",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financement pour l'achat de voitures neuves ou d'occasion avec des mensualités fixes sur une durée choisie.",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -4015,6 +4015,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Completare questi passaggi per visualizzare l'anteprima del prodotto",
+      "Complete these steps before creating the product": "Completare questi passaggi prima di creare il prodotto",
+      "Check the highlighted fields before creating the product": "Controllare i campi evidenziati prima di creare il prodotto",
       "Agriculture Loan": "Prestito agricolo",
       "Auto Loan": "Prestito auto",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finanziamento per l'acquisto di auto nuove o usate con rate mensili fisse per la durata scelta.",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -4015,6 +4015,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "제품을 미리 보려면 이 단계를 완료하세요",
+      "Complete these steps before creating the product": "제품을 만들기 전에 이 단계를 완료하세요",
+      "Check the highlighted fields before creating the product": "제품을 만들기 전에 강조 표시된 필드를 확인하세요",
       "Agriculture Loan": "농업 대출",
       "Auto Loan": "자동차 대출",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "신차 또는 중고차 구매를 위한 금융으로, 선택한 기간 동안 매월 일정한 할부금을 상환합니다.",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -4015,6 +4015,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Atlikite šiuos veiksmus, kad peržiūrėtumėte produktą",
+      "Complete these steps before creating the product": "Atlikite šiuos veiksmus prieš kurdami produktą",
+      "Check the highlighted fields before creating the product": "Patikrinkite paryškintus laukus prieš kurdami produktą",
       "Agriculture Loan": "Žemės ūkio paskola",
       "Auto Loan": "Automobilio paskola",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finansavimas naujų ar naudotų automobilių pirkimui su fiksuotomis mėnesinėmis įmokomis pasirinktu laikotarpiu.",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -4015,6 +4015,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Izpildiet šīs darbības, lai priekšskatītu produktu",
+      "Complete these steps before creating the product": "Izpildiet šīs darbības pirms produkta izveides",
+      "Check the highlighted fields before creating the product": "Pārbaudiet iezīmētos laukus pirms produkta izveides",
       "Agriculture Loan": "Lauksaimniecības aizdevums",
       "Auto Loan": "Auto aizdevums",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Finansējums jaunu vai lietotu automobiļu iegādei ar fiksētiem ikmēneša maksājumiem izvēlētajā termiņā.",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -4015,6 +4015,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "उत्पादनको पूर्वावलोकन गर्न यी चरणहरू पूरा गर्नुहोस्",
+      "Complete these steps before creating the product": "उत्पादन सिर्जना गर्नु अघि यी चरणहरू पूरा गर्नुहोस्",
+      "Check the highlighted fields before creating the product": "उत्पादन सिर्जना गर्नु अघि हाइलाइट गरिएका फिल्डहरू जाँच गर्नुहोस्",
       "Agriculture Loan": "कृषि ऋण",
       "Auto Loan": "सवारी साधन ऋण",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "नयाँ वा प्रयोग भएका कार खरिदका लागि वित्तपोषण, छनोट गरिएको अवधिभर नियमित मासिक किस्तासहित।",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -4015,6 +4015,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Conclua estes passos para pré-visualizar o produto",
+      "Complete these steps before creating the product": "Conclua estes passos antes de criar o produto",
+      "Check the highlighted fields before creating the product": "Verifique os campos destacados antes de criar o produto",
       "Agriculture Loan": "Empréstimo agrícola",
       "Auto Loan": "Crédito automóvel",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Financiamento para a compra de automóveis novos ou usados com prestações mensais fixas durante o prazo escolhido.",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -4012,6 +4012,8 @@
     },
     "text": {
       "Complete these steps to preview the product": "Kamilisha hatua hizi ili kuona onyesho la awali la bidhaa",
+      "Complete these steps before creating the product": "Kamilisha hatua hizi kabla ya kuunda bidhaa",
+      "Check the highlighted fields before creating the product": "Kagua sehemu zilizoangaziwa kabla ya kuunda bidhaa",
       "Agriculture Loan": "Mkopo wa Kilimo",
       "Auto Loan": "Mkopo wa Gari",
       "Financing for new or used car purchases with structured EMIs over a chosen tenure": "Ufadhili wa ununuzi wa magari mapya au yaliyotumika kwa malipo ya kila mwezi yaliyopangwa katika muda uliochaguliwa.",


### PR DESCRIPTION
## Description

In the guided (template) loan product wizard, "Create Loan Product" was a silent dead button. On an invalid form `submit()` called `markAllAsTouched()` and returned — no message, no stepper move, no disabled state. Because the stepper is `[linear]="false"`, the operator reaches Review with an earlier step still incomplete, so the control that blocked the create is usually on a step they are not looking at and the revealed field messages are off screen. The user clicks Create, nothing happens, repeatedly, with no way to discover why.

Classic mode in the same component already solves this with `incompleteClassicSteps` and its `review-pending` block. This ports that affordance to the guided path — the one aimed at less expert operators, and the one that did not have it.

A failed create now renders a `role="alert"` summary on the Review step naming every step that still blocks it, each a button that jumps straight to that step. The summary appears on the click rather than at page load, and clears itself as the last offending control is fixed.

The live region also closes the accessibility side of the same defect: `markAllAsTouched()` reveals messages silently, so a screen-reader user previously got no signal at all that the click had been rejected.

Notable decisions:

- `guidedSubmitBlocked` is one expression read by both `submit()` and the template, so the gate and the explanation cannot drift apart.
- `incompleteGuidedSteps` maps the flat guided FormGroup back to steps through `visibleFields`, the same visibility source of truth the Review summary uses, so a field the operator was never shown can never be named.
- The stepper is deliberately not auto-moved on a failed submit — that would pull the operator off the summary they just asked for. The per-step buttons give them the jump instead.
- `guidedSubmitBlockedWithoutCause` renders a generic line if the walk ever finds no owning step, so a blocked submit is always explained.

Two new translation keys, added to all 13 locales.

## Related issues and discussion

# WEB-1209

## Screenshots, if any

<img width="1600" height="815" alt="WhatsApp Image 2026-09-02 at 10 43 18 PM" src="https://github.com/user-attachments/assets/fac13731-7981-4a21-a357-20bef95034ab" />


## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer guidance when creating a loan product is blocked by incomplete or invalid steps.
  - Review now lists incomplete steps as clickable links to the relevant step.
  - Added a general prompt to check highlighted fields when no specific incomplete step is identified.
  - Added accessible alert messaging for blocked submissions.

- **Bug Fixes**
  - Prevented overlapping warnings when the incomplete-step summary is displayed.

- **Localization**
  - Added product-creation guidance translations across supported languages.

- **Tests**
  - Added coverage for blocked submissions, navigation, accessibility announcements, and completion updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->