### PR TITLE
WEB-1099: Strip hierarchy dots from report select option names

### DIFF
--- a/src/app/reports/common-models/select-option.model.ts
+++ b/src/app/reports/common-models/select-option.model.ts
@@ -8,11 +8,14 @@
 
 /** Select Option model */
 export class SelectOption {
-  id: number;
-  name: string;
+  /** Report SQL picks the value column, so an id can be a code such as 'USD'. */
+  id: number | string;
+  name: string | number;
 
   constructor(options: any[]) {
     this.id = options[0];
-    this.name = options[1];
+    // Fineract's report SQL indents option names with four dots per hierarchy level
+    // (e.g. "........Dubai Branch"), which a mat-option renders literally.
+    this.name = typeof options[1] === 'string' ? options[1].replace(/^\.+/, '') : options[1];
   }
 }

--- a/src/app/reports/reports.service.spec.ts
+++ b/src/app/reports/reports.service.spec.ts
@@ -11,6 +11,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { TestBed } from '@angular/core/testing';
 
 import { ReportsService } from './reports.service';
+import { SelectOption } from './common-models/select-option.model';
 
 describe('ReportsService report output formats', () => {
   let service: ReportsService;
@@ -31,6 +32,76 @@ describe('ReportsService report output formats', () => {
 
   afterEach(() => {
     httpMock.verify();
+  });
+
+  it('strips the hierarchy dots Fineract prefixes onto office names', () => {
+    let options: SelectOption[];
+    service.getSelectOptions('OfficeIdSelectOne').subscribe((response) => (options = response));
+
+    httpMock
+      .expectOne((request) => request.url === '/runreports/OfficeIdSelectOne')
+      .flush({
+        data: [
+          { row: [
+              1,
+              'Head Office'
+            ] },
+          { row: [
+              2,
+              '....Saudi Branch'
+            ] },
+          { row: [
+              3,
+              '........Dubai Branch'
+            ] }
+        ]
+      });
+
+    expect(options.map((option) => option.name)).toEqual([
+      'Head Office',
+      'Saudi Branch',
+      'Dubai Branch'
+    ]);
+    expect(options.map((option) => option.id)).toEqual([
+      1,
+      2,
+      3
+    ]);
+  });
+
+  it('leaves names without leading dots and non-string names untouched', () => {
+    let options: SelectOption[];
+    service.getSelectOptions('currencyIdSelectAll').subscribe((response) => (options = response));
+
+    httpMock
+      .expectOne((request) => request.url === '/runreports/currencyIdSelectAll')
+      .flush({
+        data: [
+          { row: [
+              'USD',
+              'US Dollar'
+            ] },
+          { row: [
+              'XOF',
+              'CFA Franc B.C.E.A.O.'
+            ] },
+          { row: [
+              -10,
+              10
+            ] }
+        ]
+      });
+
+    expect(options.map((option) => option.name)).toEqual([
+      'US Dollar',
+      'CFA Franc B.C.E.A.O.',
+      10
+    ]);
+    expect(options.map((option) => option.id)).toEqual([
+      'USD',
+      'XOF',
+      -10
+    ]);
   });
 
   it('sends XML as the selected Pentaho output type', () => {


### PR DESCRIPTION
## Description

Office names in report parameter dropdowns show up with leading dots — `........Dubai Branch` in Reports > Active Loans - Summary. The dots come from Fineract's `OfficeIdSelectOne` stretchy parameter, which indents each name by four dots per hierarchy level:

```sql
select id,
concat(substring("........................................", 1,
   ((LENGTH(`hierarchy`) - LENGTH(REPLACE(`hierarchy`, '.', '')) - 1) * 4)),
   `name`) as tc
from m_office
where hierarchy like concat('${currentUserHierarchy}', '%')
order by hierarchy
```

That was meant as indentation for a native `<select>`. A `mat-option` renders it as literal dots.

The fix strips the leading dots in `SelectOption`, which is the only place the `/runreports/...` rows become dropdown options — `ReportsService.getSelectOptions()` is its sole constructor call, and all three consumers (Run Report, and both SMS campaign business-rule steppers) go through it. So every report select parameter is covered, not just Office.

Two things worth noting:

- `name` is display-only. Templates bind `[value]="option"` and the form submission reads `option.id`, so the stripped string never reaches the API.
- Row order is untouched. The SQL orders by `hierarchy`, so parents still sort above their children — only the dot indentation is gone, not the grouping.

Non-string values pass through unchanged, since report SQL can return a number in the name column.

## Related issues and discussion

- [WEB-1099](https://mifosforge.jira.com/browse/WEB-1099)
- Supersedes #3792

## Tests

Added two cases to `src/app/reports/reports.service.spec.ts`, going through the service so the actual dropdown path is exercised rather than the constructor alone:

- office rows at 0, 4 and 8 dots render as `Head Office` / `Saudi Branch` / `Dubai Branch`, with ids preserved
- names with no leading dots, internal dots (`CFA Franc B.C.E.A.O.`) and non-string values are left alone

Verified the first one fails on `dev` without the model change.

```
npx jest --config jest.config.ts src/app/reports/reports.service.spec.ts
Tests: 4 passed, 4 total
```

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.
- [x] Read and understood the contribution guidelines at `web-app/.github/CONTRIBUTING.md`.

[WEB-1099]: https://mifosforge.jira.com/browse/WEB-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Office names in report selection options no longer display leading hierarchy dots.
  * Ordinary names and numeric values remain unchanged.
  * Option IDs continue to be preserved, including text-based codes such as currency codes.
  * Report selection options now support names and IDs represented as either text or numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->