### PR TITLE
WEB-1207: render template preview for plain text and HTML

### DIFF
--- a/src/app/templates/template.model.ts
+++ b/src/app/templates/template.model.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** A key/value mapping a template can use to resolve its parameters. */
+export interface TemplateMapper {
+  mapperorder: number;
+  mapperkey: string;
+  mappervalue: string;
+}
+
+/** A template as returned by the templates API. */
+export interface Template {
+  id: number;
+  name: string;
+  /** Entity the template is for, such as `client` or `loan`. */
+  entity: string;
+  /** Template type, such as `Document`, `E-Mail` or `SMS`. */
+  type: string;
+  /** Template text: plain text or HTML markup with `${parameter}` placeholders. */
+  text: string;
+  mappers?: TemplateMapper[];
+}

--- a/src/app/templates/view-template/view-template.component.html
+++ b/src/app/templates/view-template/view-template.component.html
@@ -46,14 +46,22 @@
           {{ templateData.type }}
         </div>
 
-        <div class="flex-50 mat-body-strong">
+        <div class="flex-100 mat-body-strong text-label">
           {{ 'labels.inputs.Text' | translate }}
         </div>
 
         @if (isHtml) {
-          <div class="flex-50" [innerHTML]="templateData.text"></div>
+          <!-- Sandboxed: the template's own styles apply while its scripts never run -->
+          <iframe
+            #preview
+            class="flex-100 html-preview"
+            sandbox="allow-same-origin"
+            [srcdoc]="htmlPreview"
+            [title]="'labels.inputs.Text' | translate"
+            (load)="onPreviewLoad(preview)"
+          ></iframe>
         } @else {
-          <div class="flex-50 plain-text">{{ templateData.text }}</div>
+          <div class="flex-100 plain-text">{{ templateData.text }}</div>
         }
       </div>
     </mat-card-content>

--- a/src/app/templates/view-template/view-template.component.scss
+++ b/src/app/templates/view-template/view-template.component.scss
@@ -7,7 +7,8 @@
  */
 
 .container {
-  max-width: 37rem;
+  // Wide enough to show a 600px email, the usual width of HTML email templates, without scrolling
+  max-width: 40rem;
 
   .content {
     div {
@@ -17,8 +18,28 @@
   }
 }
 
+// The Text label sits above the template text, which takes the full width
+.text-label {
+  margin-bottom: 0.5rem;
+}
+
 // Plain text templates keep their line breaks
 .plain-text {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+
+// HTML templates render in their own document so their styles apply and the app's do not
+.html-preview {
+  display: block;
+  min-height: 6rem;
+  border: 1px solid rgb(0 0 0 / 12%);
+  border-radius: 8px;
+
+  // Emails are designed for a light background, whatever the app theme
+  background: #fff;
+}
+
+:host-context(.dark-theme) .html-preview {
+  border-color: rgb(255 255 255 / 12%);
 }

--- a/src/app/templates/view-template/view-template.component.spec.ts
+++ b/src/app/templates/view-template/view-template.component.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { BehaviorSubject } from 'rxjs';
+
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { Template } from '../template.model';
+import { TemplatesService } from '../templates.service';
+import { ViewTemplateComponent } from './view-template.component';
+
+describe('ViewTemplateComponent', () => {
+  const template: Omit<Template, 'text'> = {
+    id: 96,
+    name: 'SELF_SERVICE_TRANSFER_SUCCESS_EMAIL',
+    entity: 'client',
+    type: 'SMS',
+    mappers: []
+  };
+
+  let routeData: BehaviorSubject<{ template: Template }>;
+
+  /**
+   * Renders the view for a template with the given text, resolved through a mocked route.
+   * @param {string} text Template text, plain or HTML.
+   * @returns {Promise<ComponentFixture<ViewTemplateComponent>>} Fixture after the first change detection.
+   */
+  async function render(text: string): Promise<ComponentFixture<ViewTemplateComponent>> {
+    TestBed.resetTestingModule();
+    routeData = new BehaviorSubject({ template: { ...template, text } });
+    await TestBed.configureTestingModule({
+      imports: [
+        ViewTemplateComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { data: routeData.asObservable() } },
+        { provide: MatDialog, useValue: { open: jest.fn() } },
+        { provide: TemplatesService, useValue: { deleteTemplate: jest.fn() } },
+        { provide: AuthenticationService, useValue: { getCredentials: () => ({ permissions: ['ALL_FUNCTIONS'] }) } }
+      ]
+    }).compileComponents();
+    TestBed.inject(FaIconLibrary).addIcons(faEdit, faTrash);
+    const fixture = TestBed.createComponent(ViewTemplateComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  /** A stand-in for the preview frame: jsdom does not lay out documents, so sizes are given explicitly. */
+  function fakeFrame(documentHeight: number, viewportHeight = documentHeight, width = 600) {
+    return {
+      clientWidth: width,
+      style: { height: '' },
+      contentDocument: {
+        documentElement: { scrollHeight: documentHeight, clientHeight: documentHeight },
+        body: { scrollHeight: documentHeight - 16 }
+      },
+      contentWindow: { innerHeight: viewportHeight }
+    } as unknown as HTMLIFrameElement;
+  }
+
+  it('shows a plain text template verbatim, line breaks included', async () => {
+    const text = 'Transferencia exitosa\nTransferencia realizada correctamente por ${transactionAmount}.\n\n<3';
+    const fixture = await render(text);
+
+    const plainText = fixture.nativeElement.querySelector('.plain-text') as HTMLElement;
+    expect(plainText.textContent).toBe(text);
+    expect(fixture.nativeElement.querySelector('iframe')).toBeNull();
+  });
+
+  it('renders an HTML template in a sandboxed frame with its styles intact', async () => {
+    const text =
+      '<style>.title { color: red; }</style>' +
+      '<h1 class="title" style="margin: 0">Hola ${firstname}</h1>' +
+      '<table border="1"><tr><td>${currency} ${transactionAmount}</td></tr></table>';
+    const fixture = await render(text);
+
+    const frame = fixture.nativeElement.querySelector('iframe') as HTMLIFrameElement;
+    expect(frame).not.toBeNull();
+    expect(frame.getAttribute('sandbox')).toBe('allow-same-origin');
+    expect(frame.srcdoc).toBe(text);
+    expect(fixture.nativeElement.querySelector('.plain-text')).toBeNull();
+  });
+
+  it('switches between plain text and HTML when the route shows another template', async () => {
+    const fixture = await render('Plain ${firstname}');
+    expect(fixture.nativeElement.querySelector('.plain-text')).not.toBeNull();
+
+    routeData.next({ template: { ...template, id: 97, text: '<p>Hola ${firstname}</p>' } });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.plain-text')).toBeNull();
+    const frame = fixture.nativeElement.querySelector('iframe') as HTMLIFrameElement;
+    expect(frame.srcdoc).toBe('<p>Hola ${firstname}</p>');
+  });
+
+  it('sizes the preview frame to its document height', async () => {
+    const fixture = await render('<p>Hola</p>');
+    const frame = fakeFrame(640);
+
+    fixture.componentInstance.fitPreview(frame);
+
+    expect(frame.style.height).toBe('640px');
+  });
+
+  it('leaves room for a horizontal scrollbar when the template is wider than the frame', async () => {
+    const fixture = await render('<p>Hola</p>');
+    const frame = fakeFrame(640, 655);
+
+    fixture.componentInstance.fitPreview(frame);
+
+    expect(frame.style.height).toBe('655px');
+  });
+
+  it('re-fits the preview frame when its width changes', async () => {
+    const callbacks: ResizeObserverCallback[] = [];
+    const observe = jest.fn();
+    const disconnect = jest.fn();
+    (globalThis as any).ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        callbacks.push(callback);
+      }
+      observe = observe;
+      disconnect = disconnect;
+    };
+    try {
+      const fixture = await render('<p>Hola</p>');
+      const component = fixture.componentInstance;
+      const frame = fakeFrame(640);
+      const fitPreview = jest.spyOn(component, 'fitPreview');
+
+      component.onPreviewLoad(frame);
+      const onResize = callbacks[callbacks.length - 1];
+      expect(fitPreview).toHaveBeenCalledTimes(1);
+      expect(observe).toHaveBeenCalledWith(frame);
+
+      onResize([], {} as ResizeObserver);
+      expect(fitPreview).toHaveBeenCalledTimes(1);
+
+      (frame as any).clientWidth = 400;
+      onResize([], {} as ResizeObserver);
+      expect(fitPreview).toHaveBeenCalledTimes(2);
+
+      fixture.destroy();
+      expect(disconnect).toHaveBeenCalled();
+    } finally {
+      delete (globalThis as any).ResizeObserver;
+    }
+  });
+});

--- a/src/app/templates/view-template/view-template.component.ts
+++ b/src/app/templates/view-template/view-template.component.ts
@@ -7,14 +7,16 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, inject, DestroyRef } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, inject, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 
 /** Custom Services */
 import { TemplatesService } from '../templates.service';
 import { isHtmlText } from '../template-text.utils';
+import { Template } from '../template.model';
 
 /** Custom Components */
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
@@ -40,13 +42,25 @@ export class ViewTemplateComponent {
   private router = inject(Router);
   private dialog = inject(MatDialog);
   private destroyRef = inject(DestroyRef);
+  private sanitizer = inject(DomSanitizer);
+  private changeDetector = inject(ChangeDetectorRef);
 
   /** Template Data */
-  templateData: any;
+  templateData: Template;
+
+  /**
+   * Text of an HTML template for the preview frame, null for plain text templates.
+   * The text is trusted as authored because the frame is sandboxed: scripts never run in it, so Angular's HTML
+   * sanitizer, which would strip the template's style sheets and inline styles, is not needed.
+   */
+  htmlPreview: SafeHtml | null = null;
+
+  /** Re-fits the preview frame when its width changes, since wrapping changes the document height. */
+  private previewResizeObserver?: ResizeObserver;
 
   /** Whether the template text is HTML markup (rendered) or plain text (shown verbatim). */
   get isHtml(): boolean {
-    return isHtmlText(this.templateData?.text);
+    return this.htmlPreview !== null;
   }
 
   /**
@@ -57,9 +71,56 @@ export class ViewTemplateComponent {
    * @param {MatDialog} dialog Dialog reference.
    */
   constructor() {
-    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { template: any }) => {
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { template: Template }) => {
       this.templateData = data.template;
+      const text = this.templateData?.text;
+      this.htmlPreview = isHtmlText(text) ? this.sanitizer.bypassSecurityTrustHtml(text) : null;
+      // The router reuses this component when only the id changes, so the OnPush view must be told to update.
+      this.changeDetector.markForCheck();
     });
+    this.destroyRef.onDestroy(() => this.previewResizeObserver?.disconnect());
+  }
+
+  /**
+   * Fits the preview frame to its document once it has loaded and keeps it fitted when its width changes.
+   * @param {HTMLIFrameElement} frame Preview frame.
+   */
+  onPreviewLoad(frame: HTMLIFrameElement): void {
+    this.fitPreview(frame);
+    this.previewResizeObserver?.disconnect();
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    let width = frame.clientWidth;
+    this.previewResizeObserver = new ResizeObserver(() => {
+      if (frame.clientWidth !== width) {
+        width = frame.clientWidth;
+        this.fitPreview(frame);
+      }
+    });
+    this.previewResizeObserver.observe(frame);
+  }
+
+  /**
+   * Gives the preview frame the height of its document so the whole template shows without an inner scrollbar.
+   * The frame is collapsed first because a document never reports a scroll height below its viewport height.
+   * @param {HTMLIFrameElement} frame Preview frame.
+   */
+  fitPreview(frame: HTMLIFrameElement): void {
+    const previewDocument = frame.contentDocument;
+    const root = previewDocument?.documentElement;
+    if (!root) {
+      return;
+    }
+    frame.style.height = '0';
+    const height = Math.max(root.scrollHeight, previewDocument.body?.scrollHeight ?? 0);
+    frame.style.height = `${height}px`;
+    // A template wider than the frame gets a horizontal scrollbar, which takes room from the viewport.
+    // Leave space for it so a vertical scrollbar does not appear as well.
+    const scrollbarHeight = (frame.contentWindow?.innerHeight ?? root.clientHeight) - root.clientHeight;
+    if (scrollbarHeight > 0) {
+      frame.style.height = `${height + scrollbarHeight}px`;
+    }
   }
 
   /**
@@ -71,7 +132,7 @@ export class ViewTemplateComponent {
     });
     deleteTemplateDialogRef.afterClosed().subscribe((response: any) => {
       if (response?.delete) {
-        this.templatesService.deleteTemplate(this.templateData.id).subscribe(() => {
+        this.templatesService.deleteTemplate(String(this.templateData.id)).subscribe(() => {
           this.router.navigate(['/templates']);
         });
       }


### PR DESCRIPTION
## Description

The template view page (Admin → Templates → open a template) passed HTML templates through `innerHTML`. Angular's HTML sanitizer strips `<style>` blocks and every inline `style` attribute, so HTML email templates rendered as bare, unstyled tables, and the result was squeezed into the half-width column next to the "Text" label.

This change makes the view page render both formats as authored:

- **HTML templates render in a sandboxed frame.** The text is fed to an `<iframe sandbox="allow-same-origin">` through `srcdoc`, so the template's own style sheets, inline styles and layout apply exactly as written and the app's CSS cannot leak in. Scripts, forms, popups and navigation are all blocked by the sandbox, which is why trusting the markup for `srcdoc` is safe. The frame keeps a white background in dark mode, since emails are designed for one.
- **The frame fits its document.** On load the component sets the frame height from the document height and re-fits it when the frame width changes (sidenav toggle, window resize). When the template is wider than the frame, the horizontal scrollbar stays inside the frame and the frame grows by the scrollbar height so no vertical scrollbar appears next to it.
- **Plain text templates** keep rendering verbatim with their line breaks.
- **Layout.** The "Text" label sits on its own row and the content takes the full card width. The card grew from 37rem to 40rem so a standard 600px email fits without horizontal scrolling.
- **Fixed stale content when switching templates.** The component is `OnPush` and the router reuses it when only the id changes, so navigating from one template straight to another left the previous template on screen. The view is now marked for check when the route data changes.

## Related issues and discussion

[WEB-1207](https://mifosforge.jira.com/browse/WEB-1207)

## Screenshots, if any

Captured with Playwright against the dev server (mocked template responses, nothing written to the demo server): the HTML email renders styled in light and dark mode, the plain text SMS shows verbatim, and at a 520px viewport the horizontal scrollbar stays inside the frame. Screenshots to be attached.

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

## Verification

- New `view-template.component.spec.ts` renders the component: plain text shown verbatim with line breaks, HTML rendered in a frame with `sandbox="allow-same-origin"` and the markup (including `<style>` and inline styles) intact in `srcdoc`, the switch from plain text to HTML when the route shows another template, frame height set from the document, scrollbar allowance, and re-fit on width change. Templates folder: 33 tests across 3 suites pass.
- `eslint .`, `stylelint`, `htmlhint` clean repo-wide; `prettier --check` clean on every changed file.
- `ng build --configuration development` completes without errors.
- Verified in headless Chromium against the dev server: an injected `<script>` inside a template never runs, the frame height matches the document (569px at 1280px wide, 587px at 520px wide where the 18px horizontal scrollbar is added), and navigating from template 96 to 97 in place updates the card.


[WEB-1207]: https://mifosforge.jira.com/browse/WEB-1207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTML templates now appear in a sandboxed, full-width preview.
  * Previews automatically adjust to fit their content and respond to width changes.
  * Plain-text templates continue to display as readable full-width text.

* **Style**
  * Expanded the template view to better accommodate typical email content.
  * Added bordered, rounded preview styling with dark-theme support.
  * Improved spacing around template labels for clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->