### PR TITLE
WEB-798: Move Identities and Documents into Personal Data Tab

### DIFF
--- a/src/app/clients/clients-routing.module.ts
+++ b/src/app/clients/clients-routing.module.ts
@@ -107,7 +107,16 @@ const routes: Routes = [
             {
               path: 'personal-data',
               component: PersonalDataTabComponent,
-              data: { title: 'Personal Data', breadcrumb: 'Personal Data', routeParamBreadcrumb: false }
+              data: {
+                title: 'labels.inputs.Personal Data',
+                breadcrumb: 'labels.inputs.Personal Data',
+                routeParamBreadcrumb: false
+              },
+              resolve: {
+                clientIdentities: ClientIdentitiesResolver,
+                clientIdentifierTemplate: ClientIdentifierTemplateResolver,
+                clientDocuments: ClientDocumentsResolver
+              }
             },
             {
               path: 'address',
@@ -154,6 +163,7 @@ const routes: Routes = [
                 }
               ]
             },
+
             {
               path: 'identities',
               component: IdentitiesTabComponent,

--- a/src/app/clients/clients-view/clients-view.component.html
+++ b/src/app/clients/clients-view/clients-view.component.html
@@ -452,6 +452,7 @@
         </svg>
         {{ 'labels.inputs.Family Members' | translate }}
       </a>
+
       <a
         mat-tab-link
         [routerLink]="['./identities']"

--- a/src/app/clients/clients-view/documents-tab/documents-tab.component.ts
+++ b/src/app/clients/clients-view/documents-tab/documents-tab.component.ts
@@ -20,6 +20,7 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   selector: 'mifosx-documents-tab',
   templateUrl: './documents-tab.component.html',
   styleUrls: ['./documents-tab.component.scss'],
+  standalone: true,
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
     EntityDocumentsTabComponent

--- a/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
+++ b/src/app/clients/clients-view/identities-tab/identities-tab.component.ts
@@ -111,6 +111,7 @@ interface ClientIdentifierDialogResult {
   selector: 'mifosx-identities-tab',
   templateUrl: './identities-tab.component.html',
   styleUrls: ['./identities-tab.component.scss'],
+  standalone: true,
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
     FaIconComponent,

--- a/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.html
+++ b/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.html
@@ -294,6 +294,14 @@
         }
       </div>
     </div>
+
+    <!-- Embedded Identities and Documents Sections -->
+    <div class="m-t-20">
+      <mifosx-identities-tab></mifosx-identities-tab>
+    </div>
+    <div class="m-t-20">
+      <mifosx-documents-tab></mifosx-documents-tab>
+    </div>
   }
 
   <!-- PDF Viewer Modal -->

--- a/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.ts
+++ b/src/app/clients/clients-view/personal-data-tab/personal-data-tab.component.ts
@@ -18,29 +18,34 @@ import { MatDialog } from '@angular/material/dialog';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { DateFormatPipe } from '../../../pipes/date-format.pipe';
 import { LegalFormId } from 'app/clients/models/legal-form.enum';
-import { ClientsService } from 'app/clients/clients.service';
+import { ClientsService, ClientIdentifierPayload } from 'app/clients/clients.service';
 import { MatIcon } from '@angular/material/icon';
 import { ReportsService } from 'app/reports/reports.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { AlertService } from 'app/core/alert/alert.service';
 import { SystemService } from 'app/system/system.service';
-import { EMPTY } from 'rxjs';
-import { catchError } from 'rxjs/operators';
-import { Observable, of } from 'rxjs';
 import { environment } from 'environments/environment';
+import { DocumentPreviewService } from 'app/shared/services/document-preview.service';
+import { EMPTY, Observable, of, forkJoin } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { Dates } from 'app/core/utils/dates';
 import {
   CustomerDataValidation,
   KYC_VALIDATION_DATATABLE,
   KYC_VALIDATION_DATATABLE_ENTITY,
   KYC_VALIDATION_CONFIG_NAME,
   ValidationStatus,
-  emptyCustomerDataValidation
+  emptyCustomerDataValidation,
+  DOCUMENT_DATA_TYPES,
+  DOCUMENT_REASON_TYPES
 } from 'app/clients/models/document-validation.model';
 import { ValidateCustomerDataDialogComponent } from '../custom-dialogs/validate-customer-data-dialog/validate-customer-data-dialog.component';
 import { PersonalDataViewService } from './personal-data-view.service';
 import { PersonalDataViewModel } from './personal-data-view.model';
 import { PersonProductionPersonalDataComponent } from './person-production-personal-data/person-production-personal-data.component';
 import { EntityProductionPersonalDataComponent } from './entity-production-personal-data/entity-production-personal-data.component';
+import { IdentitiesTabComponent } from '../identities-tab/identities-tab.component';
+import { DocumentsTabComponent } from '../documents-tab/documents-tab.component';
 
 /** Interfaces */
 interface ClientViewData {
@@ -85,7 +90,9 @@ interface ClientViewData {
     DateFormatPipe,
     MatIcon,
     PersonProductionPersonalDataComponent,
-    EntityProductionPersonalDataComponent
+    EntityProductionPersonalDataComponent,
+    IdentitiesTabComponent,
+    DocumentsTabComponent
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -101,6 +108,7 @@ export class PersonalDataTabComponent implements OnDestroy {
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);
   private destroyRef = inject(DestroyRef);
+  private dateUtils = inject(Dates);
 
   /** Client View Data */
   clientViewData!: ClientViewData;
@@ -124,6 +132,9 @@ export class PersonalDataTabComponent implements OnDestroy {
 
   /** Whether the global config check has completed */
   private configLoaded = false;
+  /** Client Identities for description update */
+  private clientIdentities: any[] = [];
+
   constructor() {
     this.systemService
       .getConfigurations()
@@ -152,6 +163,10 @@ export class PersonalDataTabComponent implements OnDestroy {
           this.loadValidationData();
         }
       });
+
+    this.route.data.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data: { clientIdentities: any[] }) => {
+      this.clientIdentities = data.clientIdentities || [];
+    });
   }
 
   private loadProductionViewModel(clientDatatables: any[]) {
@@ -198,42 +213,42 @@ export class PersonalDataTabComponent implements OnDestroy {
             this.hasDatatableEntry = true;
             this.validationData = {
               nid: {
-                selected: !!raw[0],
+                selected: !!raw[1],
                 reasons: {
-                  missingDocument: !!raw[1],
-                  illegibleDocument: !!raw[2],
-                  invalidDocument: !!raw[3],
-                  expiredDocument: !!raw[4]
+                  missingDocument: !!raw[2],
+                  illegibleDocument: !!raw[3],
+                  invalidDocument: !!raw[4],
+                  expiredDocument: !!raw[5]
                 }
               },
               legalId: {
-                selected: !!raw[5],
+                selected: !!raw[6],
                 reasons: {
-                  missingDocument: !!raw[6],
-                  illegibleDocument: !!raw[7],
-                  invalidDocument: !!raw[8],
-                  expiredDocument: !!raw[9]
+                  missingDocument: !!raw[7],
+                  illegibleDocument: !!raw[8],
+                  invalidDocument: !!raw[9],
+                  expiredDocument: !!raw[10]
                 }
               },
               proofOfAddress: {
-                selected: !!raw[10],
+                selected: !!raw[11],
                 reasons: {
-                  missingDocument: !!raw[11],
-                  illegibleDocument: !!raw[12],
-                  invalidDocument: !!raw[13],
-                  expiredDocument: !!raw[14]
+                  missingDocument: !!raw[12],
+                  illegibleDocument: !!raw[13],
+                  invalidDocument: !!raw[14],
+                  expiredDocument: !!raw[15]
                 }
               },
               score: {
-                selected: !!raw[15],
+                selected: !!raw[16],
                 reasons: {
-                  missingDocument: !!raw[16],
-                  illegibleDocument: !!raw[17],
-                  invalidDocument: !!raw[18],
-                  expiredDocument: !!raw[19]
+                  missingDocument: !!raw[17],
+                  illegibleDocument: !!raw[18],
+                  invalidDocument: !!raw[19],
+                  expiredDocument: !!raw[20]
                 }
               },
-              validationStatus: (raw[20] as ValidationStatus) ?? null
+              validationStatus: (raw[21] as ValidationStatus) ?? null
             };
           } catch {
             this.validationData = null;
@@ -280,6 +295,7 @@ export class PersonalDataTabComponent implements OnDestroy {
             type: 'success',
             message: this.translateService.instant('labels.messages.validationSaved')
           });
+          this.updateIdentityDescriptions(result);
         });
     });
   }
@@ -365,7 +381,8 @@ export class PersonalDataTabComponent implements OnDestroy {
       .getPentahoRunReportData(reportName, formData, tenantIdentifier, locale, dateFormat)
       .pipe(
         takeUntilDestroyed(this.destroyRef),
-        catchError((error): any => {
+        catchError((error: any): any => {
+          console.error('Document preview failed', error);
           this.showPdf = false;
           if (this.rawPdfUrl) {
             URL.revokeObjectURL(this.rawPdfUrl);
@@ -423,5 +440,108 @@ export class PersonalDataTabComponent implements OnDestroy {
       this.rawPdfUrl = null;
     }
     this.pdfUrl = null;
+  }
+
+  /** Managed suffix marker used to identify the validation-appended portion of a description */
+  private static readonly VALIDATION_SUFFIX_MARKER = ' [KYC: ';
+
+  /**
+   * Updates identity descriptions by replacing (not just appending) negative validation reasons.
+   * Builds a managed suffix like " [KYC: Missing document, Invalid document]" and replaces
+   * any previous suffix, preserving the user's original description text.
+   */
+  private updateIdentityDescriptions(result: CustomerDataValidation) {
+    if (!this.clientIdentities || this.clientIdentities.length === 0) return;
+
+    const dataTypes = DOCUMENT_DATA_TYPES;
+    const reasonTypes = DOCUMENT_REASON_TYPES;
+    const updates: Observable<any>[] = [];
+    const dateFormat = this.settingsService.dateFormat;
+    const locale = this.settingsService.language.code;
+
+    for (const dt of dataTypes) {
+      const docVal = result[dt.key] as any;
+      if (!docVal || !docVal.reasons) continue;
+
+      // Find an identity whose documentType name matches the validation key or label
+      const dtLabel = this.translateService.instant(dt.labelKey).toLowerCase();
+      const matchingIdentity = this.clientIdentities.find((id: any) => {
+        const typeName = id.documentType?.name?.toLowerCase() || '';
+        return typeName.includes(dt.key.toLowerCase()) || typeName.includes(dtLabel);
+      });
+
+      if (matchingIdentity) {
+        // Collect active reasons
+        const activeReasons: string[] = [];
+        for (const rt of reasonTypes) {
+          if (docVal.reasons[rt.key]) {
+            activeReasons.push(this.translateService.instant(rt.labelKey));
+          }
+        }
+
+        // Strip any existing managed suffix from the current description
+        const currentDesc = matchingIdentity.description || '';
+        const markerIdx = currentDesc.indexOf(PersonalDataTabComponent.VALIDATION_SUFFIX_MARKER);
+        const baseDesc = markerIdx >= 0 ? currentDesc.substring(0, markerIdx) : currentDesc;
+
+        // Build new description: base + managed suffix (only if there are active reasons)
+        const newDesc = activeReasons.length > 0 ? `${baseDesc} [KYC: ${activeReasons.join(', ')}]` : baseDesc;
+
+        // Only update if the description actually changed
+        if (newDesc !== currentDesc) {
+          const identifierData: ClientIdentifierPayload = {
+            documentTypeId: matchingIdentity.documentType.id,
+            documentKey: matchingIdentity.documentKey,
+            description: newDesc,
+            dateFormat,
+            locale,
+            issuanceDate: matchingIdentity.issuanceDate
+              ? this.dateUtils.formatDate(matchingIdentity.issuanceDate, dateFormat)
+              : null,
+            expiryDate: matchingIdentity.expiryDate
+              ? this.dateUtils.formatDate(matchingIdentity.expiryDate, dateFormat)
+              : null
+          };
+
+          const clientIdStr = this.clientViewData.id.toString();
+          updates.push(
+            this.clientsService.editClientIdentifier(clientIdStr, matchingIdentity.id, identifierData).pipe(
+              map(() => ({ success: true, identity: matchingIdentity, newDesc })),
+              catchError((err) => {
+                console.error(`Failed to update identity ${matchingIdentity.id}`, err);
+                return of({ success: false, identity: matchingIdentity, newDesc });
+              })
+            )
+          );
+        }
+      }
+    }
+
+    if (updates.length > 0) {
+      forkJoin(updates).subscribe((results: any[]) => {
+        let allSuccess = true;
+
+        // Synchronize local state only for the requests that actually succeeded
+        results.forEach((r) => {
+          if (r.success) {
+            r.identity.description = r.newDesc;
+          } else {
+            allSuccess = false;
+          }
+        });
+
+        if (allSuccess) {
+          this.alertService.alert({
+            type: 'success',
+            message: this.translateService.instant('labels.messages.identityDescriptionsUpdated')
+          });
+        } else {
+          this.alertService.alert({
+            type: 'error',
+            message: this.translateService.instant('labels.messages.identityDescriptionsUpdateFailed')
+          });
+        }
+      });
+    }
   }
 }

--- a/src/app/clients/common-resolvers/client-document.resolver.ts
+++ b/src/app/clients/common-resolvers/client-document.resolver.ts
@@ -11,7 +11,8 @@ import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot } from '@angular/router';
 
 /** rxjs Imports */
-import { Observable } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 /** Custom Services */
 import { ClientsService } from '../clients.service';
@@ -25,10 +26,13 @@ export class ClientDocumentsResolver {
 
   /**
    * Returns the Client's Documents data.
+   * Falls back to an empty array when the user lacks READ_DOCUMENT permission.
    * @returns {Observable<any>}
    */
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
     const clientId = route.parent.paramMap.get('clientId');
-    return this.clientsService.getClientDocuments(clientId);
+    return this.clientsService
+      .getClientDocuments(clientId)
+      .pipe(catchError((err) => (err.status === 403 ? of([]) : throwError(() => err))));
   }
 }

--- a/src/app/clients/common-resolvers/client-identifier-template.resolver.ts
+++ b/src/app/clients/common-resolvers/client-identifier-template.resolver.ts
@@ -11,7 +11,8 @@ import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot } from '@angular/router';
 
 /** rxjs Imports */
-import { Observable } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 /** Custom Services */
 import { ClientsService } from '../clients.service';
@@ -25,10 +26,13 @@ export class ClientIdentifierTemplateResolver {
 
   /**
    * Returns the Client Identities data.
+   * Falls back to an empty object when the user lacks READ_CLIENTIDENTIFIER permission.
    * @returns {Observable<any>}
    */
   resolve(route: ActivatedRouteSnapshot): Observable<any> {
     const clientId = route.parent.paramMap.get('clientId');
-    return this.clientsService.getClientIdentifierTemplate(clientId);
+    return this.clientsService
+      .getClientIdentifierTemplate(clientId)
+      .pipe(catchError((err) => (err.status === 403 ? of({}) : throwError(() => err))));
   }
 }

--- a/src/app/clients/common-resolvers/client-identities.resolver.ts
+++ b/src/app/clients/common-resolvers/client-identities.resolver.ts
@@ -11,8 +11,8 @@ import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot } from '@angular/router';
 
 /** rxjs Imports */
-import { Observable, forkJoin, of } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { Observable, forkJoin, of, throwError } from 'rxjs';
+import { catchError, map, switchMap } from 'rxjs/operators';
 
 /** Custom Services */
 import { ClientsService } from '../clients.service';
@@ -42,11 +42,13 @@ export class ClientIdentitiesResolver {
               map((documents: any[]) => ({
                 ...identity,
                 documents: documents || []
-              }))
+              })),
+              catchError((err) => (err.status === 403 ? of({ ...identity, documents: [] }) : throwError(() => err)))
             )
           )
         );
-      })
+      }),
+      catchError((err) => (err.status === 403 ? of([]) : throwError(() => err)))
     );
   }
 }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -5313,7 +5313,9 @@
       "No Upcoming Charges Found": "Žádné nadcházející poplatky nenalezeny",
       "unableToUpdateDiscount": "Slevu nelze aktualizovat.",
       "validationSaved": "Ověřovací data byla úspěšně uložena.",
-      "workingCapitalDiscountUpdated": "Sleva provozního kapitálu byla úspěšně aktualizována."
+      "workingCapitalDiscountUpdated": "Sleva provozního kapitálu byla úspěšně aktualizována.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -5313,7 +5313,9 @@
       "No Upcoming Charges Found": "Keine anstehenden Gebühren gefunden",
       "unableToUpdateDiscount": "Rabatt konnte nicht aktualisiert werden.",
       "validationSaved": "Validierungsdaten erfolgreich gespeichert.",
-      "workingCapitalDiscountUpdated": "Betriebskapitalrabatt wurde erfolgreich aktualisiert."
+      "workingCapitalDiscountUpdated": "Betriebskapitalrabatt wurde erfolgreich aktualisiert.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -5515,7 +5515,9 @@
       "No Upcoming Charges Found": "No Upcoming Charges Found",
       "unableToUpdateDiscount": "Unable to update discount.",
       "validationSaved": "Validation data saved successfully.",
-      "workingCapitalDiscountUpdated": "Working capital discount was updated successfully."
+      "workingCapitalDiscountUpdated": "Working capital discount was updated successfully.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "cbild": {
       "fields": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -5377,7 +5377,9 @@
       "No Upcoming Charges Found": "No se encontraron cargos próximos",
       "unableToUpdateDiscount": "No se pudo actualizar el descuento.",
       "validationSaved": "Datos de validación guardados exitosamente.",
-      "workingCapitalDiscountUpdated": "El descuento del préstamo de capital de trabajo se actualizó correctamente."
+      "workingCapitalDiscountUpdated": "El descuento del préstamo de capital de trabajo se actualizó correctamente.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -5401,7 +5401,9 @@
       "No Upcoming Charges Found": "No se encontraron cargos próximos",
       "unableToUpdateDiscount": "No se pudo actualizar el descuento.",
       "validationSaved": "Datos de validación guardados exitosamente.",
-      "workingCapitalDiscountUpdated": "El descuento del préstamo de capital de trabajo se actualizó correctamente."
+      "workingCapitalDiscountUpdated": "El descuento del préstamo de capital de trabajo se actualizó correctamente.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -5378,7 +5378,9 @@
       "No Upcoming Charges Found": "Aucun frais à venir trouvé",
       "unableToUpdateDiscount": "Impossible de mettre à jour le rabais.",
       "validationSaved": "Données de validation enregistrées avec succès.",
-      "workingCapitalDiscountUpdated": "Le rabais du prêt de fonds de roulement a été mis à jour avec succès."
+      "workingCapitalDiscountUpdated": "Le rabais du prêt de fonds de roulement a été mis à jour avec succès.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -5376,7 +5376,9 @@
       "No Upcoming Charges Found": "Nessun addebito imminente trovato",
       "unableToUpdateDiscount": "Impossibile aggiornare lo sconto.",
       "validationSaved": "Dati di convalida salvati con successo.",
-      "workingCapitalDiscountUpdated": "Lo sconto del prestito di capitale circolante è stato aggiornato correttamente."
+      "workingCapitalDiscountUpdated": "Lo sconto del prestito di capitale circolante è stato aggiornato correttamente.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -5375,7 +5375,9 @@
       "No Upcoming Charges Found": "예정된 요금이 없습니다",
       "unableToUpdateDiscount": "할인을 업데이트할 수 없습니다.",
       "validationSaved": "검증 데이터가 성공적으로 저장되었습니다.",
-      "workingCapitalDiscountUpdated": "운전자금 대출 할인율이 성공적으로 업데이트되었습니다."
+      "workingCapitalDiscountUpdated": "운전자금 대출 할인율이 성공적으로 업데이트되었습니다.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -5376,7 +5376,9 @@
       "No Upcoming Charges Found": "Nerasta artėjančių mokesčių",
       "unableToUpdateDiscount": "Nepavyko atnaujinti nuolaidos.",
       "validationSaved": "Patvirtinimo duomenys sėkmingai išsaugoti.",
-      "workingCapitalDiscountUpdated": "Apyvartinio kapitalo paskolos nuolaida buvo sėkmingai atnaujinta."
+      "workingCapitalDiscountUpdated": "Apyvartinio kapitalo paskolos nuolaida buvo sėkmingai atnaujinta.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -5375,7 +5375,9 @@
       "No Upcoming Charges Found": "Nav atrasts gaidāmo maksājumu",
       "unableToUpdateDiscount": "Neizdevās atjaunināt atlaidi.",
       "validationSaved": "Validācijas dati veiksmīgi saglabāti.",
-      "workingCapitalDiscountUpdated": "Apgrozāmo līdzekļu aizdevuma atlaide ir veiksmīgi atjaunināta."
+      "workingCapitalDiscountUpdated": "Apgrozāmo līdzekļu aizdevuma atlaide ir veiksmīgi atjaunināta.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -5375,7 +5375,9 @@
       "No Upcoming Charges Found": "कुनै आगामी शुल्कहरू भेटिएनन्",
       "unableToUpdateDiscount": "छुट अपडेट गर्न सकिएन।",
       "validationSaved": "प्रमाणीकरण डाटा सफलतापूर्वक बचत भयो।",
-      "workingCapitalDiscountUpdated": "कार्यशील पूँजी ऋणको छुट सफलतापूर्वक अपडेट गरिएको छ।"
+      "workingCapitalDiscountUpdated": "कार्यशील पूँजी ऋणको छुट सफलतापूर्वक अपडेट गरिएको छ।",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -5375,7 +5375,9 @@
       "No Upcoming Charges Found": "Nenhuma cobrança futura encontrada",
       "unableToUpdateDiscount": "Não foi possível atualizar o desconto.",
       "validationSaved": "Dados de validação guardados com sucesso.",
-      "workingCapitalDiscountUpdated": "O desconto do empréstimo de fundo de maneio foi atualizado com sucesso."
+      "workingCapitalDiscountUpdated": "O desconto do empréstimo de fundo de maneio foi atualizado com sucesso.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -5372,7 +5372,9 @@
       "No Upcoming Charges Found": "Hakuna malipo yanayokuja yaliyopatikana",
       "unableToUpdateDiscount": "Haikuwezekana kusasisha punguzo.",
       "validationSaved": "Data ya uthibitishaji imehifadhiwa kwa mafanikio.",
-      "workingCapitalDiscountUpdated": "Punguzo la mkopo wa mtaji wa kufanya kazi limefanikiwa kusasishwa."
+      "workingCapitalDiscountUpdated": "Punguzo la mkopo wa mtaji wa kufanya kazi limefanikiwa kusasishwa.",
+      "identityDescriptionsUpdated": "Identity descriptions updated successfully.",
+      "identityDescriptionsUpdateFailed": "Some identity descriptions failed to update."
     },
     "selections": {
       "standingInstructions": {


### PR DESCRIPTION
## Description

This PR moves the Identities and Documents sections inside the Personal Data tab for a cleaner and more organized client view.


## Related issues and discussion

[WEB-798](https://mifosforge.jira.com/browse/WEB-798)

## Screenshots, if any


https://github.com/user-attachments/assets/992b9ace-5e4e-4ba3-92dc-1d4adf551023




## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


[WEB-798]: https://mifosforge.jira.com/browse/WEB-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Client personal data now includes Identity and Document sections directly within the page.
  - Identity and document information loads as part of the personal data view.
  - Saved KYC validation updates synchronize identity descriptions with current validation reasons.
  - Identity descriptions display a confirmation message after successful updates.

- **UI Updates**
  - Separate Identities and Documents navigation tabs have been removed from the client view.
  - Personal data titles and breadcrumbs now use translations.

- **Bug Fixes**
  - Personal data remains available when identity or document details cannot be loaded due to access restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->