### PR TITLE
WEB-1217: Stop the newest word re-animating when a token changes nothing on screen

### DIFF
--- a/src/app/copilot/pipes/markdown.pipe.spec.ts
+++ b/src/app/copilot/pipes/markdown.pipe.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { DomSanitizer } from '@angular/platform-browser';
+import { TranslateService } from '@ngx-translate/core';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { MarkdownPipe } from './markdown.pipe';
+
+describe('MarkdownPipe', () => {
+  let pipe: MarkdownPipe;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MarkdownPipe,
+        { provide: TranslateService, useValue: { instant: (key: string) => key } }
+      ]
+    });
+    pipe = TestBed.inject(MarkdownPipe);
+  });
+
+  function html(safe: unknown): string {
+    return TestBed.inject(DomSanitizer).sanitize(1 /* SecurityContext.HTML */, safe as never) ?? '';
+  }
+
+  it('renders the assistant markdown', () => {
+    expect(html(pipe.transform('**Approved**'))).toContain('<strong>Approved</strong>');
+  });
+
+  /**
+   * [innerHTML] compares by reference, so a fresh wrapper is a DOM rewrite even when the markup
+   * is identical — and a rewrite rebuilds the newest-word element, restarting its fade. The
+   * ```suggest``` block is stripped as it streams, so every one of its tokens changed the input
+   * and nothing on screen, which made the last visible word blink for the length of the block.
+   */
+  it('keeps the same wrapper while a stripped suggest block streams in', () => {
+    const answer = 'Profile recorded.\n\n**Suggested next steps**\n';
+    const first = pipe.transform(answer, true);
+
+    // The opener, then the block filling up: none of it may reach the screen, so none of it
+    // may rebuild the bubble either.
+    const stripped = [
+      `${answer}\`\`\``,
+      `${answer}\`\`\`sug`,
+      `${answer}\`\`\`suggest`,
+      `${answer}\`\`\`suggest\nView the loan`,
+      `${answer}\`\`\`suggest\nView the loan\nCheck arrears`,
+      `${answer}\`\`\`suggest\nView the loan\nCheck arrears\n\`\`\``
+    ];
+    for (const content of stripped) {
+      expect(pipe.transform(content, true)).toBe(first);
+    }
+  });
+
+  it('hands back a new wrapper once the answer actually changes', () => {
+    const first = pipe.transform('Reading the account', true);
+    expect(pipe.transform('Reading the account now', true)).not.toBe(first);
+  });
+
+  /** Ending the turn drops the newest-word marker, which is a real change to the markup. */
+  it('re-renders when the reply stops streaming', () => {
+    const streaming = pipe.transform('All done', true);
+    expect(pipe.transform('All done', false)).not.toBe(streaming);
+  });
+});

--- a/src/app/copilot/pipes/markdown.pipe.ts
+++ b/src/app/copilot/pipes/markdown.pipe.ts
@@ -23,11 +23,33 @@ export class MarkdownPipe implements PipeTransform {
   private readonly sanitizer = inject(DomSanitizer);
   private readonly translate = inject(TranslateService);
 
+  /**
+   * The last markup produced, and the trusted wrapper handed out for it.
+   *
+   * <p>One pair per pipe instance, and Angular builds one instance per binding, so this is
+   * per message rather than shared between them.
+   */
+  private lastHtml: string | null = null;
+  private lastSafe: SafeHtml | null = null;
+
   transform(value: string | null | undefined, streaming = false): SafeHtml {
     // The copy control inside a fenced block is built as raw markup, so it cannot reach the
     // translate pipe. Its label is resolved here instead, where a TranslateService is at hand.
-    return this.sanitizer.bypassSecurityTrustHtml(
-      renderMarkdown(value, this.translate.instant('copilot.actions.copyCode'), streaming)
-    );
+    const html = renderMarkdown(value, this.translate.instant('copilot.actions.copyCode'), streaming);
+
+    // Hand back the SAME wrapper when the markup has not changed, because [innerHTML] compares
+    // by reference and bypassSecurityTrustHtml mints a new object every call. A token that
+    // changes nothing on screen — every token of a ```suggest``` block, which is stripped as it
+    // arrives — otherwise rewrites the bubble anyway, and rewriting it rebuilds the element
+    // carrying the newest-word fade. That restarted the animation on whatever word happened to
+    // be last, so the tail of the answer blinked for as long as the stripped block took to
+    // stream. Comparing the markup covers the language and the streaming flag too, since both
+    // are already baked into it.
+    if (html === this.lastHtml && this.lastSafe !== null) {
+      return this.lastSafe;
+    }
+    this.lastHtml = html;
+    this.lastSafe = this.sanitizer.bypassSecurityTrustHtml(html);
+    return this.lastSafe;
   }
 }


### PR DESCRIPTION
## Description

While a reply streams, the assistant writes a ```suggest block that the panel strips before it reaches the screen. Every token of that block still changed the message content, so the pipe re-ran and produced byte-identical markup — but bypassSecurityTrustHtml mints a new object each call and [innerHTML] compares by reference, so the bubble was rewritten anyway. Rewriting it rebuilt the <span class="md-token"> that carries the newest-word fade, restarting the animation from transparent. Because the stripped block never changes the last visible word, that same word re-faded once per token and read as a blink.

The pipe now keeps the markup it last produced alongside the wrapper it handed out, and returns that same wrapper when the markup is unchanged. Comparing the rendered string covers the streaming flag and the translated copy label as well, since both are already baked into it. One cache pair per pipe instance, and Angular builds one instance per binding, so it is per message rather than shared.

Reported by Victor on the Copilot panel; introduced in WEB-1201 (#3944), not a regression from WEB-1216 (#3963).

## Related issues and discussion

# WEB-1217

## Screenshots, if any
NA

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streamed Markdown rendering by preventing unnecessary visual updates when incoming content has no visible change.
  - Preserved the displayed content more consistently while suggestion blocks are streamed.
  - Ensured the view refreshes correctly when visible Markdown changes or streaming completes.

- **Tests**
  - Added coverage for Markdown rendering, sanitization, streaming behavior, and updates to displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->