### PR TITLE
 WEB-1222: Fix PDF document preview rendering blank

### DIFF
--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.html
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.html
@@ -66,6 +66,7 @@
                   <div
                     class="thumb"
                     [class.clickable]="isPreviewable(document)"
+                    [class.has-pdf]="!!pdfThumbnails[document.id]"
                     role="button"
                     tabindex="0"
                     [attr.aria-label]="('labels.buttons.Preview' | translate) + ': ' + document.name"
@@ -80,6 +81,15 @@
                         [title]="document.name"
                         loading="lazy"
                       />
+                    } @else if (pdfThumbnails[document.id]) {
+                      <iframe
+                        class="pdf-thumb"
+                        [src]="pdfThumbnails[document.id]"
+                        [title]="document.name"
+                        tabindex="-1"
+                        aria-hidden="true"
+                        loading="lazy"
+                      ></iframe>
                     } @else {
                       <div class="placeholder">
                         <fa-icon icon="file"></fa-icon>

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.scss
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.scss
@@ -73,11 +73,34 @@
     cursor: pointer;
   }
 
+  // A PDF thumbnail is a live browser viewer, which sizes itself rather than the box, so pin the
+  // height and clip anything the viewer draws outside it.
+  &.has-pdf {
+    height: 7.5rem;
+    overflow: hidden;
+    background: $white;
+  }
+
   img {
     width: 100%;
     height: 100%;
     object-fit: cover;
   }
+}
+
+.pdf-thumb {
+  position: absolute;
+  border: 0;
+  // The frame is deliberately larger than the clipping box and offset up and to the left, so two
+  // parts of the browser's PDF viewer fall outside it: the scrollbar it always draws
+  // (`#scrollbar=0` is not honoured) and the dark backdrop it paints around the page, which
+  // otherwise shows as a black border along the edges of the card.
+  top: -0.375rem;
+  left: -0.375rem;
+  width: calc(100% + 2.5rem);
+  height: 10.5rem;
+  // The card itself owns the click that opens the lightbox; the viewer must not swallow it.
+  pointer-events: none;
 }
 
 .preview-overlay {

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
@@ -19,6 +19,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatDialog } from '@angular/material/dialog';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import {
   MatTable,
   MatColumnDef,
@@ -48,7 +49,7 @@ import lgThumbnail from 'lightgallery/plugins/thumbnail';
 import lgZoom from 'lightgallery/plugins/zoom';
 import type { LightGallery } from 'lightgallery/lightgallery';
 import type { GalleryItem } from 'lightgallery/lg-utils';
-import { DocumentPreviewService } from 'app/shared/services/document-preview.service';
+import { DocumentPreviewService, PDF_GALLERY_THUMBNAIL } from 'app/shared/services/document-preview.service';
 import { TranslateService } from '@ngx-translate/core';
 import { ClientIdentifierPayload, ClientsService } from '../../clients.service';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
@@ -127,6 +128,7 @@ export class IdentitiesTabComponent implements OnDestroy {
   private translateService = inject(TranslateService);
   private documentPreviewService = inject(DocumentPreviewService);
   private changeDetectorRef = inject(ChangeDetectorRef);
+  private sanitizer = inject(DomSanitizer);
   private dateUtils = inject(Dates);
   private settingsService = inject(SettingsService);
   private alertService = inject(AlertService);
@@ -159,6 +161,7 @@ export class IdentitiesTabComponent implements OnDestroy {
 
   /** Cached thumbnails for previewable docs */
   previewThumbnails: Record<string, string> = {};
+  pdfThumbnails: Record<string, SafeResourceUrl> = {};
   private lightboxInstance: LightGallery | null = null;
   private readonly lightboxPlugins = [
     lgZoom,
@@ -409,7 +412,7 @@ export class IdentitiesTabComponent implements OnDestroy {
           }
           items.push({
             src: preview.url,
-            thumb: preview.type === 'image' ? preview.url : undefined,
+            thumb: preview.type === 'image' ? preview.url : PDF_GALLERY_THUMBNAIL,
             subHtml: this.buildSubHtml(doc, identity),
             iframe: preview.type === 'pdf'
           });
@@ -479,6 +482,14 @@ export class IdentitiesTabComponent implements OnDestroy {
       .then((preview) => {
         if (preview.type === 'image') {
           this.setPreviewThumbnail(document.id, preview.url);
+        } else if (preview.type === 'pdf') {
+          this.pdfThumbnails = {
+            ...this.pdfThumbnails,
+            [document.id]: this.sanitizer.bypassSecurityTrustResourceUrl(
+              `${preview.url}#toolbar=0&navpanes=0&scrollbar=0&view=FitH`
+            )
+          };
+          this.changeDetectorRef.markForCheck();
         }
       })
       .catch((): void => undefined);

--- a/src/app/shared/services/document-preview.service.spec.ts
+++ b/src/app/shared/services/document-preview.service.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { of } from 'rxjs';
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+import { DocumentPreviewService } from './document-preview.service';
+
+describe('DocumentPreviewService', () => {
+  let service: DocumentPreviewService;
+  let createdBlobs: Blob[];
+
+  // jsdom implements neither of these, so they are installed for the duration of the suite.
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+
+  beforeEach(() => {
+    service = new DocumentPreviewService();
+    createdBlobs = [];
+    URL.createObjectURL = jest.fn((blob: any) => {
+      createdBlobs.push(blob);
+      return `blob:preview-${createdBlobs.length}`;
+    }) as any;
+    URL.revokeObjectURL = jest.fn() as any;
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  });
+
+  it('re-tags a PDF served as application/octet-stream so the iframe renders it inline', async () => {
+    const document = { id: '1', fileName: 'statement.pdf' };
+    const downloaded = new Blob(['%PDF-1.4'], { type: 'application/octet-stream' });
+
+    const preview = await service.resolvePreviewUrl(document, () => of(downloaded));
+
+    expect(preview.type).toBe('pdf');
+    expect(createdBlobs[0].type).toBe('application/pdf');
+  });
+
+  it('re-tags a PDF served without any content type', async () => {
+    const document = { id: '2', fileName: 'receipt.pdf' };
+
+    const preview = await service.resolvePreviewUrl(document, () => of(new Blob(['%PDF-1.4'])));
+
+    expect(preview.type).toBe('pdf');
+    expect(createdBlobs[0].type).toBe('application/pdf');
+  });
+
+  it('leaves a correctly typed PDF blob untouched', async () => {
+    const document = { id: '3', fileName: 'license.pdf' };
+    const downloaded = new Blob(['%PDF-1.4'], { type: 'application/pdf' });
+
+    await service.resolvePreviewUrl(document, () => of(downloaded));
+
+    expect(createdBlobs[0]).toBe(downloaded);
+  });
+
+  it('leaves image blobs untouched', async () => {
+    const document = { id: '4', fileName: 'photo.png' };
+    const downloaded = new Blob(['png-bytes'], { type: 'application/octet-stream' });
+
+    const preview = await service.resolvePreviewUrl(document, () => of(downloaded));
+
+    expect(preview.type).toBe('image');
+    expect(createdBlobs[0]).toBe(downloaded);
+  });
+
+  it('prefers the declared mime type over a generic one from the response', async () => {
+    const document = { id: '5', fileName: 'scan', mimeType: 'application/pdf' };
+    const downloaded = new Blob(['%PDF-1.4'], { type: 'application/octet-stream' });
+
+    const preview = await service.resolvePreviewUrl(document, () => of(downloaded));
+
+    expect(preview.type).toBe('pdf');
+    expect(createdBlobs[0].type).toBe('application/pdf');
+  });
+
+  it('does not let a parameterised generic content type shadow the declared mime type', async () => {
+    const document = { id: '9', fileName: 'scan', mimeType: 'application/pdf' };
+    const downloaded = new Blob(['%PDF-1.4'], { type: 'application/octet-stream; charset=binary' });
+
+    const preview = await service.resolvePreviewUrl(document, () => of(downloaded));
+
+    expect(preview.type).toBe('pdf');
+    expect(createdBlobs[0].type).toBe('application/pdf');
+  });
+
+  it('leaves a parameterised PDF blob untouched', async () => {
+    const document = { id: '10', fileName: 'statement.pdf' };
+    const downloaded = new Blob(['%PDF-1.4'], { type: 'application/pdf; charset=binary' });
+
+    await service.resolvePreviewUrl(document, () => of(downloaded));
+
+    expect(createdBlobs[0]).toBe(downloaded);
+  });
+
+  it('downloads a document only once and serves the cached preview afterwards', async () => {
+    const document = { id: '6', fileName: 'statement.pdf' };
+    const downloadFn = jest.fn(() => of(new Blob(['%PDF-1.4'], { type: 'application/octet-stream' })));
+
+    const first = await service.resolvePreviewUrl(document, downloadFn as any);
+    const second = await service.resolvePreviewUrl(document, downloadFn as any);
+
+    expect(downloadFn).toHaveBeenCalledTimes(1);
+    expect(second.url).toBe(first.url);
+  });
+
+  it('treats PDFs as previewable from the file extension alone', () => {
+    expect(service.isPreviewable({ id: '7', fileName: 'statement.pdf' })).toBe(true);
+    expect(service.isPreviewable({ id: '8', fileName: 'notes.txt' })).toBe(false);
+  });
+});

--- a/src/app/shared/services/document-preview.service.ts
+++ b/src/app/shared/services/document-preview.service.ts
@@ -11,6 +11,22 @@ import { Observable, firstValueFrom } from 'rxjs';
 
 export type DocumentPreviewType = 'image' | 'pdf' | 'other';
 
+const PDF_MIME_TYPE = 'application/pdf';
+
+/** Content types that say nothing about the payload, so they must not shadow a better source. */
+const GENERIC_MIME_TYPES = [
+  'application/octet-stream',
+  'binary/octet-stream'
+];
+
+/**
+ * Filmstrip thumbnail for PDF slides. lightGallery writes `thumb` straight into an `<img src>`,
+ * so leaving it undefined renders a broken image in the gallery's thumbnail strip. A document
+ * glyph keeps the strip legible without having to rasterise the page.
+ */
+export const PDF_GALLERY_THUMBNAIL =
+  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2MCA2MCIgd2lkdGg9IjYwIiBoZWlnaHQ9IjYwIj48cmVjdCB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIGZpbGw9IiMyZjJmMmYiLz48cGF0aCBkPSJNMTggMTFoMTZsMTAgMTB2MjhhMiAyIDAgMCAxLTIgMkgxOGEyIDIgMCAwIDEtMi0yVjEzYTIgMiAwIDAgMSAyLTJ6IiBmaWxsPSIjZjJmMmYyIi8+PHBhdGggZD0iTTM0IDExbDEwIDEwSDM2YTIgMiAwIDAgMS0yLTJ6IiBmaWxsPSIjYzRjNGM0Ii8+PHRleHQgeD0iMzAiIHk9IjQzIiBmb250LWZhbWlseT0iSGVsdmV0aWNhLEFyaWFsLHNhbnMtc2VyaWYiIGZvbnQtc2l6ZT0iMTEiIGZvbnQtd2VpZ2h0PSJib2xkIiBmaWxsPSIjYzAzOTJiIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIj5QREY8L3RleHQ+PC9zdmc+';
+
 export interface DocumentDescriptor {
   id: string;
   name?: string;
@@ -60,8 +76,12 @@ export class DocumentPreviewService {
     }
 
     const blob = await firstValueFrom(downloadFn(document));
-    const objectUrl = URL.createObjectURL(blob);
-    const type = this.detectType(blob.type || document.mimeType, document.fileName, document.fileData);
+    const type = this.detectType(
+      this.preferSpecificMimeType(blob.type, document.mimeType),
+      document.fileName,
+      document.fileData
+    );
+    const objectUrl = URL.createObjectURL(this.withPreviewableMimeType(blob, type));
     this.previewCache.set(document.id, { url: objectUrl, type, isObjectUrl: true });
     return { url: objectUrl, type };
   }
@@ -127,6 +147,40 @@ export class DocumentPreviewService {
     }
 
     return 'other';
+  }
+
+  /**
+   * Pick the most informative content type available. Attachments are commonly served as
+   * `application/octet-stream`, which must not take precedence over the type the document
+   * itself declares.
+   */
+  private preferSpecificMimeType(...candidates: (string | undefined)[]): string | undefined {
+    return candidates.find((candidate) => candidate && !this.isGenericMimeType(candidate)) ?? candidates.find(Boolean);
+  }
+
+  private isGenericMimeType(mimeType: string): boolean {
+    return GENERIC_MIME_TYPES.includes(this.toMediaType(mimeType));
+  }
+
+  /**
+   * Reduce a content type to its media type, dropping any `; charset=...` parameters so that
+   * comparisons are not defeated by a parameterised header.
+   */
+  private toMediaType(mimeType: string): string {
+    return mimeType.split(';', 1)[0].trim().toLowerCase();
+  }
+
+  /**
+   * Re-tag the downloaded blob so its object URL can be rendered inline. A `blob:` URL typed
+   * `application/octet-stream` is downloaded rather than displayed when the PDF preview points
+   * an iframe at it, which leaves the lightbox blank. Images never hit this because `<img>`
+   * sniffs the bytes and ignores the content type.
+   */
+  private withPreviewableMimeType(blob: Blob, type: DocumentPreviewType): Blob {
+    if (type !== 'pdf' || this.toMediaType(blob.type) === PDF_MIME_TYPE) {
+      return blob;
+    }
+    return new Blob([blob], { type: PDF_MIME_TYPE });
   }
 
   private extractMimeFromData(fileData?: string): string | undefined {

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.html
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.html
@@ -25,6 +25,7 @@
             <div
               class="thumb"
               [class.clickable]="isPreviewable(document)"
+              [class.has-pdf]="!!pdfThumbnails[document.id]"
               role="button"
               tabindex="0"
               [attr.aria-label]="('labels.buttons.Preview' | translate) + ': ' + document.name"
@@ -39,6 +40,15 @@
                   [title]="document.name"
                   loading="lazy"
                 />
+              } @else if (pdfThumbnails[document.id]) {
+                <iframe
+                  class="pdf-thumb"
+                  [src]="pdfThumbnails[document.id]"
+                  [title]="document.name"
+                  tabindex="-1"
+                  aria-hidden="true"
+                  loading="lazy"
+                ></iframe>
               } @else {
                 <div class="placeholder">
                   <fa-icon icon="file"></fa-icon>

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.scss
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.scss
@@ -52,11 +52,34 @@
     cursor: pointer;
   }
 
+  // A PDF thumbnail is a live browser viewer, which sizes itself rather than the box, so pin the
+  // height and clip anything the viewer draws outside it.
+  &.has-pdf {
+    height: 9.5rem;
+    overflow: hidden;
+    background: $white;
+  }
+
   img {
     width: 100%;
     height: 100%;
     object-fit: cover;
   }
+}
+
+.pdf-thumb {
+  position: absolute;
+  border: 0;
+  // The frame is deliberately larger than the clipping box and offset up and to the left, so two
+  // parts of the browser's PDF viewer fall outside it: the scrollbar it always draws
+  // (`#scrollbar=0` is not honoured) and the dark backdrop it paints around the page, which
+  // otherwise shows as a black border along the edges of the card.
+  top: -0.375rem;
+  left: -0.375rem;
+  width: calc(100% + 2.5rem);
+  height: 12.5rem;
+  // The card itself owns the click that opens the lightbox; the viewer must not swallow it.
+  pointer-events: none;
 }
 
 .preview-overlay {

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.spec.ts
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.spec.ts
@@ -106,6 +106,35 @@ describe('EntityDocumentsTabComponent', () => {
     expect(clientsService.downloadClientDocument).toHaveBeenCalledWith('3616', 45);
   });
 
+  it('shows a PDF card as an embedded viewer with the browser chrome switched off', async () => {
+    component.entityId = '3616';
+    component.entityDocuments = [{ id: 51, name: 'Statement', fileName: 'statement.pdf' }];
+    clientsService.downloadClientDocument.mockReturnValue(of(new Blob(['%PDF-1.4'])));
+    documentPreviewService.resolvePreviewUrl.mockResolvedValue({ url: 'blob:statement', type: 'pdf' } as never);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const iframe = fixture.nativeElement.querySelector('iframe.pdf-thumb');
+    expect(iframe).toBeTruthy();
+    expect(iframe.getAttribute('src')).toBe('blob:statement#toolbar=0&navpanes=0&scrollbar=0&view=FitH');
+    // The card, not the viewer, must receive the click that opens the lightbox.
+    expect(fixture.nativeElement.querySelector('.thumb.has-pdf')).toBeTruthy();
+  });
+
+  it('falls back to the placeholder for file types that cannot be previewed', async () => {
+    component.entityDocuments = [{ id: 52, name: 'Ledger', fileName: 'ledger.xlsx' }];
+    documentPreviewService.isPreviewable.mockReturnValue(false);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('iframe.pdf-thumb')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.placeholder')).toBeTruthy();
+  });
+
   it('uploads a document with issuance and expiry dates', () => {
     const file = new File(['content'], 'statement.pdf', { type: 'application/pdf' });
     component.entityDocuments = [];

--- a/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.ts
+++ b/src/app/shared/tabs/entity-documents-tab/entity-documents-tab.component.ts
@@ -18,6 +18,7 @@ import {
   ChangeDetectorRef
 } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import lightGallery from 'lightgallery';
 import lgFullscreen from 'lightgallery/plugins/fullscreen';
 import lgThumbnail from 'lightgallery/plugins/thumbnail';
@@ -31,7 +32,7 @@ import { LoansService } from 'app/loans/loans.service';
 import { SavingsService } from 'app/savings/savings.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { DeleteDialogComponent } from 'app/shared/delete-dialog/delete-dialog.component';
-import { DocumentPreviewService } from 'app/shared/services/document-preview.service';
+import { DocumentPreviewService, PDF_GALLERY_THUMBNAIL } from 'app/shared/services/document-preview.service';
 import { Observable, throwError } from 'rxjs';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
@@ -55,6 +56,7 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
   private clientsService = inject(ClientsService);
   private settingsService = inject(SettingsService);
   private documentPreviewService = inject(DocumentPreviewService);
+  private sanitizer = inject(DomSanitizer);
 
   @ViewChild('lightboxRoot', { static: true }) lightboxRoot: ElementRef<HTMLElement>;
 
@@ -66,6 +68,7 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
   @Input() callbackDelete: (documentId: string) => void;
 
   previewThumbnails: Record<string, string> = {};
+  pdfThumbnails: Record<string, SafeResourceUrl> = {};
   private lightboxInstance: LightGallery | null = null;
   private readonly lightboxPlugins = [
     lgZoom,
@@ -140,6 +143,8 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
         this.documentPreviewService.release(documentId);
         this.previewThumbnails = { ...this.previewThumbnails };
         delete this.previewThumbnails[documentId];
+        this.pdfThumbnails = { ...this.pdfThumbnails };
+        delete this.pdfThumbnails[documentId];
         this.cdr.markForCheck();
       }
     });
@@ -168,7 +173,7 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
           }
           galleryItems.push({
             src: preview.url,
-            thumb: preview.type === 'image' ? preview.url : undefined,
+            thumb: preview.type === 'image' ? preview.url : PDF_GALLERY_THUMBNAIL,
             subHtml: this.buildSubHtml(item),
             iframe: preview.type === 'pdf'
           });
@@ -265,9 +270,20 @@ export class EntityDocumentsTabComponent implements OnInit, OnDestroy {
         if (preview.type === 'image') {
           this.previewThumbnails = { ...this.previewThumbnails, [document.id]: preview.url };
           this.cdr.markForCheck();
+        } else if (preview.type === 'pdf') {
+          this.pdfThumbnails = { ...this.pdfThumbnails, [document.id]: this.buildPdfThumbnailUrl(preview.url) };
+          this.cdr.markForCheck();
         }
       })
       .catch((): void => undefined);
+  }
+
+  /**
+   * Point the card's iframe at the PDF with the browser viewer's chrome switched off, fitted to
+   * the card width. The URL is trusted because it is an object URL this app created itself.
+   */
+  private buildPdfThumbnailUrl(url: string): SafeResourceUrl {
+    return this.sanitizer.bypassSecurityTrustResourceUrl(`${url}#toolbar=0&navpanes=0&scrollbar=0&view=FitH`);
   }
 
   private prefetchThumbnails(): void {


### PR DESCRIPTION
## Description

The PDF preview in Client Documents, Client Identifiers, Loan Account Documents and Savings Account Documents opened to a blank lightbox. Image previews were unaffected.

`DocumentPreviewService` created the preview object URL directly from the download response, so the blob inherited the attachment endpoint's `application/octet-stream` content type. A `blob:` URL with a generic binary type is downloaded by the browser rather than rendered, so the PDF iframe stayed empty. Images were immune because `<img>` sniffs the bytes and ignores the content type.

The service now re-tags a detected PDF as `application/pdf` before creating the object URL, and no longer lets a generic `application/octet-stream` response type shadow the type declared on the document during detection. Image blobs and already-correctly-typed PDFs are passed through unchanged.

Verified in a real browser against a lightGallery harness matching the component's options: with `application/octet-stream` the iframe triggers a download and stays blank; after re-tagging, the PDF viewer frame loads and the slide renders.

Adds unit coverage for the service, which previously had none.

## Related issues and discussion

# WEB-1222

## After Screenshot:

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/79c72cca-3888-410f-af2d-80061fd039d7" />

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PDF thumbnails now appear directly in identity and document lists.
  - PDF previews use an inline viewer with streamlined controls and remain compatible with card interactions.

- **Bug Fixes**
  - PDF documents no longer appear blank or download unexpectedly during previews.
  - Preview detection prioritizes specific MIME types and handles parameters correctly.
  - Existing PDF and image previews remain unaffected.
  - Documents are downloaded only once during previewing.

- **Tests**
  - Added coverage for MIME handling, PDF previews, caching, and extension-based previewability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->