### PR TITLE
WEB-1081: Allow future due dates for savings and deposit charges

### DIFF
--- a/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-charges-step/fixed-deposit-account-charges-step.component.ts
+++ b/src/app/deposits/fixed-deposits/fixed-deposit-account-stepper/fixed-deposit-account-charges-step/fixed-deposit-account-charges-step.component.ts
@@ -172,6 +172,7 @@ export class FixedDepositAccountChargesStepComponent implements OnInit, OnChange
         label: 'Date',
         value: charge.dueDate || charge.feeOnMonthDay || '',
         type: 'datetime-local',
+        maxDate: this.settingsService.maxFutureDate,
         required: false
       })
     ];

--- a/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/add-charge-fixed-deposits-account/add-charge-fixed-deposits-account.component.ts
+++ b/src/app/deposits/fixed-deposits/fixed-deposits-account-actions/add-charge-fixed-deposits-account/add-charge-fixed-deposits-account.component.ts
@@ -77,7 +77,7 @@ export class AddChargeFixedDepositsAccountComponent implements OnInit {
    * Creates the Fixed Deposits Charge form.
    */
   ngOnInit() {
-    this.maxDate = this.settingsService.businessDate;
+    this.maxDate = this.settingsService.maxFutureDate;
     this.createFixedDepositsChargeForm();
     this.buildDependencies();
   }

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/add-charge-recurring-deposits-account/add-charge-recurring-deposits-account.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-actions/add-charge-recurring-deposits-account/add-charge-recurring-deposits-account.component.ts
@@ -76,7 +76,7 @@ export class AddChargeRecurringDepositsAccountComponent implements OnInit {
    * Creates the Recurring Deposits Charge form.
    */
   ngOnInit() {
-    this.maxDate = this.settingsService.businessDate;
+    this.maxDate = this.settingsService.maxFutureDate;
     this.createRecurringDepositsChargeForm();
     this.buildDependencies();
   }

--- a/src/app/deposits/recurring-deposits/recurring-deposits-account-stepper/recurring-deposits-account-charges-step/recurring-deposits-account-charges-step.component.ts
+++ b/src/app/deposits/recurring-deposits/recurring-deposits-account-stepper/recurring-deposits-account-charges-step/recurring-deposits-account-charges-step.component.ts
@@ -176,6 +176,7 @@ export class RecurringDepositsAccountChargesStepComponent implements OnInit, OnC
         label: 'Date',
         value: charge.dueDate || charge.feeOnMonthDay || '',
         type: 'datetime-local',
+        maxDate: this.settingsService.maxFutureDate,
         required: false
       })
     ];

--- a/src/app/savings/saving-account-actions/add-charge-savings-account/add-charge-savings-account.component.ts
+++ b/src/app/savings/saving-account-actions/add-charge-savings-account/add-charge-savings-account.component.ts
@@ -72,7 +72,7 @@ export class AddChargeSavingsAccountComponent implements OnInit {
    * Creates the Savings Charge form.
    */
   ngOnInit() {
-    this.maxDate = this.settingsService.businessDate;
+    this.maxDate = this.settingsService.maxFutureDate;
     this.createSavingsChargeForm();
     this.buildDependencies();
   }

--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.spec.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+import { SavingsAccountChargesStepComponent } from './savings-account-charges-step.component';
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+
+describe('SavingsAccountChargesStepComponent', () => {
+  let component: SavingsAccountChargesStepComponent;
+  let dialog: { open: jest.Mock };
+
+  const maxFutureDate = new Date(2100, 0, 1);
+  const businessDate = new Date(2026, 0, 15);
+
+  const openedDatepicker = () => (dialog.open.mock.calls[0][1] as any).data.formfields[0];
+
+  beforeEach(async () => {
+    dialog = { open: jest.fn(() => ({ afterClosed: () => of(undefined) })) };
+
+    await TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        { provide: MatDialog, useValue: dialog },
+        { provide: Dates, useValue: { formatDate: jest.fn(() => '20 March 2100') } },
+        { provide: SettingsService, useValue: { maxFutureDate, businessDate } }
+      ]
+    }).compileComponents();
+
+    component = TestBed.runInInjectionContext(() => new SavingsAccountChargesStepComponent());
+  });
+
+  it('allows future due dates when editing a Specified due date charge', () => {
+    component.editChargeDate({ chargeTimeType: { value: 'Specified due date' }, dueDate: '15 January 2026' });
+
+    expect(openedDatepicker().maxDate).toBe(maxFutureDate);
+  });
+
+  it('allows future dates when editing an Annual Fee charge', () => {
+    component.editChargeDate({ chargeTimeType: { value: 'Annual Fee' }, feeOnMonthDay: '15 January' });
+
+    expect(openedDatepicker().maxDate).toBe(maxFutureDate);
+  });
+});

--- a/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
+++ b/src/app/savings/savings-account-stepper/savings-account-charges-step/savings-account-charges-step.component.ts
@@ -19,6 +19,7 @@ import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-
 import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
 import { DatepickerBase } from 'app/shared/form-dialog/formfield/model/datepicker-base';
 import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
 import {
   MatTableDataSource,
   MatTable,
@@ -74,6 +75,7 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
   private dialog = inject(MatDialog);
   private dateUtils = inject(Dates);
   private translateService = inject(TranslateService);
+  private settingsService = inject(SettingsService);
 
   /** Savings Account Product Template */
   @Input() savingsAccountProductTemplate: any;
@@ -186,6 +188,7 @@ export class SavingsAccountChargesStepComponent implements OnInit, OnChanges {
         label: this.translateService.instant('labels.inputs.Date'),
         value: charge.dueDate || charge.feeOnMonthDay || '',
         type: 'datetime-local',
+        maxDate: this.settingsService.maxFutureDate,
         required: false
       })
     ];


### PR DESCRIPTION
Follow-up to stale PR #3776 by @Farah-Nahle-FOO, based on @IOhacker's question there about continuing the work.

## What this fixes

A `Specified due date` charge is allowed to have a date in the future, but the savings charge date pickers currently prevent selecting anything after today.

There are two affected flows for each account type:

* **Create Savings Account → Charges step** — `editChargeDate()` creates a `DatepickerBase` without a `maxDate`, so it falls back to the default in `datepicker-base.ts`, which is `new Date()`.
* **Savings account → Add Charge** — this explicitly sets `maxDate` to `settingsService.businessDate`.

The client and loan charge screens already use `settingsService.maxFutureDate`, which is the appropriate limit here. This PR brings the savings, fixed-deposit, and recurring-deposit screens in line with that behavior.

## What changed

The fixed-deposit and recurring-deposit charge screens are essentially copies of the savings screens, so they had the same issue. I fixed all three account types together rather than leaving the same bug for a follow-up PR.

All six changes are small:

* Pass `settingsService.maxFutureDate` to the charge-date edit dialog in the savings, fixed-deposit, and recurring-deposit charges steps.
* Change `maxDate` from `businessDate` to `maxFutureDate` in the corresponding Add Charge screens.
* Added two regression tests covering the savings charge-date picker.

Charge types that don't have a date field, such as `Withdrawal Fee` and `Saving No Activity Fee`, are unaffected.

I used `settingsService.maxFutureDate` instead of the hard-coded `new Date(2100, 11, 31)` used in #3776. This keeps the limit in one place (`SettingsService.maxAllowedDate`) and matches what the client and loan screens already do.

I also left out the `switchMap` refactor from #3776. It's a valid improvement, but it's unrelated to WEB-1081, and the same nested-subscribe pattern is still used in `add-client-charge`. I felt it was better to keep this PR focused on the bug fix.

## Verification

The new regression tests pass, and the savings/deposits test suites are green: **70 tests across 11 suites**. Removing the fix causes both new tests to fail.

I also tested this against a local Fineract instance with the business date set to **9 September 2026** and a savings product configured with a `Specified due date` charge.

Before the fix, the Charges step disabled all dates after the business date. After the fix, future dates can be selected.

For the Add Charge flow, the picker now allows dates up to `2099-12-31`.

I also selected **25 September 2026** and submitted the charge successfully. Fineract stored the due date as:

```text
WEB-1081 Specified Due Date Fee
timeType: Specified due date
dueDate: [2026, 9, 25]
```

Related issue: WEB-1081, superseding #3776.

## Checklist

* [x] Squashed into a single commit
* [x] Read and understood `web-app/.github/CONTRIBUTING.md`
* [x] Added regression tests
* [x] ESLint, Prettier and TypeScript checks pass
* [x] Verified against a running local Fineract instance
