### PR TITLE
WEB-1211: Remove GitHub Pages deployment from Mifos Web App

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    name: Run Lint, Build and Deploy
+    name: Run Lint and Build
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -80,16 +80,3 @@ jobs:
 
       - name: Run production build
         run: npm run build:prod
-
-      - name: Deploy to github pages
-        if: ${{ github.event_name == 'push' }}
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: dist/web-app/browser
-          #without preserve it only builds if you have untracked files
-          PRESERVE: true
-          # github user name and email shows up in the logs,
-          # so it would be better to make it silent.
-          SILENT: true

--- a/docs/deployment/aws-amplify.md
+++ b/docs/deployment/aws-amplify.md
@@ -23,8 +23,6 @@ The deployment uses:
 - Artifact directory: `dist/web-app/browser`
 - Build cache: `.npm/**/*`
 
-Do not use `npm run build:prod` for Amplify root hosting. That script sets `--base-href=/web-app/` for the GitHub Pages deployment.
-
 The build does not set a custom `NODE_OPTIONS` memory limit by default. Add one in Amplify only if build logs show an out-of-memory failure and the selected build instance has enough memory.
 
 ## Runtime env.js Generation

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "husky",
     "ng": "ng",
     "build": "node version.js && npm run env -s && ng build --configuration production --output-hashing=none",
-    "build:prod": "node version.js && node --max-old-space-size=16384 ./node_modules/@angular/cli/bin/ng build --configuration production --output-hashing=none --base-href=/web-app/",
+    "build:prod": "node version.js && node --max-old-space-size=16384 ./node_modules/@angular/cli/bin/ng build --configuration production --output-hashing=none",
     "start": "npm run env -s && ng serve --proxy-config proxy.conf.js",
     "start:local": "npm run env -s && ng serve --proxy-config proxy.localhost.conf.js",
     "serve:dev": "npm run env -s && ng serve --source-map",


### PR DESCRIPTION
## Description

Removes the GitHub Pages deployment from the web app.

The `build` job pushed every production build to the `gh-pages` branch, and `build:prod` hard-coded `--base-href=/web-app/` to match that deployment path. Both go away here, so the job now does what its name says: lint and build.

This also fixes red CI on `dev`. The `gh-pages` branch is covered by repository rulesets that enforce `non_fast_forward`, and `JamesIves/github-pages-deploy-action` force-pushes, so the deploy step has been rejected on every run since 2026-08-29 (`SILENT: true` hides git's stderr, leaving only `The process '/usr/bin/git' failed with exit code 1`). Lint and build themselves were passing. The published Pages content has been frozen at the 2026-07-09 deploy regardless.

Changes:

- `.github/workflows/build.yml` — drop the `Deploy to github pages` step; rename the job to `Run Lint and Build`.
- `package.json` — drop `--base-href=/web-app/` from `build:prod`; a build that is not served from that sub-path should not assume it is.
- `docs/deployment/aws-amplify.md` — remove the line steering readers away from `build:prod` because of that base href. It is stale now, and the build command it points to is already listed in the build spec above it.

Two follow-ups that are out of scope here:

- The `gh-pages` branch itself still exists and needs a repo admin to delete.
- With the base href gone, `build:prod` differs from `build` only by `--max-old-space-size=16384`. Worth collapsing in a separate change.

## Related issues and discussion

WEB-1211

## Screenshots, if any

n/a — CI configuration only.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Production builds now use the site root path by default, improving compatibility when hosting the application at an AWS Amplify root URL.
  - Production builds no longer include the `/web-app/` base path intended for GitHub Pages deployments.

- **Documentation**
  - Updated AWS Amplify deployment guidance to reflect the current production build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->