### PR TITLE
WEB-1215: Translate the guided loan product wizard chrome

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -29,12 +29,7 @@ import { PortalModule } from '@angular/cdk/portal';
 /** Main Routing Module */
 import { AppRoutingModule } from './app-routing.module';
 import { DatePipe, LocationStrategy } from '@angular/common';
-import {
-  TranslateLoader,
-  TranslateModule,
-  MissingTranslationHandler,
-  MissingTranslationHandlerParams
-} from '@ngx-translate/core';
+import { TranslateLoader, TranslateModule, MissingTranslationHandler } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
 import { AuthenticationInterceptor as TokenInterceptor } from './core/authentication/authentication.interceptor';
@@ -44,13 +39,7 @@ import { environment } from '../environments/environment';
 import { CallbackComponent } from './zitadel/callback/callback.component';
 import { OAuthModule } from 'angular-oauth2-oidc';
 import { provideLottieOptions } from 'ngx-lottie';
-
-export class CustomMissingTranslationHandler implements MissingTranslationHandler {
-  handle(params: MissingTranslationHandlerParams): string {
-    // Remove the 'labels.catalogs.' prefix and return the fallback value
-    return params.key.replace('labels.catalogs.', '');
-  }
-}
+import { CustomMissingTranslationHandler } from './core/translation/missing-translation.handler';
 
 @NgModule({
   declarations: [WebAppComponent],

--- a/src/app/core/translation/missing-translation.handler.ts
+++ b/src/app/core/translation/missing-translation.handler.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { MissingTranslationHandler, MissingTranslationHandlerParams } from '@ngx-translate/core';
+
+/**
+ * Falls back to the untranslated string for the `labels.catalogs` namespace.
+ *
+ * That namespace is keyed by Fineract's own enum values, so a key it does not carry is a value the
+ * backend named — a tenant's currency or delinquency bucket, a strategy the deployment added. Those
+ * have no translation to find, and the value itself is the right thing to show. Every other
+ * namespace falls through unchanged, so a genuinely missing key still surfaces as a visible key
+ * rather than being papered over.
+ */
+export class CustomMissingTranslationHandler implements MissingTranslationHandler {
+  handle(params: MissingTranslationHandlerParams): string {
+    return params.key.replace('labels.catalogs.', '');
+  }
+}

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.html
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.html
@@ -16,7 +16,7 @@
 
   <mat-stepper orientation="vertical" [linear]="false" class="wizard-stepper">
     <mat-step *ngFor="let step of visibleSteps; trackBy: trackByStepId; let i = index">
-      <ng-template matStepLabel>{{ step.title }}</ng-template>
+      <ng-template matStepLabel>{{ step.title | translate }}</ng-template>
 
       <div [formGroup]="form" class="step-panel">
         <!--
@@ -166,11 +166,11 @@
 
                 <mat-select *ngIf="field.type === 'select'" [formControlName]="field.key" [required]="!!field.required">
                   <mat-option *ngFor="let option of field.options; trackBy: trackByOptionValue" [value]="option.value">
-                    {{ option.label }}
+                    {{ option.label | translateKey: 'catalogs' }}
                   </mat-option>
                 </mat-select>
 
-                <mat-hint *ngIf="field.hint">{{ field.hint }}</mat-hint>
+                <mat-hint *ngIf="field.hint">{{ field.hint | translate }}</mat-hint>
                 <!--
                   One `@if` per message, each with the `<mat-error>` at its root: that is what lets the
                   compiler infer the `mat-error` projection selector, so Material renders these in the
@@ -284,7 +284,7 @@
         <ng-container *ngIf="step.kind === 'review' && !usesClassicSteps">
           <ng-container *ngFor="let group of reviewGroups; trackBy: trackBySectionTitle">
             <div class="review-section">
-              <p class="review-section__title">{{ group.title }}</p>
+              <p class="review-section__title">{{ group.title | translate }}</p>
               <div class="review-row" *ngFor="let row of group.rows; trackBy: trackByRowLabel">
                 <span class="review-row__label">{{ row.label | translate }}</span>
                 <span class="review-row__value">{{ row.display }}</span>
@@ -358,13 +358,11 @@
             -->
             <li *ngFor="let incompleteStep of incompleteGuidedSteps; trackBy: trackByIncompleteStepTitle">
               <!--
-                `step.title` unpiped, matching the stepper headers exactly — the operator has to be able
-                to find the step this names. Those headers are raw English today (review finding I1,
-                wizard chrome untranslated); translating them is one wholesale change across the chrome,
-                and half-translating it here would break the match that makes the list useful.
+                Piped through the same key as the stepper header renders, so this list keeps naming the
+                steps with the exact words the operator has to go and find.
               -->
               <button type="button" class="submit-blocked__step" (click)="goToStep(incompleteStep.index)">
-                {{ incompleteStep.title }}
+                {{ incompleteStep.title | translate }}
               </button>
             </li>
           </ul>

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
@@ -9,7 +9,8 @@
 import { TestBed } from '@angular/core/testing';
 import { FormBuilder, FormGroup, UntypedFormControl, Validators } from '@angular/forms';
 import { DatePipe } from '@angular/common';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateService, MissingTranslationHandlerParams } from '@ngx-translate/core';
+import { CustomMissingTranslationHandler } from 'app/core/translation/missing-translation.handler';
 import { Router } from '@angular/router';
 import { buildPayload, LoanWizardProfileMode } from './loan-product.config';
 import { LoanProductWizardComponent } from './loan-product-wizard.component';
@@ -33,8 +34,23 @@ describe('LoanProductWizardComponent', () => {
     navigate: jest.fn()
   };
 
+  /**
+   * Mirrors how the app itself resolves a key: `app.module` wires this very handler, so a
+   * `labels.catalogs` miss falls back to the bare value — which is what lets a tenant-named currency
+   * or delinquency bucket render as its own name instead of a key. Only the entries these
+   * assertions read are listed; everything else falls through, exactly as en-US.json's identity
+   * mappings do. Constructing the real handler rather than restating its rule keeps the two from
+   * drifting apart.
+   */
+  const missingTranslationHandler = new CustomMissingTranslationHandler();
+  const translations: Record<string, string> = {
+    'labels.buttons.Yes': 'Yes',
+    'labels.buttons.No': 'No',
+    'labels.accounting.Cash': 'Cash'
+  };
   const translateServiceStub = {
-    instant: (key: string) => key
+    instant: (key: string) =>
+      translations[key] ?? missingTranslationHandler.handle({ key } as MissingTranslationHandlerParams)
   };
 
   const settingsServiceStub = {
@@ -1230,13 +1246,13 @@ describe('LoanProductWizardComponent', () => {
 
     it('locks the Personal Loan visible field set', () => {
       expect(visibleKeysByStep(personalComponent())).toEqual({
-        Details: [
+        'labels.heading.Details': [
           'name',
           'shortName',
           'externalId'
         ],
-        Currency: ['currencyCode'],
-        Terms: [
+        'labels.heading.Currency': ['currencyCode'],
+        'labels.heading.Terms': [
           'principal',
           'numberOfRepayments',
           'interestRatePerPeriod',
@@ -1244,7 +1260,7 @@ describe('LoanProductWizardComponent', () => {
           'repaymentEvery',
           'repaymentFrequencyType'
         ],
-        Settings: [
+        'labels.heading.Settings': [
           'amortizationType',
           'interestType',
           'interestCalculationPeriodType',
@@ -1253,7 +1269,7 @@ describe('LoanProductWizardComponent', () => {
           'graceOnInterestPayment',
           'interestFreePeriod'
         ],
-        'Advanced Configuration': []
+        'labels.heading.Advanced Configuration': []
       });
     });
 
@@ -1264,14 +1280,14 @@ describe('LoanProductWizardComponent', () => {
 
     it('locks the Personal Loan visible step sequence', () => {
       expect(personalComponent().visibleSteps.map((step) => step.title)).toEqual([
-        'Details',
-        'Currency',
-        'Terms',
-        'Settings',
-        'Payment Allocation',
-        'Charges',
-        'Accounting',
-        'Review'
+        'labels.heading.Details',
+        'labels.heading.Currency',
+        'labels.heading.Terms',
+        'labels.heading.Settings',
+        'labels.heading.Payment Allocation',
+        'labels.heading.Charges',
+        'labels.heading.Accounting',
+        'labels.buttons.Preview'
       ]);
     });
 
@@ -1280,13 +1296,13 @@ describe('LoanProductWizardComponent', () => {
       // already contains them: Loan Cycle Variations lives inside Classic's Terms step, and the
       // Advanced Configuration fields are Classic's Event Settings block inside its Settings step.
       expect(customAdvancedComponent().visibleSteps.map((step) => step.title)).toEqual([
-        'Details',
-        'Currency',
-        'Terms',
-        'Settings',
-        'Charges',
-        'Accounting',
-        'Review'
+        'labels.heading.Details',
+        'labels.heading.Currency',
+        'labels.heading.Terms',
+        'labels.heading.Settings',
+        'labels.heading.Charges',
+        'labels.heading.Accounting',
+        'labels.buttons.Preview'
       ]);
     });
 
@@ -1363,13 +1379,13 @@ describe('LoanProductWizardComponent', () => {
 
     it('locks the Two Wheeler visible field set: Personal plus the editable down payment %', () => {
       expect(visibleKeysByStep(twoWheelerComponent())).toEqual({
-        Details: [
+        'labels.heading.Details': [
           'name',
           'shortName',
           'externalId'
         ],
-        Currency: ['currencyCode'],
-        Terms: [
+        'labels.heading.Currency': ['currencyCode'],
+        'labels.heading.Terms': [
           'principal',
           'numberOfRepayments',
           'interestRatePerPeriod',
@@ -1377,7 +1393,7 @@ describe('LoanProductWizardComponent', () => {
           'repaymentEvery',
           'repaymentFrequencyType'
         ],
-        Settings: [
+        'labels.heading.Settings': [
           'amortizationType',
           'interestType',
           'interestCalculationPeriodType',
@@ -1388,12 +1404,12 @@ describe('LoanProductWizardComponent', () => {
           'delinquencyBucketId',
           'disbursedAmountPercentageForDownPayment'
         ],
-        'Advanced Configuration': []
+        'labels.heading.Advanced Configuration': []
       });
     });
 
     it('keeps the down payment toggle and auto-repayment flag hidden (forced by the profile)', () => {
-      const settingsKeys = visibleKeysByStep(twoWheelerComponent()).Settings;
+      const settingsKeys = visibleKeysByStep(twoWheelerComponent())['labels.heading.Settings'];
 
       expect(settingsKeys).not.toContain('enableDownPayment');
       expect(settingsKeys).not.toContain('enableAutoRepaymentForDownPayment');
@@ -1401,14 +1417,14 @@ describe('LoanProductWizardComponent', () => {
 
     it('shows the same guided step sequence as Personal, including Payment Allocation', () => {
       expect(twoWheelerComponent().visibleSteps.map((step) => step.title)).toEqual([
-        'Details',
-        'Currency',
-        'Terms',
-        'Settings',
-        'Payment Allocation',
-        'Charges',
-        'Accounting',
-        'Review'
+        'labels.heading.Details',
+        'labels.heading.Currency',
+        'labels.heading.Terms',
+        'labels.heading.Settings',
+        'labels.heading.Payment Allocation',
+        'labels.heading.Charges',
+        'labels.heading.Accounting',
+        'labels.buttons.Preview'
       ]);
     });
 
@@ -1516,13 +1532,13 @@ describe('LoanProductWizardComponent', () => {
 
     it('locks the Education visible field set: the moratorium and tranche controls headline Settings', () => {
       expect(visibleKeysByStep(educationComponent())).toEqual({
-        Details: [
+        'labels.heading.Details': [
           'name',
           'shortName',
           'externalId'
         ],
-        Currency: ['currencyCode'],
-        Terms: [
+        'labels.heading.Currency': ['currencyCode'],
+        'labels.heading.Terms': [
           'principal',
           'numberOfRepayments',
           'interestRatePerPeriod',
@@ -1530,13 +1546,13 @@ describe('LoanProductWizardComponent', () => {
           'repaymentEvery',
           'repaymentFrequencyType'
         ],
-        Settings: [
+        'labels.heading.Settings': [
           'graceOnPrincipalPayment',
           'graceOnInterestPayment',
           'delinquencyBucketId',
           'maxTrancheCount'
         ],
-        'Advanced Configuration': []
+        'labels.heading.Advanced Configuration': []
       });
     });
 
@@ -1545,13 +1561,13 @@ describe('LoanProductWizardComponent', () => {
 
       expect(component.isAdvancedPaymentStrategy).toBe(false);
       expect(component.visibleSteps.map((step) => step.title)).toEqual([
-        'Details',
-        'Currency',
-        'Terms',
-        'Settings',
-        'Charges',
-        'Accounting',
-        'Review'
+        'labels.heading.Details',
+        'labels.heading.Currency',
+        'labels.heading.Terms',
+        'labels.heading.Settings',
+        'labels.heading.Charges',
+        'labels.heading.Accounting',
+        'labels.buttons.Preview'
       ]);
     });
 
@@ -1649,13 +1665,13 @@ describe('LoanProductWizardComponent', () => {
 
     it('locks the Agriculture visible field set: the season terms plus the NPA clock', () => {
       expect(visibleKeysByStep(agricultureComponent())).toEqual({
-        Details: [
+        'labels.heading.Details': [
           'name',
           'shortName',
           'externalId'
         ],
-        Currency: ['currencyCode'],
-        Terms: [
+        'labels.heading.Currency': ['currencyCode'],
+        'labels.heading.Terms': [
           'principal',
           'numberOfRepayments',
           'interestRatePerPeriod',
@@ -1663,11 +1679,11 @@ describe('LoanProductWizardComponent', () => {
           'repaymentEvery',
           'repaymentFrequencyType'
         ],
-        Settings: [
+        'labels.heading.Settings': [
           'delinquencyBucketId',
           'overdueDaysForNPA'
         ],
-        'Advanced Configuration': []
+        'labels.heading.Advanced Configuration': []
       });
     });
 
@@ -1676,13 +1692,13 @@ describe('LoanProductWizardComponent', () => {
 
       expect(component.isAdvancedPaymentStrategy).toBe(false);
       expect(component.visibleSteps.map((step) => step.title)).toEqual([
-        'Details',
-        'Currency',
-        'Terms',
-        'Settings',
-        'Charges',
-        'Accounting',
-        'Review'
+        'labels.heading.Details',
+        'labels.heading.Currency',
+        'labels.heading.Terms',
+        'labels.heading.Settings',
+        'labels.heading.Charges',
+        'labels.heading.Accounting',
+        'labels.buttons.Preview'
       ]);
     });
 
@@ -1829,7 +1845,7 @@ describe('LoanProductWizardComponent', () => {
 
       const review = component.accountingReview;
 
-      expect(review?.ruleLabel).toBe('Cash-based');
+      expect(review?.ruleLabel).toBe('Cash');
       expect(review?.accounts).toEqual([
         { title: 'Fund source', glAccount: { id: 4, name: 'Fund', glCode: '1001' } },
         { title: 'Losses written off', glAccount: { id: 9, name: 'Write off', glCode: '5001' } }
@@ -1983,7 +1999,7 @@ describe('LoanProductWizardComponent', () => {
       expect(component.form.get('transactionProcessingStrategyCode')!.value).toBe(
         LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
       );
-      expect(component.visibleSteps.map((step) => step.title)).toContain('Payment Allocation');
+      expect(component.visibleSteps.map((step) => step.title)).toContain('labels.heading.Payment Allocation');
     });
 
     it('carries a paymentAllocation collection in the submitted payload', () => {
@@ -1995,8 +2011,8 @@ describe('LoanProductWizardComponent', () => {
 
     it('does not render the Interest Refunds or Deferred Income steps (rows 76-78 are Hidden)', () => {
       const titles = homeComponent().visibleSteps.map((step) => step.title);
-      expect(titles).not.toContain('Interest Refunds');
-      expect(titles).not.toContain('Deferred Income Recognition');
+      expect(titles).not.toContain('labels.heading.Interest Refunds');
+      expect(titles).not.toContain('labels.heading.Deferred Income Recognition');
     });
   });
 
@@ -2125,7 +2141,7 @@ describe('LoanProductWizardComponent', () => {
       expect(component.form.get('transactionProcessingStrategyCode')!.value).toBe(
         LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
       );
-      expect(component.visibleSteps.map((step) => step.title)).toContain('Payment Allocation');
+      expect(component.visibleSteps.map((step) => step.title)).toContain('labels.heading.Payment Allocation');
     });
 
     it('carries a populated paymentAllocation collection in the submitted payload', () => {
@@ -2149,8 +2165,8 @@ describe('LoanProductWizardComponent', () => {
 
     it('does not render the Interest Refunds or Deferred Income steps (rows 76-78 are Hidden)', () => {
       const titles = goldComponent().visibleSteps.map((step) => step.title);
-      expect(titles).not.toContain('Interest Refunds');
-      expect(titles).not.toContain('Deferred Income Recognition');
+      expect(titles).not.toContain('labels.heading.Interest Refunds');
+      expect(titles).not.toContain('labels.heading.Deferred Income Recognition');
     });
   });
 
@@ -2281,7 +2297,7 @@ describe('LoanProductWizardComponent', () => {
       expect(component.form.get('transactionProcessingStrategyCode')!.value).toBe(
         LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
       );
-      expect(component.visibleSteps.map((step) => step.title)).toContain('Payment Allocation');
+      expect(component.visibleSteps.map((step) => step.title)).toContain('labels.heading.Payment Allocation');
     });
 
     it('carries a populated paymentAllocation collection in the submitted payload', () => {
@@ -2305,8 +2321,8 @@ describe('LoanProductWizardComponent', () => {
 
     it('does not render the Interest Refunds or Deferred Income steps (rows 76-78 are Hidden)', () => {
       const titles = autoComponent().visibleSteps.map((step) => step.title);
-      expect(titles).not.toContain('Interest Refunds');
-      expect(titles).not.toContain('Deferred Income Recognition');
+      expect(titles).not.toContain('labels.heading.Interest Refunds');
+      expect(titles).not.toContain('labels.heading.Deferred Income Recognition');
     });
   });
 
@@ -2367,10 +2383,14 @@ describe('LoanProductWizardComponent', () => {
 
     it('renders the Loan Cycle Variations step, gated on useBorrowerCycle like Classic', () => {
       const component = jlgComponent();
-      expect(component.visibleSteps.map((step) => step.title)).toContain('Loan Cycle Variations');
+      expect(component.visibleSteps.map((step) => step.title)).toContain(
+        'labels.inputs.Terms vary based on loan cycle'
+      );
 
       component.form.get('useBorrowerCycle')!.setValue(false);
-      expect(component.visibleSteps.map((step) => step.title)).not.toContain('Loan Cycle Variations');
+      expect(component.visibleSteps.map((step) => step.title)).not.toContain(
+        'labels.inputs.Terms vary based on loan cycle'
+      );
     });
 
     it('does not render the step for any other profile', () => {
@@ -2381,7 +2401,7 @@ describe('LoanProductWizardComponent', () => {
       gold.ngOnInit();
       gold.form.get('useBorrowerCycle')?.setValue(true);
 
-      expect(gold.visibleSteps.map((step) => step.title)).not.toContain('Loan Cycle Variations');
+      expect(gold.visibleSteps.map((step) => step.title)).not.toContain('labels.inputs.Terms vary based on loan cycle');
     });
 
     it('folds the collected variation rows into the submitted payload', () => {
@@ -2441,7 +2461,7 @@ describe('LoanProductWizardComponent', () => {
       expect(component.form.get('transactionProcessingStrategyCode')!.value).toBe(
         LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
       );
-      expect(component.visibleSteps.map((step) => step.title)).toContain('Payment Allocation');
+      expect(component.visibleSteps.map((step) => step.title)).toContain('labels.heading.Payment Allocation');
     });
 
     it('carries a populated paymentAllocation collection in the submitted payload', () => {
@@ -2572,7 +2592,7 @@ describe('LoanProductWizardComponent', () => {
       expect(component.form.get('transactionProcessingStrategyCode')!.value).toBe(
         LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
       );
-      expect(component.visibleSteps.map((step) => step.title)).toContain('Payment Allocation');
+      expect(component.visibleSteps.map((step) => step.title)).toContain('labels.heading.Payment Allocation');
     });
 
     it('carries a populated paymentAllocation collection in the submitted payload', () => {
@@ -2591,8 +2611,8 @@ describe('LoanProductWizardComponent', () => {
 
     it('does not render the Interest Refunds or Deferred Income steps (rows 76-78 are Hidden)', () => {
       const titles = consumerDurableComponent().visibleSteps.map((step) => step.title);
-      expect(titles).not.toContain('Interest Refunds');
-      expect(titles).not.toContain('Deferred Income Recognition');
+      expect(titles).not.toContain('labels.heading.Interest Refunds');
+      expect(titles).not.toContain('labels.heading.Deferred Income Recognition');
     });
   });
 
@@ -2684,8 +2704,8 @@ describe('LoanProductWizardComponent', () => {
     it('renders the Interest Refund step but not the Deferred Income one', () => {
       // The defining structural difference from BNPL, which renders both.
       const titles = cardComponent().visibleSteps.map((step) => step.title);
-      expect(titles).toContain('Interest Refunds');
-      expect(titles).not.toContain('Deferred Income Recognition');
+      expect(titles).toContain('labels.heading.Interest Refunds');
+      expect(titles).not.toContain('labels.heading.Deferred Income Recognition');
     });
 
     it('hides the Interest Refund step when the strategy is not advanced payment allocation', () => {
@@ -2693,7 +2713,7 @@ describe('LoanProductWizardComponent', () => {
       const component = cardComponent();
       component.form.get('transactionProcessingStrategyCode')!.setValue('mifos-standard-strategy');
 
-      expect(component.visibleSteps.map((step) => step.title)).not.toContain('Interest Refunds');
+      expect(component.visibleSteps.map((step) => step.title)).not.toContain('labels.heading.Interest Refunds');
     });
 
     it('gates the over-applied pair on its toggle, like Classic', () => {
@@ -2722,7 +2742,7 @@ describe('LoanProductWizardComponent', () => {
       expect(component.form.get('transactionProcessingStrategyCode')!.value).toBe(
         LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
       );
-      expect(component.visibleSteps.map((step) => step.title)).toContain('Payment Allocation');
+      expect(component.visibleSteps.map((step) => step.title)).toContain('labels.heading.Payment Allocation');
     });
 
     it('carries a populated paymentAllocation collection in the submitted payload', () => {
@@ -2854,7 +2874,7 @@ describe('LoanProductWizardComponent', () => {
       expect(component.form.get('transactionProcessingStrategyCode')!.value).toBe(
         LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
       );
-      expect(component.visibleSteps.map((step) => step.title)).toContain('Payment Allocation');
+      expect(component.visibleSteps.map((step) => step.title)).toContain('labels.heading.Payment Allocation');
     });
 
     it('carries a populated paymentAllocation collection in the submitted payload', () => {
@@ -2873,8 +2893,8 @@ describe('LoanProductWizardComponent', () => {
 
     it('does not render the Interest Refunds or Deferred Income steps (rows 76-78 are Hidden)', () => {
       const titles = lasComponent().visibleSteps.map((step) => step.title);
-      expect(titles).not.toContain('Interest Refunds');
-      expect(titles).not.toContain('Deferred Income Recognition');
+      expect(titles).not.toContain('labels.heading.Interest Refunds');
+      expect(titles).not.toContain('labels.heading.Deferred Income Recognition');
     });
   });
 
@@ -2957,16 +2977,16 @@ describe('LoanProductWizardComponent', () => {
 
     it('renders the highlighted Interest Refunds and Deferred Income groups as reused Classic steps', () => {
       const titles = bnplComponent().visibleSteps.map((step) => step.title);
-      expect(titles).toContain('Interest Refunds');
-      expect(titles).toContain('Deferred Income Recognition');
+      expect(titles).toContain('labels.heading.Interest Refunds');
+      expect(titles).toContain('labels.heading.Deferred Income Recognition');
     });
 
     it('hides both reused steps when the strategy is not advanced payment allocation, like Classic', () => {
       const component = bnplComponent();
       component.form.patchValue({ transactionProcessingStrategyCode: 'mifos-standard-strategy' });
       const titles = component.visibleSteps.map((step) => step.title);
-      expect(titles).not.toContain('Interest Refunds');
-      expect(titles).not.toContain('Deferred Income Recognition');
+      expect(titles).not.toContain('labels.heading.Interest Refunds');
+      expect(titles).not.toContain('labels.heading.Deferred Income Recognition');
     });
 
     it('gates the over-applied pair on its toggle, with Classic validators and payload exclusion', () => {

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
@@ -582,7 +582,7 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
         //     renders them inline under `useBorrowerCycle`.
         //   - Advanced Configuration: Classic's Settings step owns the same Event Settings block
         //     (`useDueForRepaymentsConfigurations` plus the due / overdue day inputs).
-        if (step.kind === 'borrower-cycle' || step.title === 'Advanced Configuration') {
+        if (step.kind === 'borrower-cycle' || step.title === 'labels.heading.Advanced Configuration') {
           return false;
         }
       }
@@ -1523,6 +1523,35 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
     };
   }
 
+  /**
+   * Renders a Review value with the same words the control showed.
+   *
+   * Selects are translated through `labels.catalogs`, the namespace Classic pipes every enum value
+   * through, so guided and Classic name a value identically. Labels with no catalogs entry — the
+   * tenant's own currency and delinquency-bucket names, which only the backend can supply — come back
+   * unchanged, because `CustomMissingTranslationHandler` strips the `labels.catalogs.` prefix and
+   * returns the rest. Booleans read from `labels.buttons`, the pair the shared `yesNo` pipe uses.
+   *
+   * `namespace` names a bundle to prefer over `labels.catalogs` — accounting rules live in
+   * `labels.accounting`, which is where Classic's accounting step reads them from. The handler only
+   * rescues the catalogs prefix, so a miss in any other namespace would surface as a raw key; the
+   * lookup therefore falls back to catalogs rather than trusting it. That is not hypothetical here:
+   * `labels.accounting` carries Cash and both Accrual rules but no 'None', which catalogs does have.
+   */
+  private translateDisplayLabel(label: string, namespace?: 'accounting'): string {
+    if (label === 'Yes' || label === 'No') {
+      return this.translateService.instant(`labels.buttons.${label}`);
+    }
+    if (namespace) {
+      const namespacedKey = `labels.${namespace}.${label}`;
+      const translated = this.translateService.instant(namespacedKey);
+      if (translated !== namespacedKey) {
+        return translated;
+      }
+    }
+    return this.translateService.instant(`labels.catalogs.${label}`);
+  }
+
   formatValue(key: string, val: unknown): string {
     if (val === '' || val === null || val === undefined) {
       return '—';
@@ -1540,7 +1569,7 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
         (option) => String(option.value) === String(normalizedValue)
       )?.label;
       if (currencyLabel) {
-        return String(currencyLabel);
+        return this.translateDisplayLabel(String(currencyLabel));
       }
     }
 
@@ -1548,12 +1577,12 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
     if (map) {
       const result = map[String(normalizedValue)];
       if (result !== undefined) {
-        return result;
+        return this.translateDisplayLabel(result, key === 'accountingRule' ? 'accounting' : undefined);
       }
     }
 
     if (typeof normalizedValue === 'boolean') {
-      return normalizedValue ? 'Yes' : 'No';
+      return this.translateDisplayLabel(normalizedValue ? 'Yes' : 'No');
     }
 
     if (normalizedValue instanceof Date) {
@@ -1595,7 +1624,7 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
           ...options,
           {
             value: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY,
-            label: this.translateService.instant('Advanced payment allocation strategy')
+            label: 'Advanced payment allocation strategy'
           }
         ];
 
@@ -1620,7 +1649,7 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
     const matchingOption = this.getTransactionProcessingStrategyOptions().find(
       (option: SelectOption) => option.value === code
     );
-    return matchingOption?.label ?? code;
+    return matchingOption ? this.translateDisplayLabel(String(matchingOption.label)) : code;
   }
 
   private normalizeValueForDisplay(val: unknown): unknown {
@@ -1716,12 +1745,12 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
       return '—';
     }
     if (field.type === 'checkbox') {
-      return value ? 'Yes' : 'No';
+      return this.translateDisplayLabel(value ? 'Yes' : 'No');
     }
     if (field.type === 'select' && field.options) {
       const match = field.options.find((option) => String(option.value) === String(value));
       if (match) {
-        return String(match.label);
+        return this.translateDisplayLabel(String(match.label));
       }
     }
     return String(value);

--- a/src/app/products/loan-products/wizard/loan-product-wizard.render.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.render.spec.ts
@@ -14,6 +14,8 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { FontAwesomeTestingModule } from '@fortawesome/angular-fontawesome/testing';
+import { MissingTranslationHandler } from '@ngx-translate/core';
+import { CustomMissingTranslationHandler } from 'app/core/translation/missing-translation.handler';
 
 import { LoanProductWizardComponent } from './loan-product-wizard.component';
 import { LoanProducts } from '../loan-products';
@@ -41,7 +43,12 @@ describe('LoanProductWizardComponent (rendered)', () => {
       imports: [
         LoanProductWizardComponent,
         NoopAnimationsModule,
-        TranslateModule.forRoot(),
+        TranslateModule.forRoot({
+          // The wizard chrome leans on the app's own fallback rule: a `labels.catalogs` key the
+          // bundles do not carry renders as the bare value. Registering the real handler is what
+          // makes the option-label assertions below mean anything.
+          missingTranslationHandler: { provide: MissingTranslationHandler, useClass: CustomMissingTranslationHandler }
+        }),
         // The wizard chrome renders <fa-icon>s; the testing module stubs them out.
         FontAwesomeTestingModule
       ],
@@ -152,6 +159,44 @@ describe('LoanProductWizardComponent (rendered)', () => {
    * an interpolated value, so those assertions need the resolved string — the key alone would prove
    * neither. Values here mirror en-US.json.
    */
+  /**
+   * The chrome's own keys: step headers and the enum values the selects render. Only the entries the
+   * assertions below read are loaded — `labels.catalogs` is deliberately given just two of them, so
+   * the tenant-named values (the KES currency) exercise the fallback instead of a translation.
+   * Values mirror en-US.json.
+   */
+  function loadChromeCopy(): void {
+    const translate = TestBed.inject(TranslateService);
+    translate.setTranslation(
+      'en',
+      {
+        labels: {
+          heading: {
+            Details: 'Details',
+            Currency: 'Currency',
+            Terms: 'Terms',
+            Settings: 'Settings',
+            Charges: 'Charges',
+            Accounting: 'Accounting',
+            'Payment Allocation': 'Payment Allocation',
+            'Interest Refunds': 'Interest Refunds',
+            'Deferred Income Recognition': 'Deferred Income Recognition',
+            'Advanced Configuration': 'Advanced Configuration'
+          },
+          inputs: { 'Terms vary based on loan cycle': 'Terms vary based on loan cycle' },
+          text: { 'max 4 chars': 'no more than 4 characters' },
+          buttons: { Preview: 'Preview', Yes: 'Yes', No: 'No' },
+          // Deliberately NOT the English these keys carry in en-US.json: a value that matched its own
+          // key would pass whether or not the template pipes it, which is exactly the hole these
+          // assertions exist to close.
+          catalogs: { 'Per month': 'Monthly rate', 'Declining Balance': 'Reducing balance' }
+        }
+      },
+      true
+    );
+    translate.use('en');
+  }
+
   function loadValidationCopy(): void {
     const translate = TestBed.inject(TranslateService);
     translate.setTranslation(
@@ -263,7 +308,7 @@ describe('LoanProductWizardComponent (rendered)', () => {
       expect(summary()).not.toBeNull();
       // Details owns the required, empty `name`, so it must be named. The wording of the whole list is
       // not pinned here — which other steps start incomplete is a property of the profile config.
-      expect(listedSteps()).toContain('Details');
+      expect(listedSteps()).toContain('labels.heading.Details');
     });
 
     it('announces the summary to a screen reader', () => {
@@ -284,10 +329,10 @@ describe('LoanProductWizardComponent (rendered)', () => {
     it('jumps the stepper to a step named in the summary', () => {
       clickCreate();
 
-      const details = component.incompleteGuidedSteps.find((step) => step.title === 'Details')!;
+      const details = component.incompleteGuidedSteps.find((step) => step.title === 'labels.heading.Details')!;
       const detailsButton = Array.from(
         fixture.nativeElement.querySelectorAll('.submit-blocked__step') as NodeListOf<HTMLButtonElement>
-      ).find((button) => button.textContent!.trim() === 'Details')!;
+      ).find((button) => button.textContent!.trim() === 'labels.heading.Details')!;
 
       detailsButton.click();
       detect();
@@ -313,14 +358,14 @@ describe('LoanProductWizardComponent (rendered)', () => {
 
     it('drops a step from the list once its fields are filled', () => {
       clickCreate();
-      expect(listedSteps()).toContain('Details');
+      expect(listedSteps()).toContain('labels.heading.Details');
 
       // Every visible Details control that is currently invalid — the step is only listed because one
       // of its own fields is, so satisfying them all must remove it and leave the rest of the list.
       // Details is all text/date/checkbox, and its two required controls are `name` and `shortName`;
       // the filler is kept inside `shortName`'s 4-character limit so it satisfies rather than trades
       // one error for another.
-      const detailsStep = component.visibleSteps.find((step) => step.title === 'Details')!;
+      const detailsStep = component.visibleSteps.find((step) => step.title === 'labels.heading.Details')!;
       component.visibleFields(detailsStep).forEach((field) => {
         const control = component.form.get(field.key)!;
         if (control.invalid) {
@@ -331,7 +376,7 @@ describe('LoanProductWizardComponent (rendered)', () => {
 
       expect(component.visibleFields(detailsStep).every((field) => component.form.get(field.key)!.valid)).toBe(true);
 
-      expect(listedSteps()).not.toContain('Details');
+      expect(listedSteps()).not.toContain('labels.heading.Details');
       expect(summary()).not.toBeNull();
     });
   });
@@ -374,5 +419,72 @@ describe('LoanProductWizardComponent (rendered)', () => {
     // `layout-row`/`margin-t` classes the rule is written to match.
     const embeddedNav = fixture.nativeElement.querySelector('.wizard-accounting .layout-row.margin-t');
     expect(embeddedNav).not.toBeNull();
+  });
+
+  /**
+   * I1: the wizard chrome bypassed i18n. Field labels and placeholders were keys, but everything
+   * around them — the step headers, the select options, the field hints, the Review's section titles
+   * and its Yes/No — was raw English hardcoded in the config, so a non-English operator got a
+   * half-translated form. These are DOM-level because the defect is what the template does with the
+   * string, which the `new LoanProductWizardComponent()` specs cannot see.
+   */
+  describe('translated wizard chrome', () => {
+    beforeEach(() => {
+      loadChromeCopy();
+      detect();
+    });
+
+    it('translates the step headers', () => {
+      const headers = Array.from(
+        fixture.nativeElement.querySelectorAll('.mat-step-label') as NodeListOf<HTMLElement>
+      ).map((header) => header.textContent!.trim());
+
+      expect(headers).toContain('Details');
+      expect(headers).toContain('Currency');
+      // The last step is Classic's Preview, named from the key Classic already ships translated.
+      expect(headers).toContain('Preview');
+      // A raw key reaching the header is the exact defect; none may survive.
+      expect(headers.some((header) => header.startsWith('labels.'))).toBe(false);
+    });
+
+    /**
+     * `mat-select` renders its options lazily, into the CDK overlay attached to the document body —
+     * so they exist nowhere until the trigger is clicked, and never inside the fixture's own element.
+     */
+    function openedOptions(labelKey: string): string[] {
+      (fieldByLabel(labelKey).querySelector('.mat-mdc-select-trigger') as HTMLElement).click();
+      detect();
+      return Array.from(document.querySelectorAll('mat-option') as NodeListOf<HTMLElement>).map((option) =>
+        option.textContent!.trim()
+      );
+    }
+
+    it('translates select options through the catalogs namespace', () => {
+      expect(openedOptions('labels.inputs.Interest rate frequency')).toContain('Monthly rate');
+    });
+
+    it('shows a tenant-named option as its own name rather than a key', () => {
+      // The other half of the catalogs rule: 'Kenyan Shilling' is the tenant's currency, named by the
+      // backend, and no bundle can carry a key for it. Without the fallback this select would read
+      // 'labels.catalogs.Kenyan Shilling' — a worse result than the untranslated string it replaced.
+      expect(openedOptions('labels.inputs.CURRENCY')).toContain('Kenyan Shilling');
+    });
+
+    it('translates the field hint', () => {
+      const hint = fieldByLabel('labels.inputs.Short Name').querySelector('mat-hint');
+
+      expect(hint!.textContent!.trim()).toBe('no more than 4 characters');
+    });
+
+    it('translates a checkbox value in the Review', () => {
+      // `formatFieldValue` returned the literals 'Yes'/'No' from TypeScript, where no pipe could reach
+      // them; they now resolve through `labels.buttons`, the pair the shared `yesNo` pipe uses.
+      expect(component.formatValue('canUseForTopup', true)).toBe('Yes');
+      expect(component.formatValue('canUseForTopup', false)).toBe('No');
+    });
+
+    it('names an enum value in the Review the way Classic names it', () => {
+      expect(component.formatValue('interestType', 0)).toBe('Reducing balance');
+    });
   });
 });

--- a/src/app/products/loan-products/wizard/loan-product.config.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product.config.spec.ts
@@ -14,6 +14,8 @@ import {
   PROFILE_EXTRA_VISIBLE_FIELDS,
   PROFILE_INITIAL_OVERRIDES,
   PROFILE_LABEL_KEYS,
+  FORM_STEPS,
+  VALUE_MAP,
   buildPayload,
   dropsDisabledOverAppliedFields,
   hiddenDefaultsFor,
@@ -2935,5 +2937,66 @@ describe('loan-product.config profile invariants', () => {
 
     expect(new Set(descriptions).size).toBe(guided.length);
     expect(descriptions.every((description) => typeof description === 'string' && description !== '')).toBe(true);
+  });
+});
+
+describe('loan-product.config translation keys', () => {
+  /**
+   * I1. The two halves of the config address the translator differently, and mixing them up is
+   * silent: a field `label`/`placeholder`/`hint` is a full key rendered with the `translate` pipe,
+   * while a select option's `label` is Fineract's own enum value, rendered with
+   * `translateKey: 'catalogs'` — which prefixes it. Put a full key in an option and the prefixed
+   * lookup misses, `CustomMissingTranslationHandler` strips only `labels.catalogs.`, and the
+   * operator reads `labels.inputs.…` off the dropdown. Two option labels were exactly that.
+   */
+  it('never uses a full translation key as a select option label', () => {
+    const offenders = FORM_STEPS.flatMap((step) =>
+      step.fields.flatMap((field) =>
+        (field.options ?? [])
+          .filter((option) => String(option.label).startsWith('labels.'))
+          .map((option) => `${field.key}: ${option.label}`)
+      )
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('addresses every step header and field hint by a full translation key', () => {
+    // The mirror of the rule above: these DO go through the plain `translate` pipe, so a bare English
+    // string here renders as itself in all 13 locales — the defect I1 names.
+    const offenders = FORM_STEPS.flatMap((step) => [
+      ...(step.title.startsWith('labels.') ? [] : [`step ${step.id}: ${step.title}`]),
+      ...step.fields
+        .filter((field) => field.hint && !field.hint.startsWith('labels.'))
+        .map((field) => `${field.key} hint: ${field.hint}`)
+    ]);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('names a value the same way in the control and in the Review', () => {
+    // VALUE_MAP is the Review's copy of the same enum wording the select shows, and the two are
+    // translated by the same `labels.catalogs` lookup — so a casing drift between them does not just
+    // read oddly, it misses the catalogs key and falls back to untranslated English on the Review
+    // only. `repaymentStartDateType` did exactly that: the option said 'Disbursement Date' while the
+    // map still said 'Disbursement date', and only the capitalised spelling is a catalogs key.
+    const offenders = FORM_STEPS.flatMap((step) =>
+      step.fields.flatMap((field) => {
+        const map = VALUE_MAP[field.key];
+        if (!map) {
+          return [];
+        }
+        return (field.options ?? [])
+          .filter((option) => {
+            const mapped = map[String(option.value)];
+            return mapped !== undefined && mapped !== String(option.label);
+          })
+          .map(
+            (option) => `${field.key}[${option.value}]: option '${option.label}' vs map '${map[String(option.value)]}'`
+          );
+      })
+    );
+
+    expect(offenders).toEqual([]);
   });
 });

--- a/src/app/products/loan-products/wizard/loan-product.config.ts
+++ b/src/app/products/loan-products/wizard/loan-product.config.ts
@@ -338,17 +338,17 @@ export const VALUE_MAP: Record<string, Record<string, string>> = {
   interestRateFrequencyType: { '2': 'Per month', '3': 'Per year' },
   repaymentFrequencyType: { '0': 'Days', '1': 'Weeks', '2': 'Months' },
   amortizationType: { '0': 'Equal principal payments', '1': 'Equal installments' },
-  interestType: { '0': 'Declining balance', '1': 'Flat' },
+  interestType: { '0': 'Declining Balance', '1': 'Flat' },
   interestCalculationPeriodType: { '0': 'Daily', '1': 'Same as repayment period' },
-  daysInYearType: { '1': 'Actual', '360': '360 days', '364': '364 days', '365': '365 days' },
-  daysInMonthType: { '1': 'Same as in year', '30': '30 days' },
-  accountingRule: { '1': 'None', '2': 'Cash-based', '3': 'Accrual (periodic)', '4': 'Accrual (upfront)' },
+  daysInYearType: { '1': 'Actual', '360': '360 Days', '364': '364 Days', '365': '365 Days' },
+  daysInMonthType: { '1': 'Actual', '30': '30 Days' },
+  accountingRule: { '1': 'None', '2': 'Cash', '3': 'Accrual (periodic)', '4': 'Accrual (upfront)' },
   currencyCode: { INR: 'Indian Rupee (₹)', USD: 'US Dollar ($)', EUR: 'Euro (€)', GBP: 'British Pound (£)' },
   transactionProcessingStrategyCode: {
-    'interest-principal-penalties-fees-order-strategy': 'Interest → Principal → Penalties → Fees',
-    'principal-interest-penalties-fees-order-strategy': 'Principal → Interest → Penalties → Fees',
-    'mifos-standard-strategy': 'Mifos standard',
-    'early-repayment-strategy': 'Early repayment'
+    'interest-principal-penalties-fees-order-strategy': 'Interest, Principal, Penalties, Fees Order',
+    'principal-interest-penalties-fees-order-strategy': 'Principal, Interest, Penalties, Fees Order',
+    'mifos-standard-strategy': 'Penalties, Fees, Interest, Principal order',
+    'early-repayment-strategy': 'Early Repayment Strategy'
   },
   canUseForTopup: { true: 'Yes', false: 'No' },
   isInterestRecalculationEnabled: { true: 'Enabled', false: 'Disabled' },
@@ -368,7 +368,7 @@ export const VALUE_MAP: Record<string, Record<string, string>> = {
   isLinkedToFloatingInterestRates: { true: 'Yes', false: 'No' },
   allowApprovedDisbursedAmountsOverApplied: { true: 'Yes', false: 'No' },
   interestRecognitionOnDisbursementDate: { true: 'Yes', false: 'No' },
-  repaymentStartDateType: { '1': 'Disbursement date' },
+  repaymentStartDateType: { '1': 'Disbursement Date' },
   accountMovesOutOfNPAOnlyOnArrearsCompletion: { true: 'Yes', false: 'No' },
   holdGuaranteeFunds: { true: 'Yes', false: 'No' },
   disallowExpectedDisbursements: { true: 'Yes', false: 'No' },
@@ -405,7 +405,7 @@ export const DELINQUENCY_BUCKET_NONE_OPTION: SelectOption = { value: '', label: 
 export const FORM_STEPS: FormStep[] = [
   {
     id: 1,
-    title: 'Details',
+    title: 'labels.heading.Details',
     classicStep: 'details',
     icon: 'ti-id',
     fields: [
@@ -424,7 +424,7 @@ export const FORM_STEPS: FormStep[] = [
         required: true,
         placeholder: 'labels.placeholders.Example short name',
         maxLength: 4,
-        hint: 'max 4 chars'
+        hint: 'labels.text.max 4 chars'
       },
       {
         label: 'labels.inputs.External ID',
@@ -456,7 +456,7 @@ export const FORM_STEPS: FormStep[] = [
   },
   {
     id: 2,
-    title: 'Currency',
+    title: 'labels.heading.Currency',
     classicStep: 'currency',
     icon: 'ti-currency-dollar',
     fields: [
@@ -498,7 +498,7 @@ export const FORM_STEPS: FormStep[] = [
   },
   {
     id: 3,
-    title: 'Terms',
+    title: 'labels.heading.Terms',
     classicStep: 'terms',
     icon: 'ti-calculator',
     fields: [
@@ -599,7 +599,7 @@ export const FORM_STEPS: FormStep[] = [
         label: 'labels.inputs.Repayment start date type',
         key: 'repaymentStartDateType',
         type: 'select',
-        options: [{ value: 1, label: 'Disbursement date' }]
+        options: [{ value: 1, label: 'Disbursement Date' }]
       }
     ]
   },
@@ -614,14 +614,14 @@ export const FORM_STEPS: FormStep[] = [
     // renders the same block inside its Terms step. Declaration order is what `visibleSteps`
     // preserves, so this is what fixes the operator-facing ordering.
     id: 12,
-    title: 'Loan Cycle Variations',
+    title: 'labels.inputs.Terms vary based on loan cycle',
     icon: 'ti-repeat',
     kind: 'borrower-cycle',
     fields: []
   },
   {
     id: 4,
-    title: 'Settings',
+    title: 'labels.heading.Settings',
     classicStep: 'settings',
     icon: 'ti-settings',
     fields: [
@@ -641,7 +641,7 @@ export const FORM_STEPS: FormStep[] = [
         type: 'select',
         required: true,
         options: [
-          { value: 0, label: 'Declining balance' },
+          { value: 0, label: 'Declining Balance' },
           { value: 1, label: 'Flat' }
         ]
       },
@@ -681,16 +681,20 @@ export const FORM_STEPS: FormStep[] = [
         type: 'select',
         required: true,
         options: [
+          // Fineract's own names for these strategies, which is what the backend template supplies
+          // and what `labels.catalogs` is keyed by. They were full translation keys, from before the
+          // options were rendered through the catalogs namespace — a key here now resolves to itself
+          // and puts `labels.inputs.…` on screen.
           {
             value: 'interest-principal-penalties-fees-order-strategy',
-            label: 'labels.inputs.Interest → Principal → Penalties → Fees'
+            label: 'Interest, Principal, Penalties, Fees Order'
           },
           {
             value: 'principal-interest-penalties-fees-order-strategy',
-            label: 'labels.inputs.Principal → Interest → Penalties → Fees'
+            label: 'Principal, Interest, Penalties, Fees Order'
           },
-          { value: 'mifos-standard-strategy', label: 'Mifos standard' },
-          { value: 'early-repayment-strategy', label: 'Early repayment' }
+          { value: 'mifos-standard-strategy', label: 'Penalties, Fees, Interest, Principal order' },
+          { value: 'early-repayment-strategy', label: 'Early Repayment Strategy' }
         ]
       },
       {
@@ -729,9 +733,9 @@ export const FORM_STEPS: FormStep[] = [
         type: 'select',
         options: [
           { value: 1, label: 'Actual' },
-          { value: 360, label: '360 days' },
-          { value: 364, label: '364 days' },
-          { value: 365, label: '365 days' }
+          { value: 360, label: '360 Days' },
+          { value: 364, label: '364 Days' },
+          { value: 365, label: '365 Days' }
         ]
       },
       {
@@ -751,8 +755,8 @@ export const FORM_STEPS: FormStep[] = [
         key: 'daysInMonthType',
         type: 'select',
         options: [
-          { value: 1, label: 'Same as in year' },
-          { value: 30, label: '30 days' }
+          { value: 1, label: 'Actual' },
+          { value: 30, label: '30 Days' }
         ]
       },
       {
@@ -1022,7 +1026,7 @@ export const FORM_STEPS: FormStep[] = [
     // Reuses the Classic Payment Allocation UI (see loan-product-wizard.component.html). Carries no
     // config-driven fields; visibility is driven by the selected repayment strategy in the component.
     id: 9,
-    title: 'Payment Allocation',
+    title: 'labels.heading.Payment Allocation',
     icon: 'ti-arrows-sort',
     kind: 'payment-allocation',
     fields: []
@@ -1033,7 +1037,7 @@ export const FORM_STEPS: FormStep[] = [
     // — identical dropdowns, filters and payload as Classic — instead of free-text names. The selected
     // full charge objects are folded into the backend `charges` array by `buildChargeReferences`.
     id: 5,
-    title: 'Charges',
+    title: 'labels.heading.Charges',
     icon: 'ti-coin',
     kind: 'charges',
     fields: []
@@ -1046,7 +1050,7 @@ export const FORM_STEPS: FormStep[] = [
     // in buildPayloadForSubmit, mirroring Classic's `...loanProductAccountingStep.loanProductAccounting`
     // spread, so Cash / Accrual (periodic) / Accrual (upfront) all send every required account id.
     id: 6,
-    title: 'Accounting',
+    title: 'labels.heading.Accounting',
     icon: 'ti-report',
     kind: 'accounting',
     fields: []
@@ -1057,7 +1061,7 @@ export const FORM_STEPS: FormStep[] = [
     // strategy, which is the same gate Classic applies, so the wizard shows this step under exactly
     // that condition (see `visibleSteps`).
     id: 10,
-    title: 'Interest Refunds',
+    title: 'labels.heading.Interest Refunds',
     icon: 'ti-receipt-refund',
     kind: 'interest-refund',
     fields: []
@@ -1071,14 +1075,14 @@ export const FORM_STEPS: FormStep[] = [
     // add/removeControl logic and `Validators.required`, so the conditional behaviour is reused
     // rather than reimplemented.
     id: 11,
-    title: 'Deferred Income Recognition',
+    title: 'labels.heading.Deferred Income Recognition',
     icon: 'ti-cash-banknote',
     kind: 'deferred-income',
     fields: []
   },
   {
     id: 7,
-    title: 'Advanced Configuration',
+    title: 'labels.heading.Advanced Configuration',
     icon: 'ti-panel',
     fields: [
       {
@@ -1102,7 +1106,7 @@ export const FORM_STEPS: FormStep[] = [
       }
     ]
   },
-  { id: 8, title: 'Review', icon: 'ti-eye', kind: 'review', fields: [] }
+  { id: 8, title: 'labels.buttons.Preview', icon: 'ti-eye', kind: 'review', fields: [] }
 ];
 
 export const INITIAL_FORM_STATE: Record<string, string | number | boolean | null> = {

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1112,7 +1112,9 @@
       "transaction_loan": "Transakce Půjčky",
       "transaction_savings": "Transakce Úspor",
       "unmarried": "svobodný",
-      "xbrlmapping": "XBRL Mapování"
+      "xbrlmapping": "XBRL Mapování",
+      "Enabled": "Povoleno",
+      "Disabled": "Zakázáno"
     },
     "commons": {
       "50 characters long": "50 znaků dlouhé",
@@ -1802,7 +1804,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Prohlášení konečných skutečných majitelů - právnické osoby",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Prohlášení konečných skutečných majitelů - fyzické osoby",
       "Recovery": "Vymáhání",
-      "Upload Report Design": "Nahrát návrh zprávy"
+      "Upload Report Design": "Nahrát návrh zprávy",
+      "Payment Allocation": "Přidělení platby",
+      "Interest Refunds": "Vrácení úroku",
+      "Deferred Income Recognition": "Vykazování odložených výnosů",
+      "Advanced Configuration": "Pokročilá konfigurace"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Účet opustí NPA až po uhrazení všech nedoplatků",
@@ -5003,7 +5009,8 @@
       "The selected report design is too large": "Vybraný návrh zprávy je větší než 5 MB.",
       "Report design uploaded": "Návrh zprávy {{fileName}} byl nahrán.",
       "Report design replaced": "Návrh zprávy {{fileName}} byl nahrazen.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "max. 4 znaky"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1113,7 +1113,9 @@
       "transaction_loan": "Darlehenstransaktionen",
       "transaction_savings": "Spartransaktionen",
       "unmarried": "unverheiratet",
-      "xbrlmapping": "XBRL Zuordnung"
+      "xbrlmapping": "XBRL Zuordnung",
+      "Enabled": "Ermöglicht",
+      "Disabled": "Deaktiviert"
     },
     "commons": {
       "50 characters long": "50 Zeichen lang",
@@ -1803,7 +1805,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Erklärung der wirtschaftlich Berechtigten - juristische Personen",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Erklärung der wirtschaftlich Berechtigten - natürliche Personen",
       "Recovery": "Einbringung",
-      "Upload Report Design": "Berichtsdesign hochladen"
+      "Upload Report Design": "Berichtsdesign hochladen",
+      "Payment Allocation": "Zahlungsverteilung",
+      "Interest Refunds": "Zinsrückerstattung",
+      "Deferred Income Recognition": "Erfassung abgegrenzter Erträge",
+      "Advanced Configuration": "Erweiterte Konfiguration"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Konto verlässt NPA erst nach Ausgleich aller Rückstände",
@@ -5003,7 +5009,8 @@
       "The selected report design is too large": "Das ausgewählte Berichtsdesign ist größer als 5 MB.",
       "Report design uploaded": "Berichtsdesign {{fileName}} wurde hochgeladen.",
       "Report design replaced": "Berichtsdesign {{fileName}} wurde ersetzt.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "max. 4 Zeichen"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -1119,7 +1119,9 @@
       "transaction_loan": "Loan Transactions",
       "transaction_savings": "Savings Transactions",
       "unmarried": "unmarried",
-      "xbrlmapping": "XBRL Mapping"
+      "xbrlmapping": "XBRL Mapping",
+      "Enabled": "Enabled",
+      "Disabled": "Disabled"
     },
     "commons": {
       "50 characters long": "50 characters long",
@@ -1815,7 +1817,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Declaration of Ultimate Beneficial Owners - Legal Entities",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaration of Ultimate Beneficial Owners - Natural Persons",
       "Recovery": "Recovery",
-      "Upload Report Design": "Upload Report Design"
+      "Upload Report Design": "Upload Report Design",
+      "Payment Allocation": "Payment Allocation",
+      "Interest Refunds": "Interest Refunds",
+      "Deferred Income Recognition": "Deferred Income Recognition",
+      "Advanced Configuration": "Advanced Configuration"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Account moves out of NPA only on arrears completion",
@@ -5140,7 +5146,8 @@
       "The selected report design is too large": "The selected report design is larger than 5 MB.",
       "Report design uploaded": "Report design {{fileName}} was uploaded.",
       "Report design replaced": "Report design {{fileName}} was replaced.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "max 4 chars"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1110,7 +1110,9 @@
       "transaction_loan": "Transacciones de Crédito",
       "transaction_savings": "Transacciones de Ahorro",
       "unmarried": "soltero",
-      "xbrlmapping": "Mapeo XBRL"
+      "xbrlmapping": "Mapeo XBRL",
+      "Enabled": "Activado",
+      "Disabled": "Desactivado"
     },
     "commons": {
       "50 characters long": "50 caracteres de largo",
@@ -1801,7 +1803,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Declaración de beneficiarios finales - personas jurídicas",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaración de beneficiarios finales - personas naturales",
       "Recovery": "Recuperación",
-      "Upload Report Design": "Subir diseño de reporte"
+      "Upload Report Design": "Subir diseño de reporte",
+      "Payment Allocation": "Prelación de pagos",
+      "Interest Refunds": "Reembolso de intereses",
+      "Deferred Income Recognition": "Reconocimiento de ingresos diferidos",
+      "Advanced Configuration": "Configuración avanzada"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "La cuenta sale de NPA solo tras liquidar todos los atrasos",
@@ -5003,7 +5009,8 @@
       "The selected report design is too large": "El diseño de reporte seleccionado supera los 5 MB.",
       "Report design uploaded": "Se subió el diseño de reporte {{fileName}}.",
       "Report design replaced": "Se reemplazó el diseño de reporte {{fileName}}.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "máx. 4 caracteres"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1115,7 +1115,9 @@
       "transaction_loan": "Transacciones de Crédito",
       "transaction_savings": "Transacciones de Ahorro",
       "unmarried": "soltero",
-      "xbrlmapping": "Mapeo XBRL"
+      "xbrlmapping": "Mapeo XBRL",
+      "Enabled": "Activado",
+      "Disabled": "Desactivado"
     },
     "commons": {
       "50 characters long": "50 caracteres de largo",
@@ -1807,7 +1809,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Declaración de beneficiarios finales - personas morales",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaración de beneficiarios finales - personas físicas",
       "Recovery": "Recuperación",
-      "Upload Report Design": "Subir diseño de reporte"
+      "Upload Report Design": "Subir diseño de reporte",
+      "Payment Allocation": "Prelación de pagos",
+      "Interest Refunds": "Reembolso de intereses",
+      "Deferred Income Recognition": "Ingresos diferidos",
+      "Advanced Configuration": "Configuración avanzada"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "La cuenta sale de NPA solo tras liquidar todos los atrasos",
@@ -5027,7 +5033,8 @@
       "The selected report design is too large": "El diseño de reporte seleccionado supera los 5 MB.",
       "Report design uploaded": "Se subió el diseño de reporte {{fileName}}.",
       "Report design replaced": "Se reemplazó el diseño de reporte {{fileName}}.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "máx. 4 caracteres"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1111,7 +1111,9 @@
       "transaction_loan": "Transactions Prêt",
       "transaction_savings": "Transactions Épargne",
       "unmarried": "célibataire",
-      "xbrlmapping": "Cartographie XBRL"
+      "xbrlmapping": "Cartographie XBRL",
+      "Enabled": "Activé",
+      "Disabled": "Désactivé"
     },
     "commons": {
       "50 characters long": "50 caractères",
@@ -1804,7 +1806,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Déclaration des bénéficiaires effectifs ultimes - personnes morales",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Déclaration des bénéficiaires effectifs ultimes - personnes physiques",
       "Recovery": "Recouvrement",
-      "Upload Report Design": "Télécharger un modèle de rapport"
+      "Upload Report Design": "Télécharger un modèle de rapport",
+      "Payment Allocation": "Allocation de paiement",
+      "Interest Refunds": "Remboursement des intérêts",
+      "Deferred Income Recognition": "Comptabilisation des produits différés",
+      "Advanced Configuration": "Configuration avancée"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Le compte ne sort du statut NPA qu'après apurement des arriérés",
@@ -5004,7 +5010,8 @@
       "The selected report design is too large": "Le modèle de rapport sélectionné dépasse 5 MB.",
       "Report design uploaded": "Le modèle de rapport {{fileName}} a été téléchargé.",
       "Report design replaced": "Le modèle de rapport {{fileName}} a été remplacé.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "4 caractères max."
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1111,7 +1111,9 @@
       "transaction_loan": "Transazioni Prestito",
       "transaction_savings": "Transazioni Risparmio",
       "unmarried": "non sposato",
-      "xbrlmapping": "Mappatura XBRL"
+      "xbrlmapping": "Mappatura XBRL",
+      "Enabled": "Abilitato",
+      "Disabled": "Disabilitato"
     },
     "commons": {
       "50 characters long": "50 caratteri di lunghezza",
@@ -1801,7 +1803,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Dichiarazione dei titolari effettivi ultimi - persone giuridiche",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Dichiarazione dei titolari effettivi ultimi - persone fisiche",
       "Recovery": "Recupero",
-      "Upload Report Design": "Carica modello di rapporto"
+      "Upload Report Design": "Carica modello di rapporto",
+      "Payment Allocation": "Ripartizione pagamento",
+      "Interest Refunds": "Rimborso degli interessi",
+      "Deferred Income Recognition": "Rilevazione dei risconti passivi",
+      "Advanced Configuration": "Configurazione avanzata"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Il conto esce da NPA solo dopo il saldo di tutti gli arretrati",
@@ -5002,7 +5008,8 @@
       "The selected report design is too large": "Il modello di rapporto selezionato supera i 5 MB.",
       "Report design uploaded": "Il modello di rapporto {{fileName}} è stato caricato.",
       "Report design replaced": "Il modello di rapporto {{fileName}} è stato sostituito.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "max 4 caratteri"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1111,7 +1111,9 @@
       "transaction_loan": "대출 거래",
       "transaction_savings": "저축 거래",
       "unmarried": "미혼",
-      "xbrlmapping": "XBRL 매핑"
+      "xbrlmapping": "XBRL 매핑",
+      "Enabled": "활성화됨",
+      "Disabled": "장애가 있는"
     },
     "commons": {
       "50 characters long": "50자(영문 기준)",
@@ -1802,7 +1804,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "최종 실소유자 선언 - 법인",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "최종 실소유자 선언 - 자연인",
       "Recovery": "회수",
-      "Upload Report Design": "보고서 디자인 업로드"
+      "Upload Report Design": "보고서 디자인 업로드",
+      "Payment Allocation": "지불 할당",
+      "Interest Refunds": "이자환급",
+      "Deferred Income Recognition": "이연수익 인식",
+      "Advanced Configuration": "고급 구성"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "모든 연체가 해소된 후에만 NPA에서 해제",
@@ -5001,7 +5007,8 @@
       "The selected report design is too large": "선택한 보고서 디자인이 5 MB를 초과합니다.",
       "Report design uploaded": "보고서 디자인 {{fileName}}이(가) 업로드되었습니다.",
       "Report design replaced": "보고서 디자인 {{fileName}}이(가) 대체되었습니다.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "최대 4자"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1110,7 +1110,9 @@
       "transaction_loan": "Paskolos Sandoriai",
       "transaction_savings": "Taupymo Sandoriai",
       "unmarried": "nevedęs",
-      "xbrlmapping": "XBRL Žemėlapis"
+      "xbrlmapping": "XBRL Žemėlapis",
+      "Enabled": "Įjungtas",
+      "Disabled": "Išjungta"
     },
     "commons": {
       "50 characters long": "50 simbolių ilgio",
@@ -1800,7 +1802,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Galutinių naudos gavėjų deklaracija - juridiniai asmenys",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Galutinių naudos gavėjų deklaracija - fiziniai asmenys",
       "Recovery": "Susigrąžinimas",
-      "Upload Report Design": "Įkelti ataskaitos maketą"
+      "Upload Report Design": "Įkelti ataskaitos maketą",
+      "Payment Allocation": "Mokėjimo skirstymas",
+      "Interest Refunds": "Palūkanų grąžinimas",
+      "Deferred Income Recognition": "Atidėtųjų pajamų pripažinimas",
+      "Advanced Configuration": "Išplėstinė konfigūracija"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Sąskaita išeina iš NPA tik padengus visus įsiskolinimus",
@@ -5002,7 +5008,8 @@
       "The selected report design is too large": "Pasirinktas ataskaitos maketas viršija 5 MB.",
       "Report design uploaded": "Ataskaitos maketas {{fileName}} įkeltas.",
       "Report design replaced": "Ataskaitos maketas {{fileName}} pakeistas.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "daugiausia 4 simboliai"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1111,7 +1111,9 @@
       "transaction_loan": "Aizdevuma Darījumi",
       "transaction_savings": "Uzkrājumu Darījumi",
       "unmarried": "neprecējies",
-      "xbrlmapping": "XBRL Kartēšana"
+      "xbrlmapping": "XBRL Kartēšana",
+      "Enabled": "Iespējots",
+      "Disabled": "Atspējots"
     },
     "commons": {
       "50 characters long": "50 rakstzīmes garš",
@@ -1801,7 +1803,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Patieso labuma guvēju deklarācija - juridiskas personas",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Patieso labuma guvēju deklarācija - fiziskas personas",
       "Recovery": "Atgūšana",
-      "Upload Report Design": "Augšupielādēt pārskata veidni"
+      "Upload Report Design": "Augšupielādēt pārskata veidni",
+      "Payment Allocation": "Maksājumu piešķiršana",
+      "Interest Refunds": "Procentu atmaksāšana",
+      "Deferred Income Recognition": "Atliktā ienākuma atzīšana",
+      "Advanced Configuration": "Papildu konfigurācija"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Konts iziet no NPA tikai pēc visu parādu segšanas",
@@ -5001,7 +5007,8 @@
       "The selected report design is too large": "Atlasītā pārskata veidne pārsniedz 5 MB.",
       "Report design uploaded": "Pārskata veidne {{fileName}} ir augšupielādēta.",
       "Report design replaced": "Pārskata veidne {{fileName}} ir aizstāta.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "maks. 4 rakstzīmes"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1110,7 +1110,9 @@
       "transaction_loan": "ऋण लेनदेन",
       "transaction_savings": "बचत लेनदेन",
       "unmarried": "अविवाहित",
-      "xbrlmapping": "XBRL म्यापिङ"
+      "xbrlmapping": "XBRL म्यापिङ",
+      "Enabled": "सक्षम गरियो",
+      "Disabled": "अक्षम"
     },
     "commons": {
       "50 characters long": "५० वर्ण लामो",
@@ -1800,7 +1802,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "अन्तिम लाभग्राही मालिकहरूको घोषणा - कानुनी संस्थाहरू",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "अन्तिम लाभग्राही मालिकहरूको घोषणा - प्राकृतिक व्यक्तिहरू",
       "Recovery": "असुली",
-      "Upload Report Design": "रिपोर्ट डिजाइन अपलोड गर्नुहोस्"
+      "Upload Report Design": "रिपोर्ट डिजाइन अपलोड गर्नुहोस्",
+      "Payment Allocation": "भुक्तान विनियोजन",
+      "Interest Refunds": "व्याज परतावा",
+      "Deferred Income Recognition": "स्थगित आय पहिचान",
+      "Advanced Configuration": "उन्नत कन्फिगरेसन"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "सबै बक्यौता भुक्तानी भएपछि मात्र खाता NPA बाट बाहिरिन्छ",
@@ -5001,7 +5007,8 @@
       "The selected report design is too large": "छानिएको रिपोर्ट डिजाइन 5 MB भन्दा ठूलो छ।",
       "Report design uploaded": "रिपोर्ट डिजाइन {{fileName}} अपलोड गरियो।",
       "Report design replaced": "रिपोर्ट डिजाइन {{fileName}} प्रतिस्थापन गरियो।",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "बढीमा ४ अक्षर"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1111,7 +1111,9 @@
       "transaction_loan": "Transações de Empréstimo",
       "transaction_savings": "Transações de Poupança",
       "unmarried": "solteiro",
-      "xbrlmapping": "Mapeamento XBRL"
+      "xbrlmapping": "Mapeamento XBRL",
+      "Enabled": "Habilitado",
+      "Disabled": "Desabilitado"
     },
     "commons": {
       "50 characters long": "50 caracteres",
@@ -1800,7 +1802,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Declaração dos beneficiários efetivos finais - pessoas coletivas",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Declaração dos beneficiários efetivos finais - pessoas singulares",
       "Recovery": "Recuperação",
-      "Upload Report Design": "Carregar modelo de relatório"
+      "Upload Report Design": "Carregar modelo de relatório",
+      "Payment Allocation": "Alocação de pagamento",
+      "Interest Refunds": "Reembolso de juros",
+      "Deferred Income Recognition": "Reconhecimento de receita diferida",
+      "Advanced Configuration": "Configuração avançada"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "A conta sai de NPA apenas após a regularização de todos os atrasos",
@@ -5001,7 +5007,8 @@
       "The selected report design is too large": "O modelo de relatório selecionado excede 5 MB.",
       "Report design uploaded": "O modelo de relatório {{fileName}} foi carregado.",
       "Report design replaced": "O modelo de relatório {{fileName}} foi substituído.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "máx. 4 caracteres"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1109,7 +1109,9 @@
       "transaction_loan": "Miamala ya Mkopo",
       "transaction_savings": "Miamala ya Akiba",
       "unmarried": "bila kuolewa",
-      "xbrlmapping": "Ramani ya XBRL"
+      "xbrlmapping": "Ramani ya XBRL",
+      "Enabled": "Imewashwa",
+      "Disabled": "Imezimwa"
     },
     "commons": {
       "50 characters long": "Urefu wa herufi 50",
@@ -1798,7 +1800,11 @@
       "Declaration of Ultimate Beneficial Owners - Legal Entities": "Tamko la wamiliki wanufaika wa mwisho - taasisi za kisheria",
       "Declaration of Ultimate Beneficial Owners - Natural Persons": "Tamko la wamiliki wanufaika wa mwisho - watu binafsi",
       "Recovery": "Urejeshaji",
-      "Upload Report Design": "Pakia Muundo wa Ripoti"
+      "Upload Report Design": "Pakia Muundo wa Ripoti",
+      "Payment Allocation": "Mgao wa malipo",
+      "Interest Refunds": "Marejesho ya riba",
+      "Deferred Income Recognition": "Utambuzi wa mapato ulioahirishwa",
+      "Advanced Configuration": "Usanidi wa kina"
     },
     "inputs": {
       "Account moves out of NPA only on arrears completion": "Akaunti hutoka NPA baada tu ya kulipa madeni yote yaliyochelewa",
@@ -4998,7 +5004,8 @@
       "The selected report design is too large": "Muundo wa ripoti uliochaguliwa unazidi 5 MB.",
       "Report design uploaded": "Muundo wa ripoti {{fileName}} umepakiwa.",
       "Report design replaced": "Muundo wa ripoti {{fileName}} umebadilishwa.",
-      "KB": "KB"
+      "KB": "KB",
+      "max 4 chars": "herufi 4 kwa juu"
     },
     "permissions": {
       "actions": {


### PR DESCRIPTION
## Description

The guided loan product wizard translated its field labels and placeholders but nothing around them. Step headers, select options, the Short Name hint, the Review's section titles and its Yes/No values were English hardcoded in `loan-product.config.ts`, so an operator on any of the other 12 locales got a half-translated form.

Select options now render through `translateKey: 'catalogs'` — the namespace Classic pipes every enum value through. `CustomMissingTranslationHandler` strips only the `labels.catalogs.` prefix, so values only the backend can name (a tenant's currencies, its delinquency buckets) still render as themselves. That is the same split Classic already uses, and it means the option labels needed no new translation keys at all.

Option labels and `VALUE_MAP` were realigned to Fineract's canonical spellings in the process. The wizard had been renaming the enums — "Cash-based", "360 days", "Same as in year", "Mifos standard" — so the same value read differently depending on which flow you created the product in. Guided and Classic now name every value identically.

Step titles and the hint became translation keys. The new keys reuse the human translations Classic already ships in all 13 locales rather than introducing fresh wording: the three step headers are sentence-cased from `labels.inputs.PAYMENT ALLOCATION` and friends, and Review and Loan Cycle Variations point at the existing `labels.buttons.Preview` and `labels.inputs.Terms vary based on loan cycle`. Only "Advanced Configuration" and the `max 4 chars` hint are new copy, each built from the locale's own vocabulary.

Review values are translated in TypeScript, where no pipe could reach them: Yes/No from `labels.buttons` (the pair the shared `yesNo` pipe uses), and accounting rules from `labels.accounting` — Classic's namespace — falling back to catalogs, because `labels.accounting` carries Cash and both Accrual rules but no `None`.

Two supporting changes:

- `CustomMissingTranslationHandler` moved out of `app.module.ts` into `src/app/core/translation/missing-translation.handler.ts`, so the specs exercise the real class instead of restating its rule and drifting from it.
- Two option labels were already full translation keys, which the catalogs prefix would have turned into visible `labels.inputs.…` text on the dropdown — a regression introduced by this fix itself. Corrected, and `loan-product.config.spec.ts` now guards both directions: an option label must never be a full key, and every step title and hint must be one.

Six new specs in the render suite. Three fail without the template pipes and one fails without the missing-translation handler, verified by removing each in turn.

No dependency changes.

## Related issues and discussion

# WEB-1215

## Screenshots, if any
NA

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added translation support for loan product wizard steps, field labels, options, hints, and review values.
  * Added localized labels for wizard sections, status values, and character-limit guidance across supported languages.
  * Improved missing-translation handling with readable fallback labels.

* **Improvements**
  * Aligned wizard terminology and option labels with Fineract naming.
  * Renamed the final wizard step from “Review” to “Preview.”

* **Tests**
  * Expanded coverage for translated wizard content and configuration labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->