### PR TITLE
fix(WEB-1088): render checker inbox dates and add a filter reset

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.html
@@ -121,6 +121,9 @@
         <button mat-raised-button color="primary" id="search-button" type="button" (click)="search()">
           <fa-icon icon="search" class="m-r-10"></fa-icon>{{ 'labels.buttons.Advanced Search' | translate }}
         </button>
+        <button mat-raised-button id="reset-button" type="button" (click)="resetFilters()">
+          <fa-icon icon="undo" class="m-r-10"></fa-icon>{{ 'labels.buttons.Reset' | translate }}
+        </button>
       </div>
     </form>
   }
@@ -193,6 +196,10 @@
       <ng-container matColumnDef="entity">
         <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Entity' | translate }}</th>
         <td mat-cell *matCellDef="let makerChecker">{{ makerChecker.entityName }}</td>
+      </ng-container>
+      <ng-container matColumnDef="resourceId">
+        <th mat-header-cell *matHeaderCellDef>{{ 'labels.inputs.Resource ID' | translate }}</th>
+        <td mat-cell *matCellDef="let makerChecker">{{ makerChecker.resourceId }}</td>
       </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.scss
@@ -119,7 +119,8 @@
     align-items: flex-start;
   }
 
-  #search-button {
+  #search-button,
+  #reset-button {
     height: 2.5rem;
     margin-top: 1rem;
   }

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.spec.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { DatePipe } from '@angular/common';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faCheck, faSearch, faTimes, faTrash, faUndo } from '@fortawesome/free-solid-svg-icons';
+import { TranslateModule } from '@ngx-translate/core';
+import { Observable, of, Subject } from 'rxjs';
+
+import { ClientsService } from 'app/clients/clients.service';
+import { AuthenticationService } from 'app/core/authentication/authentication.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { TasksService } from '../../tasks.service';
+import { CheckerInboxComponent } from './checker-inbox.component';
+
+/** The slice of the `/clients` search response the customer autocomplete reads. */
+interface CustomerOption {
+  id: number;
+  displayName: string;
+}
+
+interface CustomerLookupResponse {
+  content: CustomerOption[];
+}
+
+describe('CheckerInboxComponent advanced-search reset', () => {
+  let component: CheckerInboxComponent;
+  let fixture: ComponentFixture<CheckerInboxComponent>;
+  let searchByText: jest.Mock;
+  let getMakerCheckerData: jest.Mock;
+
+  const record = { id: 23, actionName: 'UPDATE', entityName: 'CLIENT', resourceId: 1, madeOnDate: 1789064261493 };
+
+  function createComponent(customerLookup: Observable<CustomerLookupResponse> = of({ content: [] })) {
+    searchByText = jest.fn(() => customerLookup);
+    getMakerCheckerData = jest.fn(() => of([record]));
+
+    TestBed.configureTestingModule({
+      imports: [
+        CheckerInboxComponent,
+        TranslateModule.forRoot(),
+        NoopAnimationsModule
+      ],
+      providers: [
+        DatePipe,
+        provideRouter([]),
+        { provide: TasksService, useValue: { getMakerCheckerData } },
+        { provide: ClientsService, useValue: { searchByText } },
+        { provide: MatDialog, useValue: { open: jest.fn() } },
+        { provide: AuthenticationService, useValue: { getCredentials: () => ({ permissions: ['ALL_FUNCTIONS'] }) } },
+        { provide: SettingsService, useValue: { dateFormat: 'dd MMMM yyyy', language: { code: 'en' } } },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({
+              makerCheckerResource: [record],
+              makerCheckerTemplate: { actionNames: ['UPDATE'], entityNames: ['CLIENT'] }
+            })
+          }
+        }
+      ]
+    });
+
+    TestBed.inject(FaIconLibrary).addIcons(faCheck, faSearch, faTimes, faTrash, faUndo);
+
+    fixture = TestBed.createComponent(CheckerInboxComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('clears every filter, the customer control and the options, then reloads', () => {
+    createComponent();
+    component.makerCheckerSearchForm.patchValue({
+      makerDateTimeFrom: new Date(2026, 0, 1),
+      makerDateTimeTo: new Date(2026, 11, 31),
+      actionName: 'UPDATE',
+      entityName: 'CLIENT',
+      resourceId: '1'
+    });
+    component.customerControl.setValue({ id: 1, displayName: 'Web Tester' });
+    component.customers = [{ id: 1, displayName: 'Web Tester' }];
+
+    component.resetFilters();
+
+    expect(component.makerCheckerSearchForm.value).toEqual({
+      makerDateTimeFrom: null,
+      makerDateTimeTo: null,
+      actionName: null,
+      entityName: null,
+      resourceId: null
+    });
+    expect(component.customerControl.value).toBe('');
+    expect(component.customers).toEqual([]);
+    expect(getMakerCheckerData).toHaveBeenCalled();
+  });
+
+  it('does not send a cleared filter as a query parameter', () => {
+    createComponent();
+    component.makerCheckerSearchForm.patchValue({ actionName: 'UPDATE', resourceId: '1' });
+
+    component.resetFilters();
+
+    const params = getMakerCheckerData.mock.calls.at(-1)[0];
+    expect(params.actionName).toBeNull();
+    expect(params.resourceId).toBeNull();
+    expect(params.clientId).toBeUndefined();
+  });
+
+  it('drops a customer lookup that resolves after the reset', fakeAsync(() => {
+    const lookup = new Subject<CustomerLookupResponse>();
+    createComponent(lookup);
+
+    component.customerControl.setValue('web');
+    tick(300);
+    expect(searchByText).toHaveBeenCalledWith('web', 0, 20);
+
+    component.resetFilters();
+    lookup.next({ content: [{ id: 1, displayName: 'Web Tester' }] });
+    lookup.complete();
+
+    // Asserted inside the debounce window: switchMap has not cancelled the lookup yet,
+    // so only the subscriber's guard can keep the stale options out.
+    expect(component.customers).toEqual([]);
+
+    tick(300);
+    expect(component.customers).toEqual([]);
+  }));
+});

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/checker-inbox/checker-inbox.component.ts
@@ -61,7 +61,10 @@ interface MakerCheckerRecord {
   id: number;
   actionName: string;
   entityName: string;
-  madeOnDate?: string;
+  resourceId?: number;
+  /** Epoch milliseconds once `TasksService` has converted the seconds the endpoint sends;
+   *  anything non-numeric is passed through untouched. */
+  madeOnDate?: number | string;
   processingResult?: string;
   maker?: string;
 }
@@ -153,7 +156,8 @@ export class CheckerInboxComponent implements OnInit {
     'status',
     'user',
     'action',
-    'entity'
+    'entity',
+    'resourceId'
   ];
 
   /**
@@ -186,7 +190,9 @@ export class CheckerInboxComponent implements OnInit {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((customers) => {
-        this.customers = customers;
+        // A reset empties the control while a lookup may still be in flight; the 300ms
+        // debounce delays switchMap's cancellation, so drop the late result here.
+        this.customers = this.customerControl.value ? customers : [];
         this.changeDetectorRef.markForCheck();
       });
   }
@@ -212,6 +218,14 @@ export class CheckerInboxComponent implements OnInit {
   }
 
   search() {
+    this.loadMakerCheckers();
+  }
+
+  /** Clears every advanced-search filter and reloads the unfiltered inbox. */
+  resetFilters() {
+    this.makerCheckerSearchForm.reset();
+    this.customerControl.setValue('');
+    this.customers = [];
     this.loadMakerCheckers();
   }
 

--- a/src/app/tasks/tasks.service.spec.ts
+++ b/src/app/tasks/tasks.service.spec.ts
@@ -145,4 +145,44 @@ describe('TasksService maker-checker search', () => {
     expect(request.request.params.get('sortOrder')).toBe('DESC');
     request.flush({ totalFilteredRecords: 0, pageItems: [] });
   });
+
+  it('converts the epoch-seconds madeOnDate served by /makercheckers to milliseconds', () => {
+    let records: any[];
+    service.getMakerCheckerData().subscribe((response: any[]) => (records = response));
+
+    httpMock
+      .expectOne((req) => req.url === '/makercheckers')
+      .flush([
+        { id: 23, madeOnDate: 1789064261.492617 },
+        { id: 24 }
+      ]);
+
+    expect(records[0].madeOnDate).toBe(1789064261493);
+    expect(records[1].madeOnDate).toBeUndefined();
+  });
+
+  it('converts the epoch-seconds madeOnDate served by /audits/{id} to milliseconds', () => {
+    let detail: any;
+    service.getCheckerInboxDetail(23).subscribe((response: any) => (detail = response));
+
+    httpMock.expectOne('/audits/23').flush({ id: 23, madeOnDate: 1789064261.492617 });
+
+    expect(detail.madeOnDate).toBe(1789064261493);
+  });
+
+  it('leaves a non-numeric madeOnDate and the rest of the record untouched', () => {
+    let records: any[];
+    service.getMakerCheckerData().subscribe((response: any[]) => (records = response));
+
+    httpMock
+      .expectOne((req) => req.url === '/makercheckers')
+      .flush([{ id: 23, madeOnDate: '2026-09-10T18:17:41Z', actionName: 'UPDATE', resourceId: 1 }]);
+
+    expect(records[0]).toEqual({
+      id: 23,
+      madeOnDate: '2026-09-10T18:17:41Z',
+      actionName: 'UPDATE',
+      resourceId: 1
+    });
+  });
 });

--- a/src/app/tasks/tasks.service.ts
+++ b/src/app/tasks/tasks.service.ts
@@ -11,7 +11,25 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 
 /** rxjs Imports */
-import { Observable } from 'rxjs';
+import { map, Observable } from 'rxjs';
+
+/**
+ * `/makercheckers` and `/audits/{id}` return the `AuditData` DTO straight from the
+ * resource, so Jackson serialises its `ZonedDateTime` as epoch seconds
+ * (`1789064261.492617`). The `/audits` list goes through Gson's `JodaDateTimeAdapter`
+ * and sends epoch milliseconds. The date pipes read a bare number as milliseconds, so
+ * the seconds form renders as a 1970 date.
+ *
+ * Converted here, where the endpoint fixes the unit, rather than in the shared pipe:
+ * a millisecond value from before September 2001 is numerically indistinguishable from
+ * a seconds value, so no magnitude check further down can tell them apart.
+ */
+function madeOnDateToMillis(record: any): any {
+  if (typeof record?.madeOnDate !== 'number') {
+    return record;
+  }
+  return { ...record, madeOnDate: Math.round(record.madeOnDate * 1000) };
+}
 
 /**
  * Tasks Service
@@ -41,7 +59,9 @@ export class TasksService {
    * @param {searchData} SearchData search the maker checker data.
    */
   getMakerCheckerData(searchData?: any): Observable<any> {
-    return this.http.get('/makercheckers', { params: this.buildHttpParams(searchData) });
+    return this.http
+      .get('/makercheckers', { params: this.buildHttpParams(searchData) })
+      .pipe(map((records: any[]) => (records || []).map(madeOnDateToMillis)));
   }
 
   /**
@@ -145,6 +165,6 @@ export class TasksService {
    * @param {makerCheckerId} MakerCheckerId
    */
   getCheckerInboxDetail(makerCheckerId: any): Observable<any> {
-    return this.http.get(`/audits/${makerCheckerId}`);
+    return this.http.get(`/audits/${makerCheckerId}`).pipe(map(madeOnDateToMillis));
   }
 }


### PR DESCRIPTION
Picks up #3787 by @Ruba-Tawk-FOO, which has been conflicting since this screen was rewritten. @IOhacker asked there whether I could carry it forward.

### The 1970 date

Fineract sends `madeOnDate` two different ways depending on which endpoint you ask:

```
GET /audits        → 1789064261492      epoch milliseconds  (Gson)
GET /makercheckers → 1789064261.492617  epoch seconds       (Jackson)
GET /audits/{id}   → 1789064261.492617  epoch seconds       (Jackson)
```

The `/audits` list goes through `ToApiJsonSerializer`, whose `JodaDateTimeAdapter` writes `toEpochMilli()`. The other two return the `AuditData` DTO straight from the resource, so Jackson serialises the `ZonedDateTime` as seconds with a nanosecond fraction. Our date pipes read a bare number as milliseconds, and `1789064261` milliseconds is 20 days past the epoch — hence "21 January 1970".

I've put the conversion in `TasksService`, on the two endpoints that send seconds. It's tempting to fix this in `date-format.pipe.ts` with something like `value < 1e12 ? moment.unix(value) : moment(value)`, and my first version did exactly that, but it doesn't hold up: `946684800000` is 1 January 2000 in milliseconds, sits below the threshold, and would render as the year 31969. Any millisecond timestamp from before September 2001 is indistinguishable from a seconds value, so the magnitude can't tell you the unit — the endpoint can. Worth knowing that `datetime-format.pipe.ts` still has that same threshold from WEB-185; I've left it alone here, but it has the same hole.

The conversion returns a copy rather than mutating the response, and both the list and the detail screen read through this service, so it covers both.

### Reset button and Resource ID column

Reset clears the filter form, the customer autocomplete and the results. The customer control lives outside the form group, so `makerCheckerSearchForm.reset()` on its own leaves a customer filter quietly applied to what looks like a cleared search.

There's also a small race worth mentioning: `debounceTime(300)` sits before the `switchMap` in the customer lookup, so clearing the control doesn't cancel a request that's already in flight. Its result would land 300ms later and repopulate the autocomplete for a filter the user just cleared. The subscriber now ignores a result that arrives once the control is empty.

The Resource ID column is populated for UPDATE and DELETE entries. It's blank for CREATE entries because the resource doesn't exist until the entry is approved — that's the backend, not a rendering gap.

### What I didn't need to do

Three of the things #3787 reported are already handled:

- the `makerDateTimeto` → `makerDateTimeTo` rename, and results not appearing until the second Search click, were both fixed by #3952;
- the From/To date filters are fixed by [FINERACT-2683](https://issues.apache.org/jira/browse/FINERACT-2683) upstream plus @Anvay-kharb's #3981 on `dev`. I got this one wrong in an earlier version of this description — [details in the comment below](https://github.com/openMF/web-app/pull/3983#issuecomment-5624274263).

The Action, Entity and Resource ID filters all apply correctly; I couldn't reproduce that part of the report.

### One thing that is still broken

Clicking a row in the checker inbox 404s. The detail route is registered at `checker-inbox-and-tasks/checker-inbox/:id/view` but nested under the module's own `checker-inbox-and-tasks` base, so the row's `routerLink` and the route never line up; the double-prefixed URL that does match throws in `BreadcrumbComponent` and renders a blank page. That's pre-existing on `dev` and unrelated to this change, so I've left it for its own ticket — but it does mean the detail-screen half of the date fix is argued from the endpoint payload and the unit tests rather than shown working in a browser.

### Testing

Against a local Fineract with maker-checker enabled for `CREATE_CLIENT` and `UPDATE_CLIENT` and a maker user without `ALL_FUNCTIONS`, so there were three genuinely pending entries. Before the change all three rows read "21 January 1970"; after, they read "10 September 2026". Reset clears all five controls plus the customer field and brings the full list back, and the UPDATE row shows its Resource ID. Checked in light and dark mode. `Reset` and `Resource ID` already exist in all 13 translation files.

Six new unit tests cover the conversion, the reset and the lookup race. I checked they actually fail when the code they cover is reverted — the race test needed its assertion moved inside the debounce window before it would.

Thanks to @Ruba-Tawk-FOO for the original report and diagnosis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Reset button to the advanced search form.
  * Added a Resource ID column to the checker inbox table.
  * Resetting filters now clears customer selections and reloads the unfiltered inbox.

* **Bug Fixes**
  * Prevented outdated customer search results from reappearing after filters are reset.
  * Standardized checker and audit dates so epoch-second values display correctly as milliseconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->