### PR TITLE
WEB-1220: Show charges, allocations and cycle variations on the guided review

### DIFF
--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.html
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.html
@@ -293,6 +293,53 @@
           </ng-container>
 
           <!--
+            The allocation order the operator arranged, shown through the very panel the rest of the
+            app views a product's allocations with. An order is a structure, not a label/value row,
+            and reproducing it as one would be a third rendering of the same data.
+          -->
+          <div class="review-section" *ngIf="showPaymentAllocationReview">
+            <p class="review-section__title">
+              {{ 'labels.inputs.Advanced Payment Allocation Transactions' | translate }}
+            </p>
+            <mat-accordion class="review-allocations">
+              <mifosx-view-advance-paymeny-allocation
+                *ngFor="let allocation of paymentAllocation; trackBy: trackByAllocationTransactionType"
+                [paymentAllocation]="allocation"
+                [advancePaymentAllocationData]="advancePaymentAllocationData"
+              ></mifosx-view-advance-paymeny-allocation>
+            </mat-accordion>
+          </div>
+
+          <div class="review-section" *ngIf="showCreditAllocationReview">
+            <p class="review-section__title">
+              {{ 'labels.inputs.Advanced Credit Allocation Transactions' | translate }}
+            </p>
+            <mat-accordion class="review-allocations">
+              <mifosx-view-advance-paymeny-allocation
+                *ngFor="let allocation of creditAllocation; trackBy: trackByAllocationTransactionType"
+                [creditAllocation]="allocation"
+                [advancePaymentAllocationData]="advancePaymentAllocationData"
+              ></mifosx-view-advance-paymeny-allocation>
+            </mat-accordion>
+          </div>
+
+          <!--
+            Everything the operator configured on the reused Charges, Interest Refunds, Deferred Income
+            Recognition and Loan Cycle Variations steps. Section titles are translation keys, like the
+            step labels they repeat; the row labels are NOT — they are resolved in TypeScript because
+            they mix fixed captions with names the backend gave, and a tenant's charge is not a key.
+          -->
+          <ng-container *ngFor="let group of reusedStepReviewGroups; trackBy: trackBySectionTitle">
+            <div class="review-section">
+              <p class="review-section__title">{{ group.title | translate }}</p>
+              <div class="review-row" *ngFor="let row of group.rows; trackBy: trackByRowLabel">
+                <span class="review-row__label">{{ row.label }}</span>
+                <span class="review-row__value">{{ row.display }}</span>
+              </div>
+            </div>
+          </ng-container>
+
+          <!--
             Accounting summary, driven by the reused Classic accounting step and rendered with the same
             atomic mifosx-gl-account-display component Classic uses — so the selected GL accounts appear
             exactly as they do in the Classic preview.

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.scss
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.scss
@@ -421,3 +421,30 @@ mat-checkbox {
     font-weight: 500;
   }
 }
+
+.review-allocations {
+  /* The reused allocation panel is written for Classic's summary, at its type scale and with the
+     same `.flex-40` / `.flex-60` label-value pair. Bring both into line with the surrounding review
+     rows so one section does not read a size larger than the rest. */
+  font-size: 0.875rem;
+
+  ::ng-deep .flex-40 {
+    color: var(--lp-text-muted);
+  }
+
+  ::ng-deep .flex-60 {
+    color: var(--lp-text);
+    font-weight: 500;
+  }
+
+  ::ng-deep table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+  }
+
+  ::ng-deep th {
+    color: var(--lp-text-muted);
+    font-weight: 600;
+  }
+}

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.spec.ts
@@ -1200,6 +1200,237 @@ describe('LoanProductWizardComponent', () => {
     });
   });
 
+  describe('Review covers the reused Classic steps, not just the field-driven ones', () => {
+    /**
+     * Charges, Payment Allocation, Interest Refunds, Deferred Income Recognition and Loan Cycle
+     * Variations are reused Classic components, so they carry no `fields` config and were invisible to
+     * the `kind: 'fields'` walk the Review was built on. These specs pin what the operator now sees —
+     * and, just as importantly, what a step they never reached must NOT put in front of them.
+     */
+    function chargesComponent(): LoanProductWizardComponent {
+      const component = createComponent();
+      component.profileMode = 'personal';
+      component.loanProductsTemplate = {
+        currencyOptions: [{ code: 'INR' }],
+        transactionProcessingStrategyOptions: [
+          { code: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced Payment Allocation' }
+        ]
+      };
+      component.ngOnInit();
+      return component;
+    }
+
+    function bnplComponent(): LoanProductWizardComponent {
+      const component = createComponent();
+      component.profileMode = 'bnpl';
+      component.loanProductsTemplate = {
+        currencyOptions: [{ code: 'INR' }],
+        transactionProcessingStrategyOptions: [
+          { code: 'mifos-standard-strategy', name: 'Mifos standard' },
+          { code: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced Payment Allocation' }
+        ]
+      };
+      component.ngOnInit();
+      component.form.patchValue({
+        transactionProcessingStrategyCode: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY
+      });
+      return component;
+    }
+
+    function jlgComponent(): LoanProductWizardComponent {
+      const component = createComponent();
+      component.profileMode = 'jlg';
+      component.loanProductsTemplate = {
+        currencyOptions: [{ code: 'INR' }],
+        transactionProcessingStrategyOptions: [
+          { code: LoanProducts.ADVANCED_PAYMENT_ALLOCATION_STRATEGY, name: 'Advanced Payment Allocation' }
+        ],
+        valueConditionTypeOptions: [
+          { id: 2, code: 'loanProduct.valueConditionType.equal', value: 'equals' },
+          { id: 3, code: 'loanProduct.valueConditionType.greaterthan', value: 'greater than' }
+        ]
+      };
+      component.ngOnInit();
+      component.form.patchValue({ useBorrowerCycle: true });
+      return component;
+    }
+
+    function chargesStepStub(charges: any[]): any {
+      return { loanProductCharges: { charges } };
+    }
+
+    function section(component: LoanProductWizardComponent, title: string) {
+      return component.reusedStepReviewGroups.find((group) => group.title === title);
+    }
+
+    function sectionTitles(component: LoanProductWizardComponent): string[] {
+      return component.reusedStepReviewGroups.map((group) => group.title);
+    }
+
+    it('lists the selected fees and the overdue penalties as the two sections Classic splits them into', () => {
+      const component = chargesComponent();
+      component.loanProductChargesStep = chargesStepStub([
+        {
+          name: 'Processing Fee',
+          penalty: false,
+          amount: 1500,
+          chargeCalculationType: { value: 'Flat' },
+          chargeTimeType: { value: 'Disbursement' }
+        },
+        {
+          name: 'Late Payment Penalty',
+          penalty: true,
+          amount: 2,
+          chargeCalculationType: { value: '% Loan Amount' },
+          chargeTimeType: { value: 'Overdue Fees' }
+        }
+      ]);
+
+      expect(section(component, 'labels.heading.Charges')?.rows).toEqual([
+        { label: 'Processing Fee', display: 'Flat · 1,500 · Disbursement' }
+      ]);
+      expect(section(component, 'labels.inputs.Overdue Charges')?.rows).toEqual([
+        { label: 'Late Payment Penalty', display: '% Loan Amount · 2 · Overdue Fees' }
+      ]);
+    });
+
+    it('keeps a charge with no penalty flag in the fee section instead of dropping it', () => {
+      // The `chargesPenaltyFilter` pipe compares `penalty` strictly, so such a charge falls out of
+      // both of its lists. A charge the operator selected must never be missing from the Review.
+      const component = chargesComponent();
+      component.loanProductChargesStep = chargesStepStub([{ name: 'Unflagged charge', amount: 10 }]);
+
+      expect(section(component, 'labels.heading.Charges')?.rows).toEqual([
+        { label: 'Unflagged charge', display: '10' }
+      ]);
+    });
+
+    it('shows no charge section at all when none were selected', () => {
+      const component = chargesComponent();
+      component.loanProductChargesStep = chargesStepStub([]);
+
+      expect(sectionTitles(component)).not.toContain('labels.heading.Charges');
+      expect(sectionTitles(component)).not.toContain('labels.inputs.Overdue Charges');
+    });
+
+    it('names the refund types the interest-refund step collected', () => {
+      const component = bnplComponent();
+      component.setSupportedInterestRefundTypes([
+        { id: '1', code: 'MERCHANT_ISSUED_REFUND', value: 'Merchant Issued Refund' },
+        { id: '2', code: 'PAYOUT_REFUND', value: 'Payout Refund' }
+      ]);
+
+      expect(section(component, 'labels.heading.Interest Refunds')?.rows).toEqual([
+        {
+          label: 'labels.inputs.Supported Interest Refund Types',
+          display: 'Merchant Issued Refund, Payout Refund'
+        }
+      ]);
+    });
+
+    it('drops a reused step from the Review as soon as the strategy stops rendering it', () => {
+      // The Review reports what the operator configured on the steps they actually walked. Switching
+      // the strategy back hides Interest Refunds and Deferred Income Recognition, and the state those
+      // steps left behind must go with them — `buildPayload` discards it for the same reason.
+      const component = bnplComponent();
+      component.setSupportedInterestRefundTypes([
+        { id: '1', code: 'MERCHANT_ISSUED_REFUND', value: 'Merchant Issued Refund' }
+      ]);
+      expect(sectionTitles(component)).toContain('labels.heading.Interest Refunds');
+
+      component.form.patchValue({ transactionProcessingStrategyCode: 'mifos-standard-strategy' });
+
+      expect(sectionTitles(component)).not.toContain('labels.heading.Interest Refunds');
+    });
+
+    it('reports capitalized income and buy-down fees the way Classic summarizes them', () => {
+      const component = bnplComponent();
+      component.deferredIncomeRecognition = {
+        capitalizedIncome: {
+          enableIncomeCapitalization: true,
+          capitalizedIncomeCalculationType: { value: 'Flat' } as any,
+          capitalizedIncomeStrategy: { value: 'Equal amortization' } as any,
+          capitalizedIncomeType: { value: 'Fee' } as any
+        },
+        buyDownFee: { enableBuyDownFee: false }
+      };
+
+      expect(section(component, 'labels.heading.Deferred Income Recognition')?.rows).toEqual([
+        { label: 'labels.inputs.Enable income capitalization', display: 'Yes' },
+        { label: 'labels.inputs.Income capitalization calculation type', display: 'Flat' },
+        { label: 'labels.inputs.Income capitalization strategy', display: 'Equal amortization' },
+        { label: 'labels.inputs.Income type', display: 'Fee' },
+        // Off is a decision worth confirming, so the toggle reports either way — but its three
+        // dependent values stay hidden, exactly as Classic's `@if (enableBuyDownFee)` does.
+        { label: 'labels.inputs.Enable Buy down fee', display: 'No' }
+      ]);
+    });
+
+    it('lists each loan-cycle variation with its condition and bounds', () => {
+      const component = jlgComponent();
+      component.setBorrowerCycleVariations({
+        principalVariationsForBorrowerCycle: [
+          { valueConditionType: 2, borrowerCycleNumber: 1, defaultValue: 5000 },
+          { valueConditionType: 3, borrowerCycleNumber: 3, minValue: 10000, defaultValue: 20000, maxValue: 30000 }
+        ],
+        numberOfRepaymentVariationsForBorrowerCycle: [],
+        interestRateVariationsForBorrowerCycle: []
+      });
+
+      expect(section(component, 'labels.inputs.Terms vary based on loan cycle')?.rows).toEqual([
+        {
+          label: 'labels.inputs.Principal by loan cycle',
+          display: 'equals 1: 5,000 · greater than 3: 20,000 (10,000–30,000)'
+        }
+      ]);
+    });
+
+    it('shows the payment allocation panels only once the step is visible and the template can name the codes', () => {
+      const component = bnplComponent();
+      component.setPaymentAllocation([
+        {
+          transactionType: 'DEFAULT',
+          futureInstallmentAllocationRule: 'NEXT_INSTALLMENT',
+          paymentAllocationOrder: [{ paymentAllocationRule: 'PAST_DUE_PENALTY', order: 1 }]
+        }
+      ]);
+
+      // The reused panel dereferences the option lists for every code it renders, so without them the
+      // Review would throw rather than degrade.
+      expect(component.advancePaymentAllocationData).toBeNull();
+      expect(component.showPaymentAllocationReview).toBe(false);
+
+      component.loanProductsTemplate = {
+        ...component.loanProductsTemplate,
+        advancedPaymentAllocationTransactionTypes: [{ id: 1, code: 'DEFAULT', value: 'Default' }],
+        advancedPaymentAllocationTypes: [{ id: 1, code: 'PAST_DUE_PENALTY', value: 'Past due penalty' }],
+        advancedPaymentAllocationFutureInstallmentAllocationRules: [
+          { id: 1, code: 'NEXT_INSTALLMENT', value: 'Next installment' }
+        ],
+        creditAllocationTransactionTypes: [{ id: 2, code: 'CHARGEBACK', value: 'Chargeback' }],
+        creditAllocationAllocationTypes: [{ id: 2, code: 'PRINCIPAL', value: 'Principal' }]
+      };
+
+      expect(component.showPaymentAllocationReview).toBe(true);
+      // Both allocation vocabularies in one lookup, exactly as Classic's summary assembles them.
+      expect(component.advancePaymentAllocationData?.transactionTypes.map((type) => type.code)).toEqual([
+        'DEFAULT',
+        'CHARGEBACK'
+      ]);
+      expect(component.advancePaymentAllocationData?.allocationTypes.map((type) => type.code)).toEqual([
+        'PAST_DUE_PENALTY',
+        'PRINCIPAL'
+      ]);
+      // Memoised on the template it came from: the panels take it as an @Input, and a fresh object per
+      // change-detection pass would re-render them every cycle.
+      expect(component.advancePaymentAllocationData).toBe(component.advancePaymentAllocationData);
+
+      component.form.patchValue({ transactionProcessingStrategyCode: 'mifos-standard-strategy' });
+
+      expect(component.showPaymentAllocationReview).toBe(false);
+    });
+  });
+
   describe('golden parity: visible fields, steps and seeded form state per profile', () => {
     // These locks pin the exact wizard surface (which fields/steps render) and the exact form
     // seeding (what getInitialFormState + syncTemplateDefaults leave in the controls) for the

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
@@ -54,6 +54,7 @@ import {
   AdvancedCreditAllocation,
   AdvancedPaymentAllocation,
   AdvancedPaymentStrategy,
+  AdvancePaymentAllocationData,
   BuyDownFee,
   CapitalizedIncome,
   CreditAllocation,
@@ -68,9 +69,14 @@ import { LoanProductInterestRefundStepComponent } from '../loan-product-stepper/
 import { LoanProductDeferredIncomeRecognitionStepComponent } from '../loan-product-stepper/loan-product-capitalized-income-step/loan-product-deferred-income-recognition-step.component';
 import {
   LoanProductBorrowerCycleStepComponent,
+  BorrowerCycleVariation,
+  BorrowerCycleVariationKey,
   BorrowerCycleVariations
 } from './borrower-cycle-step/loan-product-borrower-cycle-step.component';
 import { GlAccountDisplayComponent } from '../../../shared/accounting/gl-account-display/gl-account-display.component';
+// The panel Classic's own summary renders for each configured allocation, reused here so the guided
+// Review shows the allocation order the same way the rest of the app does.
+import { ViewAdvancePaymenyAllocationComponent } from '../view-loan-product/shared/view-advance-paymeny-allocation/view-advance-paymeny-allocation.component';
 // The four Classic step components Custom/Advanced hosts in place of the config-driven field grid,
 // plus Classic's own preview so its Review shows the same summary Classic's does.
 import { LoanProductDetailsStepComponent } from '../loan-product-stepper/loan-product-details-step/loan-product-details-step.component';
@@ -83,6 +89,7 @@ import { Router } from '@angular/router';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import { MatButtonModule } from '@angular/material/button';
+import { MatAccordion } from '@angular/material/expansion';
 import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
 import { rangeValidator } from 'app/shared/validators/percentage.validator';
@@ -191,6 +198,54 @@ const ACCOUNTING_REVIEW_ACCOUNTS: ReadonlyArray<{ key: string; title: string }> 
   { key: 'overpaymentLiabilityAccountId', title: 'Over payment liability' }
 ];
 
+/** One `label: value` line in the guided Review. */
+interface ReviewRow {
+  label: string;
+  display: string;
+}
+
+/**
+ * One titled block of the guided Review.
+ *
+ * `title` is always a translation key, resolved by the template exactly like the step label it names.
+ * `label` inside a row is NOT: rows built from the reused Classic steps mix fixed captions with
+ * values the backend named (a tenant's charge, an allocation rule), so they are resolved in
+ * TypeScript — see {@link LoanProductWizardComponent.reusedStepReviewGroups}. The `fields`-driven
+ * {@link LoanProductWizardComponent.reviewGroups} keeps its labels as keys, because every one of them
+ * is a `FormField.label` the form itself renders through the same pipe.
+ */
+interface ReviewSection {
+  title: string;
+  rows: ReviewRow[];
+}
+
+/**
+ * The three borrower-cycle variation lists, each paired with the heading its own step renders
+ * (`LoanProductBorrowerCycleStepComponent.sections`) so the Review names them identically.
+ */
+const BORROWER_CYCLE_REVIEW_SECTIONS: ReadonlyArray<{ key: BorrowerCycleVariationKey; heading: string }> = [
+  { key: 'principalVariationsForBorrowerCycle', heading: 'labels.inputs.Principal by loan cycle' },
+  { key: 'numberOfRepaymentVariationsForBorrowerCycle', heading: 'labels.inputs.Number of repayments by loan cycle' },
+  { key: 'interestRateVariationsForBorrowerCycle', heading: 'labels.inputs.Nominal interest rate by loan cycle' }
+];
+
+/**
+ * The capitalized-income and buy-down-fee values the reused Deferred Income Recognition step
+ * collects, each with the caption Classic's summary gives it. Both lists are enum-valued, so the
+ * Review resolves them through the `labels.catalogs` namespace like every other backend enum.
+ */
+const CAPITALIZED_INCOME_REVIEW_FIELDS: ReadonlyArray<{ key: keyof CapitalizedIncome; label: string }> = [
+  { key: 'capitalizedIncomeCalculationType', label: 'labels.inputs.Income capitalization calculation type' },
+  { key: 'capitalizedIncomeStrategy', label: 'labels.inputs.Income capitalization strategy' },
+  { key: 'capitalizedIncomeType', label: 'labels.inputs.Income type' }
+];
+
+const BUY_DOWN_FEE_REVIEW_FIELDS: ReadonlyArray<{ key: keyof BuyDownFee; label: string }> = [
+  { key: 'buyDownFeeCalculationType', label: 'labels.inputs.Buy down fee calculation type' },
+  { key: 'buyDownFeeStrategy', label: 'labels.inputs.Buy down fee strategy' },
+  { key: 'buyDownFeeIncomeType', label: 'labels.inputs.Buy down fee income type' }
+];
+
 @Component({
   selector: 'mifosx-loan-product-wizard',
   standalone: true,
@@ -209,7 +264,9 @@ const ACCOUNTING_REVIEW_ACCOUNTS: ReadonlyArray<{ key: string; title: string }> 
     LoanProductTermsStepComponent,
     LoanProductSettingsStepComponent,
     LoanProductPreviewStepComponent,
-    GlAccountDisplayComponent
+    GlAccountDisplayComponent,
+    ViewAdvancePaymenyAllocationComponent,
+    MatAccordion
   ],
   templateUrl: './loan-product-wizard.component.html',
   styleUrls: ['./loan-product-wizard.component.scss']
@@ -323,6 +380,9 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
   // The strategy list depends on the schedule type too (Classic rebuilds it per type), so the cache
   // must invalidate when the user switches between Progressive and Cumulative.
   private transactionProcessingStrategyOptionsCacheProgressive?: boolean;
+  // See `advancePaymentAllocationData`: memoised on the template it was derived from, because it is
+  // bound as an @Input on the Review.
+  private advancePaymentAllocationDataCache?: { template: unknown; data: AdvancePaymentAllocationData | null };
 
   // Editable Payment Allocation state, reused wholesale from the Classic flow. `advancedPaymentAllocations`
   // seeds the reused step's tabs/drag-and-drop; `paymentAllocation`/`creditAllocation` hold the payload-shaped
@@ -674,6 +734,15 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
 
   trackByAccountTitle(_index: number, account: { title: string }): string {
     return account.title;
+  }
+
+  /**
+   * Keyed on the transaction type, which is what a payment or credit allocation IS one of: the step
+   * emits at most one allocation per type, and re-emits the whole list on every edit, so the type is
+   * both unique and stable while the index is neither.
+   */
+  trackByAllocationTransactionType(_index: number, allocation: PaymentAllocation | CreditAllocation): string {
+    return allocation.transactionType;
   }
 
   /**
@@ -1677,8 +1746,12 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
    * and profile/strategy-determined fields are all excluded exactly as they were during the wizard.
    * Values are read straight from the FormGroup; nothing the user never saw can appear here. It is
    * intentionally NOT derived from {@link reviewPayload}/`buildPayload`.
+   *
+   * The reused Classic steps carry no `fields` config and so cannot be summarised this way; they are
+   * covered by {@link reusedStepReviewGroups}, {@link showPaymentAllocationReview} and
+   * {@link accountingReview}.
    */
-  get reviewGroups(): Array<{ title: string; rows: Array<{ label: string; display: string }> }> {
+  get reviewGroups(): ReviewSection[] {
     if (!this.form) {
       return [];
     }
@@ -1694,6 +1767,278 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
           .filter((row) => row.display !== '—')
       }))
       .filter((group) => group.rows.length > 0);
+  }
+
+  /**
+   * The Review sections for the steps the wizard does not drive from `fields` config: the reused
+   * Classic Charges, Interest Refunds, Deferred Income Recognition and Loan Cycle Variations steps.
+   *
+   * {@link reviewGroups} walks `kind: 'fields'` steps only, so everything configured on those four
+   * was absent from the summary — a confirmation screen that omitted the fees the borrower pays.
+   * Every section is built from the same state the payload assembly reads at submit time
+   * ({@link selectedCharges}, {@link supportedInterestRefundTypes},
+   * {@link deferredIncomeRecognition}, {@link borrowerCycleVariations}), so the Review and the POST
+   * cannot disagree.
+   *
+   * Driven by {@link visibleSteps} rather than `steps`, for the same reason the field sections are: a
+   * step the profile or the repayment strategy hides is one the operator never filled in, and the
+   * state a hidden step left behind must not surface here. Payment Allocation and Accounting are the
+   * two reused steps missing from this list — an allocation order and a GL account mapping are
+   * structures rather than rows, and each keeps the component the rest of the app renders it with
+   * ({@link showPaymentAllocationReview}, {@link accountingReview}).
+   */
+  get reusedStepReviewGroups(): ReviewSection[] {
+    return this.visibleSteps
+      .flatMap((step) => this.reviewSectionsFor(step))
+      .filter((section) => section.rows.length > 0);
+  }
+
+  private reviewSectionsFor(step: FormStep): ReviewSection[] {
+    switch (step.kind) {
+      case 'charges':
+        return this.chargesReviewSections();
+      case 'interest-refund':
+        return [{ title: step.title, rows: this.interestRefundReviewRows() }];
+      case 'deferred-income':
+        return [{ title: step.title, rows: this.deferredIncomeReviewRows() }];
+      case 'borrower-cycle':
+        return [{ title: step.title, rows: this.borrowerCycleReviewRows() }];
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * Fees and penalties as two sections, the split Classic's summary makes — an overdue penalty is
+   * charged on a different event from a disbursement fee, and stacking them under one heading hides
+   * that.
+   *
+   * The partition is `penalty` truthy / not, NOT the strict `=== true` / `=== false` of the
+   * `chargesPenaltyFilter` pipe the tables use: a charge whose `penalty` flag is missing would fall
+   * out of both of the pipe's lists, and a charge silently absent from the Review is the defect this
+   * section exists to fix.
+   */
+  private chargesReviewSections(): ReviewSection[] {
+    const charges = this.selectedCharges;
+    return [
+      {
+        title: 'labels.heading.Charges',
+        rows: charges.filter((charge) => !charge?.penalty).map((charge) => this.chargeReviewRow(charge))
+      },
+      {
+        title: 'labels.inputs.Overdue Charges',
+        rows: charges.filter((charge) => !!charge?.penalty).map((charge) => this.chargeReviewRow(charge))
+      }
+    ];
+  }
+
+  /**
+   * One charge, carrying the three facts Classic's charge table shows beside its name, in that order:
+   * calculation type, amount, and the event it is collected on.
+   *
+   * The amount is deliberately unadorned, exactly as Classic renders it: the same column holds a
+   * currency amount for a Flat charge and a percentage for a `% Approved Amount` one, so a currency
+   * symbol would be wrong half the time. The calculation type it sits next to says which it is.
+   */
+  private chargeReviewRow(charge: any): ReviewRow {
+    const details = [
+      this.enumDisplay(charge?.chargeCalculationType),
+      this.formatReviewNumber(charge?.amount),
+      this.enumDisplay(charge?.chargeTimeType)
+    ].filter((detail) => detail !== '');
+    return { label: String(charge?.name ?? ''), display: details.join(' · ') };
+  }
+
+  private interestRefundReviewRows(): ReviewRow[] {
+    if (this.supportedInterestRefundTypes.length === 0) {
+      return [];
+    }
+    return [
+      {
+        label: this.reviewLabel('labels.inputs.Supported Interest Refund Types'),
+        display: this.supportedInterestRefundTypes.map((refundType) => this.enumDisplay(refundType)).join(', ')
+      }
+    ];
+  }
+
+  /**
+   * Capitalized income and buy-down fees, in the order and with the captions Classic's summary uses.
+   * Each block reports its own on/off row first — "off" is a decision worth confirming — and its
+   * enum values only while it is on, mirroring Classic's `@if (enable…)` guards.
+   */
+  private deferredIncomeReviewRows(): ReviewRow[] {
+    const deferredIncome = this.deferredIncomeRecognition;
+    if (!deferredIncome) {
+      return [];
+    }
+    const rows: ReviewRow[] = [];
+    const capitalizedIncome = deferredIncome.capitalizedIncome;
+    if (capitalizedIncome) {
+      rows.push(
+        this.yesNoReviewRow(
+          'labels.inputs.Enable income capitalization',
+          !!capitalizedIncome.enableIncomeCapitalization
+        )
+      );
+      if (capitalizedIncome.enableIncomeCapitalization) {
+        rows.push(...this.enumReviewRows(capitalizedIncome, CAPITALIZED_INCOME_REVIEW_FIELDS));
+      }
+    }
+    const buyDownFee = deferredIncome.buyDownFee;
+    if (buyDownFee) {
+      rows.push(this.yesNoReviewRow('labels.inputs.Enable Buy down fee', !!buyDownFee.enableBuyDownFee));
+      if (buyDownFee.enableBuyDownFee) {
+        rows.push(...this.enumReviewRows(buyDownFee, BUY_DOWN_FEE_REVIEW_FIELDS));
+        rows.push(this.yesNoReviewRow('labels.inputs.Merchant Buy down fee', !!buyDownFee.merchantBuyDownFee));
+      }
+    }
+    return rows;
+  }
+
+  /**
+   * One row per populated variation list, listing each cycle's default value (with its bounds where
+   * the operator set any) against the condition that selects it — "equals 1: 5,000 · greater than
+   * 3: 20,000 (10,000–30,000)".
+   *
+   * The values rather than a count: "3 variations" says nothing about the amounts a repeat borrower
+   * will actually be offered, which is the only reason to configure the step at all. The step's own
+   * tables remain the place to edit them.
+   */
+  private borrowerCycleReviewRows(): ReviewRow[] {
+    const variations = this.borrowerCycleVariations;
+    if (!variations) {
+      return [];
+    }
+    return BORROWER_CYCLE_REVIEW_SECTIONS.flatMap((section) => {
+      const rows = variations[section.key] ?? [];
+      if (rows.length === 0) {
+        return [];
+      }
+      return [
+        {
+          label: this.reviewLabel(section.heading),
+          display: rows.map((variation) => this.variationDisplay(variation)).join(' · ')
+        }
+      ];
+    });
+  }
+
+  private variationDisplay(variation: BorrowerCycleVariation): string {
+    const condition = this.valueConditionLabel(variation.valueConditionType);
+    const minValue = this.formatReviewNumber(variation.minValue);
+    const maxValue = this.formatReviewNumber(variation.maxValue);
+    // Both bounds are optional and either can stand alone, so an absent one shows as a dash rather
+    // than collapsing the pair into something that reads like the other bound.
+    const bounds = minValue === '' && maxValue === '' ? '' : ` (${minValue || '—'}–${maxValue || '—'})`;
+    const cycle = [
+      condition,
+      variation.borrowerCycleNumber
+    ]
+      .filter((part) => part !== '' && part !== null && part !== undefined)
+      .join(' ');
+    return `${cycle}: ${this.formatReviewNumber(variation.defaultValue)}${bounds}`;
+  }
+
+  /**
+   * The condition's own name from the template (`equals` / `greater than`), read from the very option
+   * list the borrower-cycle step builds its dialog select from. Falls back to the raw id, which is
+   * all a template-less render can honestly show.
+   */
+  private valueConditionLabel(valueConditionType: number | string): string {
+    const option = (this.loanProductsTemplate?.valueConditionTypeOptions ?? []).find(
+      (candidate: any) => String(candidate?.id) === String(valueConditionType)
+    );
+    return option ? this.enumDisplay(option) : String(valueConditionType ?? '');
+  }
+
+  private enumReviewRows<T>(source: T, fields: ReadonlyArray<{ key: keyof T & string; label: string }>): ReviewRow[] {
+    return fields
+      .map((field) => ({ label: this.reviewLabel(field.label), display: this.enumDisplay(source[field.key]) }))
+      .filter((row) => row.display !== '');
+  }
+
+  private yesNoReviewRow(labelKey: string, value: boolean): ReviewRow {
+    return { label: this.reviewLabel(labelKey), display: this.translateDisplayLabel(value ? 'Yes' : 'No') };
+  }
+
+  private reviewLabel(labelKey: string): string {
+    return this.translateService.instant(labelKey);
+  }
+
+  /**
+   * A backend-named value — a Fineract enum, a charge's calculation type, a tenant's own condition —
+   * resolved through `labels.catalogs`, where a key the bundles do not carry falls back to the value
+   * itself. Empty for a value the step never set, so the caller can drop the row.
+   */
+  private enumDisplay(value: unknown): string {
+    if (value === null || value === undefined || value === '') {
+      return '';
+    }
+    return this.translateDisplayLabel(String(this.normalizeValueForDisplay(value)));
+  }
+
+  /** Grouped in the operator's own locale, like the Review banner's principal. */
+  private formatReviewNumber(value: unknown): string {
+    if (value === null || value === undefined || value === '') {
+      return '';
+    }
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric.toLocaleString(this.settingsService.languageCode) : String(value);
+  }
+
+  /**
+   * Whether the Review shows the payment allocation panels: the step has to be one the operator
+   * actually walked, the allocations have to exist, and the template has to carry the option lists
+   * the panel resolves its codes against.
+   *
+   * That last condition is not defensive noise — the reused panel dereferences the match for every
+   * code it renders, so an allocation whose transaction type is missing from the data would throw
+   * inside the Review rather than degrade.
+   */
+  get showPaymentAllocationReview(): boolean {
+    return (
+      this.paymentAllocation.length > 0 &&
+      !!this.advancePaymentAllocationData &&
+      this.visibleSteps.some((step) => step.kind === 'payment-allocation')
+    );
+  }
+
+  get showCreditAllocationReview(): boolean {
+    return this.showPaymentAllocationReview && this.creditAllocation.length > 0;
+  }
+
+  /**
+   * The transaction types, allocation types and future-installment rules the reused panel resolves
+   * its payload codes against, assembled from the template exactly as Classic's summary assembles it
+   * for a product that does not exist yet.
+   *
+   * Memoised on the template's identity because it is bound as an `@Input`: a fresh object on every
+   * change-detection pass would re-render the panels each cycle and trip the dev-mode
+   * check-no-changes pass.
+   */
+  get advancePaymentAllocationData(): AdvancePaymentAllocationData | null {
+    if (this.advancePaymentAllocationDataCache?.template === this.loanProductsTemplate) {
+      return this.advancePaymentAllocationDataCache.data;
+    }
+    const template = this.loanProductsTemplate;
+    const data: AdvancePaymentAllocationData | null =
+      template?.advancedPaymentAllocationTransactionTypes &&
+      template?.advancedPaymentAllocationTypes &&
+      template?.advancedPaymentAllocationFutureInstallmentAllocationRules
+        ? {
+            transactionTypes: [
+              ...template.advancedPaymentAllocationTransactionTypes,
+              ...(template.creditAllocationTransactionTypes ?? [])
+            ],
+            allocationTypes: [
+              ...template.advancedPaymentAllocationTypes,
+              ...(template.creditAllocationAllocationTypes ?? [])
+            ],
+            futureInstallmentAllocationRules: template.advancedPaymentAllocationFutureInstallmentAllocationRules
+          }
+        : null;
+    this.advancePaymentAllocationDataCache = { template, data };
+    return data;
   }
 
   /**

--- a/src/app/products/loan-products/wizard/loan-product-wizard.render.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.render.spec.ts
@@ -487,4 +487,82 @@ describe('LoanProductWizardComponent (rendered)', () => {
       expect(component.formatValue('interestType', 0)).toBe('Reducing balance');
     });
   });
+
+  /**
+   * I2: the Review walked `kind: 'fields'` steps only, so nothing configured on the reused Classic
+   * steps reached it — a confirmation screen that named every term of the loan except the fees the
+   * borrower pays. DOM-level because the defect is a section that never rendered, and because the
+   * rows come from the reused step component's own state rather than from the wizard's FormGroup.
+   */
+  describe('Review sections for the reused Classic steps', () => {
+    function reviewRows(sectionTitle: string): Array<{ label: string; value: string }> {
+      return Array.from(fixture.nativeElement.querySelectorAll('.review-section') as NodeListOf<HTMLElement>)
+        .filter((section) => section.querySelector('.review-section__title')?.textContent?.trim() === sectionTitle)
+        .flatMap((section) =>
+          Array.from(section.querySelectorAll('.review-row') as NodeListOf<HTMLElement>).map((row) => ({
+            label: row.querySelector('.review-row__label')!.textContent!.trim(),
+            value: row.querySelector('.review-row__value')!.textContent!.trim()
+          }))
+        );
+    }
+
+    function selectCharges(charges: any[]): void {
+      // Written onto the reused step's own data source, the way its Add button does — so this
+      // exercises the same getter the payload assembly reads at submit time.
+      component.loanProductChargesStep!.chargesDataSource = charges;
+      detect();
+    }
+
+    beforeEach(() => {
+      loadChromeCopy();
+      detect();
+    });
+
+    it('lists a selected charge with its type, amount and collection event', () => {
+      selectCharges([
+        {
+          name: 'Processing Fee',
+          penalty: false,
+          amount: 1500,
+          currency: { displaySymbol: 'KSh' },
+          chargeCalculationType: { value: 'Flat' },
+          chargeTimeType: { value: 'Disbursement' }
+        }
+      ]);
+
+      // The charge is named by the tenant, so its label is resolved in TypeScript and rendered as-is:
+      // no bundle can carry a key for it, and piping it through `translate` would be a coin flip.
+      expect(reviewRows('Charges')).toEqual([{ label: 'Processing Fee', value: 'Flat · 1,500 · Disbursement' }]);
+    });
+
+    it('separates overdue penalties from fees, as Classic does', () => {
+      selectCharges([
+        {
+          name: 'Processing Fee',
+          penalty: false,
+          amount: 1500,
+          currency: { displaySymbol: 'KSh' },
+          chargeCalculationType: { value: 'Flat' },
+          chargeTimeType: { value: 'Disbursement' }
+        },
+        {
+          name: 'Late Payment Penalty',
+          penalty: true,
+          amount: 2,
+          currency: { displaySymbol: 'KSh' },
+          chargeCalculationType: { value: '% Loan Amount' },
+          chargeTimeType: { value: 'Overdue Fees' }
+        }
+      ]);
+
+      expect(reviewRows('Charges').map((row) => row.label)).toEqual(['Processing Fee']);
+      expect(reviewRows('labels.inputs.Overdue Charges').map((row) => row.label)).toEqual(['Late Payment Penalty']);
+    });
+
+    it('shows no charge section while nothing is selected', () => {
+      selectCharges([]);
+
+      expect(reviewRows('Charges')).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Description

The guided loan-product wizard's Review step summarised only the steps driven by field config — `reviewGroups` filters to `kind === 'fields'`. Charges, Payment Allocation, Interest Refunds, Deferred Income Recognition and Loan Cycle Variations are reused Classic components with no field config, so nothing configured on them reached the Review. Accounting was the single manual add-back. The result was a confirmation screen that named every term of the loan except the fees the borrower pays — and charges are the thing an operator is most likely to have got wrong.

This adds the missing sections:

- **Charges** — fees and Overdue Charges as two sections, as Classic's summary splits them, each row showing the charge's calculation type, amount and collection event.
- **Payment / credit allocation** — rendered with the existing `mifosx-view-advance-paymeny-allocation` panel the rest of the app views allocations with, rather than a third rendering of the same data.
- **Interest refunds**, **capitalized income / buy-down fees**, and **loan-cycle variations** (each cycle's default value with its condition and bounds).

The sections are built from the same state the payload assembly reads at submit time, and are driven by `visibleSteps`, so a step the profile or the repayment strategy hides takes its state out of the Review with it — the rule the field sections and the incomplete-step summary already follow. `<mifosx-loan-product-summary>` was deliberately not reused here: it renders the payload including hidden defaults and requires a complete product, which would contradict the guided Review's contract of showing only what the operator actually saw.

No new translation keys — every caption already ships in all 13 locale files.

## Related issues and discussion

# WEB-1220

## Screenshots, if any

<img width="1600" height="814" alt="WhatsApp Image 2026-09-08 at 8 20 33 PM" src="https://github.com/user-attachments/assets/5763c07d-510a-49dd-bdf4-83057b965e15" />


## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the loan product wizard’s Review step to include Charges, Interest Refunds, Deferred Income Recognition, and Loan Cycle Variations.
  * Added review panels for Advanced Payment Allocation and Advanced Credit Allocation transactions.
  * Improved review summaries with clearer grouping and labels, including separate handling for overdue penalties.

* **Bug Fixes**
  * Review content now reflects configured data and hides empty or inactive sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->