### PR TITLE
fix(WEB-1077): validate return URL after login

### DIFF
--- a/src/app/core/authentication/authentication.guard.spec.ts
+++ b/src/app/core/authentication/authentication.guard.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { of } from 'rxjs';
+
+import { AuthenticationGuard } from './authentication.guard';
+import { AuthenticationService } from './authentication.service';
+
+describe('AuthenticationGuard', () => {
+  function createGuard(authenticated: boolean): {
+    guard: AuthenticationGuard;
+    router: { navigate: jest.Mock };
+    authenticationService: { isAuthenticated: jest.Mock; logout: jest.Mock };
+  } {
+    const router = { navigate: jest.fn() };
+    const authenticationService = {
+      isAuthenticated: jest.fn().mockReturnValue(authenticated),
+      logout: jest.fn().mockReturnValue(of(true))
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Router, useValue: router },
+        { provide: AuthenticationService, useValue: authenticationService }
+      ]
+    });
+
+    return { guard: TestBed.runInInjectionContext(() => new AuthenticationGuard()), router, authenticationService };
+  }
+
+  function stateFor(url: string): RouterStateSnapshot {
+    return { url } as RouterStateSnapshot;
+  }
+
+  const route = {} as ActivatedRouteSnapshot;
+
+  it('should let an authenticated user through without redirecting', () => {
+    const { guard, router } = createGuard(true);
+
+    expect(guard.canActivate(route, stateFor('/clients'))).toBe(true);
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should block an unauthenticated user and redirect to login', () => {
+    const { guard, router } = createGuard(false);
+
+    expect(guard.canActivate(route, stateFor('/clients'))).toBe(false);
+    expect(router.navigate).toHaveBeenCalledWith(['/login'], expect.objectContaining({ replaceUrl: true }));
+  });
+
+  it('should preserve the requested route as the return URL', () => {
+    const { guard, router, authenticationService } = createGuard(false);
+
+    guard.canActivate(route, stateFor('/clients/1/general?tab=savings'));
+
+    expect(router.navigate).toHaveBeenCalledWith(['/login'], {
+      replaceUrl: true,
+      queryParams: { returnUrl: '/clients/1/general?tab=savings' }
+    });
+    expect(authenticationService.logout).toHaveBeenCalledWith('/clients/1/general?tab=savings');
+  });
+});

--- a/src/app/core/authentication/authentication.service.ts
+++ b/src/app/core/authentication/authentication.service.ts
@@ -33,6 +33,9 @@ import { LoginContext } from './login-context.model';
 import { Credentials } from './credentials.model';
 import { getOAuthConfig, getActiveAuthMode, AuthMode } from './oauth.config';
 
+/** Custom Utilities */
+import { sanitizeReturnUrl } from '../utils/return-url.utils';
+
 /**
  * Authentication workflow.
  */
@@ -196,7 +199,7 @@ export class AuthenticationService {
     this.sessionSyncService.onCrossTabLogin$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((sourceStorage) => {
       this.restoreSession(sourceStorage);
       if (this.router.url.startsWith('/login')) {
-        const returnUrl = this.router.parseUrl(this.router.url).queryParams['returnUrl'] || '/';
+        const returnUrl = sanitizeReturnUrl(this.router.parseUrl(this.router.url).queryParams['returnUrl']);
         this.router.navigateByUrl(returnUrl, { replaceUrl: true });
       }
     });

--- a/src/app/core/utils/return-url.utils.spec.ts
+++ b/src/app/core/utils/return-url.utils.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { DefaultUrlSerializer } from '@angular/router';
+
+import { DEFAULT_RETURN_URL, sanitizeReturnUrl } from './return-url.utils';
+
+describe('sanitizeReturnUrl', () => {
+  it('should keep in-app router URLs', () => {
+    expect(sanitizeReturnUrl('/clients')).toBe('/clients');
+    expect(sanitizeReturnUrl('/clients/1/general')).toBe('/clients/1/general');
+    expect(sanitizeReturnUrl('/clients?officeId=1')).toBe('/clients?officeId=1');
+    expect(sanitizeReturnUrl('/loginless-report')).toBe('/loginless-report');
+  });
+
+  it('should fall back to the dashboard when nothing was preserved', () => {
+    expect(sanitizeReturnUrl(null)).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl(undefined)).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('')).toBe(DEFAULT_RETURN_URL);
+  });
+
+  it('should reject destinations that leave the application origin', () => {
+    expect(sanitizeReturnUrl('//evil.example.com')).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('https://evil.example.com')).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('/\\evil.example.com')).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('javascript:alert(1)')).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('clients')).toBe(DEFAULT_RETURN_URL);
+  });
+
+  it('should refuse the login page so authentication cannot loop', () => {
+    expect(sanitizeReturnUrl('/login')).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('/login?returnUrl=%2Fclients')).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('/login/reset-password')).toBe(DEFAULT_RETURN_URL);
+  });
+
+  it('should refuse login routes disguised by encoding or matrix parameters', () => {
+    // The router decodes segments, so these all resolve to the login page.
+    expect(sanitizeReturnUrl('/lo%67in')).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('/%6C%6F%67%69%6E')).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('/login;next=/clients')).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('/login;a=b?returnUrl=%2Fclients')).toBe(DEFAULT_RETURN_URL);
+  });
+
+  it('should reject values the router cannot parse', () => {
+    // `navigateByUrl` would throw NG04010 on these.
+    expect(sanitizeReturnUrl('/(a')).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl('/a(b')).toBe(DEFAULT_RETURN_URL);
+  });
+
+  it('should reject non-string values produced by duplicated query parameters', () => {
+    // `?returnUrl=/a&returnUrl=/b` makes the router yield an array, which has no startsWith.
+    const duplicated = new DefaultUrlSerializer().parse('/login?returnUrl=%2Fa&returnUrl=%2Fb').queryParams[
+      'returnUrl'
+    ];
+    expect(Array.isArray(duplicated)).toBe(true);
+    expect(sanitizeReturnUrl(duplicated)).toBe(DEFAULT_RETURN_URL);
+
+    expect(sanitizeReturnUrl(42)).toBe(DEFAULT_RETURN_URL);
+    expect(sanitizeReturnUrl({ toString: () => '/clients' })).toBe(DEFAULT_RETURN_URL);
+  });
+});

--- a/src/app/core/utils/return-url.utils.ts
+++ b/src/app/core/utils/return-url.utils.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import { DefaultUrlSerializer, PRIMARY_OUTLET } from '@angular/router';
+
+/** Destination used whenever no safe return URL was preserved. */
+export const DEFAULT_RETURN_URL = '/';
+
+/** Stateless parser used to resolve a candidate URL the way the router would. */
+const urlSerializer = new DefaultUrlSerializer();
+
+/**
+ * Validates a preserved `returnUrl` before it is handed to `Router.navigateByUrl`.
+ *
+ * The value reaches the application through the query string, so it is attacker
+ * controlled: only in-app router URLs are allowed through, and the login page itself is
+ * refused so a preserved destination can never send the user back into the login flow.
+ *
+ * @param {unknown} returnUrl Candidate destination, typically the `returnUrl` query parameter.
+ *   Typed loosely because a duplicated query parameter makes the router yield a `string[]`.
+ * @returns {string} The destination when it is a safe in-app route, otherwise {@link DEFAULT_RETURN_URL}.
+ */
+export function sanitizeReturnUrl(returnUrl: unknown): string {
+  if (typeof returnUrl !== 'string' || !returnUrl) {
+    return DEFAULT_RETURN_URL;
+  }
+
+  // Router URLs are absolute paths. `//host` is protocol relative and browsers normalise
+  // backslashes to slashes, so either shape would escape the application origin.
+  if (!returnUrl.startsWith('/') || returnUrl.startsWith('//') || returnUrl.includes('\\')) {
+    return DEFAULT_RETURN_URL;
+  }
+
+  // Compare against the route the URL actually resolves to rather than its raw text: the
+  // serializer decodes percent-escapes and separates matrix parameters, so `/lo%67in` and
+  // `/login;foo=bar` are both recognised as the login page.
+  let segments;
+  try {
+    segments = urlSerializer.parse(returnUrl).root.children[PRIMARY_OUTLET]?.segments;
+  } catch {
+    // Unparseable as a router URL; `navigateByUrl` would throw on it too.
+    return DEFAULT_RETURN_URL;
+  }
+
+  return segments?.[0]?.path === 'login' ? DEFAULT_RETURN_URL : returnUrl;
+}

--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { EventEmitter } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { AlertService } from '../core/alert/alert.service';
+import { AuthenticationService } from '../core/authentication/authentication.service';
+import { SettingsService } from '../settings/settings.service';
+import { ThemingService } from '../shared/theme-toggle/theming.service';
+import { VersionService } from '../system/version.service';
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+  function createComponent(options: { returnUrl?: string; authenticated?: boolean } = {}): {
+    component: LoginComponent;
+    router: { navigateByUrl: jest.Mock };
+    alertService: { alertEvent: EventEmitter<any> };
+  } {
+    const router = { navigateByUrl: jest.fn() };
+    const alertService = { alertEvent: new EventEmitter<any>() };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Router, useValue: router },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { queryParamMap: { get: () => options.returnUrl ?? null } } }
+        },
+        { provide: AlertService, useValue: alertService },
+        { provide: AuthenticationService, useValue: { isAuthenticated: () => options.authenticated ?? false } },
+        {
+          provide: SettingsService,
+          useValue: { tenantIdentifier: 'default', themeDarkEnabled: false, server: 'https://localhost' }
+        },
+        {
+          provide: ThemingService,
+          useValue: { theme: new BehaviorSubject('light-theme'), setDarkMode: jest.fn() }
+        },
+        { provide: VersionService, useValue: { getBackendInfo: () => of({}) } },
+        { provide: TranslateService, useValue: { instant: (key: string) => key } }
+      ]
+    });
+
+    return { component: TestBed.runInInjectionContext(() => new LoginComponent()), router, alertService };
+  }
+
+  /** Emits the alert the authentication service raises on a successful login. */
+  function emitLoginSuccess(alertService: { alertEvent: EventEmitter<any> }): void {
+    alertService.alertEvent.emit({ type: 'errors.auth.success.type', message: 'welcome' });
+  }
+
+  it('should navigate to the preserved route after a successful login', () => {
+    const { component, router, alertService } = createComponent({ returnUrl: '/clients' });
+    component.ngOnInit();
+
+    emitLoginSuccess(alertService);
+
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/clients', { replaceUrl: true });
+  });
+
+  it('should navigate to the dashboard when no return URL was preserved', () => {
+    const { component, router, alertService } = createComponent();
+    component.ngOnInit();
+
+    emitLoginSuccess(alertService);
+
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/', { replaceUrl: true });
+  });
+
+  it('should fall back to the dashboard for an unsafe return URL', () => {
+    const { component, router, alertService } = createComponent({ returnUrl: '//evil.example.com' });
+    component.ngOnInit();
+
+    emitLoginSuccess(alertService);
+
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/', { replaceUrl: true });
+  });
+
+  it('should not use the login page as a return destination', () => {
+    const { component, router, alertService } = createComponent({ returnUrl: '/login' });
+    component.ngOnInit();
+
+    emitLoginSuccess(alertService);
+
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/', { replaceUrl: true });
+  });
+
+  it('should send an already authenticated visitor straight to the preserved route', () => {
+    const { component, router } = createComponent({ returnUrl: '/clients', authenticated: true });
+
+    component.ngOnInit();
+
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/clients', { replaceUrl: true });
+  });
+
+  it('should keep showing the password reset and two factor steps', () => {
+    const { component, router, alertService } = createComponent({ returnUrl: '/clients' });
+    component.ngOnInit();
+
+    alertService.alertEvent.emit({ type: 'errors.auth.passwordExpired.type' });
+    expect(component.resetPassword).toBe(true);
+    expect(component.twoFactorAuthenticationRequired).toBe(false);
+
+    alertService.alertEvent.emit({ type: 'errors.auth.twoFactor.type' });
+    expect(component.resetPassword).toBe(false);
+    expect(component.twoFactorAuthenticationRequired).toBe(true);
+
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -47,6 +47,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { M3IconComponent } from '../shared/m3-ui/m3-icon/m3-icon.component';
 
 import { VersionService } from '../system/version.service';
+import { sanitizeReturnUrl } from '../core/utils/return-url.utils';
 
 /**
  * Login component.
@@ -117,8 +118,7 @@ export class LoginComponent implements OnInit {
    */
   ngOnInit() {
     if (this.authenticationService.isAuthenticated()) {
-      const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl') || '/';
-      this.router.navigateByUrl(returnUrl, { replaceUrl: true });
+      this.router.navigateByUrl(this.preservedReturnUrl(), { replaceUrl: true });
       return;
     }
 
@@ -145,8 +145,7 @@ export class LoginComponent implements OnInit {
       } else if (alertType === this.translateService.instant('errors.auth.success.type')) {
         this.resetPassword = false;
         this.twoFactorAuthenticationRequired = false;
-        const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl') || '/';
-        this.router.navigateByUrl(returnUrl, { replaceUrl: true });
+        this.router.navigateByUrl(this.preservedReturnUrl(), { replaceUrl: true });
       } else if (alertType === this.translateService.instant('errors.tenant.changed.type')) {
         this.updateLogo();
       }
@@ -180,6 +179,14 @@ export class LoginComponent implements OnInit {
         }
       );
     this.server = this.settingsService.server;
+  }
+
+  /**
+   * Destination the authentication guard preserved before redirecting here.
+   * @returns {string} The requested route, or the dashboard when none is safe to restore.
+   */
+  private preservedReturnUrl(): string {
+    return sanitizeReturnUrl(this.route.snapshot.queryParamMap.get('returnUrl'));
   }
 
   reloadSettings(): void {


### PR DESCRIPTION
Follow-up to stale PR #3772.

## Context

I looked into #3772 before making these changes. Most of the original fix is already present on `dev` through WEB-956 (#3945), which added the `returnUrl` handling as part of the cross-tab authentication work.

The current `dev` branch already:

* preserves the requested route when redirecting an unauthenticated user to login
* redirects the user back to that route after login

So this PR does **not** reimplement the deep-link functionality from #3772.

## What was missing

The `returnUrl` was being passed directly to `navigateByUrl()` without validating it first.

There are three places where this value is read:

* `login.component.ts` when an already-authenticated user opens the login page
* `login.component.ts` after a successful login
* `authentication.service.ts` during cross-tab authentication

Since the value can come from the URL, it should not be trusted without validation.

There was also a case where `/login` itself could be preserved as the return URL. For example, the cross-tab logout flow can store the current `/login` URL, which could cause the user to be sent back through the login flow after signing in.

## Changes

Added a shared `sanitizeReturnUrl()` helper in:

`src/app/core/utils/return-url.utils.ts`

It:

* allows valid in-app routes such as `/clients`
* preserves query parameters
* rejects external/protocol-relative URLs such as `//example.com` and `https://example.com`
* rejects backslashes to account for browser URL normalization
* rejects `/login` and `/login/*`
* falls back to `/` for missing or invalid values

The same helper is now used by all three `returnUrl` readers.

`authentication.guard.ts` was intentionally left unchanged because the URL it produces comes directly from Angular's router state and is already in the correct format for the application's hash-based routing.

## Tests

Added 13 tests across three specs:

* `return-url.utils.spec.ts`

  * valid routes and query parameters
  * missing/empty values
  * unsafe URLs
  * login routes

* `authentication.guard.spec.ts`

  * authenticated and unauthenticated flows
  * preservation of the requested URL

* `login.component.spec.ts`

  * successful login with a return URL
  * missing/unsafe return URLs
  * login-page destinations
  * already-authenticated users
  * regression coverage for password reset and 2FA flows

The tests were also verified to catch the unsafe behavior: removing the sanitizer causes four of the new tests to fail.

## Verification

* New tests: **13 passed**
* ESLint: **passed**
* Prettier: **passed**
* TypeScript (`app + spec`): **passed**
* Full test suite: **1599 passed, 9 failed**

The 9 existing failures are in `loans-account-terms-step` and `datatable-single-row`. I verified these failures also occur on a clean `upstream/dev`, and neither suite is affected by this change.

## Checklist

* [x] Changes are limited to the WEB-1077 fix
* [x] Tests added for the new behavior
* [x] Existing behavior for password reset and 2FA verified
* [x] ESLint, Prettier and TypeScript checks pass
* [x] Existing unrelated test failures verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved login and authentication redirects by validating return destinations before navigation.
  - Valid in-app return paths are preserved after login.
  - Invalid, external, malformed, or login-page return URLs now safely fall back to the dashboard.
  - Unauthenticated users continue to be redirected to login while retaining their requested in-app destination.
- **Tests**
  - Added coverage for authentication guard behavior, login navigation, and return URL validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->