### PR TITLE
WEB-1101: Translate the withhold tax and annual fee account menu items

### DIFF
--- a/src/app/core/translation/web-1101-account-menu-translations.spec.ts
+++ b/src/app/core/translation/web-1101-account-menu-translations.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { CustomMissingTranslationHandler } from './missing-translation.handler';
+
+/**
+ * WEB-1101: the savings, fixed deposit, recurring deposit and shares account menus render every
+ * entry as `labels.menus.<option name>` — the savings and recurring deposit templates concatenate
+ * the prefix, the fixed deposit and shares ones go through `translateKey: 'menus'`, which builds
+ * the same key. The option name is therefore an implicit translation key, and a name with no entry
+ * under `labels.menus` reaches the operator as the raw key: `labels.menus.Disable Withhold Tax`.
+ *
+ * Nothing catches that at build time, and no locale falls back to English — the app only ever calls
+ * `TranslateService.use()`, never `setDefaultLang` — so a missing key is visible in all 13 locales.
+ */
+
+const locales = [
+  'cs-CS',
+  'de-DE',
+  'en-US',
+  'es-CL',
+  'es-MX',
+  'fr-FR',
+  'it-IT',
+  'ko-KO',
+  'lt-LT',
+  'lv-LV',
+  'ne-NE',
+  'pt-PT',
+  'sw-SW'
+];
+
+/** The menu names WEB-1101 added. Kept explicit so a locale dropping one is a named failure. */
+const web1101MenuNames = [
+  'Apply Annual Fees',
+  'Disable Withhold Tax',
+  'Enable Withhold Tax'
+];
+
+/** Every file that names an entry of those four account menus. */
+const menuSources = [
+  'src/app/savings/savings-account-view/savings-buttons.config.ts',
+  'src/app/savings/savings-account-view/savings-account-view.component.ts',
+  'src/app/deposits/recurring-deposits/recurring-deposits-account-view/recurring-deposits-buttons.config.ts',
+  'src/app/deposits/recurring-deposits/recurring-deposits-account-view/recurring-deposits-account-view.component.ts',
+  'src/app/deposits/fixed-deposits/fixed-deposit-account-view/fixed-deposits-buttons.config.ts',
+  'src/app/deposits/fixed-deposits/fixed-deposit-account-view/fixed-deposit-account-view.component.ts',
+  'src/app/shares/shares-account-view/shares-buttons.config.ts',
+  'src/app/shares/shares-account-view/shares-account-view.component.ts'
+];
+
+/** The two menu entries whose click opens a confirmation titled by `labels.heading.<same name>`. */
+const withholdTaxNames = [
+  'Disable Withhold Tax',
+  'Enable Withhold Tax'
+];
+
+function labelsFor(locale: string): Record<string, Record<string, string>> {
+  return JSON.parse(readFileSync(join(process.cwd(), 'src/assets/translations', `${locale}.json`), 'utf8')).labels;
+}
+
+function menusSection(locale: string): Record<string, string> {
+  return labelsFor(locale).menus;
+}
+
+/**
+ * Reads the option names out of the source text rather than instantiating the configurations: the
+ * two names this ticket is about are not in a configuration class at all, the account view
+ * components add them behind a `taxGroup` / `charges` condition, so only the source carries the
+ * full set.
+ */
+function declaredMenuNames(): string[] {
+  const names = menuSources.flatMap((source) =>
+    Array.from(readFileSync(join(process.cwd(), source), 'utf8').matchAll(/name:\s*'([^']+)'/g)).map(
+      (match) => match[1]
+    )
+  );
+  return Array.from(new Set(names)).sort();
+}
+
+describe('WEB-1101 account menu translations', () => {
+  it.each(locales)('defines every WEB-1101 menu label for %s', (locale: string) => {
+    const menus = menusSection(locale);
+
+    web1101MenuNames.forEach((name) => {
+      expect(menus[name]).toBeTruthy();
+    });
+  });
+
+  /**
+   * The withhold tax entries open a confirmation dialog whose title comes from `labels.heading`
+   * under the same name (`recurring-deposits-account-view.component.ts:315,339`). Wording that
+   * drifts between the two reads as a different action in the dialog than the one clicked, so the
+   * menu label and the dialog title are pinned to each other rather than to a fixed string.
+   */
+  it.each(locales)('titles the confirmation the way the menu item reads for %s', (locale: string) => {
+    const labels = labelsFor(locale);
+
+    withholdTaxNames.forEach((name) => {
+      expect(labels.menus[name]).toBe(labels.heading[name]);
+    });
+  });
+
+  it('gives every account menu option an English label', () => {
+    const menus = menusSection('en-US');
+
+    expect(declaredMenuNames().filter((name) => !menus[name])).toEqual([]);
+  });
+
+  /**
+   * Why a missing key is user-visible rather than degrading to the bare name: the handler unwraps
+   * `labels.catalogs.` only, because that namespace is keyed by Fineract's own enum values. Every
+   * other namespace, `labels.menus` included, surfaces the key itself.
+   */
+  it('shows a missing menu key to the operator verbatim', () => {
+    const handler = new CustomMissingTranslationHandler();
+
+    expect(handler.handle({ key: 'labels.menus.Disable Withhold Tax' } as any)).toBe(
+      'labels.menus.Disable Withhold Tax'
+    );
+  });
+});

--- a/src/app/shares/shares-account-view/shares-account-view.component.ts
+++ b/src/app/shares/shares-account-view/shares-account-view.component.ts
@@ -121,7 +121,7 @@ export class SharesAccountViewComponent implements OnInit {
       charges.forEach((charge: any) => {
         if (charge.name === 'Annual fee - INR') {
           this.buttonConfig.addOption({
-            name: 'Apply Anuual Fees',
+            name: 'Apply Annual Fees',
             taskPermissionName: 'APPLYANNUALFEE_SAVINGSACCOUNT'
           });
         }

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -1351,7 +1351,7 @@
       "Deposit Period": "Doba vkladu",
       "Details": "Podrobnosti",
       "Disable": "Zakázat",
-      "Disable Withhold Tax": "Zakázat zadržení daně",
+      "Disable Withhold Tax": "Zakázat srážkovou daň",
       "Do you want to mark the Customer Data as valid?": "Chcete označit údaje zákazníka jako platné?",
       "Documents": "Dokumenty",
       "Down Payment": "Záloha",
@@ -1365,7 +1365,7 @@
       "Email External Service": "E-mailová externí služba",
       "Employees": "Zaměstnanci",
       "Enable": "Umožnit",
-      "Enable Withhold Tax": "Povolit zadrženou daň",
+      "Enable Withhold Tax": "Povolit srážkovou daň",
       "Entity Data Table Checks": "Kontroly tabulky dat entit",
       "Entity Details": "Detaily entity",
       "Entity to Entity Mapping": "Mapování entity na entitu",
@@ -3829,6 +3829,9 @@
       "Working with Code": "Práce s kódem"
     },
     "menus": {
+      "Apply Annual Fees": "Uplatnit roční poplatky",
+      "Disable Withhold Tax": "Zakázat srážkovou daň",
+      "Enable Withhold Tax": "Povolit srážkovou daň",
       "Mark as Fraud": "Označit jako podvod",
       "Unmark as Fraud": "Zrušit označení podvodu",
       "Update Breach": "Aktualizovat porušení",

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -1365,7 +1365,7 @@
       "Email External Service": "E-Mail an externen Dienst",
       "Employees": "Mitarbeiter",
       "Enable": "Aktivieren",
-      "Enable Withhold Tax": "Ermöglichen Sie die Quellensteuer",
+      "Enable Withhold Tax": "Aktivieren Sie die Quellensteuer",
       "Entity Data Table Checks": "Überprüfungen der Entitätsdatentabelle",
       "Entity Details": "Entitätsdetails",
       "Entity to Entity Mapping": "Zuordnung von Entität zu Entität",
@@ -3830,6 +3830,9 @@
       "Working with Code": "Arbeiten mit Code"
     },
     "menus": {
+      "Apply Annual Fees": "Jahresgebühren anwenden",
+      "Disable Withhold Tax": "Deaktivieren Sie die Quellensteuer",
+      "Enable Withhold Tax": "Aktivieren Sie die Quellensteuer",
       "Mark as Fraud": "Als Betrug markieren",
       "Unmark as Fraud": "Betrugsmarkierung aufheben",
       "Update Breach": "Verstoß aktualisieren",

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3852,6 +3852,9 @@
       "Working with Code": "Working with Code"
     },
     "menus": {
+      "Apply Annual Fees": "Apply Annual Fees",
+      "Disable Withhold Tax": "Disable Withhold Tax",
+      "Enable Withhold Tax": "Enable Withhold Tax",
       "Mark as Fraud": "Mark as Fraud",
       "Unmark as Fraud": "Unmark as Fraud",
       "Update Breach": "Update Breach",

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3829,6 +3829,9 @@
       "Working with Code": "Trabajar con código"
     },
     "menus": {
+      "Apply Annual Fees": "Aplicar comisiones anuales",
+      "Disable Withhold Tax": "Desactivar retención de impuestos",
+      "Enable Withhold Tax": "Habilitar retención de impuestos",
       "Mark as Fraud": "Marcar como Fraude",
       "Unmark as Fraud": "Desmarcar como Fraude",
       "Update Breach": "Actualizar Incumplimiento",

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3834,6 +3834,9 @@
       "Working with Code": "Trabajar con código"
     },
     "menus": {
+      "Apply Annual Fees": "Aplicar comisiones anuales",
+      "Disable Withhold Tax": "Desactivar retención de impuestos",
+      "Enable Withhold Tax": "Habilitar retención de impuestos",
       "Mark as Fraud": "Marcar como Fraude",
       "Unmark as Fraud": "Desmarcar como Fraude",
       "Update Breach": "Actualizar Incumplimiento",

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -1352,7 +1352,7 @@
       "Deposit Period": "Période de dépôt",
       "Details": "Détails",
       "Disable": "Désactiver",
-      "Disable Withhold Tax": "Désactiver la retenue des impôts",
+      "Disable Withhold Tax": "Désactiver la retenue à la source",
       "Do you want to mark the Customer Data as valid?": "Voulez-vous marquer les données client comme valides?",
       "Documents": "Documents",
       "Down Payment": "Acompte",
@@ -1366,7 +1366,7 @@
       "Email External Service": "Service externe par courrier électronique",
       "Employees": "Employés",
       "Enable": "Activer",
-      "Enable Withhold Tax": "Activer la taxe de retenue",
+      "Enable Withhold Tax": "Activer la retenue à la source",
       "Entity Data Table Checks": "Vérifications du tableau de données d'entité",
       "Entity Details": "Détails de l'entité",
       "Entity to Entity Mapping": "Mappage d’entité à entité",
@@ -3831,6 +3831,9 @@
       "Working with Code": "Travailler avec du code"
     },
     "menus": {
+      "Apply Annual Fees": "Appliquer les frais annuels",
+      "Disable Withhold Tax": "Désactiver la retenue à la source",
+      "Enable Withhold Tax": "Activer la retenue à la source",
       "Mark as Fraud": "Marquer comme fraude",
       "Unmark as Fraud": "Retirer la marque de fraude",
       "Update Breach": "Mettre à jour la violation",

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -1349,7 +1349,7 @@
       "Deposit Period": "Periodo di deposito",
       "Details": "Dettagli",
       "Disable": "disattivare",
-      "Disable Withhold Tax": "Disabilitare la ritenuta a trattenere l'imposta",
+      "Disable Withhold Tax": "Disabilita la ritenuta d'acconto",
       "Do you want to mark the Customer Data as valid?": "Vuoi contrassegnare i dati del cliente come validi?",
       "Documents": "Documenti",
       "Down Payment": "Acconto",
@@ -1363,7 +1363,7 @@
       "Email External Service": "Servizio esterno di posta elettronica",
       "Employees": "Dipendenti",
       "Enable": "Abilitare",
-      "Enable Withhold Tax": "Abilita la ritenuta a trattenere le tasse",
+      "Enable Withhold Tax": "Abilita la ritenuta d'acconto",
       "Entity Data Table Checks": "Verifiche della tabella dei dati dell'entità",
       "Entity Details": "Dettagli dell'entità",
       "Entity to Entity Mapping": "Mappatura da entità a entità",
@@ -3828,6 +3828,9 @@
       "Working with Code": "Lavorare con il codice"
     },
     "menus": {
+      "Apply Annual Fees": "Applica le commissioni annuali",
+      "Disable Withhold Tax": "Disabilita la ritenuta d'acconto",
+      "Enable Withhold Tax": "Abilita la ritenuta d'acconto",
       "Mark as Fraud": "Contrassegna come frode",
       "Unmark as Fraud": "Rimuovi contrassegno di frode",
       "Update Breach": "Aggiorna violazione",

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3828,6 +3828,9 @@
       "Working with Code": "코드 작업"
     },
     "menus": {
+      "Apply Annual Fees": "연회비 적용",
+      "Disable Withhold Tax": "원천 징수 세금을 비활성화합니다",
+      "Enable Withhold Tax": "원천세를 활성화하십시오",
       "Mark as Fraud": "사기로 표시",
       "Unmark as Fraud": "사기 표시 해제",
       "Update Breach": "위반 업데이트",

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -1348,7 +1348,7 @@
       "Deposit Period": "Indėlio laikotarpis",
       "Details": "Detalės",
       "Disable": "Išjungti",
-      "Disable Withhold Tax": "Išjungti išskaičiavimo mokestį",
+      "Disable Withhold Tax": "Išjungti išskaičiuojamąjį mokestį",
       "Do you want to mark the Customer Data as valid?": "Ar norite pažymėti kliento duomenis kaip galiojančius?",
       "Documents": "Dokumentai",
       "Down Payment": "Pradinė įmoka",
@@ -1362,7 +1362,7 @@
       "Email External Service": "Pašto išorinė paslauga",
       "Employees": "Darbuotojai",
       "Enable": "Įgalinti",
-      "Enable Withhold Tax": "Įgalinti išskaičiavimo mokestį",
+      "Enable Withhold Tax": "Įgalinti išskaičiuojamąjį mokestį",
       "Entity Data Table Checks": "Subjektų duomenų lentelės patikrinimai",
       "Entity Details": "Subjekto informacija",
       "Entity to Entity Mapping": "Objekto atvaizdavimas",
@@ -3827,6 +3827,9 @@
       "Working with Code": "Darbas su kodu"
     },
     "menus": {
+      "Apply Annual Fees": "Taikyti metinius mokesčius",
+      "Disable Withhold Tax": "Išjungti išskaičiuojamąjį mokestį",
+      "Enable Withhold Tax": "Įgalinti išskaičiuojamąjį mokestį",
       "Mark as Fraud": "Pažymėti kaip sukčiavimą",
       "Unmark as Fraud": "Panaikinti sukčiavimo žymę",
       "Update Breach": "Atnaujinti pažeidimą",

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -1349,7 +1349,7 @@
       "Deposit Period": "Depozīta periods",
       "Details": "Sīkāka informācija",
       "Disable": "Atspējot",
-      "Disable Withhold Tax": "Atspējot aizturēšanas nodokli",
+      "Disable Withhold Tax": "Atspējot ieturējuma nodokli",
       "Do you want to mark the Customer Data as valid?": "Vai vēlaties atzīmēt klienta datus kā derīgus?",
       "Documents": "Dokumenti",
       "Down Payment": "Pirmā iemaksa",
@@ -1363,7 +1363,7 @@
       "Email External Service": "E-pasta ārējais pakalpojums",
       "Employees": "Darbinieki",
       "Enable": "Iespējot",
-      "Enable Withhold Tax": "Iespējot ieturēt nodokli",
+      "Enable Withhold Tax": "Iespējot ieturējuma nodokli",
       "Entity Data Table Checks": "Entītijas datu tabulu pārbaudes",
       "Entity Details": "Uzņēmuma detaļas",
       "Entity to Entity Mapping": "Entītiju kartēšana",
@@ -3828,6 +3828,9 @@
       "Working with Code": "Darbs ar kodu"
     },
     "menus": {
+      "Apply Annual Fees": "Piemērot gada maksu",
+      "Disable Withhold Tax": "Atspējot ieturējuma nodokli",
+      "Enable Withhold Tax": "Iespējot ieturējuma nodokli",
       "Mark as Fraud": "Atzīmēt kā krāpšanu",
       "Unmark as Fraud": "Noņemt krāpšanas atzīmi",
       "Update Breach": "Atjaunināt pārkāpumu",

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -1348,7 +1348,7 @@
       "Deposit Period": "जम्मा अवधि",
       "Details": "विवरणहरू",
       "Disable": "असक्षम गर्नुहोस्",
-      "Disable Withhold Tax": "प्रयोग गर्ने कर अक्षम गर्नुहोस्",
+      "Disable Withhold Tax": "कर रोक असक्षम गर्नुहोस्",
       "Do you want to mark the Customer Data as valid?": "के तपाईं ग्राहक डाटालाई मान्य भनी चिन्ह लगाउन चाहनुहुन्छ?",
       "Documents": "कागजातहरू",
       "Down Payment": "डाउन पेमेन्ट",
@@ -1362,7 +1362,7 @@
       "Email External Service": "इमेल बाह्य सेवा",
       "Employees": "कर्मचारीहरु",
       "Enable": "सक्षम गर्नुहोस्",
-      "Enable Withhold Tax": "सक्षम गर्न कर सक्षम गर्नुहोस्",
+      "Enable Withhold Tax": "कर रोक सक्षम गर्नुहोस्",
       "Entity Data Table Checks": "संस्था डेटा तालिका जाँच",
       "Entity Details": "संस्था विवरण",
       "Entity to Entity Mapping": "एकाई देखि इकाई म्यापिङ",
@@ -3827,6 +3827,9 @@
       "Working with Code": "Code मा काम गर्नुहुन्छ"
     },
     "menus": {
+      "Apply Annual Fees": "वार्षिक शुल्क लागू गर्नुहोस्",
+      "Disable Withhold Tax": "कर रोक असक्षम गर्नुहोस्",
+      "Enable Withhold Tax": "कर रोक सक्षम गर्नुहोस्",
       "Mark as Fraud": "ठगीको रूपमा चिन्ह लगाउनुहोस्",
       "Unmark as Fraud": "ठगी चिन्ह हटाउनुहोस्",
       "Update Breach": "उल्लंघन अद्यावधिक गर्नुहोस्",

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -1348,7 +1348,7 @@
       "Deposit Period": "Período de Depósito",
       "Details": "Detalhes",
       "Disable": "Desativar",
-      "Disable Withhold Tax": "Desativar o imposto retido",
+      "Disable Withhold Tax": "Desativar retenção de impostos",
       "Do you want to mark the Customer Data as valid?": "Deseja marcar os dados do cliente como válidos?",
       "Documents": "Documentos",
       "Down Payment": "Pagamento inicial",
@@ -1362,7 +1362,7 @@
       "Email External Service": "Serviço externo de e-mail",
       "Employees": "Funcionários",
       "Enable": "Habilitar",
-      "Enable Withhold Tax": "Ativar imposto reter",
+      "Enable Withhold Tax": "Ativar retenção de impostos",
       "Entity Data Table Checks": "Verificações da tabela de dados da entidade",
       "Entity Details": "Detalhes da Entidade",
       "Entity to Entity Mapping": "Mapeamento de entidade para entidade",
@@ -3827,6 +3827,9 @@
       "Working with Code": "Trabalhando com código"
     },
     "menus": {
+      "Apply Annual Fees": "Aplicar taxas anuais",
+      "Disable Withhold Tax": "Desativar retenção de impostos",
+      "Enable Withhold Tax": "Ativar retenção de impostos",
       "Mark as Fraud": "Marcar como Fraude",
       "Unmark as Fraud": "Desmarcar como Fraude",
       "Update Breach": "Atualizar violação",

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -1346,7 +1346,7 @@
       "Deposit Period": "Kipindi cha Amana",
       "Details": "Maelezo",
       "Disable": "Zima",
-      "Disable Withhold Tax": "Lemaza Ushuru",
+      "Disable Withhold Tax": "Lemaza Kodi ya Kuzuia",
       "Do you want to mark the Customer Data as valid?": "Je, unataka kuweka alama data ya mteja kuwa halali?",
       "Documents": "Nyaraka",
       "Down Payment": "Malipo ya Chini",
@@ -1360,7 +1360,7 @@
       "Email External Service": "Barua pepe ya Huduma ya Nje",
       "Employees": "Wafanyakazi",
       "Enable": "Wezesha",
-      "Enable Withhold Tax": "Wezesha Ushuru",
+      "Enable Withhold Tax": "Wezesha Kodi ya Kuzuia",
       "Entity Data Table Checks": "Ukaguzi wa Jedwali la Data ya Huluki",
       "Entity Details": "Maelezo ya Huluki",
       "Entity to Entity Mapping": "Uchoraji wa Huluki kwa Huluki",
@@ -3825,6 +3825,9 @@
       "Working with Code": "Kufanya kazi na Kanuni"
     },
     "menus": {
+      "Apply Annual Fees": "Tumia Ada ya Mwaka",
+      "Disable Withhold Tax": "Lemaza Kodi ya Kuzuia",
+      "Enable Withhold Tax": "Wezesha Kodi ya Kuzuia",
       "Mark as Fraud": "Weka Alama ya Ulaghai",
       "Unmark as Fraud": "Ondoa Alama ya Ulaghai",
       "Update Breach": "Sasisha ukiukaji",


### PR DESCRIPTION
## Description

The savings account **More** submenu currently shows `labels.menus.Disable Withhold Tax` instead of a translated label.

The savings, fixed deposit, recurring deposit, and shares account menus all use the option's `name` as the translation key. The savings and recurring deposit templates build the key with `labels.menus.` + `option.name`, while the fixed deposit and shares templates use `translateKey: 'menus'`, which resolves to the same namespace.

The problem is that `Disable Withhold Tax` and `Enable Withhold Tax` only exist under `labels.heading`, which is what the confirmation dialogs use. They are missing from `labels.menus`, so the menu displays the raw translation key.

While checking all 36 option names across these four menus, I found one more missing key: **Apply Annual Fees**, used by the savings and recurring deposit menus. I’ve included that as well rather than fixing only the two labels from the ticket.

### Locales

The fix covers all 13 supported locales, not just en-US.

The app uses `TranslateService.use()` but never calls `setDefaultLang()`, so a missing translation does not fall back to English. `CustomMissingTranslationHandler` only unwraps `labels.catalogs.`; other missing namespaces are displayed as-is.

For the withhold-tax labels, I reused the wording already present under each locale's `labels.heading`, so the menu and confirmation dialog use the same text. For **Apply Annual Fees**, the wording is composed from terms that already exist in each locale.

### Shares typo

The shares account view had the option written as `Apply Anuual Fees`. I corrected the typo so the same translation key can be shared across all three account types.

The shares `doAction` still has no case for this option, so the menu entry remains inert. That is a separate issue and isn't addressed here.

### Test

Added `web-1101-account-menu-translations.spec.ts`.

The test checks the three affected keys in every locale and also verifies that every option declared by the four account menus has an en-US translation.

The test reads the account view sources directly because the two tax options aren't in a buttons configuration. They are added by the account view components when the relevant `taxGroup` / `charges` conditions are met.

Without the fix, 14 of the 15 test cases fail.

### Other missing translations

The same sweep also found some pre-existing missing translations that are outside the scope of this change:

* `Interbank Transfer` and `Reporting Dashboard` are missing from `labels.menus` in all 12 non-English locales.
* `Assign Staff` is missing in it-IT, lv-LV, and sw-SW.
* `Recovery Payment` is missing in ko-KO.

These need actual locale-specific translations rather than reusing an existing string, so they should be handled separately as part of a locale translation pass.

## Related issues

[[WEB-1101](https://mifosforge.jira.com/browse/WEB-1101)](https://mifosforge.jira.com/browse/WEB-1101)

This continues #3793, which has been inactive for some time. The underlying issue is the same, but this change also covers the other locales, the additional missing menu entry, and regression coverage.

## Checklist

* [x] Squashed all changes into one commit.
* [x] Read and understood `web-app/.github/CONTRIBUTING.md`.

[WEB-1101]: https://mifosforge.jira.com/browse/WEB-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the “Apply Annual Fees” button label.
  * Improved consistency and accuracy of withholding-tax terminology in several languages.

* **Localization**
  * Added translated menu labels for annual fees and withholding-tax actions across supported locales.
  * Updated related headings to match established terminology.

* **Tests**
  * Added coverage verifying account-menu translations across all supported locales and identifying missing labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->