### PR TITLE
WEB-657: Add productType query param to post product creation navigation

### DIFF
--- a/src/app/products/loan-products/create-loan-product-classic/create-loan-product-classic.component.ts
+++ b/src/app/products/loan-products/create-loan-product-classic/create-loan-product-classic.component.ts
@@ -388,12 +388,21 @@ export class CreateLoanProductClassicComponent extends LoanProductBaseComponent 
     this.productsService
       .createLoanProduct(this.loanProductService.loanProductPath, loanProduct)
       .subscribe((response: any) => {
-        this.router.navigate([
-          '/',
-          'products',
-          'loan-products',
-          response.resourceId
-        ]);
+        // WC and term products have independent id sequences, so the id alone is ambiguous: without
+        // `productType` the view resolver defaults to the term loan product with the same id.
+        this.router.navigate(
+          [
+            '/',
+            'products',
+            'loan-products',
+            response.resourceId
+          ],
+          {
+            queryParams: {
+              productType: this.loanProductService.productType.value
+            }
+          }
+        );
       });
   }
 


### PR DESCRIPTION
## Description

Added loan product type query param to the post loan product creation navigation, so WC loans now correctly redirect to the just created WC loan.

## Related issues and discussion

#{Issue Number}

## Screenshots, if any

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Loan product creation now opens the correct product detail page after submission.
  - Product type information is preserved during navigation to prevent products with matching IDs from displaying the wrong details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->