### PR TITLE
WEB-1060: improve checker inbox

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.html
@@ -28,13 +28,29 @@
     >
       <mat-icon>{{ showAdvancedSearch ? 'arrow_drop_up' : 'arrow_drop_down' }}</mat-icon>
     </button>
-    <button mat-raised-button class="mat-success tasks-action-btn" (click)="approveChecker()">
+    <button
+      mat-raised-button
+      class="mat-success tasks-action-btn"
+      (click)="approveChecker()"
+      [disabled]="!selection?.hasValue() || processing"
+    >
       <fa-icon icon="check" class="m-r-10"></fa-icon>{{ 'labels.buttons.Approve' | translate }}
     </button>
-    <button mat-raised-button color="warn" (click)="deleteChecker()" class="action-button">
+    <button
+      mat-raised-button
+      color="warn"
+      (click)="deleteChecker()"
+      class="action-button"
+      [disabled]="!selection?.hasValue() || processing"
+    >
       <fa-icon icon="trash" class="m-r-10"></fa-icon>{{ 'labels.buttons.Delete' | translate }}
     </button>
-    <button mat-raised-button class="mat-reject tasks-action-btn" (click)="rejectChecker()">
+    <button
+      mat-raised-button
+      class="mat-reject tasks-action-btn"
+      (click)="rejectChecker()"
+      [disabled]="!selection?.hasValue() || processing"
+    >
       <fa-icon icon="times" class="m-r-10"></fa-icon>{{ 'labels.buttons.Reject' | translate }}
     </button>
   </div>
@@ -53,17 +69,30 @@
           <mat-datepicker-toggle matSuffix [for]="makerDateTimeFromPicker"></mat-datepicker-toggle>
           <mat-datepicker #makerDateTimeFromPicker></mat-datepicker>
         </mat-form-field>
-        <mat-form-field class="search-field" (click)="makerDateTimetoPicker.open()">
+        <mat-form-field class="search-field" (click)="makerDateTimeToPicker.open()">
           <mat-label>{{ 'labels.inputs.To date' | translate }}</mat-label>
           <input
             matInput
             [min]="minDate"
             [max]="maxDate"
-            [matDatepicker]="makerDateTimetoPicker"
-            formControlName="makerDateTimeto"
+            [matDatepicker]="makerDateTimeToPicker"
+            formControlName="makerDateTimeTo"
           />
-          <mat-datepicker-toggle matSuffix [for]="makerDateTimetoPicker"></mat-datepicker-toggle>
-          <mat-datepicker #makerDateTimetoPicker></mat-datepicker>
+          <mat-datepicker-toggle matSuffix [for]="makerDateTimeToPicker"></mat-datepicker-toggle>
+          <mat-datepicker #makerDateTimeToPicker></mat-datepicker>
+        </mat-form-field>
+        <mat-form-field class="search-field">
+          <mat-label>{{ 'labels.inputs.Customer' | translate }}</mat-label>
+          <input matInput [formControl]="customerControl" [matAutocomplete]="customerAutocomplete" />
+          <mat-autocomplete #customerAutocomplete="matAutocomplete" [displayWith]="displayCustomer">
+            @for (customer of customers; track customer.id) {
+              <mat-option [value]="customer"
+                >{{ customer.displayName }}
+                {{ customer.accountNumber ? '(' + customer.accountNumber + ')' : '' }}</mat-option
+              >
+            }
+          </mat-autocomplete>
+          <mat-hint>Search by customer name or account number, then select a customer.</mat-hint>
         </mat-form-field>
         <mat-form-field class="search-field">
           <mat-label>{{ 'labels.inputs.Select action' | translate }}</mat-label>
@@ -95,7 +124,29 @@
       </div>
     </form>
   }
-  @if (checkerData && !noSearchedData) {
+  @if (processing) {
+    <div class="alert" role="status">Processing {{ processingCount }} checker item(s)…</div>
+  }
+  @if (actionResult) {
+    <div class="alert" role="status">
+      {{ actionResult.succeeded + actionResult.failed.length }} tasks processed: {{ actionResult.succeeded }} succeeded,
+      {{ actionResult.failed.length }} failed.
+      @if (actionResult.failed.length) {
+        Failed record IDs:
+        @for (failure of actionResult.failed; track failure.id) {
+          {{ failure.id }}{{ failure.error ? ': ' + failure.error : '' }};
+        }
+      }
+    </div>
+  }
+  @if (loading) {
+    <div class="alert" role="status">Loading checker inbox…</div>
+  } @else if (searchError) {
+    <div class="alert" role="alert">Unable to load checker inbox. Please try your search again.</div>
+  } @else if (checkerData && !noSearchedData) {
+    @if (!hasActionableRows()) {
+      <div class="alert" role="status">You do not have permission to action the checker items in this list.</div>
+    }
     <table mat-table [dataSource]="dataSource">
       <ng-container matColumnDef="select">
         <th mat-header-cell *matHeaderCellDef>
@@ -104,11 +155,13 @@
             [checked]="selection.hasValue() && isAllSelected()"
             [indeterminate]="selection.hasValue() && !isAllSelected()"
             [aria-label]="checkboxLabel()"
+            [disabled]="!hasActionableRows()"
           >
           </mat-checkbox>
         </th>
         <td mat-cell *matCellDef="let row">
           <mat-checkbox
+            *mifosxHasPermission="checkerPermission(row)"
             (click)="$event.stopPropagation()"
             (change)="$event ? selection.toggle(row) : null"
             [checked]="selection.isSelected(row)"
@@ -122,7 +175,7 @@
         <td mat-cell *matCellDef="let makerChecker">{{ makerChecker.id }}</td>
       </ng-container>
       <ng-container matColumnDef="madeOnDate">
-        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Made on Date' | translate }}</th>
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Submitted On' | translate }}</th>
         <td mat-cell *matCellDef="let makerChecker">{{ makerChecker.madeOnDate | dateFormat }}</td>
       </ng-container>
       <ng-container matColumnDef="status">
@@ -149,17 +202,14 @@
         class="select-row"
       ></tr>
     </table>
-  }
-  @if (checkerData && noSearchedData) {
+  } @else if (noSearchedData) {
     <div class="alert">
       <div class="message">
         <i class="fa fa-exclamation-circle alert-check fa-2x"></i>
         {{ 'labels.text.No checker inbox data available for this search' | translate }}
       </div>
     </div>
-  }
-
-  @if (!checkerData) {
+  } @else if (!checkerData && !loading && !searchError) {
     <div class="alert">
       <div class="message">
         <i class="fa fa-exclamation-circle alert-check fa-2x"></i>

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.ts
@@ -7,11 +7,11 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, DestroyRef, ChangeDetectorRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { SelectionModel } from '@angular/cdk/collections';
-import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import {
   MatTableDataSource,
   MatTable,
@@ -27,6 +27,23 @@ import {
 } from '@angular/material/table';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { ClientsService } from 'app/clients/clients.service';
+import {
+  catchError,
+  debounceTime,
+  distinctUntilChanged,
+  finalize,
+  from,
+  map,
+  mergeMap,
+  Observable,
+  of,
+  switchMap,
+  toArray
+} from 'rxjs';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { environment } from 'environments/environment';
 
 /** Custom Services */
 import { TasksService } from '../../tasks.service';
@@ -40,6 +57,29 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+
+interface MakerCheckerRecord {
+  id: number;
+  actionName: string;
+  entityName: string;
+  madeOnDate?: string;
+  processingResult?: string;
+  maker?: string;
+}
+
+interface BulkActionFailure {
+  id: number;
+  error?: string;
+}
+
+interface BulkActionResult {
+  action: string;
+  succeeded: number;
+  failed: BulkActionFailure[];
+}
+
+type BulkActionOutcome =
+  { item: MakerCheckerRecord; success: true } | { item: MakerCheckerRecord; success: false; error: unknown };
 
 @Component({
   selector: 'mifosx-checker-inbox',
@@ -60,7 +100,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatRowDef,
     MatRow,
     DateFormatPipe,
-    MatIcon
+    MatIcon,
+    MatAutocompleteModule
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -68,21 +109,30 @@ export class CheckerInboxComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private dialog = inject(MatDialog);
   private dateUtils = inject(Dates);
-  private router = inject(Router);
   private translateService = inject(TranslateService);
   private tasksService = inject(TasksService);
   private settingsService = inject(SettingsService);
   private formBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
+  private clientsService = inject(ClientsService);
+  private changeDetectorRef = inject(ChangeDetectorRef);
+  private authenticationService = inject(AuthenticationService);
 
   /** Data to be displayed */
-  searchData: any;
+  searchData: MakerCheckerRecord[];
   /** Maker Checker Template */
   makerCheckerTemplate: any;
   /** Checks if there is any data based on the search */
   noSearchedData = false;
   /** Checks if there is any checker data */
   checkerData = false;
+  /** Request and action state. */
+  loading = false;
+  searchError = false;
+  processing = false;
+  processingCount = 0;
+  actionResult: BulkActionResult | null = null;
+  private searchRequestId = 0;
   /** Show/hide advanced search form */
   showAdvancedSearch = false;
   /** Maker Checker Search Form */
@@ -92,9 +142,12 @@ export class CheckerInboxComponent implements OnInit {
   /** Maximum date allowed. */
   maxDate = new Date(2100, 0, 1);
   /** DataSource */
-  dataSource: MatTableDataSource<any>;
+  dataSource: MatTableDataSource<MakerCheckerRecord>;
   /** Selecting rows from table */
-  selection: SelectionModel<any>;
+  selection: SelectionModel<MakerCheckerRecord>;
+  /** Customer search is backed by the clients endpoint; maker-checkers receives only the selected ID. */
+  customerControl = new FormControl<string | any>('');
+  customers: any[] = [];
   /** Displayed Column in table */
   displayedColumns: string[] = [
     'select',
@@ -119,11 +172,9 @@ export class CheckerInboxComponent implements OnInit {
   constructor() {
     this.route.data
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((data: { makerCheckerResource: any; makerCheckerTemplate: any }) => {
-        this.searchData = data.makerCheckerResource;
-        if (this.searchData.length > 0) {
-          this.checkerData = true;
-        }
+      .subscribe((data: { makerCheckerResource: MakerCheckerRecord[]; makerCheckerTemplate: any }) => {
+        this.searchData = data.makerCheckerResource || [];
+        this.checkerData = this.searchData.length > 0;
         this.makerCheckerTemplate = data.makerCheckerTemplate;
         this.dataSource = new MatTableDataSource(this.searchData);
         this.selection = new SelectionModel(true, []);
@@ -132,6 +183,17 @@ export class CheckerInboxComponent implements OnInit {
 
   ngOnInit() {
     this.createMakerCheckerSearchForm();
+    this.customerControl.valueChanges
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap((value: string | any) => this.searchCustomers(value)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((customers) => {
+        this.customers = customers;
+        this.changeDetectorRef.markForCheck();
+      });
   }
 
   /**
@@ -140,7 +202,7 @@ export class CheckerInboxComponent implements OnInit {
   createMakerCheckerSearchForm() {
     this.makerCheckerSearchForm = this.formBuilder.group({
       makerDateTimeFrom: [''],
-      makerDateTimeto: [''],
+      makerDateTimeTo: [''],
       actionName: [''],
       entityName: [''],
       resourceId: ['']
@@ -155,28 +217,76 @@ export class CheckerInboxComponent implements OnInit {
   }
 
   search() {
+    this.loadMakerCheckers();
+  }
+
+  private loadMakerCheckers(): void {
+    const requestId = ++this.searchRequestId;
     const dateFormat = this.settingsService.dateFormat;
+    const selectedCustomer = this.customerControl.value;
     const makerCheckerSearchParams = {
       ...this.makerCheckerSearchForm.value,
       makerDateTimeFrom: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.makerDateTimeFrom, dateFormat),
-      makerDateTimeto: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.makerDateTimeto, dateFormat)
+      makerDateTimeTo: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.makerDateTimeTo, dateFormat),
+      clientId: typeof selectedCustomer === 'object' ? selectedCustomer?.id : undefined
     };
-    this.tasksService.getMakerCheckerData(makerCheckerSearchParams).subscribe((response: any) => {
-      this.searchData = response;
-      if (this.searchData.length === 0) {
-        this.noSearchedData = true;
-      } else {
-        this.noSearchedData = false;
-      }
-      this.dataSource = new MatTableDataSource(this.searchData);
-      this.selection = new SelectionModel(true, []);
-    });
+    this.loading = true;
+    this.searchError = false;
+    this.tasksService
+      .getMakerCheckerData(makerCheckerSearchParams)
+      .pipe(
+        finalize(() => {
+          if (requestId === this.searchRequestId) this.loading = false;
+          this.changeDetectorRef.markForCheck();
+        })
+      )
+      .subscribe({
+        next: (response: MakerCheckerRecord[]) => {
+          if (requestId !== this.searchRequestId) return;
+          this.searchData = response;
+          this.checkerData = this.searchData.length > 0;
+          this.noSearchedData = this.searchData.length === 0;
+          this.dataSource = new MatTableDataSource(this.searchData);
+          this.selection = new SelectionModel(true, []);
+        },
+        error: () => {
+          if (requestId === this.searchRequestId) this.searchError = true;
+        }
+      });
+  }
+
+  private searchCustomers(value: string | any) {
+    if (typeof value !== 'string' || value.trim().length < 2) {
+      return of([]);
+    }
+    return this.clientsService.searchByText(value.trim(), 0, 20).pipe(
+      map((response: any) => response?.content || []),
+      catchError(() => of([]))
+    );
+  }
+
+  displayCustomer(customer: any): string {
+    return typeof customer === 'string' ? customer : customer?.displayName || customer?.accountNumber || '';
+  }
+
+  checkerPermission(row: MakerCheckerRecord): string {
+    return `${row.actionName}_${row.entityName}_CHECKER`.replace(/[^A-Za-z0-9_]/g, '_').toUpperCase();
+  }
+
+  canAction(row: MakerCheckerRecord): boolean {
+    if (!environment.productionModeEnableRBAC) return true;
+    const permissions = this.authenticationService.getCredentials()?.permissions || [];
+    return permissions.includes('ALL_FUNCTIONS') || permissions.includes(this.checkerPermission(row));
+  }
+
+  hasActionableRows(): boolean {
+    return this.dataSource?.data.some((row) => this.canAction(row)) || false;
   }
 
   /** Whether the number of selected elements matches the total number of rows. */
   isAllSelected() {
     const numSelected = this.selection.selected.length;
-    const numRows = this.dataSource.data.length;
+    const numRows = this.dataSource.data.filter((row) => this.canAction(row)).length;
     return numSelected === numRows;
   }
 
@@ -184,7 +294,7 @@ export class CheckerInboxComponent implements OnInit {
   masterToggle() {
     this.isAllSelected()
       ? this.selection.clear()
-      : this.dataSource.data.forEach((row: any) => this.selection.select(row));
+      : this.dataSource.data.filter((row) => this.canAction(row)).forEach((row) => this.selection.select(row));
   }
 
   /** The label for the checkbox on the passed row */
@@ -192,18 +302,20 @@ export class CheckerInboxComponent implements OnInit {
     if (!row) {
       return `${this.isAllSelected() ? 'select' : 'deselect'} all`;
     }
-    return `${this.selection.isSelected(row) ? 'deselect' : 'select'} row ${row.position + 1}`;
+    return `${this.selection.isSelected(row) ? 'Deselect' : 'Select'} checker item ${row.id}`;
   }
 
   approveChecker() {
     const approveCheckerDialogRef = this.dialog.open(ConfirmationDialogComponent, {
       data: {
         heading: this.translateService.instant('labels.heading.Approve Checker'),
-        dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want to approve checker')
+        dialogContext:
+          this.translateService.instant('labels.dialogContext.Are you sure you want to approve checker') +
+          ` (${this.selection.selected.length})`
       }
     });
     approveCheckerDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-      if (response.confirm) {
+      if (response?.confirm && this.selection.hasValue()) {
         this.bulkCheckerApproveorReject('approve');
       }
     });
@@ -213,11 +325,13 @@ export class CheckerInboxComponent implements OnInit {
     const rejectCheckerDialogRef = this.dialog.open(ConfirmationDialogComponent, {
       data: {
         heading: this.translateService.instant('labels.heading.Reject Checker'),
-        dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want to reject checker')
+        dialogContext:
+          this.translateService.instant('labels.dialogContext.Are you sure you want to reject checker') +
+          ` (${this.selection.selected.length})`
       }
     });
     rejectCheckerDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-      if (response.confirm) {
+      if (response?.confirm && this.selection.hasValue()) {
         this.bulkCheckerApproveorReject('reject');
       }
     });
@@ -227,42 +341,68 @@ export class CheckerInboxComponent implements OnInit {
     const deleteCheckerDialogRef = this.dialog.open(ConfirmationDialogComponent, {
       data: {
         heading: this.translateService.instant('labels.heading.Delete Checker'),
-        dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want to delete checker')
+        dialogContext:
+          'The selected pending checker item(s) will be removed. Unlike approval or rejection, deletion does not retain equivalent maker-checker audit information.'
       }
     });
     deleteCheckerDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-      if (response.confirm) {
+      if (response?.confirm && this.selection.hasValue()) {
         this.bulkDeleteChecker();
       }
     });
   }
 
-  bulkCheckerApproveorReject(action: any) {
-    const selectedAccounts = this.selection.selected.length;
-    const listSelectedAccounts = this.selection.selected;
-    let approvedAccounts = 0;
-    listSelectedAccounts.forEach((element: any) => {
-      this.tasksService.executeMakerCheckerAction(element.id, action).subscribe((response: any) => {
-        approvedAccounts++;
-        if (selectedAccounts === approvedAccounts) {
-          this.reload();
-        }
-      });
-    });
+  bulkCheckerApproveorReject(action: string) {
+    this.processSelected(action, (item) => this.tasksService.executeMakerCheckerAction(item.id, action));
   }
 
   bulkDeleteChecker() {
-    const selectedAccounts = this.selection.selected.length;
-    const listSelectedAccounts = this.selection.selected;
-    let approvedAccounts = 0;
-    listSelectedAccounts.forEach((element: any) => {
-      this.tasksService.deleteMakerChecker(element.id).subscribe((response: any) => {
-        approvedAccounts++;
-        if (selectedAccounts === approvedAccounts) {
-          this.reload();
-        }
+    this.processSelected('delete', (item) => this.tasksService.deleteMakerChecker(item.id));
+  }
+
+  private processSelected(action: string, request: (item: MakerCheckerRecord) => Observable<unknown>): void {
+    const selected = [...this.selection.selected];
+    if (!selected.length || this.processing) return;
+    this.processing = true;
+    this.actionResult = null;
+    this.processingCount = selected.length;
+    this.selection.clear();
+    from(selected)
+      .pipe(
+        mergeMap(
+          (item) =>
+            request(item).pipe(
+              map((): BulkActionOutcome => ({ item, success: true })),
+              catchError((error: unknown) => of<BulkActionOutcome>({ item, success: false, error }))
+            ),
+          4
+        ),
+        toArray(),
+        finalize(() => {
+          this.processing = false;
+          this.processingCount = 0;
+          this.changeDetectorRef.markForCheck();
+        })
+      )
+      .subscribe((results: BulkActionOutcome[]) => {
+        const failed = results.filter(this.isFailedOutcome).map((result) => ({
+          id: result.item.id,
+          error: this.bulkErrorMessage(result.error)
+        }));
+        this.actionResult = { action, succeeded: results.length - failed.length, failed };
+        this.loadMakerCheckers();
       });
-    });
+  }
+
+  private bulkErrorMessage(error: unknown): string | undefined {
+    if (typeof error !== 'object' || error === null) return undefined;
+    const response = error as { error?: { defaultUserMessage?: unknown }; message?: unknown };
+    if (typeof response.error?.defaultUserMessage === 'string') return response.error.defaultUserMessage;
+    return typeof response.message === 'string' ? response.message : undefined;
+  }
+
+  private isFailedOutcome(result: BulkActionOutcome): result is Extract<BulkActionOutcome, { success: false }> {
+    return !result.success;
   }
 
   applyFilter(filterValue: string = '') {
@@ -274,9 +414,6 @@ export class CheckerInboxComponent implements OnInit {
    * TODO: Replace by a custom reload component instead of hard-coded back-routing.
    */
   reload() {
-    const url: string = this.router.url;
-    this.router
-      .navigateByUrl(`/checker-inbox-and-tasks`, { skipLocationChange: true })
-      .then(() => this.router.navigate([url]));
+    this.loadMakerCheckers();
   }
 }

--- a/src/app/tasks/tasks.service.spec.ts
+++ b/src/app/tasks/tasks.service.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { TasksService } from './tasks.service';
+
+describe('TasksService maker-checker search', () => {
+  let service: TasksService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TasksService,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+    service = TestBed.inject(TasksService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('preserves the makerDateTimeTo parameter sent by the checker inbox', () => {
+    service
+      .getMakerCheckerData({ makerDateTimeFrom: '01 January 2026', makerDateTimeTo: '31 January 2026' })
+      .subscribe();
+
+    const request = httpMock.expectOne(
+      '/makercheckers?makerDateTimeFrom=01%20January%202026&makerDateTimeTo=31%20January%202026'
+    );
+    expect(request.request.params.get('makerDateTimeTo')).toBe('31 January 2026');
+    expect(request.request.params.has('makerDateTimeto')).toBe(false);
+    request.flush([]);
+  });
+});

--- a/src/app/tasks/view-checker-inbox/view-checker-inbox.component.html
+++ b/src/app/tasks/view-checker-inbox/view-checker-inbox.component.html
@@ -7,13 +7,31 @@
 -->
 
 <div class="layout-row align-end gap-1percent layout-lt-md-column container m-b-20">
-  <button mat-raised-button class="mat-success" (click)="approveChecker()">
+  <button
+    *mifosxHasPermission="checkerPermission()"
+    mat-raised-button
+    class="mat-success"
+    (click)="approveChecker()"
+    [disabled]="processing"
+  >
     <fa-icon icon="check" class="m-r-10"></fa-icon>{{ 'labels.buttons.Approve' | translate }}
   </button>
-  <button mat-raised-button color="warn" (click)="deleteChecker()">
+  <button
+    *mifosxHasPermission="checkerPermission()"
+    mat-raised-button
+    color="warn"
+    (click)="deleteChecker()"
+    [disabled]="processing"
+  >
     <fa-icon icon="trash" class="m-r-10"></fa-icon>{{ 'labels.buttons.Delete' | translate }}
   </button>
-  <button mat-raised-button class="mat-reject" (click)="rejectChecker()">
+  <button
+    *mifosxHasPermission="checkerPermission()"
+    mat-raised-button
+    class="mat-reject"
+    (click)="rejectChecker()"
+    [disabled]="processing"
+  >
     <fa-icon icon="times" class="m-r-10"></fa-icon>{{ 'labels.buttons.Reject' | translate }}
   </button>
 </div>

--- a/src/app/tasks/view-checker-inbox/view-checker-inbox.component.ts
+++ b/src/app/tasks/view-checker-inbox/view-checker-inbox.component.ts
@@ -12,6 +12,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import * as _ from 'lodash';
 import { MatDialog } from '@angular/material/dialog';
+import { HttpErrorResponse } from '@angular/common/http';
 
 /** Custom Services */
 import { TasksService } from '../tasks.service';
@@ -24,6 +25,8 @@ import { MatDivider } from '@angular/material/divider';
 import { KeyValuePipe } from '@angular/common';
 import { DateFormatPipe } from '../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { ErrorHandlerService } from 'app/core/error-handler/error-handler.service';
+import { finalize, Observable } from 'rxjs';
 
 @Component({
   selector: 'mifosx-view-checker-inbox',
@@ -45,6 +48,7 @@ export class ViewCheckerInboxComponent {
   private translateService = inject(TranslateService);
   private tasksService = inject(TasksService);
   private destroyRef = inject(DestroyRef);
+  private errorHandler = inject(ErrorHandlerService);
 
   /** Checker Inbox Details Data */
   checkerInboxDetail: any;
@@ -52,6 +56,7 @@ export class ViewCheckerInboxComponent {
   jsondata: any;
   /** Checks if there is any object or not in jsondata */
   displayJSONData = false;
+  processing = false;
 
   /**
    * Retrieves the maker checker id data from `resolve`.
@@ -72,38 +77,14 @@ export class ViewCheckerInboxComponent {
    * Approve Checker
    */
   approveChecker() {
-    const approveCheckerDialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      data: {
-        heading: this.translateService.instant('labels.heading.Approve Checker'),
-        dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want to approve checker')
-      }
-    });
-    approveCheckerDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-      if (response.confirm) {
-        this.tasksService.executeMakerCheckerAction(this.checkerInboxDetail.id, 'approve').subscribe((res: any) => {
-          this.router.navigate(['../../'], { relativeTo: this.route });
-        });
-      }
-    });
+    this.confirmAndProcess('approve');
   }
 
   /**
    * Reject checker
    */
   rejectChecker() {
-    const rejectCheckerDialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      data: {
-        heading: this.translateService.instant('labels.heading.Reject Checker'),
-        dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want to reject checker')
-      }
-    });
-    rejectCheckerDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-      if (response.confirm) {
-        this.tasksService.executeMakerCheckerAction(this.checkerInboxDetail.id, 'reject').subscribe((res: any) => {
-          this.router.navigate(['../../'], { relativeTo: this.route });
-        });
-      }
-    });
+    this.confirmAndProcess('reject');
   }
 
   /**
@@ -113,15 +94,54 @@ export class ViewCheckerInboxComponent {
     const deleteCheckerDialogRef = this.dialog.open(ConfirmationDialogComponent, {
       data: {
         heading: this.translateService.instant('labels.heading.Delete Checker'),
-        dialogContext: this.translateService.instant('labels.dialogContext.Are you sure you want to delete checker')
+        dialogContext:
+          'This removes the pending checker item. Unlike approval or rejection, deletion does not retain equivalent maker-checker audit information.'
       }
     });
     deleteCheckerDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-      if (response.confirm) {
-        this.tasksService.deleteMakerChecker(this.checkerInboxDetail.id).subscribe((res: any) => {
-          this.router.navigate(['../../'], { relativeTo: this.route });
-        });
+      if (response?.confirm) {
+        this.process(() => this.tasksService.deleteMakerChecker(this.checkerInboxDetail.id), 'Checker item deleted');
       }
     });
+  }
+
+  checkerPermission(): string {
+    return `${this.checkerInboxDetail.actionName}_${this.checkerInboxDetail.entityName}_CHECKER`
+      .replace(/[^A-Za-z0-9_]/g, '_')
+      .toUpperCase();
+  }
+
+  private confirmAndProcess(action: 'approve' | 'reject'): void {
+    const actionLabel = action === 'approve' ? 'Approve Checker' : 'Reject Checker';
+    const context =
+      action === 'approve' ? 'Are you sure you want to approve checker' : 'Are you sure you want to reject checker';
+    const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+      data: {
+        heading: this.translateService.instant(`labels.heading.${actionLabel}`),
+        dialogContext: this.translateService.instant(`labels.dialogContext.${context}`)
+      }
+    });
+    dialogRef.afterClosed().subscribe((response: { confirm: any }) => {
+      if (response?.confirm) {
+        this.process(
+          () => this.tasksService.executeMakerCheckerAction(this.checkerInboxDetail.id, action),
+          `Checker item ${action}d`
+        );
+      }
+    });
+  }
+
+  private process(request: () => Observable<unknown>, successMessage: string): void {
+    if (this.processing) return;
+    this.processing = true;
+    request()
+      .pipe(finalize(() => (this.processing = false)))
+      .subscribe({
+        next: () => {
+          this.errorHandler.showSuccess(successMessage);
+          this.router.navigate(['../../'], { relativeTo: this.route });
+        },
+        error: (error: HttpErrorResponse) => this.errorHandler.handleError(error).subscribe({ error: () => undefined })
+      });
   }
 }


### PR DESCRIPTION
### Description

Improves the existing Checker Inbox task workflow by adding customer-based filtering, correcting the pending-task date filter, strengthening permission-aware actions, and providing reliable feedback for Approve, Reject, and Delete operations, including partial failures during multi-select processing. Existing maker-checker APIs and workflow behavior remain unchanged.

### Related issues and discussion

**WEB-1060**

### Screenshots, if any

<img width="1470" height="768" alt="Screenshot 2026-09-04 at 1 16 13 PM" src="https://github.com/user-attachments/assets/56a87bf4-c999-4d9e-b279-95d7b762dd84" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added customer autocomplete filtering to advanced search.
  - Added permission-aware row selection and action controls.
  - Added bulk approve, reject, and delete processing with per-item results.
  - Added loading, processing, search-error, permission, and action-result alerts.
  - Improved empty-state messaging for no results versus missing account data.

- **Bug Fixes**
  - Corrected advanced search “To date” control and parameter naming.
  - Prevented duplicate actions while requests are processing.
  - Refreshed inbox data directly after completed actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->