### PR TITLE
WEB-1216: Steady the follow-up chips, show turn progress, stop the rail covering the conversation

### DIFF
--- a/src/app/copilot/components/prompt-nav/prompt-nav.component.spec.ts
+++ b/src/app/copilot/components/prompt-nav/prompt-nav.component.spec.ts
@@ -144,7 +144,8 @@ describe('PromptNavComponent', () => {
     expect(jumped).toBe('u-2');
   });
 
-  it('collapses to a strip of rules and back', () => {
+  /** Expanded, the rail is wide enough to cover the questions it lists, so it never starts there. */
+  it('arrives collapsed to a strip of rules, and expands only when asked', () => {
     fixture.componentRef.setInput('messages', [
       ask('u-1', 'One'),
       ask('u-2', 'Two')
@@ -152,13 +153,15 @@ describe('PromptNavComponent', () => {
     fixture.detectChanges();
 
     const toggle = fixture.nativeElement.querySelector('.prompt-nav__toggle');
-    expect(toggle.getAttribute('aria-expanded')).toBe('true');
-
-    toggle.click();
-    fixture.detectChanges();
     expect(component.collapsed).toBe(true);
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(fixture.nativeElement.querySelector('.prompt-nav').classList).toContain('prompt-nav--collapsed');
+
+    toggle.click();
+    fixture.detectChanges();
+    expect(component.collapsed).toBe(false);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(fixture.nativeElement.querySelector('.prompt-nav').classList).not.toContain('prompt-nav--collapsed');
   });
 
   /** Collapsing must not drop the list: it is what the officer clicks to move about. */
@@ -167,8 +170,6 @@ describe('PromptNavComponent', () => {
       ask('u-1', 'One'),
       ask('u-2', 'Two')
     ]);
-    fixture.detectChanges();
-    fixture.nativeElement.querySelector('.prompt-nav__toggle').click();
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelectorAll('.prompt-nav__item').length).toBe(2);

--- a/src/app/copilot/components/prompt-nav/prompt-nav.component.ts
+++ b/src/app/copilot/components/prompt-nav/prompt-nav.component.ts
@@ -70,8 +70,17 @@ export class PromptNavComponent {
 
   entries: PromptEntry[] = NO_ENTRIES;
 
-  /** Collapsed to a strip of rules, which keeps the position readable at a glance. */
-  collapsed = false;
+  /**
+   * Starts collapsed to a strip of rules, which keeps the position readable at a glance.
+   *
+   * <p>It used to open expanded, and expanded it is wide enough to sit on top of the questions
+   * themselves: an officer's own message came back to them with its right-hand half behind the
+   * rail listing that same message. A rail is for getting back to something, so covering the
+   * thing it points at is the one thing it must not do. Collapsed it is a column of rules
+   * narrower than the gutter, and widening it is then the officer's decision, taken when they
+   * want to read the labels and are not reading anything else.
+   */
+  collapsed = true;
 
   get hasEntries(): boolean {
     return this.entries.length > 0;

--- a/src/app/copilot/components/thinking-trail/thinking-trail.component.html
+++ b/src/app/copilot/components/thinking-trail/thinking-trail.component.html
@@ -6,6 +6,17 @@
   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 -->
 <div class="trail" *ngIf="hasAnything">
+  <!-- What it has already done, while it is still working. Held back until the turn ended, the
+       whole wait was one unchanging line: an officer watching a slow turn could not tell a model
+       reading three accounts apart from one stuck on the first. These rows are the record part
+       of the trail — named by the tool manifest, never by a model — so showing them as they land
+       costs nothing in credibility, and they are the only progress there is to show. The model's
+       own working text is not here; it stays in the disclosure below, read after the answer
+       rather than in front of it. -->
+  <ol class="trail__steps trail__steps--live" *ngIf="isLive && doneSteps.length">
+    <ng-container *ngTemplateOutlet="stepRows; context: { $implicit: doneSteps }"></ng-container>
+  </ol>
+
   <!-- While the turn runs, one line naming what is happening right now. An officer waiting on a
        slow branch connection needs to tell working apart from hung, and this is what does it.
        aria-live announces it, because a silent wait is the same wait for a screen reader. -->
@@ -43,26 +54,7 @@
       <div class="trail__body-inner">
         <!-- What it actually did. This is the part that is a record. -->
         <ol class="trail__steps" *ngIf="steps.length">
-          <li *ngFor="let step of steps" class="trail__step" [class.trail__step--write]="isWrite(step)">
-            <!-- A step that changed a record is marked as one. Reading and writing are not the
-                 same act, and a log that renders them identically hides the difference that
-                 matters most when an officer is checking what was done. -->
-            <span class="trail__tick" aria-hidden="true">
-              <svg *ngIf="!isWrite(step)" viewBox="0 0 24 24">
-                <path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
-              </svg>
-              <svg *ngIf="isWrite(step)" viewBox="0 0 24 24">
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
-                />
-              </svg>
-            </span>
-            <span class="trail__step-kind" *ngIf="isWrite(step)">{{ 'copilot.trail.wrote' | translate }}</span>
-            <span class="trail__step-label">{{ step.label }}</span>
-            <span class="trail__step-time" *ngIf="step.durationMs !== null && step.durationMs !== undefined">{{
-              seconds(step.durationMs)
-            }}</span>
-          </li>
+          <ng-container *ngTemplateOutlet="stepRows; context: { $implicit: steps }"></ng-container>
         </ol>
 
         <!-- What it wrote while doing it, which is not a record. The caution sits with it, read
@@ -83,3 +75,28 @@
     </div>
   </div>
 </div>
+
+<!-- One definition of a step row, rendered both while the turn runs and inside the disclosure
+     afterwards, so the record cannot come to read differently depending on when it is read. -->
+<ng-template #stepRows let-list>
+  <li *ngFor="let step of list; trackBy: trackByStep" class="trail__step" [class.trail__step--write]="isWrite(step)">
+    <!-- A step that changed a record is marked as one. Reading and writing are not the
+         same act, and a log that renders them identically hides the difference that
+         matters most when an officer is checking what was done. -->
+    <span class="trail__tick" aria-hidden="true">
+      <svg *ngIf="!isWrite(step)" viewBox="0 0 24 24">
+        <path d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+      </svg>
+      <svg *ngIf="isWrite(step)" viewBox="0 0 24 24">
+        <path
+          d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+        />
+      </svg>
+    </span>
+    <span class="trail__step-kind" *ngIf="isWrite(step)">{{ 'copilot.trail.wrote' | translate }}</span>
+    <span class="trail__step-label">{{ step.label }}</span>
+    <span class="trail__step-time" *ngIf="step.durationMs !== null && step.durationMs !== undefined">{{
+      seconds(step.durationMs)
+    }}</span>
+  </li>
+</ng-template>

--- a/src/app/copilot/components/thinking-trail/thinking-trail.component.spec.ts
+++ b/src/app/copilot/components/thinking-trail/thinking-trail.component.spec.ts
@@ -118,6 +118,89 @@ describe('ThinkingTrailComponent', () => {
     );
   });
 
+  // ─── What is visible while the turn runs ───────────────────────────────────
+
+  /**
+   * The steps used to be sealed in the disclosure until the turn ended, so a long turn showed
+   * one unchanging line and an officer could not tell three accounts being read from one call
+   * hanging. Finished rows now land as they happen.
+   */
+  it('lists the finished steps while the turn is still running', () => {
+    fixture.componentRef.setInput('phase', 'thinking');
+    fixture.componentRef.setInput('steps', [
+      step('Reading the client profile'),
+      step('Reading the loan account'),
+      step('Checking the repayment schedule', false)
+    ]);
+    fixture.detectChanges();
+
+    const live = Array.from(
+      fixture.nativeElement.querySelectorAll('.trail__steps--live .trail__step-label') as NodeListOf<HTMLElement>
+    ).map((node) => node.textContent?.trim());
+    expect(live).toEqual([
+      'Reading the client profile',
+      'Reading the loan account'
+    ]);
+  });
+
+  /** The running step is named on the live line, so listing it above would double it. */
+  it('leaves the step in flight to the live line', () => {
+    fixture.componentRef.setInput('phase', 'thinking');
+    fixture.componentRef.setInput('steps', [step('Checking the repayment schedule', false)]);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.trail__steps--live')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.trail__live-label').textContent).toContain(
+      'Checking the repayment schedule'
+    );
+  });
+
+  /** The answer arriving does not end the turn, and the record so far stays on screen for it. */
+  it('keeps the steps visible while the answer streams', () => {
+    fixture.componentRef.setInput('phase', 'streaming');
+    fixture.componentRef.setInput('steps', [step('Reading the loan account')]);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.trail__steps--live')).not.toBeNull();
+    // No tool in flight, so the live line has nothing to name and stands down.
+    expect(fixture.nativeElement.querySelector('.trail__live')).toBeNull();
+  });
+
+  /** Once the turn ends the same rows are in the disclosure, and nowhere else. */
+  it('folds the live list into the disclosure when the turn ends', () => {
+    fixture.componentRef.setInput('phase', 'streaming');
+    fixture.componentRef.setInput('steps', [step('Reading the loan account')]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.trail__steps--live')).not.toBeNull();
+
+    fixture.componentRef.setInput('phase', 'idle');
+    fixture.componentRef.setInput('turnMs', 5200);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.trail__steps--live')).toBeNull();
+    expect(fixture.nativeElement.querySelectorAll('.trail__step-label').length).toBe(1);
+  });
+
+  /**
+   * The model's own prose is not a record and stays where it was: behind the disclosure, read
+   * after the answer rather than streaming in front of it.
+   */
+  it('keeps the working notes out of the live view', () => {
+    fixture.componentRef.setInput('phase', 'thinking');
+    fixture.componentRef.setInput('steps', [step('Reading the loan account')]);
+    fixture.componentRef.setInput('workingNotes', 'Checking the schedule before quoting a figure.');
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.trail__notes')).toBeNull();
+  });
+
+  it('treats a turn with nothing finished yet as the same empty list every time', () => {
+    fixture.componentRef.setInput('steps', [step('Reading the loan account', false)]);
+    const first = component.doneSteps;
+    fixture.componentRef.setInput('steps', [step('Checking the repayment schedule', false)]);
+    expect(component.doneSteps).toBe(first);
+  });
+
   // ─── Collapsed by default ──────────────────────────────────────────────────
 
   it('is collapsed when the turn completes', () => {

--- a/src/app/copilot/components/thinking-trail/thinking-trail.component.ts
+++ b/src/app/copilot/components/thinking-trail/thinking-trail.component.ts
@@ -172,6 +172,20 @@ export class ThinkingTrailComponent implements OnChanges, OnDestroy {
   }
 
   /**
+   * The steps already finished, which is what the live list shows.
+   *
+   * <p>Only the finished ones: the step still running is named on the live line right below,
+   * and a row that says the same thing twice reads as two calls rather than one.
+   */
+  get doneSteps(): CopilotStep[] {
+    const done = this.steps.filter((step) => step.done);
+    // A fresh [] every check would be a changed reference for the *ngFor above it, on a
+    // component that is otherwise built to be skipped. Empty is the common case, so it gets
+    // the shared constant and only a non-empty list allocates.
+    return done.length ? done : NO_STEPS;
+  }
+
+  /**
    * What to call what is happening right now.
    *
    * <p>Before the first tool call there is still a wait, and it used to be shown by nothing at
@@ -206,6 +220,17 @@ export class ThinkingTrailComponent implements OnChanges, OnDestroy {
   /** A step that changes a record, which does not look like one that only read. */
   isWrite(step: CopilotStep): boolean {
     return step.readOnly === false;
+  }
+
+  /**
+   * Steps are identified by position, because that is what they are.
+   *
+   * <p>A step has no id and its label is not unique — the same account can honestly be read
+   * twice in one turn. Position is stable for the life of the list: rows are appended, and the
+   * only edit is the running step being marked finished in place, which position survives.
+   */
+  trackByStep(index: number): number {
+    return index;
   }
 
   /**

--- a/src/app/copilot/core/follow-ups.spec.ts
+++ b/src/app/copilot/core/follow-ups.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+import { fallbackFollowUps } from './follow-ups';
+
+describe('fallbackFollowUps', () => {
+  it('offers loan questions from a loan', () => {
+    expect(fallbackFollowUps('loan-detail')).toEqual([
+      'copilot.suggestions.repaymentSchedule',
+      'copilot.suggestions.clientDetails',
+      'copilot.suggestions.savingsBalance'
+    ]);
+  });
+
+  /** Offering "show me this client's profile" to someone already reading it is not a suggestion. */
+  it('does not offer the client profile back on the client page', () => {
+    expect(fallbackFollowUps('client-detail')).not.toContain('copilot.suggestions.clientDetails');
+  });
+
+  /** Away from a record, only what can be answered from anywhere. */
+  it('falls back to what holds on any screen', () => {
+    expect(fallbackFollowUps('dashboard')).toEqual([
+      'copilot.suggestions.clientDetails',
+      'copilot.suggestions.overdueLoans'
+    ]);
+    expect(fallbackFollowUps('organization')).toEqual(fallbackFollowUps('dashboard'));
+    expect(fallbackFollowUps(null)).toEqual(fallbackFollowUps('dashboard'));
+    expect(fallbackFollowUps(undefined)).toEqual(fallbackFollowUps('dashboard'));
+  });
+
+  /**
+   * The screen name is the first segment of the route the officer is on, and an unknown route
+   * renders "not found" at that URL rather than redirecting, so these names are reachable by
+   * mistyping an address. Off an object literal they find Object.prototype and its members —
+   * and 'constructor' answers with a function whose length is 1, which is truthy enough to get
+   * past the chip row's guard and then hand *ngFor something it cannot iterate.
+   */
+  it('answers prototype member names with prompts, not with Object', () => {
+    for (const screen of [
+      '__proto__',
+      'constructor',
+      'toString',
+      'valueOf',
+      'hasOwnProperty'
+    ]) {
+      const prompts = fallbackFollowUps(screen);
+      expect(Array.isArray(prompts)).toBe(true);
+      expect(prompts).toEqual(fallbackFollowUps('dashboard'));
+    }
+  });
+
+  /** Handed to an OnPush chip list, so the same screen has to mean the same array. */
+  it('answers with one array per screen', () => {
+    expect(fallbackFollowUps('client-detail')).toBe(fallbackFollowUps('client-detail'));
+    expect(fallbackFollowUps('nowhere')).toBe(fallbackFollowUps('elsewhere'));
+  });
+
+  /** A fourth chip wraps to a second row on a narrow panel and buys nothing. */
+  it('never offers more than three', () => {
+    for (const screen of [
+      'loan-detail',
+      'client-detail',
+      'client-list',
+      'dashboard'
+    ]) {
+      expect(fallbackFollowUps(screen).length).toBeLessThanOrEqual(3);
+    }
+  });
+});

--- a/src/app/copilot/core/follow-ups.ts
+++ b/src/app/copilot/core/follow-ups.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * What to offer next when a reply suggests nothing of its own.
+ *
+ * <p>Follow-up chips used to exist only when the model remembered to write a ```suggest```
+ * block, which meant the row under an answer was there on one turn and gone on the next. An
+ * officer reads that as the panel breaking rather than as the model declining to suggest
+ * anything, and worse, asked about it directly it explains its own instructions back to them.
+ * A control that comes and goes for reasons the officer cannot see is not a control.
+ *
+ * <p>So the chips fall back to a fixed set chosen by the screen the question was asked from.
+ * Fixed is the point: these are translation keys, they read the same every time, and they
+ * only ever offer something the panel can actually answer from where the officer is standing.
+ * A model-written suggestion, when there is one, is still better — it knows what was just
+ * discussed — so it always wins.
+ */
+
+/** Everything the panel can suggest, as translation keys. */
+const CLIENT_DETAILS = 'copilot.suggestions.clientDetails';
+const REPAYMENT_SCHEDULE = 'copilot.suggestions.repaymentSchedule';
+const SAVINGS_BALANCE = 'copilot.suggestions.savingsBalance';
+const OVERDUE_LOANS = 'copilot.suggestions.overdueLoans';
+
+/**
+ * Per screen, in the order they are shown.
+ *
+ * <p>Each list leaves out the question the officer is most likely to have just asked from
+ * that screen: on a client page "show me this client's profile" is what got them there, and
+ * offering it back is the panel not paying attention. Three is the ceiling, because a fourth
+ * chip wraps to a second row on a narrow panel and buys nothing.
+ */
+const BY_SCREEN = new Map<string, string[]>([
+  [
+    'loan-detail',
+    [
+      REPAYMENT_SCHEDULE,
+      CLIENT_DETAILS,
+      SAVINGS_BALANCE
+    ]
+  ],
+  [
+    'client-detail',
+    [
+      SAVINGS_BALANCE,
+      REPAYMENT_SCHEDULE,
+      OVERDUE_LOANS
+    ]
+  ],
+  [
+    'client-list',
+    [
+      CLIENT_DETAILS,
+      OVERDUE_LOANS
+    ]
+  ]
+]);
+
+/** Away from a client or a loan, only what holds anywhere. */
+const ANYWHERE: string[] = [
+  CLIENT_DETAILS,
+  OVERDUE_LOANS
+];
+
+/**
+ * Follow-ups for a reply that offered none, given the screen the question came from.
+ *
+ * <p>A Map rather than an object, because the screen name is not a literal this module chose.
+ * It is the first segment of whatever route the officer is on, and the app answers an unknown
+ * route by rendering "not found" at that URL rather than redirecting away from it — so a
+ * screen of 'constructor' is one mistyped address away. Read off an object literal that name
+ * finds Object through the prototype chain, and this function hands back a function with a
+ * length of 1 where the caller's types promise a list of prompts. Map has no such chain and
+ * cannot answer with anything that was not put in it.
+ *
+ * <p>Returns the same array reference for the same screen, so handing it to an OnPush chip
+ * list does not count as a changed input on every check.
+ */
+export function fallbackFollowUps(screen: string | null | undefined): string[] {
+  return BY_SCREEN.get(screen ?? '') ?? ANYWHERE;
+}

--- a/src/app/copilot/services/chat.service.spec.ts
+++ b/src/app/copilot/services/chat.service.spec.ts
@@ -166,6 +166,94 @@ describe('ChatService', () => {
     );
   });
 
+  // ─── Follow-up chips ───────────────────────────────────────────────────────
+
+  /**
+   * The chips used to exist only when the model remembered to write a ```suggest``` block, so
+   * the row under an answer was there on one turn and gone on the next — which an officer
+   * reads as the panel breaking, not as the model declining to suggest anything.
+   */
+  it('offers follow-ups for the screen when the reply suggests none', () => {
+    mcpMock.chat.mockReturnValue(
+      from([
+        { type: 'token', token: 'Her balance is 4,200.' },
+        { type: 'done' }
+      ] as McpStreamEvent[])
+    );
+
+    service.sendMessage('what is her savings balance');
+
+    expect(service.messages$.value[1].suggestedPrompts).toEqual([
+      'copilot.suggestions.savingsBalance',
+      'copilot.suggestions.repaymentSchedule',
+      'copilot.suggestions.overdueLoans'
+    ]);
+  });
+
+  /** The model knows what was just discussed; a fixed list never beats that when there is one. */
+  it('prefers what the reply suggested to the fallback', () => {
+    mcpMock.chat.mockReturnValue(
+      from([
+        { type: 'token', token: 'Here it is.' },
+        { type: 'suggest', suggestions: ['Show the arrears'] },
+        { type: 'done' }
+      ] as McpStreamEvent[])
+    );
+
+    service.sendMessage('show me the schedule');
+
+    expect(service.messages$.value[1].suggestedPrompts).toEqual(['Show the arrears']);
+  });
+
+  it('prefers a fenced suggest block to the fallback', () => {
+    mcpMock.chat.mockReturnValue(
+      from([
+        { type: 'token', token: 'Here it is.\n\n```suggest\nShow the arrears\n```' },
+        { type: 'done' }
+      ] as McpStreamEvent[])
+    );
+
+    service.sendMessage('show me the schedule');
+
+    expect(service.messages$.value[1].suggestedPrompts).toEqual(['Show the arrears']);
+  });
+
+  /** After a failure the officer needs the retry the reply offers, not a change of subject. */
+  it('offers no follow-ups when the turn failed', () => {
+    mcpMock.chat.mockReturnValue(
+      from([
+        { type: 'error', errorCode: 'TOOL_FAILED', message: 'The loan service did not answer.' }
+      ] as McpStreamEvent[])
+    );
+
+    service.sendMessage('show me the schedule');
+
+    expect(service.messages$.value[1].suggestedPrompts).toBeUndefined();
+  });
+
+  /** A paused write is a decision to take, and a row of unrelated questions under it is noise. */
+  it('offers no follow-ups while a write is awaiting approval', () => {
+    mcpMock.chat.mockReturnValue(
+      from([
+        { type: 'token', token: 'This will approve the loan.' },
+        {
+          type: 'action_card',
+          pendingAction: {
+            cardId: 'card-1',
+            tool: 'approveLoan',
+            args: {},
+            display: [],
+            humanSummary: 'Approve loan #4521'
+          }
+        }
+      ] as McpStreamEvent[])
+    );
+
+    service.sendMessage('approve loan 4521');
+
+    expect(service.messages$.value[1].suggestedPrompts).toBeUndefined();
+  });
+
   it('attaches display cards to the streaming message', () => {
     mcpMock.chat.mockReturnValue(
       from([

--- a/src/app/copilot/services/chat.service.ts
+++ b/src/app/copilot/services/chat.service.ts
@@ -26,6 +26,7 @@ import { translateStepLabel } from '../core/step-label';
 import { CopilotTurnPhase, isTurnActive, nextTurnPhase } from '../core/turn-phase';
 import { InputSanitizer } from '../core/input-sanitizer';
 import { ResponseParser } from '../core/response-parser';
+import { fallbackFollowUps } from '../core/follow-ups';
 import { COPILOT_CONFIG } from '../copilot.config';
 import { McpClientService } from './mcp-client.service';
 import { AiContextService } from './ai-context.service';
@@ -339,6 +340,23 @@ export class ChatService {
     return this.translate.instant(key);
   }
 
+  /**
+   * Follow-up chips for an answer that suggested none of its own.
+   *
+   * <p>Withheld from a turn that did not produce an answer. After an error the officer needs
+   * the retry the reply already offers, and after a confirmation card they need to decide;
+   * a row of unrelated questions under either one is the panel changing the subject.
+   *
+   * <p>Read from the screen at the moment the turn ends rather than when it started, because
+   * a turn that navigated the officer somewhere should suggest what fits where they now are.
+   */
+  private followUpsFor(content: string): string[] | undefined {
+    if (!content || this.turnPhase$.value === 'error' || this.turnPhase$.value === 'awaitingApproval') {
+      return undefined;
+    }
+    return fallbackFollowUps(this.contextService.getContextSnapshot().screen);
+  }
+
   private recordStep(event: McpStreamEvent): void {
     // Resolved here rather than in the template: a step log is part of the record of what was
     // done on a client's account, so the wording is fixed at the moment the step happened.
@@ -600,7 +618,7 @@ export class ChatService {
       return {
         ...draft,
         content,
-        suggestedPrompts: suggestions.length ? suggestions : undefined,
+        suggestedPrompts: suggestions.length ? suggestions : this.followUpsFor(content),
         turnMs,
         isStreaming: false
       };


### PR DESCRIPTION
## Description

Fixes three Copilot panel defects found in Victor's testing pass.

Follow-up chips no longer come and go. They existed only when the model remembered a ```suggest block, so the chip row was there on one turn and gone on the next — asked about it directly, the assistant explained its own system instructions back to the officer instead. core/follow-ups.ts maps the current screen to a fixed set of translation keys, used only when a reply suggests none of its own. A model-written suggestion still takes precedence, since it knows what was just discussed. Withheld after an error (the retry the reply already offers is what's needed) and while a confirmation card is pending (a decision is what's needed).

Turn progress is now visible while the turn runs. The step log was sealed inside the post-answer disclosure, so the entire wait rendered as one unchanging line, and a model reading three accounts looked identical to one stuck on the first. Finished steps now appear as they land, above the status line; the step still in flight stays on the status line so nothing is shown twice. The row markup is shared between the live view and the disclosure via ng-template, so the record can't read differently depending on when it's read. The model's own working notes stay in the post-answer disclosure, unchanged — they are text the model produced, not a record, and the panel is careful to label them as such.

The question rail starts collapsed. Expanded, it is wide enough to sit on top of the messages it lists — an officer's own question came back to them with its right half hidden behind the rail naming that same question. Collapsed, it is a column of rules inside the gutter; expanding it is now the officer's choice.

## Related issues and discussion

# WEB-1216

## Screenshots, if any

https://github.com/user-attachments/assets/6aa9b262-9815-433e-baa5-a3e98a77b3af



## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The prompt navigation rail now starts collapsed and can be expanded when needed.
  * Completed thinking steps are displayed live while a response is in progress, then organized into the completed trail.
  * Copilot now provides context-aware follow-up suggestions when responses do not include suggested prompts.
  * Provided or response-generated suggestions take precedence over fallbacks; suggestions are withheld for errors, empty responses, and pending approvals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->