### PR TITLE
WEB-1231: Name the guided interest rate and grace fields for what they measure

### DIFF
--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.html
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.html
@@ -170,7 +170,9 @@
                   </mat-option>
                 </mat-select>
 
-                <mat-hint *ngIf="field.hint">{{ field.hint | translate }}</mat-hint>
+                @if (fieldHint(field); as hint) {
+                  <mat-hint>{{ hint }}</mat-hint>
+                }
                 <!--
                   One `@if` per message, each with the `<mat-error>` at its root: that is what lets the
                   compiler infer the `mat-error` projection selector, so Material renders these in the

--- a/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.component.ts
@@ -290,6 +290,8 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
   private hiddenFieldKeysCache?: { profileMode: LoanWizardProfileMode; keys: Set<string> };
   // Single source of truth for each control's config, so the `required`/`maxLength` metadata declared
   // in FORM_STEPS is wired into real Angular Validators instead of only decorating the template.
+  // Resolved period-unit hints, keyed by frequency value and language — see `periodUnitHint`.
+  private readonly periodUnitHintCache = new Map<string, string>();
   private readonly fieldConfigByKey = new Map<string, FormField>(
     FORM_STEPS.flatMap((step) => step.fields).map((field) => [
       field.key,
@@ -786,6 +788,59 @@ export class LoanProductWizardComponent implements OnInit, OnChanges, AfterViewC
       return 'maxlength';
     }
     return null;
+  }
+
+  /**
+   * The subscript hint under a field: the static `hint` declared in FORM_STEPS, or — for a field
+   * counted in repayment periods — one naming the unit currently selected in the frequency control
+   * it points at, so "3" on a weekly product reads as three weekly periods, not three months.
+   *
+   * The hint names the frequency and leaves the arithmetic alone on purpose: with `repaymentEvery`
+   * above 1 a period is several of those units, so stating "3 weeks" outright would trade one wrong
+   * claim for another.
+   *
+   * One method rather than two `<mat-hint>` bindings: `mat-form-field` rejects a second hint in the
+   * same subscript slot, and — like {@link fieldErrorKey} — a projected element only reaches that
+   * slot when it is the single root of its control-flow block.
+   */
+  fieldHint(field: FormField): string | null {
+    const periodUnitHint = field.periodUnitFrom ? this.periodUnitHint(field.periodUnitFrom) : null;
+    if (periodUnitHint) {
+      return periodUnitHint;
+    }
+    return field.hint ? this.translateService.instant(field.hint) : null;
+  }
+
+  /**
+   * Reads the unit off the frequency select the same way the grid renders it — template-sourced
+   * options first, the config's static list as the fallback — so the hint keeps naming the operator's
+   * own selection if those options ever move into `TEMPLATE_OPTION_SOURCES`. Memoised per
+   * value-and-language because the field grid asks for every field's hint on each change detection
+   * pass, while the answer only changes when one of those two does.
+   */
+  private periodUnitHint(frequencyKey: FormField['periodUnitFrom'] & string): string | null {
+    const selected = this.form?.get(frequencyKey)?.value;
+    if (selected === null || selected === undefined || selected === '') {
+      return null;
+    }
+
+    const cacheKey = `${frequencyKey}:${selected}:${this.translateService.currentLang}`;
+    const cached = this.periodUnitHintCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const options = this.getTemplateSourcedOptions(frequencyKey) ?? this.fieldConfigByKey.get(frequencyKey)?.options;
+    const option = options?.find((candidate) => String(candidate.value) === String(selected));
+    if (!option) {
+      return null;
+    }
+
+    const hint = this.translateService.instant('labels.text.Counted in repayment periods', {
+      unit: this.translateDisplayLabel(String(option.label))
+    });
+    this.periodUnitHintCache.set(cacheKey, hint);
+    return hint;
   }
 
   visibleFields(step: FormStep): FormField[] {

--- a/src/app/products/loan-products/wizard/loan-product-wizard.render.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product-wizard.render.spec.ts
@@ -184,12 +184,22 @@ describe('LoanProductWizardComponent (rendered)', () => {
             'Advanced Configuration': 'Advanced Configuration'
           },
           inputs: { 'Terms vary based on loan cycle': 'Terms vary based on loan cycle' },
-          text: { 'max 4 chars': 'no more than 4 characters' },
+          text: {
+            'max 4 chars': 'no more than 4 characters',
+            'Counted in repayment periods': 'Counted in repayment periods ({{unit}})'
+          },
           buttons: { Preview: 'Preview', Yes: 'Yes', No: 'No' },
           // Deliberately NOT the English these keys carry in en-US.json: a value that matched its own
           // key would pass whether or not the template pipes it, which is exactly the hole these
           // assertions exist to close.
-          catalogs: { 'Per month': 'Monthly rate', 'Declining Balance': 'Reducing balance' }
+          // The two repayment units are given their German names for the same reason: a hint that
+          // read 'Weeks' would pass whether or not the unit went through `labels.catalogs`.
+          catalogs: {
+            'Per month': 'Monthly rate',
+            'Declining Balance': 'Reducing balance',
+            Weeks: 'Wochen',
+            Months: 'Monate'
+          }
         }
       },
       true
@@ -248,7 +258,7 @@ describe('LoanProductWizardComponent (rendered)', () => {
     control.markAsTouched();
     detect();
 
-    const error = fieldByLabel('labels.inputs.Annual interest rate').querySelector('mat-error')!;
+    const error = fieldByLabel('labels.inputs.Nominal interest rate').querySelector('mat-error')!;
     expect(error.textContent).toContain('Up to 6 decimal places allowed');
     expect(error.textContent!.toLowerCase()).not.toContain('positive');
   });
@@ -262,7 +272,7 @@ describe('LoanProductWizardComponent (rendered)', () => {
     detect();
 
     expect(control.errors).toBeNull();
-    expect(fieldByLabel('labels.inputs.Annual interest rate').querySelectorAll('mat-error').length).toBe(0);
+    expect(fieldByLabel('labels.inputs.Nominal interest rate').querySelectorAll('mat-error').length).toBe(0);
   });
 
   /**
@@ -474,6 +484,51 @@ describe('LoanProductWizardComponent (rendered)', () => {
       const hint = fieldByLabel('labels.inputs.Short Name').querySelector('mat-hint');
 
       expect(hint!.textContent!.trim()).toBe('no more than 4 characters');
+    });
+
+    /**
+     * I3(b): the three moratorium fields were labelled "(months)" while Fineract counts them in
+     * repayment periods, so on a weekly product the label was wrong by a factor of four. The label
+     * now matches Classic — which states no unit at all — and the hint names the unit the operator
+     * actually picked. DOM-level because the defect is what reaches the operator's eye.
+     */
+    describe('grace fields counted in repayment periods', () => {
+      function graceField(): HTMLElement {
+        return fieldByLabel('labels.inputs.Grace on principal payment');
+      }
+
+      function graceHint(): string {
+        return graceField().querySelector('mat-hint')!.textContent!.trim();
+      }
+
+      it('names the unit of the repayment frequency the operator selected', () => {
+        component.form.get('repaymentFrequencyType')!.setValue(1);
+        detect();
+
+        expect(graceHint()).toBe('Counted in repayment periods (Wochen)');
+      });
+
+      it('follows a change of repayment frequency', () => {
+        // The hint is memoised per value and language; a cache keyed any more loosely would leave the
+        // operator reading the unit they just moved away from.
+        component.form.get('repaymentFrequencyType')!.setValue(1);
+        detect();
+        component.form.get('repaymentFrequencyType')!.setValue(2);
+        detect();
+
+        expect(graceHint()).toBe('Counted in repayment periods (Monate)');
+      });
+
+      it('carries the unit in the hint and not in the label', () => {
+        component.form.get('repaymentFrequencyType')!.setValue(1);
+        detect();
+
+        const label = graceField().querySelector('mat-label')!.textContent!;
+        expect(label).not.toContain('months');
+        // `mat-form-field` renders at most one hint in a subscript slot and throws on a second, so
+        // the static and period-unit hints have to resolve to one element rather than two bindings.
+        expect(graceField().querySelectorAll('mat-hint').length).toBe(1);
+      });
     });
 
     it('translates a checkbox value in the Review', () => {

--- a/src/app/products/loan-products/wizard/loan-product.config.spec.ts
+++ b/src/app/products/loan-products/wizard/loan-product.config.spec.ts
@@ -3000,3 +3000,60 @@ describe('loan-product.config translation keys', () => {
     expect(offenders).toEqual([]);
   });
 });
+
+/**
+ * I3. Two labels contradicted the control sitting next to them: the interest rate was called
+ * "Annual" beside a Per month / Per year frequency select, and the three moratorium fields were
+ * called "(months)" though Fineract counts them in repayment periods and the repayment frequency
+ * offers Days / Weeks / Months. A mislabelled rate on a weekly microfinance product is a 12×
+ * pricing error, so these are invariants rather than assertions on the current strings.
+ */
+describe('loan-product.config field labels vs the controls beside them', () => {
+  const fieldsByKey = new Map(
+    FORM_STEPS.flatMap((step) => step.fields).map((field) => [
+      field.key,
+      field
+    ])
+  );
+
+  it('names the interest rate without promising a period the frequency select can contradict', () => {
+    // Classic heads the same control "Annual interest rate" and offers the frequency select anyway,
+    // so Classic is not the authority here; Fineract's own name for the field is.
+    const label = fieldsByKey.get('interestRatePerPeriod')!.label;
+
+    expect(label).toBe('labels.inputs.Nominal interest rate');
+    expect(label).not.toMatch(/annual|month|year/i);
+  });
+
+  it('states no calendar unit on a field counted in repayment periods', () => {
+    const periodCounted = [
+      'graceOnPrincipalPayment',
+      'graceOnInterestPayment',
+      'interestFreePeriod'
+    ];
+
+    const offenders = periodCounted
+      .map((key) => fieldsByKey.get(key)!)
+      .filter((field) => /\b(day|week|month|year)s?\b/i.test(field.label))
+      .map((field) => `${field.key}: ${field.label}`);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('points every period-counted field at a frequency select that exists and is selectable', () => {
+    // The hint reads its unit off this control's options; a key naming a control the config does not
+    // render (or one with no options) would silently drop the hint rather than fail.
+    const offenders = FORM_STEPS.flatMap((step) =>
+      step.fields
+        .filter((field) => field.periodUnitFrom)
+        .filter((field) => {
+          const source = fieldsByKey.get(field.periodUnitFrom!);
+          return !source || source.type !== 'select' || !source.options?.length;
+        })
+        .map((field) => `${field.key} → ${field.periodUnitFrom}`)
+    );
+
+    expect(offenders).toEqual([]);
+    expect(FORM_STEPS.flatMap((step) => step.fields).filter((field) => field.periodUnitFrom)).toHaveLength(3);
+  });
+});

--- a/src/app/products/loan-products/wizard/loan-product.config.ts
+++ b/src/app/products/loan-products/wizard/loan-product.config.ts
@@ -126,6 +126,15 @@ export interface FormField {
    * already covers with the shared `rangeValidator(0, 100)`. Hence no `max` here.
    */
   decimals?: number;
+  /**
+   * Marks a field Fineract counts in repayment periods rather than in a fixed calendar unit, naming
+   * the frequency control that decides what one period actually is. The wizard renders that unit as
+   * a hint, so a `3` on a weekly product reads as three weekly periods rather than three months.
+   *
+   * Typed to the one frequency control the config has today: widening it is a one-word change, and
+   * until then the compiler points at every caller that would need the hint text generalised.
+   */
+  periodUnitFrom?: 'repaymentFrequencyType';
   options?: SelectOption[];
 }
 /**
@@ -520,7 +529,10 @@ export const FORM_STEPS: FormStep[] = [
         decimals: 0
       },
       {
-        label: 'labels.inputs.Annual interest rate',
+        // Classic heads the same control "Annual interest rate" (loan-product-terms-step) while
+        // offering a Per month / Per year frequency select right beside it, so the guided form takes
+        // Fineract's own name for the field instead — the one its validators report errors under.
+        label: 'labels.inputs.Nominal interest rate',
         key: 'interestRatePerPeriod',
         type: 'number',
         required: true,
@@ -707,25 +719,28 @@ export const FORM_STEPS: FormStep[] = [
         ]
       },
       {
-        label: 'labels.inputs.Grace on principal payment (months)',
+        label: 'labels.inputs.Grace on principal payment',
         key: 'graceOnPrincipalPayment',
         type: 'number',
         placeholder: '0',
-        min: 0
+        min: 0,
+        periodUnitFrom: 'repaymentFrequencyType'
       },
       {
-        label: 'labels.inputs.Grace on interest payment (months)',
+        label: 'labels.inputs.Grace on interest payment',
         key: 'graceOnInterestPayment',
         type: 'number',
         placeholder: '0',
-        min: 0
+        min: 0,
+        periodUnitFrom: 'repaymentFrequencyType'
       },
       {
-        label: 'labels.inputs.Interest free period (months)',
+        label: 'labels.inputs.Interest free period',
         key: 'interestFreePeriod',
         type: 'number',
         placeholder: '0',
-        min: 0
+        min: 0,
+        periodUnitFrom: 'repaymentFrequencyType'
       },
       {
         label: 'labels.inputs.Days in Year',

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -5045,7 +5045,8 @@
       "Select at least one credit application to reject": "Vyberte alespoň jednu žádost o úvěr k zamítnutí.",
       "All selected credit applications were rejected successfully": "Všechny vybrané žádosti o úvěr byly úspěšně zamítnuty.",
       "No selected credit applications could be rejected": "Žádné vybrané žádosti o úvěr se nepodařilo zamítnout.",
-      "Selected credit applications rejection partial result": "{{succeeded}} z {{total}} vybraných žádostí o úvěr bylo zamítnuto. {{failed}} selhalo."
+      "Selected credit applications rejection partial result": "{{succeeded}} z {{total}} vybraných žádostí o úvěr bylo zamítnuto. {{failed}} selhalo.",
+      "Counted in repayment periods": "Počítáno ve splátkových obdobích ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -5045,7 +5045,8 @@
       "Select at least one credit application to reject": "Wählen Sie mindestens einen Kreditantrag zum Ablehnen aus.",
       "All selected credit applications were rejected successfully": "Alle ausgewählten Kreditanträge wurden erfolgreich abgelehnt.",
       "No selected credit applications could be rejected": "Keiner der ausgewählten Kreditanträge konnte abgelehnt werden.",
-      "Selected credit applications rejection partial result": "{{succeeded}} von {{total}} ausgewählten Kreditanträgen wurden abgelehnt. {{failed}} fehlgeschlagen."
+      "Selected credit applications rejection partial result": "{{succeeded}} von {{total}} ausgewählten Kreditanträgen wurden abgelehnt. Fehlgeschlagen: {{failed}}.",
+      "Counted in repayment periods": "Wird in Rückzahlungsperioden gezählt ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -5183,7 +5183,8 @@
       "Select at least one credit application to reject": "Select at least one credit application to reject.",
       "All selected credit applications were rejected successfully": "All selected credit applications were rejected successfully.",
       "No selected credit applications could be rejected": "No selected credit applications could be rejected.",
-      "Selected credit applications rejection partial result": "{{succeeded}} of {{total}} selected credit applications were rejected. {{failed}} failed."
+      "Selected credit applications rejection partial result": "{{succeeded}} of {{total}} selected credit applications were rejected. {{failed}} failed.",
+      "Counted in repayment periods": "Counted in repayment periods ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -5045,7 +5045,8 @@
       "Select at least one credit application to reject": "Seleccione al menos una solicitud de crédito para rechazar.",
       "All selected credit applications were rejected successfully": "Todas las solicitudes de crédito seleccionadas se rechazaron correctamente.",
       "No selected credit applications could be rejected": "No se pudo rechazar ninguna solicitud de crédito seleccionada.",
-      "Selected credit applications rejection partial result": "{{succeeded}} de {{total}} solicitudes de crédito seleccionadas fueron rechazadas. {{failed}} fallaron."
+      "Selected credit applications rejection partial result": "{{succeeded}} de {{total}} solicitudes de crédito seleccionadas fueron rechazadas. {{failed}} fallaron.",
+      "Counted in repayment periods": "Contado en períodos de pago ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -5069,7 +5069,8 @@
       "Select at least one credit application to reject": "Seleccione al menos una solicitud de crédito para rechazar.",
       "All selected credit applications were rejected successfully": "Todas las solicitudes de crédito seleccionadas se rechazaron correctamente.",
       "No selected credit applications could be rejected": "No se pudo rechazar ninguna solicitud de crédito seleccionada.",
-      "Selected credit applications rejection partial result": "{{succeeded}} de {{total}} solicitudes de crédito seleccionadas fueron rechazadas. {{failed}} fallaron."
+      "Selected credit applications rejection partial result": "{{succeeded}} de {{total}} solicitudes de crédito seleccionadas fueron rechazadas. {{failed}} fallaron.",
+      "Counted in repayment periods": "Contado en períodos de pago ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -5046,7 +5046,8 @@
       "Select at least one credit application to reject": "Sélectionnez au moins une demande de crédit à rejeter.",
       "All selected credit applications were rejected successfully": "Toutes les demandes de crédit sélectionnées ont été rejetées avec succès.",
       "No selected credit applications could be rejected": "Aucune demande de crédit sélectionnée n’a pu être rejetée.",
-      "Selected credit applications rejection partial result": "{{succeeded}} sur {{total}} demandes de crédit sélectionnées ont été rejetées. {{failed}} ont échoué."
+      "Selected credit applications rejection partial result": "{{succeeded}} sur {{total}} demandes de crédit sélectionnées ont été rejetées. {{failed}} ont échoué.",
+      "Counted in repayment periods": "Compté en périodes de remboursement ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -5044,7 +5044,8 @@
       "Select at least one credit application to reject": "Selezionare almeno una richiesta di credito da rifiutare.",
       "All selected credit applications were rejected successfully": "Tutte le richieste di credito selezionate sono state rifiutate correttamente.",
       "No selected credit applications could be rejected": "Nessuna richiesta di credito selezionata può essere rifiutata.",
-      "Selected credit applications rejection partial result": "{{succeeded}} di {{total}} richieste di credito selezionate sono state rifiutate. {{failed}} non riuscite."
+      "Selected credit applications rejection partial result": "{{succeeded}} di {{total}} richieste di credito selezionate sono state rifiutate. {{failed}} non riuscite.",
+      "Counted in repayment periods": "Conteggiato in periodi di rimborso ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -5043,7 +5043,8 @@
       "Select at least one credit application to reject": "거절할 신용 신청을 하나 이상 선택하세요.",
       "All selected credit applications were rejected successfully": "선택한 모든 신용 신청이 성공적으로 거절되었습니다.",
       "No selected credit applications could be rejected": "선택한 신용 신청을 거절할 수 없습니다.",
-      "Selected credit applications rejection partial result": "선택한 신용 신청 {{total}}건 중 {{succeeded}}건이 거절되었습니다. {{failed}}건은 실패했습니다."
+      "Selected credit applications rejection partial result": "선택한 신용 신청 {{total}}건 중 {{succeeded}}건이 거절되었습니다. {{failed}}건은 실패했습니다.",
+      "Counted in repayment periods": "상환 주기 단위로 계산됩니다 ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -5044,7 +5044,8 @@
       "Select at least one credit application to reject": "Pasirinkite bent vieną kredito paraišką atmetimui.",
       "All selected credit applications were rejected successfully": "Visos pasirinktos kredito paraiškos sėkmingai atmestos.",
       "No selected credit applications could be rejected": "Nepavyko atmesti nė vienos pasirinktos kredito paraiškos.",
-      "Selected credit applications rejection partial result": "Atmesta {{succeeded}} iš {{total}} pasirinktų kredito paraiškų. {{failed}} nepavyko."
+      "Selected credit applications rejection partial result": "Atmesta {{succeeded}} iš {{total}} pasirinktų kredito paraiškų. {{failed}} nepavyko.",
+      "Counted in repayment periods": "Skaičiuojama grąžinimo laikotarpiais ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -5043,7 +5043,8 @@
       "Select at least one credit application to reject": "Atlasiet vismaz vienu kredīta pieteikumu noraidīšanai.",
       "All selected credit applications were rejected successfully": "Visi atlasītie kredīta pieteikumi tika veiksmīgi noraidīti.",
       "No selected credit applications could be rejected": "Nevienu atlasīto kredīta pieteikumu neizdevās noraidīt.",
-      "Selected credit applications rejection partial result": "Noraidīti {{succeeded}} no {{total}} atlasītajiem kredīta pieteikumiem. {{failed}} neizdevās."
+      "Selected credit applications rejection partial result": "Noraidīti {{succeeded}} no {{total}} atlasītajiem kredīta pieteikumiem. {{failed}} neizdevās.",
+      "Counted in repayment periods": "Tiek skaitīts atmaksas periodos ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -5043,7 +5043,8 @@
       "Select at least one credit application to reject": "अस्वीकार गर्न कम्तीमा एउटा क्रेडिट आवेदन चयन गर्नुहोस्।",
       "All selected credit applications were rejected successfully": "सबै चयन गरिएका क्रेडिट आवेदनहरू सफलतापूर्वक अस्वीकार गरिए।",
       "No selected credit applications could be rejected": "चयन गरिएका कुनै पनि क्रेडिट आवेदन अस्वीकार गर्न सकिएन।",
-      "Selected credit applications rejection partial result": "{{total}} चयन गरिएका क्रेडिट आवेदनमध्ये {{succeeded}} अस्वीकार गरिए। {{failed}} असफल भए।"
+      "Selected credit applications rejection partial result": "{{total}} चयन गरिएका क्रेडिट आवेदनमध्ये {{succeeded}} अस्वीकार गरिए। {{failed}} असफल भए।",
+      "Counted in repayment periods": "भुक्तानी अवधिमा गणना गरिन्छ ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -5043,7 +5043,8 @@
       "Select at least one credit application to reject": "Selecione pelo menos uma candidatura de crédito para rejeitar.",
       "All selected credit applications were rejected successfully": "Todas as candidaturas de crédito selecionadas foram rejeitadas com sucesso.",
       "No selected credit applications could be rejected": "Não foi possível rejeitar nenhuma candidatura de crédito selecionada.",
-      "Selected credit applications rejection partial result": "{{succeeded}} de {{total}} candidaturas de crédito selecionadas foram rejeitadas. {{failed}} falharam."
+      "Selected credit applications rejection partial result": "{{succeeded}} de {{total}} candidaturas de crédito selecionadas foram rejeitadas. {{failed}} falharam.",
+      "Counted in repayment periods": "Contado em períodos de reembolso ({{unit}})"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -5040,7 +5040,8 @@
       "Select at least one credit application to reject": "Chagua angalau ombi moja la mkopo la kukataa.",
       "All selected credit applications were rejected successfully": "Maombi yote ya mkopo yaliyochaguliwa yamekataliwa kwa mafanikio.",
       "No selected credit applications could be rejected": "Hakuna ombi la mkopo lililochaguliwa lililoweza kukataliwa.",
-      "Selected credit applications rejection partial result": "{{succeeded}} kati ya {{total}} maombi ya mkopo yaliyochaguliwa yamekataliwa. {{failed}} yameshindwa."
+      "Selected credit applications rejection partial result": "{{succeeded}} kati ya {{total}} maombi ya mkopo yaliyochaguliwa yamekataliwa. {{failed}} yameshindwa.",
+      "Counted in repayment periods": "Huhesabiwa kwa vipindi vya marejesho ({{unit}})"
     },
     "permissions": {
       "actions": {


### PR DESCRIPTION
## Description

Two labels in the guided loan product wizard contradicted the control sitting next to them.

**Interest rate.** `interestRatePerPeriod` was labelled "Annual interest rate" directly beside a frequency select offering Per month / Per year — pick Per month and the field labelled *annual* holds a monthly rate. On a weekly microfinance product that is a 12× pricing error. Classic is no help here: `loan-product-terms-step.component.html` heads the same control "Annual interest rate" and offers the same frequency select, so it carries the identical contradiction. The field is now
"Nominal interest rate" — Fineract's own name for it, and the one its validator messages report errors under. The string already exists in all 13 locales.

**Moratorium fields.** "Grace on principal payment (months)", "Grace on interest payment (months)" and "Interest free period (months)" are not counted in months: Fineract counts them in repayment periods, and the repayment frequency offers Days / Weeks / Months. The labels now match Classic, which states no unit at all, and the real unit moves to a hint that names the frequency the operator actually selected — "Counted in repayment periods (Weeks)". The hint deliberately names the frequency rather than doing the arithmetic: with `repaymentEvery` above 1 a period is several of those units, so "3 weeks" would trade one wrong claim for another.

Mechanically, `FormField` gains `periodUnitFrom`, and the field grid's hint moves from a template binding to `fieldHint()` — `mat-form-field` rejects a second hint in the same subscript slot, so the static and period-unit hints have to resolve to one element. The unit is read through the same path the grid renders the select with (template-sourced options first, the config's static list as fallback), so it keeps working if those options later move to `TEMPLATE_OPTION_SOURCES`.

One new translation key, added to all 13 locale files.

6 new tests: 3 DOM-level in `loan-product-wizard.render.spec.ts` (the hint names the selected unit, follows a change of frequency, and is the field's only hint) and 3 config invariants in `loan-product.config.spec.ts` (the rate label promises no period; no period-counted field states a calendar unit; every `periodUnitFrom` points at a real, populated select). 5 of the 6 were verified
to fail with the change reverted. Full `loan-products` suite: 359 passing.

## Related issues and discussion

# WEB-1231

## Screenshots, if any
NA

## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dynamic hints to loan product wizard fields, indicating whether values are counted in weeks, months, or other repayment units.
  - Hints update when the repayment frequency changes and are available in supported languages.

- **Updates**
  - Simplified period-based field labels by removing fixed time-unit wording.
  - Renamed “Annual interest rate” to “Nominal interest rate.”
  - Added and updated translations for repayment-period hints and partial-result messaging.

- **Tests**
  - Added coverage for labels, repayment-unit hints, frequency changes, localization, and hint rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->