### PR TITLE
WEB-1230: keep the loading bar hidden until a request starts

### DIFF
--- a/src/app/core/shell/shell.component.spec.ts
+++ b/src/app/core/shell/shell.component.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { MatSidenav } from '@angular/material/sidenav';
+import { TranslateModule } from '@ngx-translate/core';
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { ShellComponent } from './shell.component';
+import { SidenavComponent } from './sidenav/sidenav.component';
+import { ToolbarComponent } from './toolbar/toolbar.component';
+import { BreadcrumbComponent } from './breadcrumb/breadcrumb.component';
+import { ContentComponent } from './content/content.component';
+import { FooterComponent } from '../../shared/footer/footer.component';
+import { ProgressBarService } from '../progress-bar/progress-bar.service';
+
+/* The shell's children each pull in the whole application dependency tree.
+   Stubbing them keeps the real shell template, and therefore the real progress
+   bar condition, while leaving the rest out of the way. */
+@Component({ selector: 'mifosx-sidenav', template: '' })
+class StubSidenavComponent {
+  @Input() sidenavCollapsed = true;
+}
+
+@Component({ selector: 'mifosx-toolbar', template: '' })
+class StubToolbarComponent {
+  @Input() sidenav: MatSidenav;
+  @Output() collapse = new EventEmitter<boolean>();
+}
+
+@Component({ selector: 'mifosx-breadcrumb', template: '' })
+class StubBreadcrumbComponent {}
+
+@Component({ selector: 'mifosx-content', template: '' })
+class StubContentComponent {}
+
+@Component({ selector: 'mifosx-footer', template: '' })
+class StubFooterComponent {
+  @Input() styleClass = '';
+}
+
+describe('ShellComponent — progress bar visibility', () => {
+  let component: ShellComponent;
+  let fixture: ComponentFixture<ShellComponent>;
+  let progressBarService: ProgressBarService;
+
+  /** The animated bar rendered by the shell while a request is in flight. */
+  const loadingBar = () => fixture.nativeElement.querySelector('.loading');
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        ShellComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        ProgressBarService,
+        provideAnimationsAsync(),
+        provideRouter([])
+      ]
+    })
+      .overrideComponent(ShellComponent, {
+        remove: {
+          imports: [
+            SidenavComponent,
+            ToolbarComponent,
+            BreadcrumbComponent,
+            ContentComponent,
+            FooterComponent
+          ]
+        },
+        add: {
+          imports: [
+            StubSidenavComponent,
+            StubToolbarComponent,
+            StubBreadcrumbComponent,
+            StubContentComponent,
+            StubFooterComponent
+          ]
+        }
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ShellComponent);
+    component = fixture.componentInstance;
+    progressBarService = TestBed.inject(ProgressBarService);
+    fixture.detectChanges();
+  });
+
+  it('does not render the loading bar before any request has started', () => {
+    // Left uninitialised this was undefined, which is not 'none', so the bar was
+    // rendered on every route that issues no request of its own.
+    expect(component.progressBarMode).toBe('none');
+    expect(loadingBar()).toBeNull();
+  });
+
+  it('renders the loading bar while a request is running', () => {
+    progressBarService.increase();
+    fixture.detectChanges();
+
+    expect(component.progressBarMode).toBe('indeterminate');
+    expect(loadingBar()).not.toBeNull();
+  });
+
+  it('removes the loading bar once the last request finishes', () => {
+    progressBarService.increase();
+    fixture.detectChanges();
+    expect(loadingBar()).not.toBeNull();
+
+    progressBarService.decrease();
+    fixture.detectChanges();
+
+    expect(component.progressBarMode).toBe('none');
+    expect(loadingBar()).toBeNull();
+  });
+
+  it('keeps the loading bar rendered until every concurrent request finishes', () => {
+    progressBarService.increase();
+    progressBarService.increase();
+    progressBarService.decrease();
+    fixture.detectChanges();
+
+    expect(loadingBar()).not.toBeNull();
+
+    progressBarService.decrease();
+    fixture.detectChanges();
+
+    expect(loadingBar()).toBeNull();
+  });
+});

--- a/src/app/core/shell/shell.component.ts
+++ b/src/app/core/shell/shell.component.ts
@@ -76,8 +76,14 @@ export class ShellComponent implements OnInit, AfterViewInit {
     .pipe(map((result) => result.matches));
   /** Sets the initial state of sidenav as collapsed. Not collapsed if false. */
   sidenavCollapsed = true;
-  /** Progress bar mode. */
-  progressBarMode: string;
+  /**
+   * Progress bar mode. Starts as 'none' so the bar stays hidden until a request
+   * actually begins. The service emits through a plain EventEmitter, so
+   * subscribing here yields nothing until the next emission, and a route that
+   * issues no requests of its own (Home) would otherwise leave this undefined
+   * and render the bar indefinitely.
+   */
+  progressBarMode = 'none';
 
   /**
    * Subscribes to progress bar to update its mode.


### PR DESCRIPTION
## Description

## Problem
The shell's loading bar is displayed on the Home page and never goes away. The page has finished loading and nothing is pending, but the animated bar keeps running under the toolbar until the user navigates elsewhere.

## Changes Made
- Initialise `progressBarMode` to `'none'` so the bar stays hidden until
  the service reports a request in flight.
- Add `shell.component.spec.ts` covering the shell's rendered output for
  the initial state, a single request, and overlapping requests. The spec
  stubs the shell's child components so the real template, and therefore
  the real progress bar condition, is exercised.



## Related issues and discussion

https://mifosforge.jira.com/browse/WEB-1230

## Screenshots, if any
after changes:
<img width="1920" height="1080" alt="{9ED4305D-508A-446B-8D1A-3787EE967D1E}" src="https://github.com/user-attachments/assets/454002b4-d4ef-4610-9e3d-f62b293488f3" />


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the loading progress bar appearing indefinitely on pages that do not make requests.
  - The progress bar now starts hidden, appears during active requests, and disappears after all concurrent requests finish.

- **Tests**
  - Added coverage for progress bar behavior before, during, and after single or concurrent requests.
  - Added validation that the indicator remains visible until all active requests have completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->