### PR TITLE
WEB-1225: show sort direction on entity list column headers

### DIFF
--- a/src/app/centers/centers.component.html
+++ b/src/app/centers/centers.component.html
@@ -107,21 +107,49 @@
     <div class="list-header">
       <span></span>
       <span></span>
-      <span class="sortable" [class.active]="sortAttribute === 'name'" (click)="setSort('name')">
+      <button
+        type="button"
+        class="sortable"
+        [class.active]="sortAttribute === 'name'"
+        [class.desc]="sortAttribute === 'name' && sortDirection === 'desc'"
+        (click)="setSort('name')"
+      >
         {{ 'labels.inputs.name' | translate }}
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M7 10l5-5 5 5M7 14l5 5 5-5"></path>
+        <svg
+          class="sort-arrow"
+          viewBox="5 4.5 14 14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M7 14l5-5 5 5"></path>
         </svg>
-      </span>
+      </button>
       <span>{{ 'labels.inputs.Status' | translate }}</span>
       <span>{{ 'labels.inputs.Account No' | translate }}</span>
       <span>{{ 'labels.inputs.External Id' | translate }}</span>
-      <span class="sortable" [class.active]="sortAttribute === 'officeName'" (click)="setSort('officeName')">
+      <button
+        type="button"
+        class="sortable"
+        [class.active]="sortAttribute === 'officeName'"
+        [class.desc]="sortAttribute === 'officeName' && sortDirection === 'desc'"
+        (click)="setSort('officeName')"
+      >
         {{ 'labels.inputs.Office Name' | translate }}
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M7 10l5-5 5 5M7 14l5 5 5-5"></path>
+        <svg
+          class="sort-arrow"
+          viewBox="5 4.5 14 14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M7 14l5-5 5 5"></path>
         </svg>
-      </span>
+      </button>
     </div>
 
     @for (row of dataSource.data; track row.id) {

--- a/src/app/clients/clients.component.html
+++ b/src/app/clients/clients.component.html
@@ -83,19 +83,67 @@
     <div class="list-header">
       <span></span>
       <span></span>
-      <span class="sortable" [class.active]="sortAttribute === 'displayName'" (click)="setSort('displayName')">
+      <button
+        type="button"
+        class="sortable"
+        [class.active]="sortAttribute === 'displayName'"
+        [class.desc]="sortAttribute === 'displayName' && sortDirection === 'desc'"
+        (click)="setSort('displayName')"
+      >
         {{ 'labels.inputs.name' | translate }}
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M7 10l5-5 5 5M7 14l5 5 5-5"></path>
+        <svg
+          class="sort-arrow"
+          viewBox="5 4.5 14 14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M7 14l5-5 5 5"></path>
         </svg>
-      </span>
+      </button>
       <span>{{ 'labels.inputs.Status' | translate }}</span>
-      <span class="sortable" [class.active]="sortAttribute === 'accountNumber'" (click)="setSort('accountNumber')">
+      <button
+        type="button"
+        class="sortable"
+        [class.active]="sortAttribute === 'accountNumber'"
+        [class.desc]="sortAttribute === 'accountNumber' && sortDirection === 'desc'"
+        (click)="setSort('accountNumber')"
+      >
         {{ 'labels.inputs.Account No' | translate }}
-      </span>
-      <span class="sortable" [class.active]="sortAttribute === 'externalId'" (click)="setSort('externalId')">
+        <svg
+          class="sort-arrow"
+          viewBox="5 4.5 14 14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M7 14l5-5 5 5"></path>
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="sortable"
+        [class.active]="sortAttribute === 'externalId'"
+        [class.desc]="sortAttribute === 'externalId' && sortDirection === 'desc'"
+        (click)="setSort('externalId')"
+      >
         {{ 'labels.inputs.External Id' | translate }}
-      </span>
+        <svg
+          class="sort-arrow"
+          viewBox="5 4.5 14 14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M7 14l5-5 5 5"></path>
+        </svg>
+      </button>
       <span>{{ 'labels.inputs.Office Name' | translate }}</span>
     </div>
 

--- a/src/app/groups/groups.component.html
+++ b/src/app/groups/groups.component.html
@@ -83,21 +83,49 @@
     <div class="list-header">
       <span></span>
       <span></span>
-      <span class="sortable" [class.active]="sortAttribute === 'name'" (click)="setSort('name')">
+      <button
+        type="button"
+        class="sortable"
+        [class.active]="sortAttribute === 'name'"
+        [class.desc]="sortAttribute === 'name' && sortDirection === 'desc'"
+        (click)="setSort('name')"
+      >
         {{ 'labels.inputs.name' | translate }}
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M7 10l5-5 5 5M7 14l5 5 5-5"></path>
+        <svg
+          class="sort-arrow"
+          viewBox="5 4.5 14 14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M7 14l5-5 5 5"></path>
         </svg>
-      </span>
+      </button>
       <span>{{ 'labels.inputs.Status' | translate }}</span>
       <span>{{ 'labels.inputs.Account No' | translate }}</span>
       <span>{{ 'labels.inputs.External Id' | translate }}</span>
-      <span class="sortable" [class.active]="sortAttribute === 'officeName'" (click)="setSort('officeName')">
+      <button
+        type="button"
+        class="sortable"
+        [class.active]="sortAttribute === 'officeName'"
+        [class.desc]="sortAttribute === 'officeName' && sortDirection === 'desc'"
+        (click)="setSort('officeName')"
+      >
         {{ 'labels.inputs.Office Name' | translate }}
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M7 10l5-5 5 5M7 14l5 5 5-5"></path>
+        <svg
+          class="sort-arrow"
+          viewBox="5 4.5 14 14"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M7 14l5-5 5 5"></path>
         </svg>
-      </span>
+      </button>
     </div>
 
     @for (row of dataSource.data; track row.id) {

--- a/src/assets/styles/_entity-list.scss
+++ b/src/assets/styles/_entity-list.scss
@@ -331,11 +331,28 @@
     white-space: nowrap;
   }
 
+  // Sortable headers are real buttons so they can be reached with Tab and fired
+  // with Enter/Space; the reset keeps them looking like the plain header text.
   .sortable {
     cursor: pointer;
     display: inline-flex;
     align-items: center;
     gap: 4px;
+    user-select: none;
+    white-space: nowrap;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    text-transform: inherit;
+    letter-spacing: inherit;
+  }
+
+  .sortable:focus-visible {
+    outline: 2px solid var(--loan-blue-700);
+    outline-offset: 2px;
   }
 
   .sortable:hover {
@@ -346,9 +363,24 @@
     color: var(--loan-blue-700);
   }
 
-  .sortable svg {
-    width: 10px;
-    height: 10px;
+  // The arrow points up while ascending and flips over for descending, so the
+  // direction is readable at a glance. It stays dimmed on the columns that are
+  // not currently sorted, where it only advertises that the column can sort.
+  .sortable .sort-arrow {
+    width: 14px;
+    height: 14px;
+    opacity: 0.6;
+    transition:
+      opacity 0.14s ease,
+      transform 0.14s ease;
+  }
+
+  .sortable.active .sort-arrow {
+    opacity: 1;
+  }
+
+  .sortable.active.desc .sort-arrow {
+    transform: rotate(180deg);
   }
 
   .list-row {


### PR DESCRIPTION
## Description
### Problem
The sortable column headers on the Clients, Groups and Centers lists render a fixed up/down chevron that never changes. Clicking a header cycles the sort through ascending, descending and off, but the icon looks identical in all three states, so there is no way to tell which direction the list is sorted without reading the rows.

Two headers on the Clients list, Account No and External Id, are sortable butrender no icon at all, so nothing indicates that they can be clicked.



## Changes Made:
- Replace the static chevron with a single arrow that points up while ascending
  and rotates for descending, following the pattern already used by the Loans
  list.
- Add the arrow to the Account No and External Id headers on the Clients list.
- Change the headers from `span` to `button` so they can be reached with Tab and
  activated with Enter or Space, with a visible focus outline.
- Size the arrow at 14px against a cropped viewBox. At the previous 8px against
  a 24 unit viewBox the drawn arrow measured about 3px wide with a sub-pixel
  stroke, which did not render reliably.

## Related issues and discussion

https://mifosforge.jira.com/browse/WEB-1225

## Screenshots, if any
before:
<img width="1920" height="1080" alt="{6C46260F-CA17-47C9-8BE3-A0AA0FED26C5}" src="https://github.com/user-attachments/assets/1d5b2464-ceb3-421f-b115-344d7c759d0e" />
after:
for the ascending sorting (A-Z)
<img width="1920" height="1080" alt="{9D8B2E96-9838-4F99-85F7-75F0A5CA47C4}" src="https://github.com/user-attachments/assets/24291ab1-44f1-4860-886d-29577f623b78" />

for the descrnding sorting(Z-A)
<img width="1920" height="1080" alt="{FF8BEA5E-8A61-4D81-9F4C-81C27D98C8E7}" src="https://github.com/user-attachments/assets/fd861cb9-31f1-4594-b1b0-300177c0fa38" />

for no sorting
<img width="1920" height="1080" alt="{797DEC3F-2478-47CE-9CB1-154E0ACE32AB}" src="https://github.com/user-attachments/assets/1ab38ece-1353-4431-867c-dda8cf2a69f8" />

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Sortable list headers across centers, clients, and groups can now be operated using keyboard-accessible buttons.
  * Visible focus styling makes the active header easier to identify.

* **User Interface**
  * Sort indicators now clearly reflect the selected column and direction.
  * Unselected sort indicators appear subdued, while active indicators are emphasized with directional transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->