### PR TITLE
WEB-944: Add null guards to dialog afterClosed subscriptions in Clients, Savings, and Loans

### DIFF
--- a/src/app/clients/client-stepper/client-address-step/client-address-step.component.ts
+++ b/src/app/clients/client-stepper/client-address-step/client-address-step.component.ts
@@ -97,7 +97,7 @@ export class ClientAddressStepComponent {
     };
     const addAddressDialogRef = this.dialog.open(FormDialogComponent, { data, width: '50rem' });
     addAddressDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const normalizedAddressData = this.normalizeAddressData(response.data.value);
         normalizedAddressData.isActive = false;
         for (const key in normalizedAddressData) {
@@ -128,7 +128,7 @@ export class ClientAddressStepComponent {
     };
     const editAddressDialogRef = this.dialog.open(FormDialogComponent, { data, width: '50rem' });
     editAddressDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const normalizedAddressData = this.normalizeAddressData(response.data.value);
         normalizedAddressData.isActive = address.isActive;
         for (const key in normalizedAddressData) {
@@ -152,7 +152,7 @@ export class ClientAddressStepComponent {
       }
     });
     deleteAddressDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.clientAddressData.splice(index, 1);
       }
     });

--- a/src/app/clients/client-stepper/client-family-members-step/client-family-members-step.component.ts
+++ b/src/app/clients/client-stepper/client-family-members-step/client-family-members-step.component.ts
@@ -72,7 +72,7 @@ export class ClientFamilyMembersStepComponent {
       width: '50rem'
     });
     addFamilyMemberDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.member) {
+      if (response?.member) {
         this.clientFamilyMembers.push(response.member);
       }
     });
@@ -93,7 +93,7 @@ export class ClientFamilyMembersStepComponent {
       width: '50rem'
     });
     addFamilyMemberDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.member) {
+      if (response?.member) {
         this.clientFamilyMembers.splice(index, 1, response.member);
       }
     });
@@ -107,7 +107,7 @@ export class ClientFamilyMembersStepComponent {
       data: { deleteContext: `Family member name : ${name} ${index}` }
     });
     deleteFamilyMemberDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.clientFamilyMembers.splice(index, 1);
       }
     });

--- a/src/app/clients/clients-view/address-tab/address-tab.component.ts
+++ b/src/app/clients/clients-view/address-tab/address-tab.component.ts
@@ -132,7 +132,7 @@ export class AddressTabComponent {
     const addAddressDialogRef = this.dialog.open(FormDialogComponent, { data });
     this.setupPostalCodeLookup(addAddressDialogRef);
     addAddressDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const normalizedAddressData = this.normalizeAddressData(response.data.value);
         this.clientService
           .createClientAddress(this.clientId, normalizedAddressData.addressType, normalizedAddressData)
@@ -169,7 +169,7 @@ export class AddressTabComponent {
     const editAddressDialogRef = this.dialog.open(FormDialogComponent, { data });
     this.setupPostalCodeLookup(editAddressDialogRef);
     editAddressDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const normalizedAddressData = this.normalizeAddressData(response.data.value);
         normalizedAddressData.addressId = address.addressId;
         normalizedAddressData.isActive = address.isActive;

--- a/src/app/clients/clients-view/clients-view.component.ts
+++ b/src/app/clients/clients-view/clients-view.component.ts
@@ -414,7 +414,7 @@ export class ClientsViewComponent implements OnInit {
       data: { deleteContext: `the profile image of ${this.clientViewData.displayName}` }
     });
     deleteClientImageDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.clientsService.deleteClientProfileImage(this.clientViewData.id).subscribe(() => {
           this.reload();
         });

--- a/src/app/clients/clients-view/family-members-tab/family-members-tab.component.ts
+++ b/src/app/clients/clients-view/family-members-tab/family-members-tab.component.ts
@@ -80,7 +80,7 @@ export class FamilyMembersTabComponent {
       data: { deleteContext: `Family member id:${id} name : ${name} ${index}` }
     });
     deleteFamilyMemberDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.clientsService.deleteFamilyMember(clientId, id).subscribe(() => {
           this.clientFamilyMembers.splice(index, 1);
         });

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
@@ -379,7 +379,7 @@ export class IdentitiesTabComponent implements OnDestroy {
       data: { deleteContext: `${this.translateService.instant('labels.heading.identifier id')} : ${identifierId}` }
     });
     deleteIdentifierDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.clientService.deleteClientIdentifier(clientId, identifierId).subscribe((res) => {
           this.clientIdentities.splice(index, 1);
           this.identifiersTable.renderRows();

--- a/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-charges-step/loans-account-charges-step.component.ts
@@ -245,7 +245,7 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
     };
     const editNoteDialogRef = this.dialog.open(FormDialogComponent, { data });
     editNoteDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const newCharge = { ...charge, amount: response.data.value.amount };
         this.chargesDataSource.splice(this.chargesDataSource.indexOf(charge), 1, newCharge);
         this.chargesDataSource = this.chargesDataSource.concat([]);
@@ -279,7 +279,7 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
     };
     const editNoteDialogRef = this.dialog.open(FormDialogComponent, { data });
     editNoteDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         let newCharge: any;
         const dateFormat = this.settingsService.dateFormat;
         const date = this.dateUtils.formatDate(response.data.value.date, dateFormat);
@@ -320,7 +320,7 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
     };
     const editNoteDialogRef = this.dialog.open(FormDialogComponent, { data });
     editNoteDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const newCharge = { ...charge, feeInterval: response.data.value.feeInterval };
         this.chargesDataSource.splice(this.chargesDataSource.indexOf(charge), 1, newCharge);
         this.chargesDataSource = this.chargesDataSource.concat([]);
@@ -338,7 +338,7 @@ export class LoansAccountChargesStepComponent implements OnInit, OnChanges {
       data: { deleteContext: `charge ${charge.name}` }
     });
     deleteChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.chargesDataSource.splice(this.chargesDataSource.indexOf(charge), 1);
         this.chargesDataSource = this.chargesDataSource.concat([]);
         this.pristine = false;

--- a/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-terms-step/loans-account-terms-step.component.ts
@@ -934,7 +934,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
     };
     const disbursementDialogRef = this.dialog.open(FormDialogComponent, { data });
     disbursementDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const principal = response.data.value.principal * 1;
         if (this.totalMultiDisbursed + principal <= currentPrincipalAmount) {
           this.disbursementDataSource = this.disbursementDataSource.concat(response.data.value);
@@ -956,7 +956,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
       data: { deleteContext: `this` }
     });
     dialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         const principal = this.disbursementDataSource[index]['principal'] * 1;
         this.disbursementDataSource.splice(index, 1);
         this.disbursementDataSource = this.disbursementDataSource.concat([]);
@@ -974,7 +974,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
       data: { collateralOptions: this.collateralOptions }
     });
     addCollateralDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const collateralData = {
           type: response.data.value.collateral,
           value: response.data.value.quantity
@@ -1002,7 +1002,7 @@ export class LoansAccountTermsStepComponent extends LoanProductBaseComponent imp
       data: { deleteContext: `collateral` }
     });
     deleteCollateralDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         const removed: any = this.collateralDataSource.splice(id, 1);
         this.collateralOptions = this.collateralOptions.concat(removed[0].type);
         this.totalCollateralValue -= (removed[0].type.pctToBase * removed[0].type.basePrice * removed[0].value) / 100;

--- a/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
+++ b/src/app/loans/loans-view/charges-tab/charges-tab.component.ts
@@ -265,7 +265,7 @@ export class ChargesTabComponent extends LoanAccountTabBaseComponent implements 
     };
     const payChargeDialogRef = this.dialog.open(FormDialogComponent, { data });
     payChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         const dataObject = {
@@ -297,7 +297,7 @@ export class ChargesTabComponent extends LoanAccountTabBaseComponent implements 
       }
     });
     waiveChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         this.loansService
           .executeLoansAccountChargesCommand(
             this.loanProductService.loanAccountPath,
@@ -328,7 +328,7 @@ export class ChargesTabComponent extends LoanAccountTabBaseComponent implements 
     };
     const editChargeDialogRef = this.dialog.open(FormDialogComponent, { data });
     editChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         this.loansService
@@ -348,7 +348,7 @@ export class ChargesTabComponent extends LoanAccountTabBaseComponent implements 
       data: { deleteContext: `charge id:${chargeId}` }
     });
     deleteChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.loansService
           .deleteLoansAccountCharge(this.loanProductService.loanAccountPath, this.loanDetails.id, chargeId)
           .subscribe(() => this.reload());

--- a/src/app/loans/loans-view/external-asset-owner-tab/external-asset-owner-tab.component.ts
+++ b/src/app/loans/loans-view/external-asset-owner-tab/external-asset-owner-tab.component.ts
@@ -147,7 +147,7 @@ export class ExternalAssetOwnerTabComponent extends LoanAccountTabBaseComponent 
       data: { cancelContext: `the Asset Transfer with the Owner External Id ${this.currentItem.owner.externalId} ` }
     });
     deleteDataTableDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.cancel) {
+      if (response?.cancel) {
         const payload: any = {
           transferExternalId: this.currentItem.transferExternalId
         };

--- a/src/app/loans/loans-view/loan-account-actions/edit-repayment-schedule/edit-repayment-schedule.component.ts
+++ b/src/app/loans/loans-view/loan-account-actions/edit-repayment-schedule/edit-repayment-schedule.component.ts
@@ -109,7 +109,7 @@ export class EditRepaymentScheduleComponent extends LoanAccountActionsBaseCompon
     addDialogRef
       .afterClosed()
       .subscribe((response: { data?: { value?: { fromPeriod: number; toPeriod: number; amount: number } } }) => {
-        if (response.data?.value && this.repaymentScheduleDetails) {
+        if (response?.data?.value && this.repaymentScheduleDetails) {
           const fromPeriod = response.data.value.fromPeriod;
           const toPeriod = response.data.value.toPeriod;
           const amount = response.data.value.amount;
@@ -141,7 +141,7 @@ export class EditRepaymentScheduleComponent extends LoanAccountActionsBaseCompon
       }
     });
     recoverScheduleDialogRef.afterClosed().subscribe((responseConfirmation: { confirm?: boolean }) => {
-      if (responseConfirmation.confirm) {
+      if (responseConfirmation?.confirm) {
         this.loanService.applyCommandLoanScheduleVariations(this.loanId, 'deleteVariations', {}).subscribe({
           next: () => {
             this.getRepaymentSchedule();

--- a/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.ts
+++ b/src/app/loans/loans-view/loan-delinquency-tags-tab/loan-delinquency-tags-tab.component.ts
@@ -376,6 +376,9 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
       }
     });
     loanDelinquencyActionDialogRef.afterClosed().subscribe((response: { data: any }) => {
+      if (!response?.data) {
+        return;
+      }
       const startDate: Date = response.data.value.startDate;
       const endDate: Date = response.data.value.endDate;
 
@@ -393,6 +396,9 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
       }
     });
     loanDelinquencyActionDialogRef.afterClosed().subscribe((response: { data: any }) => {
+      if (!response?.data) {
+        return;
+      }
       const minimumPayment: number = response.data.value.minimumPayment;
       const minimumPaymentType: string = response.data.value.minimumPaymentType;
       const frequency: number = response.data.value.frequency;
@@ -439,7 +445,7 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
       }
     });
     loanDelinquencyActionDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         this.sendDelinquencyAction(action, null, null, null, null, null, null, null);
       }
     });
@@ -492,7 +498,7 @@ export class LoanDelinquencyTagsTabComponent extends LoanProductBaseComponent im
       }
     });
     removePauseDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         if (this.loanProductService.isLoanProduct) {
           this.sendDelinquencyAction('resume', null, null, null, null, null, null, null);
         } else {

--- a/src/app/loans/loans-view/loan-term-variations-tab/loan-term-variations-tab.component.ts
+++ b/src/app/loans/loans-view/loan-term-variations-tab/loan-term-variations-tab.component.ts
@@ -227,7 +227,7 @@ export class LoanTermVariationsTabComponent extends LoanAccountTabBaseComponent 
       data: { deleteContext: `interest pause from ${variation.startDate} to ${variation.endDate}` }
     });
     deleteStandingInstructionDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.loansService.deleteInterestPause(this.loanId, variation.id).subscribe((response: any) => {
           this.reload();
         });
@@ -262,7 +262,7 @@ export class LoanTermVariationsTabComponent extends LoanAccountTabBaseComponent 
     };
     const editDialogRef = this.dialog.open(FormDialogComponent, { data, width: '50rem' });
     editDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         if (response.data.value.startDate <= response.data.value.endDate) {
           const locale = this.settingsService.language.code;
           const dateFormat = this.settingsService.dateFormat;

--- a/src/app/loans/loans-view/loan-tranche-details/loan-tranche-details.component.ts
+++ b/src/app/loans/loans-view/loan-tranche-details/loan-tranche-details.component.ts
@@ -208,7 +208,7 @@ export class LoanTrancheDetailsComponent extends LoanAccountTabBaseComponent imp
     };
     const disbursementDialogRef = this.dialog.open(FormDialogComponent, { data });
     disbursementDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const principal = response.data.value.principal * 1;
         if (this.totalMultiDisbursed + principal <= this.currentPrincipalAmount) {
           this.disbursementDataSource = this.disbursementDataSource.concat(response.data.value);
@@ -235,7 +235,7 @@ export class LoanTrancheDetailsComponent extends LoanAccountTabBaseComponent imp
     };
     const disbursementDialogRef = this.dialog.open(FormDialogComponent, { data });
     disbursementDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const newPrincipal = response.data.value.principal * 1;
         if (this.totalMultiDisbursed - principal + newPrincipal <= this.currentPrincipalAmount) {
           this.disbursementDataSource[index]['principal'] = newPrincipal;
@@ -251,7 +251,7 @@ export class LoanTrancheDetailsComponent extends LoanAccountTabBaseComponent imp
       data: { deleteContext: `this` }
     });
     dialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         const principal = this.disbursementDataSource[index]['principal'] * 1;
         this.disbursementDataSource.splice(index, 1);
         this.disbursementDataSource = this.disbursementDataSource.concat([]);

--- a/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.ts
+++ b/src/app/loans/loans-view/repayment-schedule-tab/repayment-schedule-tab.component.ts
@@ -315,7 +315,7 @@ export class RepaymentScheduleTabComponent implements OnInit, OnChanges {
     };
     const addDialogRef = this.dialog.open(FormDialogComponent, { data, width: '50rem' });
     addDialogRef.afterClosed().subscribe((response: { data?: { value?: Record<string, unknown> } }) => {
-      if (response.data) {
+      if (response?.data) {
       }
     });
   }

--- a/src/app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component.ts
+++ b/src/app/loans/loans-view/standing-instructions-tab/standing-instructions-tab.component.ts
@@ -126,7 +126,7 @@ export class StandingInstructionsTabComponent implements OnInit {
       data: { deleteContext: `standing instruction id: ${instructionId}` }
     });
     deleteStandingInstructionDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.accountTransfersService.deleteStandingInstrucions(instructionId).subscribe(() => {});
       }
     });

--- a/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/loans/loans-view/transactions-tab/transactions-tab.component.ts
@@ -500,7 +500,7 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
       }
     });
     undoTransactionAccountDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         let transactionId = transaction.id;
         if (command === 'undowriteoff' || this.isWriteOff(transaction.type)) {
           transactionId = null;
@@ -579,7 +579,7 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
       }
     });
     undoTransactionAccountDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         const undoCommand = actionName === 'Re-Age' ? 'undoReAge' : 'undoReAmortize';
         this.loansService.executeLoansAccountTransactionsCommand(String(this.loanId), undoCommand, {}).subscribe(() => {
           this.reload();
@@ -796,7 +796,7 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
           };
           const chargebackDialogRef = this.dialog.open(FormDialogComponent, { data });
           chargebackDialogRef.afterClosed().subscribe((response: { data: any }) => {
-            if (response.data) {
+            if (response?.data) {
               const dateFormat = this.settingsService.dateFormat;
 
               if (response.data.value.amount <= transactionAmount) {
@@ -877,7 +877,7 @@ export class TransactionsTabComponent extends LoanProductBaseComponent implement
           };
           const chargebackDialogRef = this.dialog.open(FormDialogComponent, { data });
           chargebackDialogRef.afterClosed().subscribe((response: { data: any }) => {
-            if (response.data) {
+            if (response?.data) {
               const dateFormat = this.settingsService.dateFormat;
 
               if (response.data.value.amount <= transactionAmount) {

--- a/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
+++ b/src/app/loans/loans-view/transactions/view-transaction/view-transaction.component.ts
@@ -284,7 +284,7 @@ export class ViewTransactionComponent extends LoanAccountActionsBaseComponent im
       };
       const undoTransactionAccountDialogRef = this.dialog.open(FormDialogComponent, { data, width: '50rem' });
       undoTransactionAccountDialogRef.afterClosed().subscribe((response: any) => {
-        if (response.data) {
+        if (response?.data) {
           const payload = {
             note: response.data.value.note,
             reversalExternalId: response.data.value.reversalExternalId
@@ -313,7 +313,7 @@ export class ViewTransactionComponent extends LoanAccountActionsBaseComponent im
         }
       });
       undoTransactionAccountDialogRef.afterClosed().subscribe((response: { confirm: any }) => {
-        if (response.confirm) {
+        if (response?.confirm) {
           const locale = this.settingsService.language.code;
           const dateFormat = this.settingsService.dateFormat;
           const data = this.loanProductService.isLoanProduct
@@ -403,7 +403,7 @@ export class ViewTransactionComponent extends LoanAccountActionsBaseComponent im
     };
     const chargebackDialogRef = this.dialog.open(FormDialogComponent, { data });
     chargebackDialogRef.afterClosed().subscribe((response: { data: any }) => {
-      if (response.data) {
+      if (response?.data) {
         if (response.data.value.amount <= this.amountRelationsAllowed) {
           const locale = this.settingsService.language.code;
           const payload = {

--- a/src/app/loans/loans-view/view-charge/view-charge.component.ts
+++ b/src/app/loans/loans-view/view-charge/view-charge.component.ts
@@ -108,7 +108,7 @@ export class ViewChargeComponent extends LoanAccountTabBaseComponent {
     };
     const payChargeDialogRef = this.dialog.open(FormDialogComponent, { data });
     payChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         const prevTransactionDate: Date = response.data.value.transactionDate;
@@ -146,7 +146,7 @@ export class ViewChargeComponent extends LoanAccountTabBaseComponent {
       }
     });
     waiveChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         this.loansService
           .executeLoansAccountChargesCommand(
             this.loanProductService.loanAccountPath,
@@ -190,7 +190,7 @@ export class ViewChargeComponent extends LoanAccountTabBaseComponent {
     };
     const editChargeDialogRef = this.dialog.open(FormDialogComponent, { data });
     editChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         const dueDate = this.dateUtils.formatDate(response.data.value.dueDate, dateFormat);
@@ -223,7 +223,7 @@ export class ViewChargeComponent extends LoanAccountTabBaseComponent {
       data: { deleteContext: `charge id:${this.chargeData.id}` }
     });
     deleteChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.loansService
           .deleteLoansAccountCharge(
             this.loanProductService.loanAccountPath,

--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
@@ -166,7 +166,7 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
     };
     const editNoteDialogRef = this.dialog.open(FormDialogComponent, { data });
     editNoteDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const newCharge = { ...charge, amount: response.data.value.amount };
         this.chargesDataSource.splice(this.chargesDataSource.indexOf(charge), 1, newCharge);
         this.chargesDataSource = this.chargesDataSource.concat([]);
@@ -196,7 +196,7 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
     };
     const editNoteDialogRef = this.dialog.open(FormDialogComponent, { data });
     editNoteDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         let newCharge: any;
         const dateFormat = 'dd MMMM yyyy';
         const date = this.dateUtils.formatDate(response.data.value.date, dateFormat);
@@ -239,7 +239,7 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
     };
     const editNoteDialogRef = this.dialog.open(FormDialogComponent, { data });
     editNoteDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const newCharge = { ...charge, feeInterval: response.data.value.feeInterval };
         this.chargesDataSource.splice(this.chargesDataSource.indexOf(charge), 1, newCharge);
         this.chargesDataSource = this.chargesDataSource.concat([]);

--- a/src/app/savings/savings-account-view/charges-tab/charges-tab.component.ts
+++ b/src/app/savings/savings-account-view/charges-tab/charges-tab.component.ts
@@ -169,7 +169,7 @@ export class ChargesTabComponent implements OnInit {
     };
     const payChargeDialogRef = this.dialog.open(FormDialogComponent, { data });
     payChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         const dataObject = {
@@ -194,7 +194,7 @@ export class ChargesTabComponent implements OnInit {
   waiveCharge(chargeId: any) {
     const waiveChargeDialogRef = this.dialog.open(WaiveChargeDialogComponent, { data: { id: chargeId } });
     waiveChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         this.savingsService
           .executeSavingsAccountChargesCommand(this.savingsAccountData.id, 'waive', {}, chargeId)
           .subscribe(() => {
@@ -211,7 +211,7 @@ export class ChargesTabComponent implements OnInit {
   inactivateCharge(chargeId: any) {
     const inactivateChargeDialogRef = this.dialog.open(InactivateChargeDialogComponent, { data: { id: chargeId } });
     inactivateChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         this.savingsService
           .executeSavingsAccountChargesCommand(this.savingsAccountData.id, 'inactivate', {}, chargeId)
           .subscribe(() => {
@@ -242,7 +242,7 @@ export class ChargesTabComponent implements OnInit {
     };
     const editChargeDialogRef = this.dialog.open(FormDialogComponent, { data });
     editChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         const dataObject = {
@@ -268,7 +268,7 @@ export class ChargesTabComponent implements OnInit {
       data: { deleteContext: `charge id:${chargeId}` }
     });
     deleteChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.savingsService.deleteSavingsAccountCharge(this.savingsAccountData.id, chargeId).subscribe(() => {
           this.reload();
         });

--- a/src/app/savings/savings-account-view/standing-instructions-tab/standing-instructions-tab.component.ts
+++ b/src/app/savings/savings-account-view/standing-instructions-tab/standing-instructions-tab.component.ts
@@ -124,7 +124,7 @@ export class StandingInstructionsTabComponent implements OnInit {
       data: { deleteContext: `standing instruction id: ${instructionId}` }
     });
     deleteStandingInstructionDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.accountTransfersService.deleteStandingInstrucions(instructionId).subscribe(() => {});
       }
     });

--- a/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.ts
+++ b/src/app/savings/savings-account-view/transactions-tab/transactions-tab.component.ts
@@ -264,7 +264,7 @@ export class TransactionsTabComponent implements OnInit {
   undoTransaction(transactionData: SavingsAccountTransaction): void {
     const undoTransactionAccountDialogRef = this.dialog.open(UndoTransactionDialogComponent);
     undoTransactionAccountDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         const data = {

--- a/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.ts
+++ b/src/app/savings/savings-account-view/transactions/view-transaction/savings-transaction-general-tab/savings-transaction-general-tab.component.ts
@@ -65,7 +65,7 @@ export class SavingsTransactionGeneralTabComponent {
   releaseAmount(): void {
     const releaseAmountDialogRef = this.dialog.open(ReleaseAmountDialogComponent);
     releaseAmountDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         const data = {};
         this.savingsService
           .executeSavingsAccountTransactionsCommand(this.accountId, 'releaseAmount', data, this.transactionData.id)
@@ -79,7 +79,7 @@ export class SavingsTransactionGeneralTabComponent {
   undoTransaction(): void {
     const undoTransactionAccountDialogRef = this.dialog.open(UndoTransactionDialogComponent);
     undoTransactionAccountDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         const data = {

--- a/src/app/savings/savings-account-view/view-charge/view-charge.component.ts
+++ b/src/app/savings/savings-account-view/view-charge/view-charge.component.ts
@@ -106,7 +106,7 @@ export class ViewChargeComponent {
     };
     const payChargeDialogRef = this.dialog.open(FormDialogComponent, { data });
     payChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         const dataObject = {
@@ -130,7 +130,7 @@ export class ViewChargeComponent {
   waiveCharge() {
     const waiveChargeDialogRef = this.dialog.open(WaiveChargeDialogComponent, { data: { id: this.chargeData.id } });
     waiveChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         this.savingsService
           .executeSavingsAccountChargesCommand(this.chargeData.accountId, 'waive', {}, this.chargeData.id)
           .subscribe(() => {
@@ -148,7 +148,7 @@ export class ViewChargeComponent {
       data: { id: this.chargeData.id }
     });
     inactivateChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.confirm) {
+      if (response?.confirm) {
         this.savingsService
           .executeSavingsAccountChargesCommand(this.chargeData.accountId, 'inactivate', {}, this.chargeData.id)
           .subscribe(() => {
@@ -178,7 +178,7 @@ export class ViewChargeComponent {
     };
     const editChargeDialogRef = this.dialog.open(FormDialogComponent, { data });
     editChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.data) {
+      if (response?.data) {
         const locale = this.settingsService.language.code;
         const dateFormat = this.settingsService.dateFormat;
         const dataObject = {
@@ -203,7 +203,7 @@ export class ViewChargeComponent {
       data: { deleteContext: `charge id:${this.chargeData.id}` }
     });
     deleteChargeDialogRef.afterClosed().subscribe((response: any) => {
-      if (response.delete) {
+      if (response?.delete) {
         this.savingsService.deleteSavingsAccountCharge(this.chargeData.accountId, this.chargeData.id).subscribe(() => {
           this.reload();
         });


### PR DESCRIPTION
## Description
Adds null guards (optional chaining `?.` and explicit early returns) to all unguarded `dialogRef.afterClosed().subscribe(...)` callbacks across the Clients, Savings, and Loans modules.

Previously, dismissing any of these dialogs via the Escape key, backdrop click, or Cancel button emitted `undefined`, which resulted in an unhandled `TypeError: Cannot read properties of undefined` when attempting to access properties like `response.data`, `response.confirm`, or `response.delete`. With these guards in place, dismissals exit gracefully without error.

## Related issues and discussion
[WEB-944](https://mifosforge.jira.com/jira/software/c/projects/WEB/boards/62?label=Bug%2Cbug%2CStarterIssue&selectedIssue=WEB-944)

## Screenshots, if any
<img width="1920" height="1032" alt="Screenshot 2026-09-05 002243" src="https://github.com/user-attachments/assets/8648c70e-23ad-490a-8ada-bbf4362c2363" />
<img width="1920" height="1032" alt="Screenshot 2026-09-05 002253" src="https://github.com/user-attachments/assets/04909582-cb52-4547-a633-037b2d686ff1" />

## Checklist
- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-944]: https://mifosforge.jira.com/browse/WEB-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented errors when confirmation or data-entry dialogs are dismissed without returning a response.
  - Improved reliability across client, loan, and savings workflows, including charges, transactions, disbursements, repayments, family members, addresses, and standing instructions.
  - Actions now proceed only when the expected confirmation or data is available.

- **UI Improvements**
  - Updated template details to display HTML content directly and adjusted the layout for improved readability.
  - Plain-text template content continues to preserve spacing and wrap long lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->