### PR TITLE
WEB-1224: Add JSON datatable field support

### DIFF
--- a/src/app/clients/client-stepper/client-datatable-step/client-datatable-step.component.html
+++ b/src/app/clients/client-stepper/client-datatable-step/client-datatable-step.component.html
@@ -28,8 +28,20 @@
             @if (isString(datatableInput.columnDisplayType)) {
               <input matInput formControlName="{{ datatableInput.controlName }}" />
             }
-            @if (isText(datatableInput.columnDisplayType)) {
+            @if (isText(datatableInput.columnDisplayType) && !isJson(datatableInput)) {
               <textarea matInput formControlName="{{ datatableInput.controlName }}"></textarea>
+            }
+            @if (isJson(datatableInput)) {
+              <textarea
+                matInput
+                cdkTextareaAutosize
+                cdkAutosizeMinRows="6"
+                cdkAutosizeMaxRows="18"
+                formControlName="{{ datatableInput.controlName }}"
+              ></textarea>
+              @if (datatableForm.controls[datatableInput.controlName].hasError('json')) {
+                <mat-error>{{ 'labels.inputs.Invalid JSON' | translate }}</mat-error>
+              }
             }
             @if (isDate(datatableInput.columnDisplayType)) {
               <span (click)="datePicker.open()">

--- a/src/app/clients/client-stepper/client-datatable-step/client-datatable-step.component.ts
+++ b/src/app/clients/client-stepper/client-datatable-step/client-datatable-step.component.ts
@@ -14,6 +14,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 
 @Component({
   selector: 'mifosx-client-datatable-step',
@@ -24,7 +25,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatCheckbox,
     MatStepperPrevious,
     FaIconComponent,
-    MatStepperNext
+    MatStepperNext,
+    CdkTextareaAutosize
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -48,9 +50,16 @@ export class ClientDatatableStepComponent implements OnInit {
       if (!input.isColumnNullable) {
         if (this.isNumeric(input.columnDisplayType)) {
           inputItems[input.controlName] = new FormControl(0, [Validators.required]);
+        } else if (this.isJson(input)) {
+          inputItems[input.controlName] = new FormControl('', [
+            Validators.required,
+            this.datatableService.jsonValidator
+          ]);
         } else {
           inputItems[input.controlName] = new FormControl('', [Validators.required]);
         }
+      } else if (this.isJson(input)) {
+        inputItems[input.controlName] = new FormControl('', [this.datatableService.jsonValidator]);
       } else {
         inputItems[input.controlName] = new FormControl('');
       }
@@ -88,6 +97,10 @@ export class ClientDatatableStepComponent implements OnInit {
 
   isText(columnType: string) {
     return this.datatableService.isText(columnType);
+  }
+
+  isJson(datatableInput: any) {
+    return this.datatableService.isJson(datatableInput.columnDisplayType, datatableInput.columnType);
   }
 
   get payload(): any {

--- a/src/app/clients/edit-client/edit-client.component.html
+++ b/src/app/clients/edit-client/edit-client.component.html
@@ -716,6 +716,28 @@
             [title]="datatableColumnLabel(column)"
           ></textarea>
         </mat-form-field>
+      } @else if (isDatatableJson(column)) {
+        <mat-form-field class="flex-48">
+          <mat-label>{{ datatableColumnLabel(column) }}</mat-label>
+          <textarea
+            matInput
+            cdkTextareaAutosize
+            cdkAutosizeMinRows="6"
+            cdkAutosizeMaxRows="18"
+            [formControlName]="datatableControlName(column)"
+            [placeholder]="datatableColumnLabel(column)"
+            [title]="datatableColumnLabel(column)"
+          ></textarea>
+          @if (form.controls[datatableControlName(column)].hasError('required')) {
+            <mat-error>
+              {{ datatableColumnLabel(column) }} {{ 'labels.commons.is' | translate }}
+              <strong>{{ 'labels.commons.required' | translate }}</strong>
+            </mat-error>
+          }
+          @if (form.controls[datatableControlName(column)].hasError('json')) {
+            <mat-error>{{ 'labels.inputs.Invalid JSON' | translate }}</mat-error>
+          }
+        </mat-form-field>
       } @else {
         <mat-form-field class="flex-24">
           <mat-label>{{ datatableColumnLabel(column) }}</mat-label>

--- a/src/app/clients/edit-client/edit-client.component.ts
+++ b/src/app/clients/edit-client/edit-client.component.ts
@@ -400,9 +400,13 @@ export class EditClientComponent implements OnInit {
 
   isDatatableText(column: PersonalDataTableColumn): boolean {
     return [
-      'STRING',
-      'TEXT'
-    ].includes(this.datatableColumnType(column));
+        'STRING',
+        'TEXT'
+      ].includes(this.datatableColumnType(column)) && !this.isDatatableJson(column);
+  }
+
+  isDatatableJson(column: PersonalDataTableColumn): boolean {
+    return this.datatables.isJson(column.columnDisplayType, column.columnType);
   }
 
   addDatatableBlankRow(section: PersonalDataTableSection): void {
@@ -495,6 +499,9 @@ export class EditClientComponent implements OnInit {
     const controls = section.columns.reduce((acc: Record<string, FormControl>, column) => {
       const field = record?.fields.find((recordField) => recordField.columnName === column.columnName);
       const validators = this.isDatatableColumnRequired(column) ? [Validators.required] : [];
+      if (this.isDatatableJson(column)) {
+        validators.push(this.datatables.jsonValidator);
+      }
       acc[this.datatableControlName(column)] = new FormControl(
         this.toDatatableControlValue(column, field?.value),
         validators
@@ -735,6 +742,8 @@ export class EditClientComponent implements OnInit {
         payload[column.columnName] = this.toDatatableDropdownPayloadValue(column, value);
       } else if (this.isDatatableBoolean(column)) {
         payload[column.columnName] = this.toDatatableBooleanPayloadValue(value);
+      } else if (this.isDatatableJson(column)) {
+        payload[column.columnName] = value === null || value === undefined ? '' : value.toString();
       } else {
         payload[column.columnName] = value === null || value === undefined ? '' : value.toString();
       }
@@ -813,6 +822,9 @@ export class EditClientComponent implements OnInit {
     if (this.isDatatableDropdown(column)) {
       return this.toDatatableDropdownControlValue(column, value);
     }
+    if (this.isDatatableJson(column)) {
+      return this.datatables.formatJsonValue(value);
+    }
     return value;
   }
 
@@ -858,7 +870,9 @@ export class EditClientComponent implements OnInit {
   }
 
   private datatableColumnType(column: PersonalDataTableColumn): string {
-    const type = (column.columnDisplayType || column.columnType || '').toString().trim().toUpperCase();
+    const type = this.isDatatableJson(column)
+      ? 'JSON'
+      : (column.columnDisplayType || column.columnType || '').toString().trim().toUpperCase();
     if (type === 'NUMBER') {
       return 'INTEGER';
     }

--- a/src/app/core/utils/datatable-step-json-support.spec.ts
+++ b/src/app/core/utils/datatable-step-json-support.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { DatePipe } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { TranslateService } from '@ngx-translate/core';
+
+import { ClientDatatableStepComponent } from 'app/clients/client-stepper/client-datatable-step/client-datatable-step.component';
+import { Datatables } from 'app/core/utils/datatables';
+import { Dates } from 'app/core/utils/dates';
+import { LoansAccountDatatableStepComponent } from 'app/loans/loans-account-stepper/loans-account-datatable-step/loans-account-datatable-step.component';
+import { SettingsService } from 'app/settings/settings.service';
+
+describe.each([
+  {
+    label: 'client',
+    componentClass: ClientDatatableStepComponent,
+    registeredTableName: 'client_profile',
+    systemColumn: 'client_id'
+  },
+  {
+    label: 'loan',
+    componentClass: LoansAccountDatatableStepComponent,
+    registeredTableName: 'loan_profile',
+    systemColumn: 'loan_id'
+  }
+])('$label datatable step JSON support', ({ componentClass, registeredTableName, systemColumn }) => {
+  let component: ClientDatatableStepComponent | LoansAccountDatatableStepComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DatePipe,
+        Datatables,
+        Dates,
+        {
+          provide: SettingsService,
+          useValue: {
+            language: { code: 'en' },
+            dateFormat: 'yyyy-MM-dd',
+            maxAllowedDate: new Date(2030, 0, 1)
+          }
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            instant: jest.fn((key: string) => key),
+            get: jest.fn((key: string) => of(key))
+          }
+        }
+      ]
+    });
+    component = TestBed.runInInjectionContext(() => new componentClass());
+    component.datatableData = {
+      registeredTableName,
+      columnHeaderData: [
+        { columnName: systemColumn, columnDisplayType: 'INTEGER' },
+        { columnName: 'profile', columnDisplayType: 'JSON', isColumnNullable: false },
+        { columnName: 'legacy_profile', columnDisplayType: 'TEXT', columnType: 'JSON', isColumnNullable: true }
+      ]
+    };
+    component.ngOnInit();
+  });
+
+  it('validates required and nullable JSON fields from both metadata forms', () => {
+    const profile = component.datatableForm.get('profile');
+    const legacyProfile = component.datatableForm.get('legacy_profile');
+
+    expect(profile.hasError('required')).toBe(true);
+    expect(legacyProfile.valid).toBe(true);
+
+    profile.setValue('{bad}');
+    legacyProfile.setValue('[object Object]');
+
+    expect(profile.hasError('json')).toBe(true);
+    expect(legacyProfile.hasError('json')).toBe(true);
+  });
+
+  it('keeps JSON values as text in the datatable payload', () => {
+    const jsonText = '{"risk":{"score":12}}';
+    component.datatableForm.patchValue({
+      profile: jsonText,
+      legacy_profile: '["verified"]'
+    });
+
+    expect(component.payload).toEqual({
+      registeredTableName,
+      data: {
+        locale: 'en',
+        profile: jsonText,
+        legacy_profile: '["verified"]'
+      }
+    });
+    expect(typeof component.payload.data.profile).toBe('string');
+  });
+});

--- a/src/app/core/utils/datatables.spec.ts
+++ b/src/app/core/utils/datatables.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { DatePipe } from '@angular/common';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { TranslateService } from '@ngx-translate/core';
+
+import { SettingsService } from 'app/settings/settings.service';
+import { Datatables } from './datatables';
+
+describe('Datatables JSON support', () => {
+  let datatables: Datatables;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DatePipe,
+        {
+          provide: SettingsService,
+          useValue: {
+            language: { code: 'en' },
+            dateFormat: 'yyyy-MM-dd',
+            maxAllowedDate: new Date(2030, 0, 1)
+          }
+        },
+        {
+          provide: TranslateService,
+          useValue: {
+            instant: jest.fn((key: string) => (key === 'labels.inputs.Invalid JSON' ? 'Enter valid JSON.' : key)),
+            get: jest.fn((key: string) => of(key))
+          }
+        }
+      ]
+    });
+    datatables = TestBed.inject(Datatables);
+  });
+
+  it('creates textarea form fields for both Fineract JSON metadata forms', () => {
+    const formfields = datatables.getFormfields(
+      [
+        { columnName: 'json_display_type', columnDisplayType: 'JSON', isColumnNullable: false },
+        { columnName: 'json_column_type', columnDisplayType: 'TEXT', columnType: 'JSON', isColumnNullable: true }
+      ],
+      [],
+      {}
+    );
+
+    expect(formfields.map((field: any) => field.controlType)).toEqual([
+      'textarea',
+      'textarea'
+    ]);
+    expect(formfields[0].required).toBe(true);
+    expect(formfields[1].required).toBe(false);
+  });
+
+  it('keeps existing non-JSON datatable field types unchanged', () => {
+    const dateTransformColumns: string[] = [];
+    const entryObject: any = {};
+    const formfields = datatables.getFormfields(
+      [
+        { columnName: 'number_value', columnDisplayType: 'INTEGER', isColumnNullable: false },
+        { columnName: 'decimal_value', columnDisplayType: 'DECIMAL', isColumnNullable: true },
+        { columnName: 'string_value', columnDisplayType: 'STRING', isColumnNullable: true },
+        { columnName: 'text_value', columnDisplayType: 'TEXT', isColumnNullable: true },
+        { columnName: 'date_value', columnDisplayType: 'DATE', isColumnNullable: true },
+        { columnName: 'datetime_value', columnDisplayType: 'DATETIME', isColumnNullable: true },
+        {
+          columnName: 'status_cd_Status',
+          columnDisplayType: 'CODELOOKUP',
+          isColumnNullable: true,
+          columnValues: [{ id: 1, value: 'Active' }]
+        },
+        { columnName: 'boolean_value', columnDisplayType: 'BOOLEAN', isColumnNullable: true }
+      ],
+      dateTransformColumns,
+      entryObject
+    );
+
+    expect(formfields.map((field: any) => field.controlType)).toEqual([
+      'input',
+      'input',
+      'input',
+      'input',
+      'datepicker',
+      'datetimepicker',
+      'select',
+      'checkbox'
+    ]);
+    expect(dateTransformColumns).toEqual([
+      'date_value',
+      'datetime_value'
+    ]);
+  });
+
+  it.each([
+    [
+      'nested object',
+      '{"customerType":"business","risk":{"score":12}}'
+    ],
+    [
+      'array',
+      '["priority","verified"]'
+    ],
+    [
+      'JSON string',
+      '"plain string"'
+    ],
+    [
+      'number',
+      '12'
+    ],
+    [
+      'boolean',
+      'true'
+    ],
+    [
+      'null',
+      'null'
+    ],
+    [
+      'empty object',
+      '{}'
+    ],
+    [
+      'empty array',
+      '[]'
+    ]
+  ])('accepts valid JSON values: %s', (_label, value) => {
+    expect(datatables.jsonValidator({ value } as any)).toBeNull();
+  });
+
+  it('rejects malformed JSON but allows nullable empty values', () => {
+    expect(datatables.jsonValidator({ value: '{"name":"John",}' } as any)).toEqual({ json: true });
+    expect(datatables.jsonValidator({ value: '' } as any)).toBeNull();
+    expect(datatables.jsonValidator({ value: null } as any)).toBeNull();
+  });
+
+  it('formats JSON safely without rendering object values as [object Object]', () => {
+    expect(datatables.formatJsonValue({ customerType: 'business', risk: { score: 12 } })).toContain(
+      '"customerType": "business"'
+    );
+    expect(datatables.formatJsonValue(['priority'])).toContain('"priority"');
+    expect(datatables.formatJsonValue('{"customerType":"business"}')).toBe('{\n  "customerType": "business"\n}');
+    expect(datatables.formatJsonValue('legacy malformed {')).toBe('legacy malformed {');
+    expect(datatables.formatJsonValue({ customerType: 'business' })).not.toContain('[object Object]');
+  });
+
+  it('submits JSON field values as JSON text, matching the current Fineract datatable entry contract', () => {
+    const jsonText = '{\n  "customerType": "business",\n  "risk": {\n    "score": 12\n  }\n}';
+    const payload = datatables.buildPayload(
+      [{ columnName: 'profile', columnDisplayType: 'JSON' }],
+      { profile: jsonText },
+      'yyyy-MM-dd',
+      { locale: 'en' }
+    );
+
+    expect(payload).toEqual({ locale: 'en', profile: jsonText });
+    expect(typeof payload.profile).toBe('string');
+    expect(JSON.parse(payload.profile)).toEqual({ customerType: 'business', risk: { score: 12 } });
+  });
+});

--- a/src/app/core/utils/datatables.ts
+++ b/src/app/core/utils/datatables.ts
@@ -12,9 +12,11 @@ import { TranslateService } from '@ngx-translate/core';
 import { CheckboxBase } from 'app/shared/form-dialog/formfield/model/checkbox-base';
 import { DatepickerBase } from 'app/shared/form-dialog/formfield/model/datepicker-base';
 import { DateTimepickerBase } from 'app/shared/form-dialog/formfield/model/datetimepicker-base';
+import { FormfieldBase } from 'app/shared/form-dialog/formfield/model/formfield-base';
 import { InputBase } from 'app/shared/form-dialog/formfield/model/input-base';
 import { SelectBase } from 'app/shared/form-dialog/formfield/model/select-base';
 import { Dates } from './dates';
+import { AbstractControl, ValidationErrors } from '@angular/forms';
 
 @Injectable({
   providedIn: 'root'
@@ -58,8 +60,11 @@ export class Datatables {
         'office_phone',
         'office phone'
       ].some((name) => colName.includes(name.replace(/[_\s]+/g, '')));
-      const isNumericField = column.columnDisplayType === 'INTEGER' || column.columnDisplayType === 'DECIMAL';
-      switch (column.columnDisplayType) {
+      const columnDisplayType = this.isJson(column.columnDisplayType, column.columnType)
+        ? 'JSON'
+        : this.normalizeColumnType(column.columnDisplayType);
+      const isNumericField = columnDisplayType === 'INTEGER' || columnDisplayType === 'DECIMAL';
+      switch (columnDisplayType) {
         case 'INTEGER':
         case 'STRING':
         case 'DECIMAL':
@@ -68,7 +73,7 @@ export class Datatables {
             controlName: column.columnName,
             label: displayLabel,
             value: '',
-            type: column.columnDisplayType === 'INTEGER' || column.columnDisplayType === 'DECIMAL' ? 'number' : 'text',
+            type: columnDisplayType === 'INTEGER' || columnDisplayType === 'DECIMAL' ? 'number' : 'text',
             required: column.isColumnNullable ? false : true
           };
           if (isMinSavingsAmount || isPriceOneShare || isRestrictedField || isNumericField) {
@@ -116,6 +121,15 @@ export class Datatables {
             required: column.isColumnNullable ? false : true
           });
         }
+        case 'JSON':
+          return new FormfieldBase({
+            controlType: 'textarea',
+            controlName: column.columnName,
+            label: displayLabel,
+            value: '',
+            required: column.isColumnNullable ? false : true,
+            validators: [this.jsonValidator]
+          });
       }
     });
   }
@@ -168,8 +182,16 @@ export class Datatables {
     return this.isColumnType(columnType, 'TEXT');
   }
 
+  public isJson(columnType: string, columnTypeName?: string): boolean {
+    return this.isColumnType(columnType, 'JSON') || this.isColumnType(columnTypeName || '', 'JSON');
+  }
+
   public isColumnType(columnType: string, expectedType: string): boolean {
-    return columnType === expectedType;
+    return this.normalizeColumnType(columnType) === this.normalizeColumnType(expectedType);
+  }
+
+  public normalizeColumnType(columnType: string): string {
+    return (columnType || '').toString().trim().toUpperCase();
   }
 
   public buildPayload(datatableInputs: any, datatableDataValues: any, dateFormat: string, output: any): any {
@@ -256,6 +278,40 @@ export class Datatables {
     }
     const codeValue = columnHeader.columnValues.find((cv: any) => cv.id === id);
     return codeValue ? codeValue.value : id.toString();
+  }
+
+  public jsonValidator(control: AbstractControl): ValidationErrors | null {
+    const value = control.value;
+    if (value === null || value === undefined || value === '') {
+      return null;
+    }
+    if (typeof value !== 'string') {
+      return null;
+    }
+    try {
+      JSON.parse(value);
+      return null;
+    } catch {
+      return { json: true };
+    }
+  }
+
+  public formatJsonValue(value: any): string {
+    if (value === null || value === undefined || value === '') {
+      return '';
+    }
+    if (typeof value === 'string') {
+      try {
+        return JSON.stringify(JSON.parse(value), null, 2);
+      } catch {
+        return value;
+      }
+    }
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
   }
 
   public getCodeName(columnName: string): string {

--- a/src/app/core/utils/translations.spec.ts
+++ b/src/app/core/utils/translations.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from '@jest/globals';
+
+const locales = [
+  'cs-CS',
+  'de-DE',
+  'en-US',
+  'es-CL',
+  'es-MX',
+  'fr-FR',
+  'it-IT',
+  'ko-KO',
+  'lt-LT',
+  'lv-LV',
+  'ne-NE',
+  'pt-PT',
+  'sw-SW'
+];
+
+const expectedInvalidJsonMessages: Record<string, string> = {
+  'cs-CS': 'Zadejte platný JSON.',
+  'de-DE': 'Geben Sie gültiges JSON ein.',
+  'en-US': 'Enter valid JSON.',
+  'es-CL': 'Ingrese un JSON válido.',
+  'es-MX': 'Ingrese un JSON válido.',
+  'fr-FR': 'Saisissez un JSON valide.',
+  'it-IT': 'Inserisci JSON valido.',
+  'ko-KO': '유효한 JSON을 입력하세요.',
+  'lt-LT': 'Įveskite galiojantį JSON.',
+  'lv-LV': 'Ievadiet derīgu JSON.',
+  'ne-NE': 'मान्य JSON प्रविष्ट गर्नुहोस्।',
+  'pt-PT': 'Introduza um JSON válido.',
+  'sw-SW': 'Weka JSON halali.'
+};
+
+describe('translation completeness', () => {
+  it.each(locales)('%s includes JSON datatable labels and parses successfully', (locale) => {
+    const translations = JSON.parse(
+      readFileSync(join(process.cwd(), 'src/assets/translations', `${locale}.json`), 'utf8')
+    );
+
+    expect(translations.labels.inputs.JSON).toBe('JSON');
+    expect(translations.labels.inputs['Invalid JSON']).toBe(expectedInvalidJsonMessages[locale]);
+  });
+});

--- a/src/app/loans/loans-account-stepper/loans-account-datatable-step/loans-account-datatable-step.component.html
+++ b/src/app/loans/loans-account-stepper/loans-account-datatable-step/loans-account-datatable-step.component.html
@@ -28,8 +28,20 @@
             @if (isString(datatableInput.columnDisplayType)) {
               <input matInput formControlName="{{ datatableInput.controlName }}" />
             }
-            @if (isText(datatableInput.columnDisplayType)) {
+            @if (isText(datatableInput.columnDisplayType) && !isJson(datatableInput)) {
               <textarea matInput formControlName="{{ datatableInput.controlName }}"></textarea>
+            }
+            @if (isJson(datatableInput)) {
+              <textarea
+                matInput
+                cdkTextareaAutosize
+                cdkAutosizeMinRows="6"
+                cdkAutosizeMaxRows="18"
+                formControlName="{{ datatableInput.controlName }}"
+              ></textarea>
+              @if (datatableForm.controls[datatableInput.controlName].hasError('json')) {
+                <mat-error>{{ 'labels.inputs.Invalid JSON' | translate }}</mat-error>
+              }
             }
             @if (isDate(datatableInput.columnDisplayType)) {
               <span (click)="datePicker.open()">

--- a/src/app/loans/loans-account-stepper/loans-account-datatable-step/loans-account-datatable-step.component.ts
+++ b/src/app/loans/loans-account-stepper/loans-account-datatable-step/loans-account-datatable-step.component.ts
@@ -14,12 +14,14 @@ import {
   Validators,
   ReactiveFormsModule
 } from '@angular/forms';
+import { Datatables } from 'app/core/utils/datatables';
 import { Dates } from 'app/core/utils/dates';
 import { SettingsService } from 'app/settings/settings.service';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { MatStepperPrevious, MatStepperNext } from '@angular/material/stepper';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 
 @Component({
   selector: 'mifosx-loans-account-datatable-step',
@@ -30,7 +32,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
     MatCheckbox,
     MatStepperPrevious,
     FaIconComponent,
-    MatStepperNext
+    MatStepperNext,
+    CdkTextareaAutosize
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -38,6 +41,7 @@ export class LoansAccountDatatableStepComponent implements OnInit {
   private formBuilder = inject(UntypedFormBuilder);
   private settingsService = inject(SettingsService);
   private dateUtils = inject(Dates);
+  private datatableService = inject(Datatables);
 
   /** Input Fields Data */
   @Input() datatableData: any;
@@ -61,9 +65,16 @@ export class LoansAccountDatatableStepComponent implements OnInit {
       if (!input.isColumnNullable) {
         if (this.isNumeric(input.columnDisplayType)) {
           inputItems[input.controlName] = new UntypedFormControl(0, [Validators.required]);
+        } else if (this.isJson(input)) {
+          inputItems[input.controlName] = new UntypedFormControl('', [
+            Validators.required,
+            this.datatableService.jsonValidator
+          ]);
         } else {
           inputItems[input.controlName] = new UntypedFormControl('', [Validators.required]);
         }
+      } else if (this.isJson(input)) {
+        inputItems[input.controlName] = new UntypedFormControl('', [this.datatableService.jsonValidator]);
       } else {
         inputItems[input.controlName] = new UntypedFormControl('');
       }
@@ -102,8 +113,12 @@ export class LoansAccountDatatableStepComponent implements OnInit {
     return this.isColumnType(columnType, 'TEXT');
   }
 
+  isJson(datatableInput: any) {
+    return this.datatableService.isJson(datatableInput.columnDisplayType, datatableInput.columnType);
+  }
+
   isColumnType(columnType: string, expectedType: string) {
-    return columnType === expectedType;
+    return this.datatableService.isColumnType(columnType, expectedType);
   }
 
   get payload(): any {

--- a/src/app/loans/loans.component.ts
+++ b/src/app/loans/loans.component.ts
@@ -41,6 +41,7 @@ import { AccountNumberComponent } from '../shared/account-number/account-number.
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { nameInitials } from 'app/core/utils/name-initials';
 import { Dates } from 'app/core/utils/dates';
+import { Datatables } from 'app/core/utils/datatables';
 import { sanitizeCsvValue } from 'app/core/utils/csv.utils';
 import { SettingsService } from 'app/settings/settings.service';
 
@@ -178,6 +179,7 @@ export class LoansComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   private cdr = inject(ChangeDetectorRef);
   private dateUtils = inject(Dates);
+  private datatables = inject(Datatables);
   private settingsService = inject(SettingsService);
   private translateService = inject(TranslateService);
   private locale = inject(LOCALE_ID);
@@ -874,7 +876,9 @@ export class LoansComponent implements OnInit {
         .map((col: any) => ({
           name: col.columnName,
           label: humanizeName(col.columnName ?? ''),
-          type: (col.columnDisplayType ?? 'STRING').toUpperCase(),
+          type: this.datatables.isJson(col.columnDisplayType, col.columnType)
+            ? 'JSON'
+            : (col.columnDisplayType ?? 'STRING').toUpperCase(),
           codeValues: col.columnValues?.length
             ? new Map<number, string>(
                 col.columnValues.map((value: any) => [
@@ -1398,6 +1402,10 @@ export class LoansComponent implements OnInit {
       case 'CODELOOKUP':
       case 'CODEVALUE': {
         const text = col.codeValues?.get(Number(value)) ?? String(value);
+        return { text, raw: text.toLowerCase() };
+      }
+      case 'JSON': {
+        const text = this.datatables.formatJsonValue(value);
         return { text, raw: text.toLowerCase() };
       }
       default:

--- a/src/app/shared/form-dialog/formfield/formfield.component.html
+++ b/src/app/shared/form-dialog/formfield/formfield.component.html
@@ -93,6 +93,31 @@
     </mat-form-field>
   }
 
+  @if (formfield.controlType === 'textarea') {
+    <mat-form-field class="flex-fill">
+      <mat-label>{{ formfield.label }}</mat-label>
+      <textarea
+        matInput
+        cdkTextareaAutosize
+        cdkAutosizeMinRows="6"
+        cdkAutosizeMaxRows="18"
+        [formControlName]="formfield.controlName"
+        [required]="formfield.required"
+      ></textarea>
+      @if (form.controls[formfield.controlName].hasError('required')) {
+        <mat-error>
+          {{ formfield.label }} {{ 'labels.commons.is' | translate }}
+          <strong>{{ 'labels.commons.required' | translate }}</strong>
+        </mat-error>
+      }
+      @if (form.controls[formfield.controlName].hasError('json')) {
+        <mat-error>
+          {{ 'labels.inputs.Invalid JSON' | translate }}
+        </mat-error>
+      }
+    </mat-form-field>
+  }
+
   @if (formfield.controlType === 'checkbox') {
     <mat-checkbox
       labelPosition="before"

--- a/src/app/shared/form-dialog/formfield/formfield.component.ts
+++ b/src/app/shared/form-dialog/formfield/formfield.component.ts
@@ -12,6 +12,7 @@ import { UntypedFormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FormfieldBase } from './model/formfield-base';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 
 @Component({
   selector: 'mifosx-formfield',
@@ -19,7 +20,8 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
   styleUrls: ['./formfield.component.scss'],
   imports: [
     ...STANDALONE_SHARED_IMPORTS,
-    MatCheckbox
+    MatCheckbox,
+    CdkTextareaAutosize
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.html
@@ -92,7 +92,17 @@
                   [attr.data-label]="getInputName(datatableColumn)"
                 >
                   <span class="mobile-cell-label">{{ getInputName(datatableColumn) }}</span>
-                  <span class="cell-value">{{ formatValue(data, datatableColumn) }}</span>
+                  <span
+                    class="cell-value"
+                    [ngClass]="{
+                      'json-value': datatables.isJson(
+                        getColumnDisplayType(datatableColumn),
+                        getColumnType(datatableColumn)
+                      )
+                    }"
+                  >
+                    {{ formatValue(data, datatableColumn) }}
+                  </span>
                 </td>
               }
             </ng-container>

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.scss
@@ -79,6 +79,20 @@
       white-space: normal;
     }
 
+    .json-value {
+      max-height: 18rem;
+      padding: 8px;
+      border: 1px solid rgb(0 0 0 / 12%);
+      border-radius: var(--ds-radius);
+      background: var(--ds-surface-alt);
+      font-family: 'Roboto Mono', 'JetBrains Mono', monospace;
+      font-size: 0.8125rem;
+      line-height: 1.4;
+      overflow: auto;
+      white-space: pre-wrap;
+      text-align: left;
+    }
+
     .data-row {
       transition: background-color 0.2s ease;
       cursor: pointer;

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.spec.ts
@@ -331,6 +331,56 @@ describe('DatatableMultiRowComponent', () => {
     expect(verifiedCell.textContent.trim()).toBe('No');
   });
 
+  it('renders JSON values as formatted structured text in multi-row cells', () => {
+    setDataObject({
+      columnHeaders: [
+        { columnName: 'id', columnDisplayType: 'INTEGER' },
+        { columnName: 'client_id', columnDisplayType: 'INTEGER' },
+        { columnName: 'profile', columnDisplayType: 'TEXT', columnType: 'JSON' }
+      ],
+      data: [{ row: [
+            7,
+            99,
+            { customerType: 'business', risk: { score: 12 }, tags: ['priority'] }
+          ] }]
+    });
+
+    const jsonCell = fixture.nativeElement.querySelector('td[data-label="profile"] .json-value') as HTMLElement;
+
+    expect(jsonCell.textContent).toContain('"customerType": "business"');
+    expect(jsonCell.textContent).toContain('"score": 12');
+    expect(jsonCell.textContent).toContain('"tags": [');
+    expect(jsonCell.textContent).not.toContain('[object Object]');
+  });
+
+  it('prefills JSON edit fields with formatted JSON text', () => {
+    const selectedRow = {
+      row: [
+        7,
+        99,
+        '{"customerType":"business","risk":{"score":12}}'
+      ]
+    };
+    setDataObject({
+      columnHeaders: [
+        { columnName: 'id', columnDisplayType: 'INTEGER' },
+        { columnName: 'client_id', columnDisplayType: 'INTEGER' },
+        { columnName: 'profile', columnDisplayType: 'TEXT', columnType: 'JSON', isColumnNullable: false }
+      ],
+      data: [selectedRow]
+    });
+
+    component.edit(selectedRow);
+
+    const dialogData = (matDialog.open.mock.calls[0][1] as any).data;
+    const jsonField = dialogData.formfields[0] as any;
+
+    expect(jsonField.controlType).toBe('textarea');
+    expect(jsonField.value).toContain('"customerType": "business"');
+    expect(jsonField.value).toContain('"score": 12');
+    expect(jsonField.validators[0]({ value: '{"name":"John",}' })).toEqual({ json: true });
+  });
+
   it('keeps multi-row Code Value column labels unchanged', () => {
     expect(component.getInputName('Marital Status_cd_Estado Civil')).toBe('Marital Status');
   });

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-multi-row/datatable-multi-row.component.ts
@@ -58,6 +58,13 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { PageLoaderComponent } from 'app/shared/page-loader/page-loader.component';
 
+interface DatatableColumnHeader {
+  columnName: string;
+  columnDisplayType?: string;
+  columnType?: string;
+  columnValues?: { id: number; value: string }[];
+}
+
 @Component({
   selector: 'mifosx-datatable-multi-row',
   templateUrl: './datatable-multi-row.component.html',
@@ -98,7 +105,7 @@ export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDest
   private settingsService = inject(SettingsService);
   private dialog = inject(MatDialog);
   private changeDetectorRef = inject(ChangeDetectorRef);
-  private datatables = inject(Datatables);
+  public datatables = inject(Datatables);
   private dateFormat = inject(DateFormatPipe);
   private dateTimeFormat = inject(DatetimeFormatPipe);
   private numberFormat = inject(DecimalPipe);
@@ -281,6 +288,11 @@ export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDest
           formfield.value = this.dateUtils.parseDate(value);
         } else if (formfield.controlType === 'datetimepicker') {
           formfield.value = this.dateUtils.parseDatetime(value);
+        } else if (
+          formfield.controlType === 'textarea' &&
+          this.datatables.isJson(column.columnDisplayType, column.columnType)
+        ) {
+          formfield.value = this.datatables.formatJsonValue(value);
         } else {
           formfield.value = value;
         }
@@ -424,6 +436,8 @@ export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDest
               const codeValue = columnHeader.columnValues.find((cv: any) => cv.id === value);
               value = codeValue ? codeValue.value : value;
             }
+          } else if (this.datatables.isJson(columnDisplayType, columnHeader.columnType)) {
+            value = this.datatables.formatJsonValue(value);
           }
           return true;
         }
@@ -450,6 +464,9 @@ export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDest
     const columnHeader = this.dataObject.columnHeaders[columnIndex];
     const value = data.row[columnIndex];
     const isMissingValue = value === null || value === undefined || value === '';
+    if (this.datatables.isJson(columnHeader.columnDisplayType, columnHeader.columnType)) {
+      return this.datatables.formatJsonValue(value).toLocaleLowerCase();
+    }
     switch (columnHeader.columnDisplayType) {
       case 'INTEGER':
       case 'DECIMAL': {
@@ -474,6 +491,20 @@ export class DatatableMultiRowComponent implements OnInit, AfterViewInit, OnDest
         }
         return value.toString().toLocaleLowerCase();
     }
+  }
+
+  getColumnDisplayType(columnName: string): string {
+    return this.getColumnHeader(columnName)?.columnDisplayType || '';
+  }
+
+  getColumnType(columnName: string): string {
+    return this.getColumnHeader(columnName)?.columnType || '';
+  }
+
+  private getColumnHeader(columnName: string): DatatableColumnHeader | undefined {
+    return this.dataObject?.columnHeaders?.find(
+      (columnHeader: DatatableColumnHeader) => columnHeader.columnName === columnName
+    );
   }
 
   /** Whether the number of selected elements matches the total number of rows. */

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.html
@@ -92,14 +92,7 @@
                       </span>
                     }
                     @case ('JSON') {
-                      <textarea
-                        cdkTextareaAutosize="true"
-                        cdkAutosizeMaxRows="20"
-                        cdkAutosizeMinRows="1"
-                        class="json-textarea"
-                        [innerHTML]="dataObject.data[0].row[i].value | prettyPrint"
-                      >
-                      </textarea>
+                      <pre class="json-value">{{ formatJsonValue(dataObject.data[0].row[i]) }}</pre>
                     }
                     @default {
                       <div class="default-value">

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.scss
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.scss
@@ -33,6 +33,7 @@
 .data-item {
   display: flex;
   flex-direction: column;
+  align-items: stretch;
   padding: 16px 24px;
   border-radius: var(--ds-radius);
   background-color: #fcfcfc;
@@ -106,16 +107,19 @@
   height: 30px;
 }
 
-.json-textarea {
+.json-value {
   width: 100%;
-  height: 100%;
+  max-height: 24rem;
+  margin: 0;
   padding: 12px;
   border: 1px solid rgb(0 0 0 / 12%);
   border-radius: 4px;
-  font-family: 'Courier New', monospace;
+  font-family: 'Roboto Mono', 'JetBrains Mono', monospace;
   font-size: 0.875rem;
-  background-color: #f5f5f5;
-  resize: vertical;
+  background: var(--ds-surface-alt);
+  overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 @media (width <= 768px) {

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.spec.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.spec.ts
@@ -22,6 +22,7 @@ import { describe, it, expect, jest, beforeEach } from '@jest/globals';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
 import { SettingsService } from 'app/settings/settings.service';
 import { SystemService } from 'app/system/system.service';
+import { UsersService } from 'app/users/users.service';
 import { DateFormatPipe } from 'app/pipes/date-format.pipe';
 import { DatetimeFormatPipe } from 'app/pipes/datetime-format.pipe';
 import { FormDialogComponent } from 'app/shared/form-dialog/form-dialog.component';
@@ -117,6 +118,7 @@ describe('DatatableSingleRowComponent', () => {
         DateFormatPipe,
         DatetimeFormatPipe,
         { provide: SystemService, useValue: { getEntityDatatable: jest.fn() } },
+        { provide: UsersService, useValue: { getUser: jest.fn(() => of({})) } },
         {
           provide: SettingsService,
           useValue: {
@@ -181,6 +183,39 @@ describe('DatatableSingleRowComponent', () => {
     expect(stylesheet).toContain('align-items: stretch;');
     expect(stylesheet).toContain('align-items: flex-start;');
     expect(stylesheet).toContain('min-width: 0;');
+  });
+
+  it('renders JSON values as formatted structured text', () => {
+    setDataObject({
+      columnHeaders: [{ columnName: 'profile', columnDisplayType: 'TEXT', columnType: 'JSON' }],
+      data: [{ row: ['{"customerType":"business","risk":{"score":12},"tags":["priority"]}'] }]
+    });
+
+    const jsonValue = fixture.nativeElement.querySelector('.json-value') as HTMLElement;
+
+    expect(jsonValue.textContent).toContain('"customerType": "business"');
+    expect(jsonValue.textContent).toContain('"score": 12');
+    expect(jsonValue.textContent).toContain('"tags": [');
+    expect(jsonValue.textContent).not.toContain('[object Object]');
+  });
+
+  it('uses a JSON textarea with validation for adding JSON fields', () => {
+    setDataObject({
+      columnHeaders: [
+        { columnName: 'profile', columnDisplayType: 'TEXT', columnType: 'JSON', isColumnNullable: false }
+      ],
+      data: []
+    });
+
+    component.add();
+
+    const dialogData = (matDialog.open.mock.calls[0][1] as any).data;
+    const jsonField = dialogData.formfields[0] as any;
+
+    expect(jsonField.controlType).toBe('textarea');
+    expect(jsonField.required).toBe(true);
+    expect(jsonField.validators[0]({ value: '{"name":"John",}' })).toEqual({ json: true });
+    expect(jsonField.validators[0]({ value: '{"name":"John"}' })).toBeNull();
   });
 
   it('translates single-row system timestamp labels', () => {

--- a/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
+++ b/src/app/shared/tabs/entity-datatable-tab/datatable-single-row/datatable-single-row.component.ts
@@ -31,13 +31,11 @@ import { MatButton, MatIconButton } from '@angular/material/button';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { MatDivider } from '@angular/material/divider';
 import { MatCard, MatCardContent } from '@angular/material/card';
-import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { MatTooltip } from '@angular/material/tooltip';
 import { TranslateService } from '@ngx-translate/core';
 import { DateFormatPipe } from '../../../../pipes/date-format.pipe';
 import { DatetimeFormatPipe } from '../../../../pipes/datetime-format.pipe';
 import { FormatNumberPipe } from '../../../../pipes/format-number.pipe';
-import { PrettyPrintPipe } from '../../../../pipes/pretty-print.pipe';
 import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 import { formatDatatableDisplayLabel } from '@pipes/datatable-display-label.pipe';
 import { PageLoaderComponent } from 'app/shared/page-loader/page-loader.component';
@@ -54,13 +52,11 @@ import { PageLoaderComponent } from 'app/shared/page-loader/page-loader.componen
     MatCard,
     MatCardContent,
     NgClass,
-    CdkTextareaAutosize,
     MatIconButton,
     MatTooltip,
     DateFormatPipe,
     DatetimeFormatPipe,
-    FormatNumberPipe,
-    PrettyPrintPipe
+    FormatNumberPipe
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -238,6 +234,11 @@ export class DatatableSingleRowComponent implements OnInit, OnChanges {
         formfield.value = this.dataObject.data[0].row[columns[index].idx]
           ? this.dateUtils.parseDatetime(this.dataObject.data[0].row[columns[index].idx])
           : '';
+      } else if (
+        formfield.controlType === 'textarea' &&
+        this.datatables.isJson(columns[index].columnDisplayType, columns[index].columnType)
+      ) {
+        formfield.value = this.datatables.formatJsonValue(this.dataObject.data[0].row[columns[index].idx]);
       } else {
         formfield.value = this.dataObject.data[0].row[columns[index].idx]
           ? this.dataObject.data[0].row[columns[index].idx]
@@ -338,8 +339,11 @@ export class DatatableSingleRowComponent implements OnInit, OnChanges {
       case 'BOOLEAN': {
         return columnDisplayType;
       }
+      case 'JSON': {
+        return columnDisplayType;
+      }
       case 'TEXT': {
-        if (columnType === 'JSON') {
+        if (this.datatables.isJson(columnType)) {
           return 'JSON';
         } else {
           return columnDisplayType;
@@ -362,6 +366,10 @@ export class DatatableSingleRowComponent implements OnInit, OnChanges {
     }
 
     return value;
+  }
+
+  formatJsonValue(value: any): string {
+    return this.datatables.formatJsonValue(value);
   }
 
   isValidUrl(urlString: string): boolean {

--- a/src/app/system/manage-data-tables/column-dialog/column-dialog.component.ts
+++ b/src/app/system/manage-data-tables/column-dialog/column-dialog.component.ts
@@ -66,7 +66,7 @@ export class ColumnDialogComponent implements OnInit {
           value: this.data
             ? this.data.columnDisplayType === ''
               ? ''
-              : this.getColumnType(this.data.columnDisplayType)
+              : this.getColumnType(this.data.columnDisplayType, this.data.columnType)
             : '',
           disabled: this.data.type === 'existing'
         },
@@ -75,7 +75,9 @@ export class ColumnDialogComponent implements OnInit {
       length: [
         {
           value: this.data ? +this.data.columnLength : '',
-          disabled: this.getColumnType(this.data.columnDisplayType) !== 'String' || this.data.type === 'existing'
+          disabled:
+            this.getColumnType(this.data.columnDisplayType, this.data.columnType) !== 'String' ||
+            this.data.type === 'existing'
         },
         [
           Validators.required,
@@ -90,7 +92,9 @@ export class ColumnDialogComponent implements OnInit {
       code: [
         {
           value: this.data ? this.data.columnCode : '',
-          disabled: this.getColumnType(this.data.columnDisplayType) !== 'Dropdown' || this.data.type === 'existing'
+          disabled:
+            this.getColumnType(this.data.columnDisplayType, this.data.columnType) !== 'Dropdown' ||
+            this.data.type === 'existing'
         },
         Validators.required
       ]
@@ -103,7 +107,10 @@ export class ColumnDialogComponent implements OnInit {
    * @param {string} columnDisplayType Column Display Type.
    * @returns {string} Column Type.
    */
-  getColumnType(columnDisplayType: string): string {
+  getColumnType(columnDisplayType: string, columnType?: string): string {
+    if (columnDisplayType === 'TEXT' && columnType && columnType.toString().toLowerCase() === 'json') {
+      return 'json';
+    }
     switch (columnDisplayType) {
       case undefined: {
         return '';
@@ -113,6 +120,10 @@ export class ColumnDialogComponent implements OnInit {
       }
       case 'CODELOOKUP': {
         return 'Dropdown';
+      }
+      case 'JSON':
+      case 'json': {
+        return 'json';
       }
       default: {
         return columnDisplayType[0] + columnDisplayType.substring(1).toLowerCase();

--- a/src/app/system/manage-data-tables/column-type-data.ts
+++ b/src/app/system/manage-data-tables/column-type-data.ts
@@ -12,6 +12,7 @@ export const columnTypeData: { displayValue: string; value: string }[] = [
   { displayValue: 'Date and Time', value: 'Datetime' },
   { displayValue: 'Decimal', value: 'Decimal' },
   { displayValue: 'Dropdown', value: 'Dropdown' },
+  { displayValue: 'JSON', value: 'json' },
   { displayValue: 'Number', value: 'Number' },
   { displayValue: 'String', value: 'String' },
   { displayValue: 'Text', value: 'Text' }

--- a/src/app/system/manage-data-tables/data-table-json-support.spec.ts
+++ b/src/app/system/manage-data-tables/data-table-json-support.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { UntypedFormBuilder } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { describe, expect, it, beforeEach, jest } from '@jest/globals';
+import { TranslateService } from '@ngx-translate/core';
+
+import { ConfigurationWizardService } from 'app/configuration-wizard/configuration-wizard.service';
+import { PopoverService } from 'app/configuration-wizard/popover/popover.service';
+import { SystemService } from '../system.service';
+import { columnTypeData } from './column-type-data';
+import { ColumnDialogComponent } from './column-dialog/column-dialog.component';
+import { CreateDataTableComponent } from './create-data-table/create-data-table.component';
+import { EditDataTableComponent } from './edit-data-table/edit-data-table.component';
+
+describe('Data table JSON column support', () => {
+  const translateService = {
+    instant: jest.fn((key: string) => key),
+    get: jest.fn((key: string) => of(key))
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('exposes JSON in the add-column type list with the exact API value', () => {
+    const jsonType = columnTypeData.find((columnType) => columnType.displayValue === 'JSON');
+
+    expect(jsonType).toEqual({ displayValue: 'JSON', value: 'json' });
+  });
+
+  it('returns type json when JSON is selected in the column dialog', () => {
+    const dialogRef = { close: jest.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        UntypedFormBuilder,
+        { provide: MAT_DIALOG_DATA, useValue: { type: 'new', columnCodes: [] } },
+        { provide: MatDialogRef, useValue: dialogRef }
+      ]
+    });
+    const component = TestBed.runInInjectionContext(() => new ColumnDialogComponent());
+    component.ngOnInit();
+
+    component.columnForm.patchValue({
+      name: 'profile',
+      type: 'json',
+      mandatory: true,
+      unique: false,
+      indexed: false
+    });
+    component.submit();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'profile',
+        type: 'json',
+        mandatory: true,
+        unique: false,
+        indexed: false
+      })
+    );
+  });
+
+  it('recognizes both JSON metadata forms when editing an existing datatable', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        UntypedFormBuilder,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({
+              dataTable: {
+                applicationTableName: 'm_client',
+                registeredTableName: 'client_profile',
+                entitySubType: '',
+                columnHeaderData: [
+                  { columnName: 'client_id', columnDisplayType: 'INTEGER' },
+                  { columnName: 'profile', columnDisplayType: 'JSON' },
+                  { columnName: 'profile_legacy', columnDisplayType: 'TEXT', columnType: 'JSON' }
+                ]
+              },
+              columnCodes: []
+            })
+          }
+        },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+        { provide: MatDialog, useValue: { open: jest.fn() } },
+        { provide: SystemService, useValue: { updateDataTable: jest.fn(() => of({})) } },
+        { provide: TranslateService, useValue: translateService }
+      ]
+    });
+    const component = TestBed.runInInjectionContext(() => new EditDataTableComponent());
+    component.ngOnInit();
+
+    expect(component.columnData.map((column) => column.columnDisplayType)).toEqual([
+      'Number',
+      'json',
+      'json'
+    ]);
+  });
+
+  it('sends JSON column type unchanged in create and edit requests while preserving existing types', () => {
+    const router = { navigate: jest.fn() };
+    const createDataTable = jest.fn(() => of({ resourceIdentifier: 'client_profile' }));
+    TestBed.configureTestingModule({
+      providers: [
+        UntypedFormBuilder,
+        { provide: ActivatedRoute, useValue: { data: of({ columnCodes: [] }) } },
+        { provide: Router, useValue: router },
+        { provide: MatDialog, useValue: { open: jest.fn() } },
+        { provide: SystemService, useValue: { createDataTable } },
+        { provide: ConfigurationWizardService, useValue: { showDatatablesForm: false } },
+        { provide: PopoverService, useValue: { open: jest.fn() } },
+        { provide: TranslateService, useValue: translateService }
+      ]
+    });
+    const component = TestBed.runInInjectionContext(() => new CreateDataTableComponent());
+    component.ngOnInit();
+    component.dataTableForm.patchValue({
+      datatableName: 'client_profile',
+      apptableName: 'm_client',
+      multiRow: false
+    });
+    component.columnData = [
+      { columnName: 'json_value', columnDisplayType: 'json' },
+      { columnName: 'string_value', columnDisplayType: 'String' },
+      { columnName: 'text_value', columnDisplayType: 'Text' },
+      { columnName: 'number_value', columnDisplayType: 'Number' },
+      { columnName: 'decimal_value', columnDisplayType: 'Decimal' },
+      { columnName: 'date_value', columnDisplayType: 'Date' },
+      { columnName: 'datetime_value', columnDisplayType: 'Datetime' },
+      { columnName: 'dropdown_value', columnDisplayType: 'Dropdown', columnCode: 'ClientStatus' }
+    ] as any;
+
+    component.submit();
+
+    expect(createDataTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        datatableName: 'client_profile',
+        apptableName: 'm_client',
+        columns: [
+          expect.objectContaining({ name: 'json_value', type: 'json' }),
+          expect.objectContaining({ name: 'string_value', type: 'String' }),
+          expect.objectContaining({ name: 'text_value', type: 'Text' }),
+          expect.objectContaining({ name: 'number_value', type: 'Number' }),
+          expect.objectContaining({ name: 'decimal_value', type: 'Decimal' }),
+          expect.objectContaining({ name: 'date_value', type: 'Date' }),
+          expect.objectContaining({ name: 'datetime_value', type: 'Datetime' }),
+          expect.objectContaining({ name: 'dropdown_value', type: 'Dropdown', code: 'ClientStatus' })
+        ]
+      })
+    );
+  });
+
+  it('adds type json to the edit-datatable payload', () => {
+    const updateDataTable = jest.fn(() => of({}));
+    const dialog = {
+      open: jest.fn(() => ({
+        afterClosed: () =>
+          of({
+            name: 'profile',
+            type: 'json',
+            mandatory: false,
+            unique: false,
+            indexed: false
+          })
+      }))
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        UntypedFormBuilder,
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({
+              dataTable: {
+                applicationTableName: 'm_client',
+                registeredTableName: 'client_profile',
+                entitySubType: '',
+                columnHeaderData: [{ columnName: 'client_id', columnDisplayType: 'INTEGER' }]
+              },
+              columnCodes: []
+            })
+          }
+        },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+        { provide: MatDialog, useValue: dialog },
+        { provide: SystemService, useValue: { updateDataTable } },
+        { provide: TranslateService, useValue: translateService }
+      ]
+    });
+    const component = TestBed.runInInjectionContext(() => new EditDataTableComponent());
+    component.ngOnInit();
+    component.dataSource = { connect: () => ({ next: jest.fn() }) } as any;
+
+    component.addColumn();
+    component.submit();
+
+    expect(updateDataTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        addColumns: [expect.objectContaining({ name: 'profile', type: 'json' })],
+        changeColumns: undefined,
+        dropColumns: undefined
+      }),
+      'client_profile'
+    );
+  });
+});

--- a/src/app/system/manage-data-tables/datatable-column.model.ts
+++ b/src/app/system/manage-data-tables/datatable-column.model.ts
@@ -9,6 +9,7 @@
 export interface DatatableColumn {
   columnName: string;
   columnDisplayType: string;
+  columnType?: string;
   isColumnNullable: boolean;
   columnLength: string;
   columnCode: string;

--- a/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.ts
+++ b/src/app/system/manage-data-tables/edit-data-table/edit-data-table.component.ts
@@ -239,7 +239,10 @@ export class EditDataTableComponent implements OnInit {
     this.dataTableChangesData.apptableName = this.dataTableData.applicationTableName;
     this.dataTableChangesData.entitySubType = this.dataTableData.entitySubType;
     for (let index = 0; index < this.columnData.length; index++) {
-      this.columnData[index].columnDisplayType = this.getColumnType(this.columnData[index].columnDisplayType);
+      this.columnData[index].columnDisplayType = this.getColumnType(
+        this.columnData[index].columnDisplayType,
+        this.columnData[index].columnType
+      );
       this.columnData[index].type = 'existing';
     }
     this.showEntitySubType = this.dataTableData.applicationTableName === 'm_client';
@@ -268,6 +271,7 @@ export class EditDataTableComponent implements OnInit {
   addColumn() {
     this.dataForDialog.columnName = undefined;
     this.dataForDialog.columnDisplayType = undefined;
+    this.dataForDialog.columnType = undefined;
     this.dataForDialog.isColumnNullable = false;
     this.dataForDialog.isColumnUnique = false;
     this.dataForDialog.isColumnIndexed = false;
@@ -285,6 +289,7 @@ export class EditDataTableComponent implements OnInit {
         const newColumn: DatatableColumn = {
           columnName: response.name,
           columnDisplayType: response.type,
+          columnType: response.type === 'json' ? 'JSON' : undefined,
           isColumnNullable: !response.mandatory,
           isColumnUnique: response.unique,
           isColumnIndexed: response.indexed,
@@ -327,6 +332,7 @@ export class EditDataTableComponent implements OnInit {
   editColumn(column: any) {
     this.dataForDialog.columnName = column.columnName;
     this.dataForDialog.columnDisplayType = column.columnDisplayType;
+    this.dataForDialog.columnType = column.columnType;
     this.dataForDialog.isColumnNullable = !column.isColumnNullable;
     this.dataForDialog.isColumnUnique = column.isColumnUnique;
     this.dataForDialog.isColumnIndexed = column.isColumnIndexed;
@@ -443,13 +449,24 @@ export class EditDataTableComponent implements OnInit {
    * @param {string} columnDisplayType Column Display Type.
    * @returns {string} Column Type.
    */
-  getColumnType(columnDisplayType: string): string {
+  getColumnType(columnDisplayType: string, columnType?: string): string {
+    return this.normalizeColumnType(columnDisplayType, columnType);
+  }
+
+  normalizeColumnType(columnDisplayType: string, columnType?: string): string {
+    if (columnDisplayType === 'TEXT' && columnType && columnType.toString().toLowerCase() === 'json') {
+      return 'json';
+    }
     switch (columnDisplayType) {
       case 'INTEGER': {
         return 'Number';
       }
       case 'CODELOOKUP': {
         return 'Dropdown';
+      }
+      case 'JSON':
+      case 'json': {
+        return 'json';
       }
       default: {
         return columnDisplayType[0] + columnDisplayType.substring(1).toLowerCase();

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1990,6 +1990,8 @@
       "Beneficiary": "Příjemce",
       "Beneficiary Selection": "Výběr příjemce",
       "Boolean": "Boolean",
+      "Invalid JSON": "Zadejte platný JSON.",
+      "JSON": "JSON",
       "Branch": "Větev",
       "Branch Office": "Pobočka",
       "Breach": "Porušení",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1990,6 +1990,8 @@
       "Beneficiary": "Begünstigter",
       "Beneficiary Selection": "Begünstigtenauswahl",
       "Boolean": "Boolescher Wert",
+      "Invalid JSON": "Geben Sie gültiges JSON ein.",
+      "JSON": "JSON",
       "Branch": "Zweig",
       "Branch Office": "Zweigstelle",
       "Breach": "Verstoß",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -2005,6 +2005,8 @@
       "Beneficiary": "Beneficiary",
       "Beneficiary Selection": "Beneficiary Selection",
       "Boolean": "Boolean",
+      "Invalid JSON": "Enter valid JSON.",
+      "JSON": "JSON",
       "Borrower": "Borrower",
       "Branch": "Branch",
       "Branch Office": "Branch Office",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -1988,6 +1988,8 @@
       "Beneficiary": "Beneficiario",
       "Beneficiary Selection": "Selección de beneficiario",
       "Boolean": "Booleano",
+      "Invalid JSON": "Ingrese un JSON válido.",
+      "JSON": "JSON",
       "Branch": "Sucursal",
       "Branch Office": "Sucursal",
       "Breach": "Incumplimiento",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -1996,6 +1996,8 @@
       "Beneficiary": "Beneficiario",
       "Beneficiary Selection": "Selección de beneficiario",
       "Boolean": "Booleano",
+      "Invalid JSON": "Ingrese un JSON válido.",
+      "JSON": "JSON",
       "Branch": "Sucursal",
       "Branch Office": "Sucursal",
       "Breach": "Incumplimiento",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1991,6 +1991,8 @@
       "Beneficiary": "Bénéficiaire",
       "Beneficiary Selection": "Sélection du bénéficiaire",
       "Boolean": "Booléen",
+      "Invalid JSON": "Saisissez un JSON valide.",
+      "JSON": "JSON",
       "Branch": "Bifurquer",
       "Branch Office": "Succursale",
       "Breach": "Violation",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1988,6 +1988,8 @@
       "Beneficiary": "Beneficiario",
       "Beneficiary Selection": "Selezione beneficiario",
       "Boolean": "Booleano",
+      "Invalid JSON": "Inserisci JSON valido.",
+      "JSON": "JSON",
       "Branch": "Ramo",
       "Branch Office": "Filiale",
       "Breach": "Violazione",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -1989,6 +1989,8 @@
       "Beneficiary": "수익자",
       "Beneficiary Selection": "수익자 선택",
       "Boolean": "부울",
+      "Invalid JSON": "유효한 JSON을 입력하세요.",
+      "JSON": "JSON",
       "Branch": "나뭇가지",
       "Branch Office": "지점",
       "Breach": "위반",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1987,6 +1987,8 @@
       "Beneficiary": "Naudos gavėjas",
       "Beneficiary Selection": "Gavėjo pasirinkimas",
       "Boolean": "Būlio",
+      "Invalid JSON": "Įveskite galiojantį JSON.",
+      "JSON": "JSON",
       "Branch": "Filialas",
       "Branch Office": "Filialas",
       "Breach": "Pažeidimas",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1988,6 +1988,8 @@
       "Beneficiary": "Saņēmējs",
       "Beneficiary Selection": "Saņēmēja izvēle",
       "Boolean": "Būla",
+      "Invalid JSON": "Ievadiet derīgu JSON.",
+      "JSON": "JSON",
       "Branch": "Filiāle",
       "Branch Office": "Filiāle",
       "Breach": "Pārkāpums",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1987,6 +1987,8 @@
       "Beneficiary": "लाभार्थी",
       "Beneficiary Selection": "लाभार्थी चयन",
       "Boolean": "बुलियन",
+      "Invalid JSON": "मान्य JSON प्रविष्ट गर्नुहोस्।",
+      "JSON": "JSON",
       "Branch": "साखा",
       "Branch Office": "साखा कार्यालय",
       "Breach": "उल्लंघन",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1987,6 +1987,8 @@
       "Beneficiary": "Beneficiário",
       "Beneficiary Selection": "Seleção de beneficiário",
       "Boolean": "boleano",
+      "Invalid JSON": "Introduza um JSON válido.",
+      "JSON": "JSON",
       "Branch": "Filial",
       "Branch Office": "Filial",
       "Breach": "Violação",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1985,6 +1985,8 @@
       "Beneficiary": "Anayefaidika",
       "Beneficiary Selection": "Uchaguzi wa Mpokeaji",
       "Boolean": "Boolean",
+      "Invalid JSON": "Weka JSON halali.",
+      "JSON": "JSON",
       "Branch": "Tawi",
       "Branch Office": "Ofisi ya tawi",
       "Breach": "Ukiukaji",


### PR DESCRIPTION
## Description

Adds JSON field support to Data Tables in the Web App, including JSON column creation, multiline input and validation, formatted display, editing, and support across existing Data Table flows.

## Related issues and discussion

WEB-1224

## Screenshots, if any


https://github.com/user-attachments/assets/77072882-bf45-43ee-aae2-54cb422a9cfb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added JSON column support when creating and managing data tables.
  - JSON fields now use formatted, auto-sizing text areas with required-field and invalid-JSON validation.
  - JSON values display as readable structured text in client, loan, and data-table views.
  - JSON values are preserved correctly when saving, editing, sorting, and filtering.
  - Added localized JSON labels and validation messages across supported languages.

- **Tests**
  - Added coverage for JSON validation, formatting, persistence, display, and data-table management workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->