### PR TITLE
fix(WEB-1089): filter audit trails on selection, not on keystroke

### DIFF
--- a/src/app/system/audit-trails/audit-trails.component.html
+++ b/src/app/system/audit-trails/audit-trails.component.html
@@ -154,7 +154,12 @@
 </mat-card>
 
 <!-- Autocomplete data -->
-<mat-autocomplete autoActiveFirstOption #userNameAutocomplete="matAutocomplete" [displayWith]="displayUserName">
+<mat-autocomplete
+  autoActiveFirstOption
+  #userNameAutocomplete="matAutocomplete"
+  [displayWith]="displayUserName"
+  (optionSelected)="applyFilter($event.option.value.id ?? '', 'makerId')"
+>
   @for (user of filteredUserData | async; track user) {
     <mat-option [value]="{ id: user.id, name: user.username }">
       {{ user.username }}
@@ -162,7 +167,12 @@
   }
 </mat-autocomplete>
 
-<mat-autocomplete autoActiveFirstOption #actionNameAutocomplete="matAutocomplete" [displayWith]="displayActionName">
+<mat-autocomplete
+  autoActiveFirstOption
+  #actionNameAutocomplete="matAutocomplete"
+  [displayWith]="displayActionName"
+  (optionSelected)="applyFilter($event.option.value, 'actionName')"
+>
   @for (action of filteredActionData | async; track action) {
     <mat-option [value]="action">
       {{ action }}
@@ -170,7 +180,12 @@
   }
 </mat-autocomplete>
 
-<mat-autocomplete autoActiveFirstOption #entityNameAutocomplete="matAutocomplete" [displayWith]="displayEntityName">
+<mat-autocomplete
+  autoActiveFirstOption
+  #entityNameAutocomplete="matAutocomplete"
+  [displayWith]="displayEntityName"
+  (optionSelected)="applyFilter($event.option.value, 'entityName')"
+>
   @for (entity of filteredEntityData | async; track entity) {
     <mat-option [value]="entity">
       {{ entity }}
@@ -178,7 +193,12 @@
   }
 </mat-autocomplete>
 
-<mat-autocomplete autoActiveFirstOption #checkerAutocomplete="matAutocomplete" [displayWith]="displayUserName">
+<mat-autocomplete
+  autoActiveFirstOption
+  #checkerAutocomplete="matAutocomplete"
+  [displayWith]="displayUserName"
+  (optionSelected)="applyFilter($event.option.value.id ?? '', 'checkerId')"
+>
   @for (user of filteredCheckerData | async; track user) {
     <mat-option [value]="{ id: user.id, name: user.username }">
       {{ user.username }}

--- a/src/app/system/audit-trails/audit-trails.component.spec.ts
+++ b/src/app/system/audit-trails/audit-trails.component.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { DatePipe } from '@angular/common';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { MatAutocomplete } from '@angular/material/autocomplete';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { faFile } from '@fortawesome/free-solid-svg-icons';
+import { TranslateModule } from '@ngx-translate/core';
+import { of } from 'rxjs';
+
+import { SettingsService } from 'app/settings/settings.service';
+import { SystemService } from '../system.service';
+import { AuditTrailsComponent } from './audit-trails.component';
+
+/** One entry of the filter list the component hands to the service. */
+interface AuditFilter {
+  type: string;
+  value: string;
+}
+
+describe('AuditTrailsComponent autocomplete filters', () => {
+  let component: AuditTrailsComponent;
+  let fixture: ComponentFixture<AuditTrailsComponent>;
+  let requests: AuditFilter[][];
+
+  const template = {
+    appUsers: [{ id: 5, username: 'mifos' }],
+    actionNames: ['CREATE'],
+    entityNames: ['CLIENT'],
+    processingResults: [{ id: 1, processingResult: 'approved' }]
+  };
+
+  /** The autocompletes in template order: user, action, entity, checker. */
+  function autocompleteAt(index: number): MatAutocomplete {
+    return fixture.debugElement.queryAll(By.directive(MatAutocomplete))[index].componentInstance;
+  }
+
+  function filterValue(request: AuditFilter[], type: string): string {
+    return request.find((filter) => filter.type === type).value;
+  }
+
+  beforeEach(() => {
+    requests = [];
+    const getAuditTrails = jest.fn((filterBy: AuditFilter[]) => {
+      requests.push(filterBy.map((filter) => ({ ...filter })));
+      return of({ totalFilteredRecords: 0, pageItems: [] });
+    });
+
+    TestBed.configureTestingModule({
+      imports: [
+        AuditTrailsComponent,
+        TranslateModule.forRoot(),
+        NoopAnimationsModule
+      ],
+      providers: [
+        DatePipe,
+        provideRouter([]),
+        provideNativeDateAdapter(),
+        { provide: SystemService, useValue: { getAuditTrails } },
+        {
+          provide: SettingsService,
+          useValue: { businessDate: new Date(2026, 0, 1), dateFormat: 'dd MMMM yyyy', language: { code: 'en' } }
+        },
+        { provide: ActivatedRoute, useValue: { data: of({ auditTrailSearchTemplate: template }) } }
+      ]
+    });
+
+    TestBed.inject(FaIconLibrary).addIcons(faFile);
+
+    fixture = TestBed.createComponent(AuditTrailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    requests = [];
+  });
+
+  it('sends no request while an option is being typed', fakeAsync(() => {
+    component.user.setValue('mif');
+    component.actionName.setValue('CRE');
+    component.entityName.setValue('CLI');
+    component.checker.setValue('mif');
+    tick(500);
+
+    expect(requests).toEqual([]);
+  }));
+
+  it('sends the selected option once it is picked', () => {
+    autocompleteAt(0).optionSelected.emit({ option: { value: { id: 5, name: 'mifos' } } } as any);
+    autocompleteAt(1).optionSelected.emit({ option: { value: 'CREATE' } } as any);
+
+    expect(requests).toHaveLength(2);
+    expect(filterValue(requests[0], 'makerId')).toBe(5);
+    expect(filterValue(requests[1], 'actionName')).toBe('CREATE');
+  });
+
+  it('clears the filter when the field is emptied', fakeAsync(() => {
+    autocompleteAt(3).optionSelected.emit({ option: { value: { id: 5, name: 'mifos' } } } as any);
+    expect(filterValue(requests[0], 'checkerId')).toBe(5);
+
+    component.checker.setValue('');
+    tick(500);
+
+    expect(requests).toHaveLength(2);
+    expect(filterValue(requests[1], 'checkerId')).toBe('');
+  }));
+
+  it('sends no id when the selected user option carries none', () => {
+    // `/audits/searchtemplate` can answer with app users that have no id, which used to reach the
+    // server as `makerId=undefined` and come back 404.
+    autocompleteAt(0).optionSelected.emit({ option: { value: { selfServiceUser: false } } } as any);
+
+    expect(requests).toEqual([]);
+  });
+
+  it('does not reload when a filter is set to the value it already has', fakeAsync(() => {
+    component.entityName.setValue('CLI');
+    tick(500);
+    component.entityName.setValue('');
+    tick(500);
+
+    expect(requests).toEqual([]);
+  }));
+});

--- a/src/app/system/audit-trails/audit-trails.component.ts
+++ b/src/app/system/audit-trails/audit-trails.component.ts
@@ -235,16 +235,7 @@ export class AuditTrailsComponent implements OnInit, AfterViewInit {
    * sort change and page change.
    */
   ngAfterViewInit() {
-    this.user.valueChanges
-      .pipe(
-        map((value) => (value.id ? value.id : '')),
-        debounceTime(500),
-        distinctUntilChanged(),
-        tap((filterValue) => {
-          this.applyFilter(filterValue, 'makerId');
-        })
-      )
-      .subscribe();
+    this.clearFilterWhenEmptied(this.user, 'makerId');
 
     this.fromDate.valueChanges
       .pipe(
@@ -336,38 +327,9 @@ export class AuditTrailsComponent implements OnInit, AfterViewInit {
       )
       .subscribe();
 
-    this.actionName.valueChanges
-      .pipe(
-        map((value) => (value ? value : '')),
-        debounceTime(500),
-        distinctUntilChanged(),
-        tap((filterValue) => {
-          this.applyFilter(filterValue, 'actionName');
-        })
-      )
-      .subscribe();
-
-    this.entityName.valueChanges
-      .pipe(
-        map((value) => (value ? value : '')),
-        debounceTime(500),
-        distinctUntilChanged(),
-        tap((filterValue) => {
-          this.applyFilter(filterValue, 'entityName');
-        })
-      )
-      .subscribe();
-
-    this.checker.valueChanges
-      .pipe(
-        map((value) => (value ? value : '')),
-        debounceTime(500),
-        distinctUntilChanged(),
-        tap((filterValue) => {
-          this.applyFilter(filterValue.id, 'checkerId');
-        })
-      )
-      .subscribe();
+    this.clearFilterWhenEmptied(this.actionName, 'actionName');
+    this.clearFilterWhenEmptied(this.entityName, 'entityName');
+    this.clearFilterWhenEmptied(this.checker, 'checkerId');
 
     //this.sort.sortChange.subscribe(() => (this.paginator.pageIndex = 0));
 
@@ -408,12 +370,30 @@ export class AuditTrailsComponent implements OnInit, AfterViewInit {
    * @param {string} property Property to filter data by.
    */
   applyFilter(filterValue: string, property: string) {
+    const findIndex = this.filterAuditTrailsBy.findIndex((filter) => filter.type === property);
+    if (this.filterAuditTrailsBy[findIndex].value === filterValue) {
+      return;
+    }
     if (this.paginator) {
       this.paginator.pageIndex = 0;
     }
-    const findIndex = this.filterAuditTrailsBy.findIndex((filter) => filter.type === property);
     this.filterAuditTrailsBy[findIndex].value = filterValue;
     this.loadAuditTrailsPage();
+  }
+
+  /**
+   * Clears an autocomplete filter once its input is emptied.
+   * A selection is applied by the autocomplete's `optionSelected` output, so half-typed text never
+   * reaches the server: it is not a valid option and the request would come back with no records.
+   * @param {UntypedFormControl} control Autocomplete form control.
+   * @param {string} property Filter property the control feeds.
+   */
+  private clearFilterWhenEmptied(control: UntypedFormControl, property: string): void {
+    control.valueChanges.pipe(debounceTime(500), distinctUntilChanged()).subscribe((value) => {
+      if (!value) {
+        this.applyFilter('', property);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
<html><head></head><body><h2>Description</h2><p>Continues #3789, which went stale. This fixes the same issue with a different approach.</p><p>On Audit Trails, the User, Action, Entity, and Checker autocompletes were calling <code inline="">applyFilter</code> from <code inline="">valueChanges</code>. This meant a request was sent on every keystroke. Since partially typed text isn't a valid filter, typing something like <code inline="">LOA</code> would send <code inline="">entityName=LOA</code>, return no results, and make the table appear empty until a valid option was selected.</p><p>The Checker autocomplete also had an issue where <code inline="">.id</code> could be read from a string, resulting in <code inline="">checkerId=undefined</code>.</p><p>The four autocompletes now apply filters through Material's <code inline="">optionSelected</code> event, so a request is only made when an actual option is selected. <code inline="">valueChanges</code> is still used to handle clearing the filter when the input is emptied.</p><p><code inline="">applyFilter</code> also skips the request when the selected value is already the active filter, so selecting the same value again doesn't trigger an unnecessary reload.</p><p>While testing against a local Fineract instance, I noticed that <code inline="">/audits/searchtemplate</code> can return users without an <code inline="">id</code> or <code inline="">username</code>, which results in blank entries in the User and Checker dropdowns. That's a separate issue, but it exposed another problem here: selecting one of those entries could result in <code inline="">makerId=undefined</code> and a 404. Using <code inline="">?? ''</code> keeps the filter empty instead of sending an invalid request.</p><h3>Verified locally</h3>
Action | Requests to /audits
-- | --
Type CRE in Action | None
Select CREATE | 1 — actionName=CREATE
Clear the Action field | 1 — no actionName
Type LOA in Entity | None
Select LOAN | 1 — entityName=LOAN
Select an id-less User option | None — previously sent makerId=undefined and returned 404

<p><code inline="">audit-trails.component.spec.ts</code> covers these cases, and all five tests fail against <code inline="">dev</code>.</p><h2>Related issue</h2><p><a href="https://mifosforge.jira.com/browse/WEB-1089">WEB-1089</a></p><h2>Checklist</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Squashed multiple commits into one.</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Read and understood <code inline="">web-app/.github/CONTRIBUTING.md</code>.</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Verified the fix against a local Fineract instance.</p></li></ul></body></html>## Description

Continues #3789, which went stale. This fixes the same issue with a different approach.

On Audit Trails, the User, Action, Entity, and Checker autocompletes were calling `applyFilter` from `valueChanges`. This meant a request was sent on every keystroke. Since partially typed text isn't a valid filter, typing something like `LOA` would send `entityName=LOA`, return no results, and make the table appear empty until a valid option was selected.

The Checker autocomplete also had an issue where `.id` could be read from a string, resulting in `checkerId=undefined`.

The four autocompletes now apply filters through Material's `optionSelected` event, so a request is only made when an actual option is selected. `valueChanges` is still used to handle clearing the filter when the input is emptied.

`applyFilter` also skips the request when the selected value is already the active filter, so selecting the same value again doesn't trigger an unnecessary reload.

While testing against a local Fineract instance, I noticed that `/audits/searchtemplate` can return users without an `id` or `username`, which results in blank entries in the User and Checker dropdowns. That's a separate issue, but it exposed another problem here: selecting one of those entries could result in `makerId=undefined` and a 404. Using `?? ''` keeps the filter empty instead of sending an invalid request.

### Verified locally

| Action                        | Requests to `/audits`                                       |
| ----------------------------- | ----------------------------------------------------------- |
| Type `CRE` in Action          | None                                                        |
| Select `CREATE`               | 1 — `actionName=CREATE`                                     |
| Clear the Action field        | 1 — no `actionName`                                         |
| Type `LOA` in Entity          | None                                                        |
| Select `LOAN`                 | 1 — `entityName=LOAN`                                       |
| Select an id-less User option | None — previously sent `makerId=undefined` and returned 404 |

`audit-trails.component.spec.ts` covers these cases, and all five tests fail against `dev`.

## Related issue

[[WEB-1089](https://mifosforge.jira.com/browse/WEB-1089)](https://mifosforge.jira.com/browse/WEB-1089)

## Checklist

* [x] Squashed multiple commits into one.
* [x] Read and understood `web-app/.github/CONTRIBUTING.md`.
* [x] Verified the fix against a local Fineract instance.

[WEB-1089]: https://mifosforge.jira.com/browse/WEB-1089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ