### PR TITLE
WEB-1062: Add credit task section

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/credit-applications/credit-applications.component.spec.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/credit-applications/credit-applications.component.spec.ts
@@ -203,6 +203,17 @@ describe('CreditApplicationsComponent', () => {
     );
   });
 
+  it('resets paging without emitting a duplicate paginator request', () => {
+    component.pageIndex = 2;
+    component.paginator = { pageIndex: 2, firstPage: jest.fn() } as any;
+
+    component.applyFilters();
+
+    expect(component.paginator.pageIndex).toBe(0);
+    expect(component.paginator.firstPage).not.toHaveBeenCalled();
+    expect(tasksService.getCreditApplications).toHaveBeenCalledTimes(1);
+  });
+
   it('requests the server again when sorting changes', () => {
     component.sortData({ active: 'amount', direction: 'asc' });
 
@@ -211,6 +222,18 @@ describe('CreditApplicationsComponent', () => {
       expect.objectContaining({
         orderBy: 'amount',
         sortOrder: 'ASC',
+        offset: 0
+      })
+    );
+  });
+
+  it('resets to the default server sort when sorting is cleared', () => {
+    component.sortData({ active: 'amount', direction: '' });
+
+    expect(tasksService.getCreditApplications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: 'submittedOnDate',
+        sortOrder: 'DESC',
         offset: 0
       })
     );

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/credit-applications/credit-applications.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/credit-applications/credit-applications.component.ts
@@ -151,16 +151,14 @@ export class CreditApplicationsComponent implements OnInit {
     if (!this.validateFilters()) {
       return;
     }
-    this.pageIndex = 0;
-    this.paginator?.firstPage();
+    this.resetPage();
     this.loadCreditApplications();
   }
 
   clearFilters(): void {
     this.creditApplicationsForm.reset();
     this.filterError = '';
-    this.pageIndex = 0;
-    this.paginator?.firstPage();
+    this.resetPage();
     this.loadCreditApplications();
   }
 
@@ -171,10 +169,9 @@ export class CreditApplicationsComponent implements OnInit {
   }
 
   sortData(sort: Sort): void {
-    this.orderBy = sort.active || 'submittedOnDate';
+    this.orderBy = sort.direction ? sort.active : 'submittedOnDate';
     this.sortOrder = sort.direction === 'asc' ? 'ASC' : 'DESC';
-    this.pageIndex = 0;
-    this.paginator?.firstPage();
+    this.resetPage();
     this.loadCreditApplications();
   }
 
@@ -311,5 +308,12 @@ export class CreditApplicationsComponent implements OnInit {
 
   private formatApiDate(date: Date | string): string {
     return date ? this.dateUtils.formatDate(date, Dates.DEFAULT_DATEFORMAT) : '';
+  }
+
+  private resetPage(): void {
+    this.pageIndex = 0;
+    if (this.paginator) {
+      this.paginator.pageIndex = 0;
+    }
   }
 }

--- a/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
@@ -76,10 +76,20 @@
           mat-tab-link
           [routerLink]="['./requests']"
           routerLinkActive
-          #creditApplications="routerLinkActive"
-          [active]="creditApplications.isActive"
+          #creditRequests="routerLinkActive"
+          [active]="creditRequests.isActive"
         >
           {{ 'labels.inputs.Requests' | translate }}
+        </a>
+        <a
+          mat-tab-link
+          [routerLink]="['./credit']"
+          routerLinkActive
+          #creditTaskSection="routerLinkActive"
+          [active]="creditTaskSection.isActive"
+          *mifosxHasPermission="'READ_LOAN'"
+        >
+          {{ 'labels.inputs.Credit' | translate }}
         </a>
       </nav>
 

--- a/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.spec.ts
+++ b/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.spec.ts
@@ -8,12 +8,14 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { provideRouter } from '@angular/router';
+import { Route as AngularRoute, provideRouter } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
 import { environment } from 'environments/environment';
+import { CreditApplicationsComponent } from '../checker-inbox-and-tasks-tabs/credit-applications/credit-applications.component';
+import { routes } from '../tasks-routing.module';
 import { CheckerInboxAndTasksComponent } from './checker-inbox-and-tasks.component';
 
 describe('CheckerInboxAndTasksComponent', () => {
@@ -73,7 +75,18 @@ describe('CheckerInboxAndTasksComponent', () => {
     environment.productionModeEnableRBAC = rbacEnabled;
   });
 
-  it('shows the Requests tab without a tab-level permission gate', () => {
+  it('shows the Credit tab for users who can read loans', () => {
+    createComponent(['READ_LOAN']);
+
+    const tabLabels = Array.from(fixture.nativeElement.querySelectorAll('a[mat-tab-link]')).map((tab: HTMLElement) =>
+      tab.textContent?.trim()
+    );
+
+    expect(tabLabels).toContain('labels.inputs.Requests');
+    expect(tabLabels).toContain('labels.inputs.Credit');
+  });
+
+  it('keeps Requests visible and hides Credit for users who cannot read loans', () => {
     createComponent([]);
 
     const tabLabels = Array.from(fixture.nativeElement.querySelectorAll('a[mat-tab-link]')).map((tab: HTMLElement) =>
@@ -81,9 +94,10 @@ describe('CheckerInboxAndTasksComponent', () => {
     );
 
     expect(tabLabels).toContain('labels.inputs.Requests');
+    expect(tabLabels).not.toContain('labels.inputs.Credit');
   });
 
-  it('places the Requests tab after Reschedule Loan', () => {
+  it('places Requests and Credit after Reschedule Loan', () => {
     createComponent(['ALL_FUNCTIONS']);
 
     const tabLabels = Array.from(fixture.nativeElement.querySelectorAll('a[mat-tab-link]')).map((tab: HTMLElement) =>
@@ -91,11 +105,13 @@ describe('CheckerInboxAndTasksComponent', () => {
     );
     const rescheduleLoanIndex = tabLabels.indexOf('labels.inputs.Reschedule Loan');
     const requestsIndex = tabLabels.indexOf('labels.inputs.Requests');
+    const creditIndex = tabLabels.indexOf('labels.inputs.Credit');
 
     expect(requestsIndex).toBe(rescheduleLoanIndex + 1);
+    expect(creditIndex).toBe(requestsIndex + 1);
   });
 
-  it('routes Requests to the credit applications page', async () => {
+  it('routes Requests to the existing credit applications page', async () => {
     const routeElement = await navigateToComponent();
 
     const requestsTab = Array.from(routeElement.querySelectorAll('a[mat-tab-link]')).find((tab: HTMLElement) =>
@@ -103,5 +119,25 @@ describe('CheckerInboxAndTasksComponent', () => {
     ) as HTMLAnchorElement;
 
     expect(requestsTab.getAttribute('href')).toBe('/checker-inbox-and-tasks/requests');
+  });
+
+  it('routes Credit to the credit applications page', async () => {
+    const routeElement = await navigateToComponent(['READ_LOAN']);
+
+    const creditTab = Array.from(routeElement.querySelectorAll('a[mat-tab-link]')).find((tab: HTMLElement) =>
+      tab.textContent?.includes('labels.inputs.Credit')
+    ) as HTMLAnchorElement;
+
+    expect(creditTab.getAttribute('href')).toBe('/checker-inbox-and-tasks/credit');
+  });
+
+  it('uses CreditApplicationsComponent for both Requests and Credit routes', () => {
+    const shellRoute = routes[0] as AngularRoute;
+    const taskRoute = shellRoute.children?.find((route: AngularRoute) => route.path === '');
+    const requestsRoute = taskRoute?.children?.find((route: AngularRoute) => route.path === 'requests');
+    const creditRoute = taskRoute?.children?.find((route: AngularRoute) => route.path === 'credit');
+
+    expect(requestsRoute?.component).toBe(CreditApplicationsComponent);
+    expect(creditRoute?.component).toBe(CreditApplicationsComponent);
   });
 });

--- a/src/app/tasks/tasks-routing.module.ts
+++ b/src/app/tasks/tasks-routing.module.ts
@@ -35,7 +35,7 @@ import { MakerCheckerTemplate } from './common-resolvers/makerCheckerTemplate.re
 import { GetCheckerInboxDetailResolver } from './common-resolvers/getCheckerInboxDetail.resolver';
 
 /** Tasks Routes */
-const routes: Routes = [
+export const routes: Routes = [
   Route.withShell([
     {
       path: '',
@@ -72,6 +72,11 @@ const routes: Routes = [
           path: 'requests',
           component: CreditApplicationsComponent,
           data: { title: 'Requests' }
+        },
+        {
+          path: 'credit',
+          component: CreditApplicationsComponent,
+          data: { title: 'Credit' }
         },
         {
           path: 'council-approval',


### PR DESCRIPTION
## Description

Adds the WEB-1062 Credit section to Checker Inbox & Tasks, reusing the existing credit application search API with server-side filtering, pagination, sorting, and navigation while maintaining existing functionality.

## Related issues and discussion

WEB-1062

## Screenshots, if any


https://github.com/user-attachments/assets/aaec5c60-f5e9-493f-84f9-4e339c88c9e3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Credit tab to the Checker Inbox and Tasks area.
  * Credit applications are available at the Credit route and shown only to users with the required loan-view permission.
  * The existing Requests tab remains available.

* **Bug Fixes**
  * Applying or clearing filters now reliably returns results to the first page without duplicate requests.
  * Clearing sorting now restores the default submitted-date descending order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->