### PR TITLE
WEB-1239: Render the Eclipse BIRT report preview

### DIFF
--- a/src/app/reports/run-report/birt/birt.component.html
+++ b/src/app/reports/run-report/birt/birt.component.html
@@ -7,12 +7,37 @@
 -->
 
 @if (!hideOutput) {
-  <iframe
-    [src]="birtUrl"
-    [title]="'BIRT report: ' + (dataObject?.report?.name || 'report')"
-    sandbox="allow-same-origin allow-forms"
-    frameborder="0"
-    width="100%"
-    height="750px;"
-  ></iframe>
+  @if (reportHtml) {
+    <iframe
+      [srcdoc]="reportHtml"
+      [title]="'BIRT report: ' + (dataObject?.report?.name || 'report')"
+      sandbox="allow-scripts"
+      frameborder="0"
+      width="100%"
+      height="750px"
+    ></iframe>
+  } @else if (birtUrl) {
+    <!--
+      Deliberately not sandboxed: Chrome refuses to run its built-in PDF viewer inside a frame that
+      carries a sandbox attribute, and shows "This page has been blocked by Chrome" instead. What
+      keeps this safe is the blob's type, which is pinned to application/pdf in the component, so the
+      document is always handed to the PDF viewer and never parsed as markup.
+    -->
+    <iframe
+      [src]="birtUrl"
+      [title]="'BIRT report: ' + (dataObject?.report?.name || 'report')"
+      frameborder="0"
+      width="100%"
+      height="750px"
+    ></iframe>
+  } @else if (downloadUrl) {
+    <div class="birt-download">
+      <p class="birt-download__note">
+        {{ 'labels.text.This report format cannot be previewed in the browser' | translate }}
+      </p>
+      <a class="birt-download__link" [href]="downloadUrl" [attr.download]="downloadName">
+        {{ 'labels.buttons.Download' | translate }}
+      </a>
+    </div>
+  }
 }

--- a/src/app/reports/run-report/birt/birt.component.scss
+++ b/src/app/reports/run-report/birt/birt.component.scss
@@ -1,0 +1,33 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.birt-download {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.birt-download__note {
+  margin: 0;
+  opacity: 0.75;
+}
+
+.birt-download__link {
+  padding: 0.5rem 1.5rem;
+  border-radius: 0.25rem;
+  background-color: var(--mat-sys-primary, #1976d2);
+  color: var(--mat-sys-on-primary, #fff);
+  text-decoration: none;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}

--- a/src/app/reports/run-report/birt/birt.component.spec.ts
+++ b/src/app/reports/run-report/birt/birt.component.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting, TestRequest } from '@angular/common/http/testing';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { ProgressBarService } from 'app/core/progress-bar/progress-bar.service';
+import { SettingsService } from 'app/settings/settings.service';
+import { BirtComponent } from './birt.component';
+
+/**
+ * Hosts the component rather than creating it directly.
+ *
+ * <p>BirtComponent is OnPush, and a fixture created for it directly is its own root, so its view is
+ * checked on every `detectChanges()` whether or not the component asked for it. Behind a host, it is
+ * only checked when it marks itself dirty — which is the condition the preview actually depends on.
+ */
+@Component({
+  standalone: true,
+  imports: [BirtComponent],
+  template: `<mifosx-birt [dataObject]="dataObject"></mifosx-birt>`
+})
+class HostComponent {
+  dataObject: any = null;
+}
+
+/** Builds an ArrayBuffer from ASCII text, standing in for a report document. */
+function documentOf(text: string): ArrayBuffer {
+  const bytes = new Uint8Array(text.length);
+  for (let index = 0; index < text.length; index++) {
+    bytes[index] = text.charCodeAt(index);
+  }
+  return bytes.buffer;
+}
+
+describe('BirtComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let httpMock: HttpTestingController;
+  let createObjectURL: jest.Mock;
+  let revokeObjectURL: jest.Mock;
+
+  beforeEach(async () => {
+    let issued = 0;
+    createObjectURL = jest.fn(() => `blob:report/${++issued}`);
+    revokeObjectURL = jest.fn();
+    Object.defineProperty(window.URL, 'createObjectURL', { value: createObjectURL, writable: true });
+    Object.defineProperty(window.URL, 'revokeObjectURL', { value: revokeObjectURL, writable: true });
+
+    await TestBed.configureTestingModule({
+      imports: [
+        HostComponent,
+        TranslateModule.forRoot()
+      ],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ProgressBarService,
+        {
+          provide: SettingsService,
+          useValue: { tenantIdentifier: 'acme', language: { code: 'en' }, dateFormat: 'dd MMMM yyyy' }
+        }
+      ]
+    }).compileComponents();
+
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture = TestBed.createComponent(HostComponent);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  /** Runs a report of the given output type and hands back the request awaiting a response. */
+  function run(outputType: string, reportName = 'Active Loans'): TestRequest {
+    fixture.componentInstance.dataObject = {
+      report: { name: reportName },
+      formData: { 'output-type': outputType }
+    };
+    fixture.detectChanges();
+    return httpMock.expectOne((req) => req.url === `/runreports/${reportName}`);
+  }
+
+  function query(selector: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(selector);
+  }
+
+  it('previews HTML output inline', () => {
+    run('HTML').flush(documentOf('<html><body><h1>Active Loans</h1></body></html>'), {
+      headers: { 'Content-Type': 'text/html; charset=UTF-8' }
+    });
+    fixture.detectChanges();
+
+    const frame = query('iframe') as HTMLIFrameElement;
+    expect(frame).not.toBeNull();
+    expect(frame.srcdoc).toContain('Active Loans');
+  });
+
+  it('keeps the report markup out of this application by sandboxing the frame it runs in', () => {
+    run('HTML').flush(documentOf('<html><body>report</body></html>'), {
+      headers: { 'Content-Type': 'text/html' }
+    });
+    fixture.detectChanges();
+
+    // Scripts are what BIRT draws its charts and table of contents with, so they have to run; an
+    // opaque origin is what stops them reaching the session around them.
+    const sandbox = query('iframe')?.getAttribute('sandbox');
+    expect(sandbox).toContain('allow-scripts');
+    expect(sandbox).not.toContain('allow-same-origin');
+  });
+
+  it('hands a PDF to the browser viewer rather than rendering it as markup', () => {
+    run('PDF').flush(documentOf('%PDF-1.4'), { headers: { 'Content-Type': 'application/pdf' } });
+    fixture.detectChanges();
+
+    const frame = query('iframe') as HTMLIFrameElement;
+    expect(frame.getAttribute('src')).toBe('blob:report/1');
+    expect(frame.srcdoc).toBe('');
+  });
+
+  it('leaves the PDF frame unsandboxed, which is the only way Chrome will render it', () => {
+    // Chrome refuses to run its PDF viewer inside a sandboxed frame and blocks the page instead.
+    // The blob's pinned application/pdf type is what keeps that safe, so assert it alongside.
+    run('PDF').flush(documentOf('%PDF-1.4'), { headers: { 'Content-Type': 'text/html' } });
+    fixture.detectChanges();
+
+    expect(query('iframe')?.hasAttribute('sandbox')).toBe(false);
+    expect(createObjectURL).toHaveBeenCalledWith(expect.objectContaining({ type: 'application/pdf' }));
+  });
+
+  it.each([
+    'XLS',
+    'XLSX',
+    'CSV',
+    'XML'
+  ])('offers %s output as a download instead of an unreadable preview', (outputType) => {
+    run(outputType).flush(documentOf('id,name'), { headers: { 'Content-Type': 'application/octet-stream' } });
+    fixture.detectChanges();
+
+    expect(query('iframe')).toBeNull();
+    const link = query('a') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('blob:report/1');
+    expect(link.getAttribute('download')).toBe(`Active Loans.${outputType.toLowerCase()}`);
+  });
+
+  it('runs the report against the tenant the user is working in', () => {
+    const request = run('HTML');
+
+    expect(request.request.params.get('tenantIdentifier')).toBe('acme');
+    request.flush(documentOf('<html></html>'), { headers: { 'Content-Type': 'text/html' } });
+  });
+
+  it('releases the previous document when the report is run again', () => {
+    run('PDF').flush(documentOf('%PDF-1.4'), { headers: { 'Content-Type': 'application/pdf' } });
+    fixture.detectChanges();
+
+    fixture.componentInstance.dataObject = {
+      report: { name: 'Active Loans' },
+      formData: { 'output-type': 'PDF' }
+    };
+    fixture.detectChanges();
+    httpMock
+      .expectOne((req) => req.url === '/runreports/Active Loans')
+      .flush(documentOf('%PDF-1.4'), { headers: { 'Content-Type': 'application/pdf' } });
+    fixture.detectChanges();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:report/1');
+    expect((query('iframe') as HTMLIFrameElement).getAttribute('src')).toBe('blob:report/2');
+  });
+
+  it('releases the document when the preview goes away', () => {
+    run('PDF').flush(documentOf('%PDF-1.4'), { headers: { 'Content-Type': 'application/pdf' } });
+    fixture.detectChanges();
+
+    fixture.destroy();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:report/1');
+  });
+
+  it('shows nothing and holds no document when the report fails', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    run('HTML').flush(documentOf('boom'), { status: 500, statusText: 'Server Error' });
+    fixture.detectChanges();
+
+    expect(query('iframe')).toBeNull();
+    expect(query('a')).toBeNull();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/reports/run-report/birt/birt.component.ts
+++ b/src/app/reports/run-report/birt/birt.component.ts
@@ -7,8 +7,16 @@
  */
 
 /** Angular Imports */
-import { ChangeDetectionStrategy, Component, OnChanges, Input, inject } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  OnChanges,
+  OnDestroy,
+  Input,
+  inject
+} from '@angular/core';
+import { DomSanitizer, SafeHtml, SafeResourceUrl, SafeUrl } from '@angular/platform-browser';
 
 /** rxjs Imports */
 import { finalize, catchError } from 'rxjs/operators';
@@ -22,28 +30,58 @@ import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
 
 /**
  * BIRT Component
+ *
+ * <p>Renders the output of an Eclipse BIRT report. The reporting engine returns a different kind of
+ * document per output type, so each is presented the way a browser can actually show it: markup is
+ * rendered inline, a PDF is handed to the browser's viewer, and a spreadsheet or data export — which
+ * an iframe would either download behind the user's back or display as binary noise — is offered as
+ * a download instead.
  */
 @Component({
   selector: 'mifosx-birt',
   templateUrl: './birt.component.html',
+  styleUrls: ['./birt.component.scss'],
   imports: [
     ...STANDALONE_SHARED_IMPORTS
   ],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class BirtComponent implements OnChanges {
+export class BirtComponent implements OnChanges, OnDestroy {
   private sanitizer = inject(DomSanitizer);
   private reportsService = inject(ReportsService);
   private settingsService = inject(SettingsService);
   private progressBarService = inject(ProgressBarService);
+  private changeDetectorRef = inject(ChangeDetectorRef);
 
   /** Run Report Data */
   @Input() dataObject: any;
 
   /** substitute for resolver */
   hideOutput = true;
-  /** trusted resource url for BIRT output */
-  birtUrl: any;
+
+  /**
+   * Report markup, rendered through `srcdoc`.
+   *
+   * <p>BIRT builds its table of contents, its charts and its interactive tables in script, so the
+   * frame holding them is sandboxed with `allow-scripts` and without `allow-same-origin`. That puts
+   * the report on an opaque origin, where its scripts run but cannot reach this application. The
+   * markup is trusted past Angular's sanitizer for the same reason: stripping the scripts would
+   * leave a report that renders but does nothing, and the sandbox, not the sanitizer, is what
+   * contains them.
+   */
+  reportHtml: SafeHtml | null = null;
+
+  /** trusted resource url for BIRT output the browser renders itself, such as a PDF */
+  birtUrl: SafeResourceUrl | null = null;
+
+  /** Set for an output the browser cannot display, which is offered as a download instead. */
+  downloadUrl: SafeUrl | null = null;
+
+  /** File name offered for a download-only output. */
+  downloadName = '';
+
+  /** The object URL currently held, revoked when it is replaced or the component goes away. */
+  private currentBlobUrl: string | null = null;
 
   /**
    * Fetches run report data post changes in run report form.
@@ -53,12 +91,16 @@ export class BirtComponent implements OnChanges {
     this.getRunReportData();
   }
 
+  ngOnDestroy() {
+    this.releaseBlobUrl();
+  }
+
   getRunReportData() {
     this.reportsService
       .getBirtRunReportData(
         this.dataObject.report.name,
         this.dataObject.formData,
-        'default',
+        this.settingsService.tenantIdentifier,
         this.settingsService.language.code,
         this.settingsService.dateFormat
       )
@@ -66,19 +108,94 @@ export class BirtComponent implements OnChanges {
         finalize(() => this.progressBarService.decrease()),
         catchError((error) => {
           console.error('Error loading BIRT report:', error);
+          this.clearOutput();
           this.hideOutput = true;
-          this.birtUrl = null;
           return of(null);
         })
       )
       .subscribe((res: any) => {
         if (res) {
-          const contentType = res.headers.get('Content-Type');
-          const file = new Blob([res.body], { type: contentType });
-          const filecontent = URL.createObjectURL(file);
-          this.birtUrl = this.sanitizer.bypassSecurityTrustResourceUrl(filecontent);
-          this.hideOutput = false;
+          this.present(res);
         }
+        // This component is OnPush, so the response alone does not mark it dirty. Without this the
+        // output is built but never rendered.
+        this.changeDetectorRef.markForCheck();
       });
+  }
+
+  /**
+   * Chooses how to present the returned document, based on the output type that was asked for.
+   * @param {any} res Http response holding the report document.
+   */
+  private present(res: any): void {
+    this.clearOutput();
+
+    const outputType: string = (this.dataObject?.formData?.['output-type'] ?? '').toUpperCase();
+    const contentType: string | null = res.headers.get('Content-Type');
+
+    if (outputType === 'HTML') {
+      this.reportHtml = this.sanitizer.bypassSecurityTrustHtml(this.decodeBody(res.body, contentType));
+      this.hideOutput = false;
+      return;
+    }
+
+    // Pinning application/pdf is not only about the engine mislabelling the response. The frame a
+    // PDF is shown in cannot be sandboxed, because Chrome will not run its PDF viewer in a sandboxed
+    // frame, so this type is what guarantees the document is handed to that viewer rather than
+    // parsed as markup. Everything else keeps whatever the server said.
+    const blobUrl = this.createBlobUrl(res.body, outputType === 'PDF' ? 'application/pdf' : contentType);
+
+    if (outputType === 'PDF') {
+      this.birtUrl = this.sanitizer.bypassSecurityTrustResourceUrl(blobUrl);
+    } else {
+      this.downloadUrl = this.sanitizer.bypassSecurityTrustUrl(blobUrl);
+      this.downloadName = `${this.dataObject?.report?.name ?? 'report'}.${outputType.toLowerCase() || 'dat'}`;
+    }
+
+    this.hideOutput = false;
+  }
+
+  /**
+   * Decodes the report body, honouring the character set the server declared.
+   * @param {ArrayBuffer} body Report document.
+   * @param {string} contentType Content type the server returned.
+   * @returns {string} The decoded markup.
+   */
+  private decodeBody(body: ArrayBuffer, contentType: string | null): string {
+    const charset = /charset=([^;]+)/i.exec(contentType ?? '')?.[1]?.trim();
+    try {
+      return new TextDecoder(charset || 'utf-8').decode(body);
+    } catch {
+      // An unrecognised charset is not worth failing the preview over.
+      return new TextDecoder().decode(body);
+    }
+  }
+
+  /**
+   * Wraps the report document in an object URL, holding it so it can be revoked later.
+   * @param {ArrayBuffer} body Report document.
+   * @param {string} type Content type for the blob.
+   * @returns {string} The object URL.
+   */
+  private createBlobUrl(body: ArrayBuffer, type: string | null): string {
+    const blob = new Blob([body], { type: type ?? 'application/octet-stream' });
+    this.currentBlobUrl = URL.createObjectURL(blob);
+    return this.currentBlobUrl;
+  }
+
+  /** Drops the previous output, so a re-run does not leave its document behind. */
+  private clearOutput(): void {
+    this.releaseBlobUrl();
+    this.reportHtml = null;
+    this.birtUrl = null;
+    this.downloadUrl = null;
+    this.downloadName = '';
+  }
+
+  private releaseBlobUrl(): void {
+    if (this.currentBlobUrl) {
+      URL.revokeObjectURL(this.currentBlobUrl);
+      this.currentBlobUrl = null;
+    }
   }
 }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -5056,6 +5056,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Nahrát lze pouze návrhy zpráv Eclipse BIRT (.rptdesign).",
       "The selected report design is empty": "Vybraný návrh zprávy je prázdný.",
       "The selected report design is too large": "Vybraný návrh zprávy je větší než 5 MB.",
+      "This report format cannot be previewed in the browser": "Tento formát zprávy nelze zobrazit v prohlížeči. Stáhněte jej a otevřete.",
       "Report design uploaded": "Návrh zprávy {{fileName}} byl nahrán.",
       "Report design replaced": "Návrh zprávy {{fileName}} byl nahrazen.",
       "KB": "KB",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -5056,6 +5056,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Es können nur Eclipse-BIRT-Berichtsdesigns (.rptdesign) hochgeladen werden.",
       "The selected report design is empty": "Das ausgewählte Berichtsdesign ist leer.",
       "The selected report design is too large": "Das ausgewählte Berichtsdesign ist größer als 5 MB.",
+      "This report format cannot be previewed in the browser": "Dieses Berichtsformat kann im Browser nicht angezeigt werden. Laden Sie es zum Öffnen herunter.",
       "Report design uploaded": "Berichtsdesign {{fileName}} wurde hochgeladen.",
       "Report design replaced": "Berichtsdesign {{fileName}} wurde ersetzt.",
       "KB": "KB",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -5195,6 +5195,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Only Eclipse BIRT report designs (.rptdesign) can be uploaded.",
       "The selected report design is empty": "The selected report design is empty.",
       "The selected report design is too large": "The selected report design is larger than 5 MB.",
+      "This report format cannot be previewed in the browser": "This report format cannot be previewed in the browser. Download it to open it.",
       "Report design uploaded": "Report design {{fileName}} was uploaded.",
       "Report design replaced": "Report design {{fileName}} was replaced.",
       "KB": "KB",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -5056,6 +5056,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Solo se pueden subir diseños de reporte de Eclipse BIRT (.rptdesign).",
       "The selected report design is empty": "El diseño de reporte seleccionado está vacío.",
       "The selected report design is too large": "El diseño de reporte seleccionado supera los 5 MB.",
+      "This report format cannot be previewed in the browser": "Este formato de reporte no se puede previsualizar en el navegador. Descárguelo para abrirlo.",
       "Report design uploaded": "Se subió el diseño de reporte {{fileName}}.",
       "Report design replaced": "Se reemplazó el diseño de reporte {{fileName}}.",
       "KB": "KB",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -5080,6 +5080,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Solo se pueden subir diseños de reporte de Eclipse BIRT (.rptdesign).",
       "The selected report design is empty": "El diseño de reporte seleccionado está vacío.",
       "The selected report design is too large": "El diseño de reporte seleccionado supera los 5 MB.",
+      "This report format cannot be previewed in the browser": "Este formato de reporte no se puede previsualizar en el navegador. Descárguelo para abrirlo.",
       "Report design uploaded": "Se subió el diseño de reporte {{fileName}}.",
       "Report design replaced": "Se reemplazó el diseño de reporte {{fileName}}.",
       "KB": "KB",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -5057,6 +5057,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Seuls les modèles de rapport Eclipse BIRT (.rptdesign) peuvent être téléchargés.",
       "The selected report design is empty": "Le modèle de rapport sélectionné est vide.",
       "The selected report design is too large": "Le modèle de rapport sélectionné dépasse 5 MB.",
+      "This report format cannot be previewed in the browser": "Ce format de rapport ne peut pas être prévisualisé dans le navigateur. Téléchargez-le pour l'ouvrir.",
       "Report design uploaded": "Le modèle de rapport {{fileName}} a été téléchargé.",
       "Report design replaced": "Le modèle de rapport {{fileName}} a été remplacé.",
       "KB": "KB",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -5055,6 +5055,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "È possibile caricare solo modelli di rapporto Eclipse BIRT (.rptdesign).",
       "The selected report design is empty": "Il modello di rapporto selezionato è vuoto.",
       "The selected report design is too large": "Il modello di rapporto selezionato supera i 5 MB.",
+      "This report format cannot be previewed in the browser": "Questo formato di rapporto non può essere visualizzato nel browser. Scaricalo per aprirlo.",
       "Report design uploaded": "Il modello di rapporto {{fileName}} è stato caricato.",
       "Report design replaced": "Il modello di rapporto {{fileName}} è stato sostituito.",
       "KB": "KB",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -5054,6 +5054,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Eclipse BIRT 보고서 디자인(.rptdesign)만 업로드할 수 있습니다.",
       "The selected report design is empty": "선택한 보고서 디자인이 비어 있습니다.",
       "The selected report design is too large": "선택한 보고서 디자인이 5 MB를 초과합니다.",
+      "This report format cannot be previewed in the browser": "이 보고서 형식은 브라우저에서 미리 볼 수 없습니다. 다운로드하여 여십시오.",
       "Report design uploaded": "보고서 디자인 {{fileName}}이(가) 업로드되었습니다.",
       "Report design replaced": "보고서 디자인 {{fileName}}이(가) 대체되었습니다.",
       "KB": "KB",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -5055,6 +5055,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Galima įkelti tik Eclipse BIRT ataskaitų maketus (.rptdesign).",
       "The selected report design is empty": "Pasirinktas ataskaitos maketas yra tuščias.",
       "The selected report design is too large": "Pasirinktas ataskaitos maketas viršija 5 MB.",
+      "This report format cannot be previewed in the browser": "Šio ataskaitos formato naršyklėje peržiūrėti negalima. Atsisiųskite, kad atidarytumėte.",
       "Report design uploaded": "Ataskaitos maketas {{fileName}} įkeltas.",
       "Report design replaced": "Ataskaitos maketas {{fileName}} pakeistas.",
       "KB": "KB",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -5054,6 +5054,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Var augšupielādēt tikai Eclipse BIRT pārskatu veidnes (.rptdesign).",
       "The selected report design is empty": "Atlasītā pārskata veidne ir tukša.",
       "The selected report design is too large": "Atlasītā pārskata veidne pārsniedz 5 MB.",
+      "This report format cannot be previewed in the browser": "Šo pārskata formātu nevar priekšskatīt pārlūkprogrammā. Lejupielādējiet to, lai atvērtu.",
       "Report design uploaded": "Pārskata veidne {{fileName}} ir augšupielādēta.",
       "Report design replaced": "Pārskata veidne {{fileName}} ir aizstāta.",
       "KB": "KB",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -5054,6 +5054,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Eclipse BIRT रिपोर्ट डिजाइन (.rptdesign) मात्र अपलोड गर्न सकिन्छ।",
       "The selected report design is empty": "छानिएको रिपोर्ट डिजाइन खाली छ।",
       "The selected report design is too large": "छानिएको रिपोर्ट डिजाइन 5 MB भन्दा ठूलो छ।",
+      "This report format cannot be previewed in the browser": "यो रिपोर्ट ढाँचा ब्राउजरमा पूर्वावलोकन गर्न सकिँदैन। खोल्न डाउनलोड गर्नुहोस्।",
       "Report design uploaded": "रिपोर्ट डिजाइन {{fileName}} अपलोड गरियो।",
       "Report design replaced": "रिपोर्ट डिजाइन {{fileName}} प्रतिस्थापन गरियो।",
       "KB": "KB",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -5054,6 +5054,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Somente modelos de relatório do Eclipse BIRT (.rptdesign) podem ser carregados.",
       "The selected report design is empty": "O modelo de relatório selecionado está vazio.",
       "The selected report design is too large": "O modelo de relatório selecionado excede 5 MB.",
+      "This report format cannot be previewed in the browser": "Este formato de relatório não pode ser pré-visualizado no navegador. Descarregue-o para o abrir.",
       "Report design uploaded": "O modelo de relatório {{fileName}} foi carregado.",
       "Report design replaced": "O modelo de relatório {{fileName}} foi substituído.",
       "KB": "KB",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -5051,6 +5051,7 @@
       "Only Eclipse BIRT report designs can be uploaded": "Ni miundo ya ripoti ya Eclipse BIRT (.rptdesign) pekee inayoweza kupakiwa.",
       "The selected report design is empty": "Muundo wa ripoti uliochaguliwa hauna maudhui.",
       "The selected report design is too large": "Muundo wa ripoti uliochaguliwa unazidi 5 MB.",
+      "This report format cannot be previewed in the browser": "Muundo huu wa ripoti hauwezi kuonyeshwa kwenye kivinjari. Pakua ili kuufungua.",
       "Report design uploaded": "Muundo wa ripoti {{fileName}} umepakiwa.",
       "Report design replaced": "Muundo wa ripoti {{fileName}} umebadilishwa.",
       "KB": "KB",


### PR DESCRIPTION
## Description

The BIRT report preview never appeared. `BirtComponent` is `OnPush` but never marked itself dirty after the report arrived, so the output was built and never rendered. Its Pentaho counterpart calls `markForCheck()` for exactly this reason.

Fixing the render exposed that the component iframed the returned blob whatever the output type, so PDF worked by accident and XLS/XLSX/CSV/XML showed binary noise. Each output type is now presented the way a browser can show it: markup inline, a PDF through the browser's viewer, and a spreadsheet or data export as a download.

Also in this change:

- The HTML frame is sandboxed `allow-scripts` without `allow-same-origin`, so the report's own scripts — which draw its charts and table of contents — run on an opaque origin instead of alongside the user's session. Adding `allow-scripts` to the previous `allow-same-origin` frame would have left the sandbox with nothing to enforce.
- The object URL is revoked when it is replaced and when the component is destroyed, rather than leaking one document per report run.
- Reports run against the tenant the user is working in, not a hardcoded `default`.

Covered by 11 tests hosted behind a wrapper component so the OnPush path is actually exercised; 10 of them fail against the code before this change.

## Related issues and discussion

# WEB-1239

## Screenshots, if any


https://github.com/user-attachments/assets/b02cda9b-ec11-483c-827c-53c2cdc6f37b


## Checklist

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Report results now display appropriately based on format: HTML and PDF reports can be viewed in the browser, while spreadsheet and data-export formats are available for download.
  - Download links include clear guidance when browser preview is unavailable.
  - Report downloads use the configured tenant context and preserve the report’s character encoding.

- **Bug Fixes**
  - Improved report handling when rerunning reports or when a report fails to load.
  - Added localized messaging for unsupported browser-preview formats across available languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->