### PR TITLE
WEB-1060: Fix checker inbox date serialization

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.ts
@@ -47,16 +47,15 @@ import { environment } from 'environments/environment';
 
 /** Custom Services */
 import { TasksService } from '../../tasks.service';
-import { SettingsService } from 'app/settings/settings.service';
 
 /** Dialog Components */
 import { ConfirmationDialogComponent } from 'app/shared/confirmation-dialog/confirmation-dialog.component';
-import { Dates } from 'app/core/utils/dates';
 import { TranslateService } from '@ngx-translate/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { serializeMakerCheckerDate } from './maker-checker-date-serializer';
 
 interface MakerCheckerRecord {
   id: number;
@@ -108,10 +107,8 @@ type BulkActionOutcome =
 export class CheckerInboxComponent implements OnInit {
   private route = inject(ActivatedRoute);
   private dialog = inject(MatDialog);
-  private dateUtils = inject(Dates);
   private translateService = inject(TranslateService);
   private tasksService = inject(TasksService);
-  private settingsService = inject(SettingsService);
   private formBuilder = inject(FormBuilder);
   private destroyRef = inject(DestroyRef);
   private clientsService = inject(ClientsService);
@@ -163,9 +160,7 @@ export class CheckerInboxComponent implements OnInit {
    * Retrieves the maker checker data from `resolve`.
    * @param {ActivatedRoute} route Activated Route.
    * @param {Dialog} dialog MatDialog.
-   * @param {Dates} dateUtils Date Utils.
    * @param {router} router Router.
-   * @param {SettingsService} settingsService Settings Service.
    * @param {TasksService} tasksService Tasks Service.
    * @param {FormBuilder} formBuilder Form Builder.
    */
@@ -222,12 +217,11 @@ export class CheckerInboxComponent implements OnInit {
 
   private loadMakerCheckers(): void {
     const requestId = ++this.searchRequestId;
-    const dateFormat = this.settingsService.dateFormat;
     const selectedCustomer = this.customerControl.value;
     const makerCheckerSearchParams = {
       ...this.makerCheckerSearchForm.value,
-      makerDateTimeFrom: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.makerDateTimeFrom, dateFormat),
-      makerDateTimeTo: this.dateUtils.formatDate(this.makerCheckerSearchForm.value.makerDateTimeTo, dateFormat),
+      makerDateTimeFrom: serializeMakerCheckerDate(this.makerCheckerSearchForm.value.makerDateTimeFrom),
+      makerDateTimeTo: serializeMakerCheckerDate(this.makerCheckerSearchForm.value.makerDateTimeTo),
       clientId: typeof selectedCustomer === 'object' ? selectedCustomer?.id : undefined
     };
     this.loading = true;

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/maker-checker-date-serializer.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/maker-checker-date-serializer.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+const ENGLISH_MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December'
+];
+
+/**
+ * Serializes a datepicker value for Fineract's MakerCheckerRequest.
+ * The API parses `dd MMMM yyyy` with Locale.ENGLISH and applies the
+ * appropriate start/end-of-day boundary itself.
+ */
+export function serializeMakerCheckerDate(value: unknown): string | undefined {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    return undefined;
+  }
+
+  return `${String(value.getDate()).padStart(2, '0')} ${ENGLISH_MONTH_NAMES[value.getMonth()]} ${String(value.getFullYear()).padStart(4, '0')}`;
+}

--- a/src/app/tasks/tasks.service.spec.ts
+++ b/src/app/tasks/tasks.service.spec.ts
@@ -11,6 +11,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { TestBed } from '@angular/core/testing';
 
 import { TasksService } from './tasks.service';
+import { serializeMakerCheckerDate } from './checker-inbox-and-tasks-tabs/checker-inbox/maker-checker-date-serializer';
 
 describe('TasksService maker-checker search', () => {
   let service: TasksService;
@@ -30,17 +31,91 @@ describe('TasksService maker-checker search', () => {
 
   afterEach(() => httpMock.verify());
 
-  it('preserves the makerDateTimeTo parameter sent by the checker inbox', () => {
+  it('sends locale-independent Maker Checker dates and preserves the remaining filters', () => {
+    const from = serializeMakerCheckerDate(new Date(2016, 0, 2));
+    const to = serializeMakerCheckerDate(new Date(2026, 8, 9));
     service
-      .getMakerCheckerData({ makerDateTimeFrom: '01 January 2026', makerDateTimeTo: '31 January 2026' })
+      .getMakerCheckerData({
+        makerDateTimeFrom: from,
+        makerDateTimeTo: to,
+        clientId: 42,
+        actionName: 'CREATE',
+        entityName: 'CLIENT'
+      })
       .subscribe();
 
-    const request = httpMock.expectOne(
-      '/makercheckers?makerDateTimeFrom=01%20January%202026&makerDateTimeTo=31%20January%202026'
-    );
-    expect(request.request.params.get('makerDateTimeTo')).toBe('31 January 2026');
+    const request = httpMock.expectOne((req) => req.url === '/makercheckers');
+    expect(request.request.params.get('makerDateTimeFrom')).toBe('02 January 2016');
+    expect(request.request.params.get('makerDateTimeTo')).toBe('09 September 2026');
     expect(request.request.params.has('makerDateTimeto')).toBe(false);
+    expect(request.request.params.get('clientId')).toBe('42');
+    expect(request.request.params.get('actionName')).toBe('CREATE');
+    expect(request.request.params.get('entityName')).toBe('CLIENT');
+    expect(request.request.urlWithParams).not.toContain('enero');
+    expect(request.request.urlWithParams).not.toContain('septiembre');
     request.flush([]);
+  });
+
+  it('serializes the same selected calendar date independently of display locale', () => {
+    const englishCalendarSelection = new Date(2016, 0, 2);
+    const spanishCalendarSelection = new Date(2016, 0, 2);
+    const frenchCalendarSelection = new Date(2016, 0, 2);
+
+    // The serializer deliberately does not use the Web App locale or DatePipe.
+    expect(serializeMakerCheckerDate(englishCalendarSelection)).toBe('02 January 2016');
+    expect(serializeMakerCheckerDate(spanishCalendarSelection)).toBe('02 January 2016');
+    expect(serializeMakerCheckerDate(frenchCalendarSelection)).toBe('02 January 2016');
+    expect(serializeMakerCheckerDate(spanishCalendarSelection)).not.toContain('enero');
+    expect(serializeMakerCheckerDate(frenchCalendarSelection)).not.toContain('janvier');
+  });
+
+  it('preserves a date-only calendar value without a timezone shift', () => {
+    const selectedDate = new Date(2026, 8, 9, 23, 30);
+
+    expect(serializeMakerCheckerDate(selectedDate)).toBe('09 September 2026');
+  });
+
+  it('pads Maker Checker years below four digits', () => {
+    const selectedDate = new Date(0);
+    selectedDate.setFullYear(100, 0, 2);
+
+    expect(serializeMakerCheckerDate(selectedDate)).toBe('02 January 0100');
+  });
+
+  it('sends only populated Maker Checker date filters and omits invalid values', () => {
+    service
+      .getMakerCheckerData({
+        makerDateTimeFrom: serializeMakerCheckerDate(new Date(2016, 0, 2)),
+        makerDateTimeTo: serializeMakerCheckerDate(undefined),
+        invalid: serializeMakerCheckerDate(new Date('invalid'))
+      })
+      .subscribe();
+
+    const fromOnlyRequest = httpMock.expectOne((req) => req.url === '/makercheckers');
+    expect(fromOnlyRequest.request.params.get('makerDateTimeFrom')).toBe('02 January 2016');
+    expect(fromOnlyRequest.request.params.has('makerDateTimeTo')).toBe(false);
+    expect(fromOnlyRequest.request.params.has('invalid')).toBe(false);
+    fromOnlyRequest.flush([]);
+
+    service.getMakerCheckerData({ makerDateTimeTo: serializeMakerCheckerDate(new Date(2026, 8, 9)) }).subscribe();
+
+    const toOnlyRequest = httpMock.expectOne((req) => req.url === '/makercheckers');
+    expect(toOnlyRequest.request.params.has('makerDateTimeFrom')).toBe(false);
+    expect(toOnlyRequest.request.params.get('makerDateTimeTo')).toBe('09 September 2026');
+    toOnlyRequest.flush([]);
+
+    service
+      .getMakerCheckerData({
+        makerDateTimeFrom: serializeMakerCheckerDate(null),
+        makerDateTimeTo: serializeMakerCheckerDate(undefined)
+      })
+      .subscribe();
+
+    const emptyDatesRequest = httpMock.expectOne((req) => req.url === '/makercheckers');
+    expect(emptyDatesRequest.request.params.has('makerDateTimeFrom')).toBe(false);
+    expect(emptyDatesRequest.request.params.has('makerDateTimeTo')).toBe(false);
+    expect(emptyDatesRequest.request.urlWithParams).not.toContain('Invalid%20Date');
+    emptyDatesRequest.flush([]);
   });
 
   it('requests credit applications with only populated server-side parameters', () => {


### PR DESCRIPTION
## Description

Fixes WEB-1060 Checker Inbox date serialization so localized display dates are no longer sent directly to the Fineract Maker Checker API. The selected dates are now serialized in the locale-independent format expected by the backend, preventing date parsing failures in non-English languages.

## Related issues and discussion

WEB-1060

## Screenshots, if any



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized maker-checker search date formatting, regardless of the user’s locale.
  - Improved date-only handling to prevent timezone-related shifts.
  - Invalid or empty date filters are now omitted instead of being submitted.
  - Preserved other search filters while ensuring date parameters use the expected format.
  - Ensured dates are consistently padded and displayed with English month names for reliable search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->