### PR TITLE
WEB-1057: Add pending prospects task view

### DIFF
--- a/src/app/tasks/checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component.html
@@ -1,0 +1,174 @@
+<!--
+  Copyright since 2025 Mifos Initiative
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-->
+
+<div class="tab-container mat-typography">
+  <form [formGroup]="pendingProspectsForm" (ngSubmit)="applyFilters()" class="pending-prospects-filter">
+    <mat-form-field>
+      <mat-label>{{ 'labels.text.Search' | translate }}</mat-label>
+      <input matInput formControlName="q" />
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>{{ 'labels.inputs.From Date' | translate }}</mat-label>
+      <input matInput [matDatepicker]="createdFromPicker" formControlName="createdFrom" />
+      <mat-datepicker-toggle matSuffix [for]="createdFromPicker"></mat-datepicker-toggle>
+      <mat-datepicker #createdFromPicker></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>{{ 'labels.inputs.To Date' | translate }}</mat-label>
+      <input matInput [matDatepicker]="createdToPicker" formControlName="createdTo" />
+      <mat-datepicker-toggle matSuffix [for]="createdToPicker"></mat-datepicker-toggle>
+      <mat-datepicker #createdToPicker></mat-datepicker>
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-label>{{ 'labels.inputs.Registration Status' | translate }}</mat-label>
+      <mat-select formControlName="registrationStatus">
+        @for (status of registrationStatusOptions; track status.value) {
+          <mat-option [value]="status.value">{{ status.labelKey | translate }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+
+    <div class="filter-actions">
+      <button mat-raised-button color="primary" type="submit">{{ 'labels.buttons.Search' | translate }}</button>
+      <button mat-button type="button" (click)="clearFilters()">{{ 'labels.buttons.Clear' | translate }}</button>
+    </div>
+  </form>
+
+  @if (filterError) {
+    <div class="alert error" role="alert">
+      <div class="message">
+        <mat-icon class="alert-check">error</mat-icon>
+        {{ filterError | translate }}
+      </div>
+    </div>
+  }
+
+  @if (loadError) {
+    <div class="alert error" role="alert">
+      <div class="message">
+        <mat-icon class="alert-check">error</mat-icon>
+        {{ loadError | translate }}
+      </div>
+    </div>
+  }
+
+  @if (loading) {
+    <div class="alert">
+      <div class="message">
+        <mat-icon class="alert-check loading-icon">sync</mat-icon>
+        {{ 'labels.text.Loading pending prospects' | translate }}
+      </div>
+    </div>
+  }
+
+  <div class="table-wrapper">
+    <table mat-table [dataSource]="dataSource" matSort (matSortChange)="sortData($event)">
+      <ng-container matColumnDef="displayName">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="displayName">
+          {{ 'labels.inputs.Prospect' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let prospect">
+          @if (hasClientLink(prospect)) {
+            <button mat-button type="button" (click)="viewClient(prospect); $event.stopPropagation()">
+              {{ prospect.displayName || '-' }}
+            </button>
+          } @else {
+            {{ prospect.displayName || '-' }}
+          }
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="externalRef">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="externalRef">
+          {{ 'labels.inputs.External Reference' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let prospect">{{ prospect.externalRef || '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="registrationStatus">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="registrationStatus">
+          {{ 'labels.inputs.Registration Status' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let prospect">
+          <span class="status-chip" [ngClass]="'status-' + (prospect.registrationStatus || 'unknown').toLowerCase()">
+            {{ registrationStatusLabel(prospect.registrationStatus) | translate }}
+          </span>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="currentStage">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="currentStage">
+          {{ 'labels.inputs.Current Stage' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let prospect">{{ stageLabel(prospect.currentStage) | translate }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="lastCompletedStage">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="lastCompletedStage">
+          {{ 'labels.inputs.Last Completed Stage' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let prospect">{{ stageLabel(prospect.lastCompletedStage) | translate }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="stoppedAtStage">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="stoppedAtStage">
+          {{ 'labels.inputs.Stopped At' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let prospect">{{ stageLabel(prospect.stoppedAtStage) | translate }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="pendingCreditCount">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="pendingCreditCount">
+          {{ 'labels.inputs.Pending Credits' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let prospect">{{ pendingCreditCount(prospect) }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="createdAt">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="createdAt">
+          {{ 'labels.inputs.Created' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let prospect">{{ prospect.createdAt ? (prospect.createdAt | dateFormat) : '-' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="lastUpdatedAt">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header="lastUpdatedAt">
+          {{ 'labels.inputs.Last Updated' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let prospect">
+          {{ prospect.lastUpdatedAt ? (prospect.lastUpdatedAt | dateFormat) : '-' }}
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </div>
+
+  @if (!loading && dataSource.data.length === 0) {
+    <div class="alert">
+      <div class="message">
+        <mat-icon class="alert-check">info</mat-icon>
+        {{ 'labels.text.No pending prospects found' | translate }}
+      </div>
+    </div>
+  }
+
+  <mat-paginator
+    [length]="totalFilteredRecords"
+    [pageSize]="pageSize"
+    [pageIndex]="pageIndex"
+    [pageSizeOptions]="[10, 25, 50, 100]"
+    showFirstLastButtons
+    (page)="changePaging($event)"
+  >
+  </mat-paginator>
+</div>

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component.scss
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component.scss
@@ -1,0 +1,118 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+.tab-container {
+  padding: 1%;
+  margin: 1%;
+
+  .pending-prospects-filter {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: start;
+    margin-bottom: 16px;
+
+    mat-form-field {
+      flex: 1 1 180px;
+    }
+  }
+
+  .filter-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    min-height: 56px;
+  }
+
+  .table-wrapper {
+    overflow-x: auto;
+  }
+
+  table {
+    width: 100%;
+  }
+
+  .status-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .status-completed {
+    background-color: #e6f4ea;
+    color: #137333;
+  }
+
+  .status-pending,
+  .status-submitted,
+  .status-in_progress {
+    background-color: #fff8e1;
+    color: #8d6e00;
+  }
+
+  .status-rejected {
+    background-color: #fdecea;
+    color: #b3261e;
+  }
+
+  .status-withdrawn {
+    background-color: #eceff1;
+    color: #455a64;
+  }
+
+  .status-unknown {
+    background-color: #f1f3f4;
+    color: #5f6368;
+  }
+}
+
+.alert {
+  background-color: #e8f4fd;
+  padding: 6px 16px;
+  font-size: 0.875rem;
+  font-family: Roboto, 'Helvetica Neue', sans-serif;
+  font-weight: 400;
+  line-height: 1.43;
+  border-radius: 4px;
+  letter-spacing: normal;
+  margin: 10px 0;
+
+  &.error {
+    background-color: #fdecea;
+  }
+
+  .message {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 8px 0;
+    font-size: 18px;
+  }
+
+  .alert-check {
+    color: #359ff4;
+    width: 1.4rem;
+    height: 1.4rem;
+    font-size: 1.4rem;
+  }
+
+  .loading-icon {
+    animation: pending-prospects-spin 1s linear infinite;
+  }
+}
+
+@keyframes pending-prospects-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component.spec.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { DatePipe } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNativeDateAdapter } from '@angular/material/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { of, Subject, throwError } from 'rxjs';
+
+import { Dates } from 'app/core/utils/dates';
+import { SettingsService } from 'app/settings/settings.service';
+import { PendingProspectsResponse, TasksService } from '../../tasks.service';
+import { PendingProspectsComponent } from './pending-prospects.component';
+
+describe('PendingProspectsComponent', () => {
+  let component: PendingProspectsComponent;
+  let fixture: ComponentFixture<PendingProspectsComponent>;
+  let tasksService: jest.Mocked<TasksService>;
+  let routerNavigate: jest.SpyInstance;
+
+  const page: PendingProspectsResponse = {
+    totalFilteredRecords: 2,
+    pageItems: [
+      {
+        prospectId: 1,
+        externalRef: 'EXT-1',
+        displayName: 'Acme Prospect',
+        clientId: 42,
+        registrationStatus: 'IN_PROGRESS',
+        createdAt: '2026-01-01',
+        lastUpdatedAt: '2026-01-02',
+        currentStage: 'COMMERCIAL_REGISTRATION',
+        lastCompletedStage: 'KYC_LEVEL_1',
+        stoppedAtStage: 'UNKNOWN',
+        pendingCreditCount: 0
+      },
+      {
+        prospectId: 2,
+        displayName: 'Pre Client Prospect',
+        registrationStatus: 'PENDING',
+        currentStage: null as any,
+        pendingCreditCount: 3
+      }
+    ]
+  };
+
+  function createComponent(pendingProspectsResponse = of(page)) {
+    TestBed.resetTestingModule();
+    tasksService = {
+      getPendingProspects: jest.fn(() => pendingProspectsResponse)
+    } as any;
+
+    TestBed.configureTestingModule({
+      imports: [
+        PendingProspectsComponent,
+        TranslateModule.forRoot(),
+        NoopAnimationsModule
+      ],
+      providers: [
+        DatePipe,
+        {
+          provide: Dates,
+          useValue: {
+            formatDate: (date: Date) =>
+              `${date.getFullYear()}-${`${date.getMonth() + 1}`.padStart(2, '0')}-${`${date.getDate()}`.padStart(2, '0')}`,
+            isAfter: (date1: Date, date2: Date) => date1.getTime() > date2.getTime(),
+            angularToMomentFormat: () => 'YYYY-MM-DD',
+            getMomentLocale: () => 'en'
+          }
+        },
+        { provide: SettingsService, useValue: { dateFormat: 'yyyy-MM-dd', language: { code: 'en' } } },
+        { provide: TasksService, useValue: tasksService },
+        provideNativeDateAdapter(),
+        provideRouter([])
+      ]
+    });
+
+    fixture = TestBed.createComponent(PendingProspectsComponent);
+    component = fixture.componentInstance;
+    routerNavigate = jest.spyOn((component as any).router, 'navigate');
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    createComponent();
+    tasksService.getPendingProspects.mockClear();
+  });
+
+  it('loads pending prospects on init with default server paging and sorting', () => {
+    createComponent();
+
+    expect(tasksService.getPendingProspects).toHaveBeenCalledWith(
+      expect.objectContaining({
+        offset: 0,
+        limit: 10,
+        orderBy: 'lastUpdatedAt',
+        sortOrder: 'DESC'
+      })
+    );
+    expect(component.dataSource.data).toHaveLength(2);
+    expect(component.totalFilteredRecords).toBe(2);
+  });
+
+  it('applies filters with ISO dates and resets pagination', () => {
+    component.pageIndex = 2;
+    component.pendingProspectsForm.patchValue({
+      q: 'acme',
+      createdFrom: new Date(2026, 0, 1),
+      createdTo: new Date(2026, 0, 31),
+      registrationStatus: 'IN_PROGRESS'
+    });
+
+    component.applyFilters();
+
+    expect(component.pageIndex).toBe(0);
+    expect(tasksService.getPendingProspects).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        q: 'acme',
+        createdFrom: '2026-01-01',
+        createdTo: '2026-01-31',
+        registrationStatus: 'IN_PROGRESS',
+        offset: 0
+      })
+    );
+  });
+
+  it('blocks invalid reversed date range', () => {
+    component.pendingProspectsForm.patchValue({
+      createdFrom: new Date(2026, 0, 31),
+      createdTo: new Date(2026, 0, 1)
+    });
+
+    component.applyFilters();
+
+    expect(component.filterError).toBe('labels.text.From Date cannot be after To Date');
+    expect(tasksService.getPendingProspects).not.toHaveBeenCalled();
+  });
+
+  it('preserves filters when changing pages', () => {
+    component.pendingProspectsForm.patchValue({ q: 'acme', registrationStatus: 'PENDING' });
+
+    component.changePaging({ pageIndex: 2, pageSize: 25, length: 100 });
+
+    expect(tasksService.getPendingProspects).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        q: 'acme',
+        registrationStatus: 'PENDING',
+        offset: 50,
+        limit: 25
+      })
+    );
+  });
+
+  it('uses backend sort fields and resets pagination', () => {
+    component.pageIndex = 3;
+
+    component.sortData({ active: 'createdAt', direction: 'asc' });
+
+    expect(component.pageIndex).toBe(0);
+    expect(tasksService.getPendingProspects).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        orderBy: 'createdAt',
+        sortOrder: 'ASC',
+        offset: 0
+      })
+    );
+  });
+
+  it('falls back to default sorting for unsupported sort fields', () => {
+    component.sortData({ active: 'unsupported', direction: 'asc' });
+
+    expect(tasksService.getPendingProspects).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        orderBy: 'lastUpdatedAt',
+        sortOrder: 'ASC'
+      })
+    );
+  });
+
+  it('shows loading, empty, and error states', () => {
+    const pendingResponse = new Subject<PendingProspectsResponse>();
+    createComponent(pendingResponse.asObservable());
+
+    expect(component.loading).toBe(true);
+    pendingResponse.next({ totalFilteredRecords: 0, pageItems: [] });
+    pendingResponse.complete();
+    fixture.detectChanges();
+
+    expect(component.loading).toBe(false);
+    expect(component.dataSource.data).toEqual([]);
+    expect(fixture.nativeElement.textContent).toContain('labels.text.No pending prospects found');
+
+    createComponent(throwError(() => new Error('failed')));
+    expect(component.loadError).toBe('labels.text.Unable to load pending prospects');
+    expect(component.dataSource.data).toEqual([]);
+  });
+
+  it('renders UNKNOWN and null stages as Unknown and formats stage codes', () => {
+    expect(component.stageLabel('UNKNOWN')).toBe('labels.inputs.Unknown');
+    expect(component.stageLabel(null as any)).toBe('labels.inputs.Unknown');
+    expect(component.stageLabel('COMMERCIAL_REGISTRATION')).toBe('Commercial Registration');
+    expect(component.stageLabel('KYC_LEVEL_1')).toBe('KYC Level 1');
+  });
+
+  it('displays pending credit count exactly as returned with zero visible', () => {
+    expect(component.pendingCreditCount({ pendingCreditCount: 0 })).toBe(0);
+    expect(component.pendingCreditCount({ pendingCreditCount: 3 })).toBe(3);
+  });
+
+  it('only navigates to a client when clientId exists', () => {
+    component.viewClient({ clientId: 42 });
+    expect(routerNavigate).toHaveBeenCalledWith([
+      '/clients',
+      42,
+      'general'
+    ]);
+
+    routerNavigate.mockClear();
+    component.viewClient({});
+    expect(routerNavigate).not.toHaveBeenCalled();
+    expect(component.hasClientLink({})).toBe(false);
+  });
+});

--- a/src/app/tasks/checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component.ts
+++ b/src/app/tasks/checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component.ts
@@ -1,0 +1,273 @@
+/**
+ * Copyright since 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/** Angular Imports */
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  OnInit,
+  ViewChild,
+  inject
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
+import { Router } from '@angular/router';
+
+/** Angular Material Imports */
+import { MatIcon } from '@angular/material/icon';
+import { MatPaginator, PageEvent } from '@angular/material/paginator';
+import { MatSort, MatSortHeader, Sort } from '@angular/material/sort';
+import {
+  MatTable,
+  MatTableDataSource,
+  MatColumnDef,
+  MatHeaderCellDef,
+  MatHeaderCell,
+  MatCellDef,
+  MatCell,
+  MatHeaderRowDef,
+  MatHeaderRow,
+  MatRowDef,
+  MatRow
+} from '@angular/material/table';
+
+/** Custom Services */
+import { Dates } from 'app/core/utils/dates';
+import { STANDALONE_SHARED_IMPORTS } from 'app/standalone-shared.module';
+import { PendingProspect, PendingProspectsResponse, TasksService } from '../../tasks.service';
+
+interface RegistrationStatusOption {
+  value: string;
+  labelKey: string;
+}
+
+const REGISTRATION_STATUS_OPTIONS: RegistrationStatusOption[] = [
+  { value: 'PENDING', labelKey: 'labels.inputs.Pending' },
+  { value: 'IN_PROGRESS', labelKey: 'labels.inputs.In Progress' },
+  { value: 'SUBMITTED', labelKey: 'labels.inputs.Submitted' },
+  { value: 'COMPLETED', labelKey: 'labels.inputs.Completed' },
+  { value: 'REJECTED', labelKey: 'labels.inputs.Rejected' },
+  { value: 'WITHDRAWN', labelKey: 'labels.inputs.Withdrawn' }
+];
+
+const SORT_FIELDS = new Set([
+  'displayName',
+  'externalRef',
+  'registrationStatus',
+  'currentStage',
+  'lastCompletedStage',
+  'stoppedAtStage',
+  'pendingCreditCount',
+  'createdAt',
+  'lastUpdatedAt'
+]);
+
+@Component({
+  selector: 'mifosx-pending-prospects',
+  templateUrl: './pending-prospects.component.html',
+  styleUrls: ['./pending-prospects.component.scss'],
+  imports: [
+    ...STANDALONE_SHARED_IMPORTS,
+    MatTable,
+    MatColumnDef,
+    MatHeaderCellDef,
+    MatHeaderCell,
+    MatCellDef,
+    MatCell,
+    MatHeaderRowDef,
+    MatHeaderRow,
+    MatRowDef,
+    MatRow,
+    MatPaginator,
+    MatSort,
+    MatSortHeader,
+    MatIcon
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class PendingProspectsComponent implements OnInit {
+  private formBuilder = inject(UntypedFormBuilder);
+  private tasksService = inject(TasksService);
+  private dateUtils = inject(Dates);
+  private router = inject(Router);
+  private changeDetectorRef = inject(ChangeDetectorRef);
+  private destroyRef = inject(DestroyRef);
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  pendingProspectsForm: UntypedFormGroup = this.formBuilder.group({
+    q: [''],
+    createdFrom: [''],
+    createdTo: [''],
+    registrationStatus: ['']
+  });
+
+  dataSource = new MatTableDataSource<PendingProspect>([]);
+  displayedColumns: string[] = [
+    'displayName',
+    'externalRef',
+    'registrationStatus',
+    'currentStage',
+    'lastCompletedStage',
+    'stoppedAtStage',
+    'pendingCreditCount',
+    'createdAt',
+    'lastUpdatedAt'
+  ];
+  registrationStatusOptions = REGISTRATION_STATUS_OPTIONS;
+
+  pageSize = 10;
+  pageIndex = 0;
+  totalFilteredRecords = 0;
+  orderBy = 'lastUpdatedAt';
+  sortOrder = 'DESC';
+  loading = false;
+  loadError = '';
+  filterError = '';
+
+  ngOnInit(): void {
+    this.loadPendingProspects();
+  }
+
+  applyFilters(): void {
+    if (!this.validateFilters()) {
+      return;
+    }
+    this.resetPage();
+    this.loadPendingProspects();
+  }
+
+  clearFilters(): void {
+    this.pendingProspectsForm.reset();
+    this.filterError = '';
+    this.resetPage();
+    this.loadPendingProspects();
+  }
+
+  changePaging(event: PageEvent): void {
+    this.pageSize = event.pageSize;
+    this.pageIndex = event.pageIndex;
+    this.loadPendingProspects();
+  }
+
+  sortData(sort: Sort): void {
+    this.orderBy = sort.direction && SORT_FIELDS.has(sort.active) ? sort.active : 'lastUpdatedAt';
+    this.sortOrder = sort.direction === 'asc' ? 'ASC' : 'DESC';
+    this.resetPage();
+    this.loadPendingProspects();
+  }
+
+  viewClient(prospect: PendingProspect): void {
+    if (prospect.clientId) {
+      this.router.navigate([
+        '/clients',
+        prospect.clientId,
+        'general'
+      ]);
+    }
+  }
+
+  hasClientLink(prospect: PendingProspect): boolean {
+    return !!prospect.clientId;
+  }
+
+  registrationStatusLabel(status?: string): string {
+    const normalized = `${status || ''}`.trim().toUpperCase();
+    const option = this.registrationStatusOptions.find((statusOption) => statusOption.value === normalized);
+    return option?.labelKey || this.readableCode(status);
+  }
+
+  stageLabel(stage?: string): string {
+    return this.readableCode(stage) || 'labels.inputs.Unknown';
+  }
+
+  pendingCreditCount(prospect: PendingProspect): number | string {
+    return prospect.pendingCreditCount ?? 0;
+  }
+
+  private loadPendingProspects(): void {
+    this.loading = true;
+    this.loadError = '';
+
+    this.tasksService
+      .getPendingProspects(this.buildSearchParams())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data: PendingProspectsResponse) => {
+          this.dataSource.data = data?.pageItems || [];
+          this.totalFilteredRecords = data?.totalFilteredRecords || 0;
+          this.loading = false;
+          this.changeDetectorRef.markForCheck();
+        },
+        error: () => {
+          this.dataSource.data = [];
+          this.totalFilteredRecords = 0;
+          this.loading = false;
+          this.loadError = 'labels.text.Unable to load pending prospects';
+          this.changeDetectorRef.markForCheck();
+        }
+      });
+  }
+
+  private buildSearchParams(): any {
+    const formValue = this.pendingProspectsForm.value;
+    return {
+      q: formValue.q,
+      createdFrom: this.formatApiDate(formValue.createdFrom),
+      createdTo: this.formatApiDate(formValue.createdTo),
+      registrationStatus: formValue.registrationStatus,
+      offset: this.pageIndex * this.pageSize,
+      limit: this.pageSize,
+      orderBy: this.orderBy,
+      sortOrder: this.sortOrder
+    };
+  }
+
+  private validateFilters(): boolean {
+    const formValue = this.pendingProspectsForm.value;
+    this.filterError = '';
+
+    if (
+      formValue.createdFrom &&
+      formValue.createdTo &&
+      this.dateUtils.isAfter(formValue.createdFrom, formValue.createdTo)
+    ) {
+      this.filterError = 'labels.text.From Date cannot be after To Date';
+    }
+
+    this.changeDetectorRef.markForCheck();
+    return !this.filterError;
+  }
+
+  private formatApiDate(date: Date | string): string {
+    return date ? this.dateUtils.formatDate(date, Dates.DEFAULT_DATEFORMAT) : '';
+  }
+
+  private resetPage(): void {
+    this.pageIndex = 0;
+    if (this.paginator) {
+      this.paginator.pageIndex = 0;
+    }
+  }
+
+  private readableCode(value?: string): string {
+    const rawValue = `${value || ''}`.trim();
+    if (!rawValue || rawValue.toUpperCase() === 'UNKNOWN') {
+      return '';
+    }
+
+    return rawValue
+      .toLowerCase()
+      .split(/[_\s-]+/)
+      .filter((part) => !!part)
+      .map((part) => (part.length <= 3 ? part.toUpperCase() : part.charAt(0).toUpperCase() + part.slice(1)))
+      .join(' ');
+  }
+}

--- a/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
+++ b/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.html
@@ -101,6 +101,16 @@
         >
           {{ 'labels.inputs.Enrollment Status' | translate }}
         </a>
+        <a
+          mat-tab-link
+          [routerLink]="['./pending-prospects']"
+          routerLinkActive
+          #pendingProspects="routerLinkActive"
+          [active]="pendingProspects.isActive"
+          *mifosxHasPermission="'READ_PROSPECT'"
+        >
+          {{ 'labels.inputs.Pending Prospects' | translate }}
+        </a>
       </nav>
 
       <mat-tab-nav-panel #tabPanel>

--- a/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.spec.ts
+++ b/src/app/tasks/checker-inbox-and-tasks/checker-inbox-and-tasks.component.spec.ts
@@ -15,6 +15,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { AuthenticationService } from 'app/core/authentication/authentication.service';
 import { environment } from 'environments/environment';
 import { CreditApplicationsComponent } from '../checker-inbox-and-tasks-tabs/credit-applications/credit-applications.component';
+import { PendingProspectsComponent } from '../checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component';
 import { routes } from '../tasks-routing.module';
 import { CheckerInboxAndTasksComponent } from './checker-inbox-and-tasks.component';
 
@@ -23,6 +24,7 @@ describe('CheckerInboxAndTasksComponent', () => {
   const rbacEnabled = environment.productionModeEnableRBAC;
 
   function createComponent(permissions: string[] = ['APPROVE_LOAN_CHECKER']) {
+    TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       imports: [
         CheckerInboxAndTasksComponent,
@@ -45,6 +47,7 @@ describe('CheckerInboxAndTasksComponent', () => {
   }
 
   async function navigateToComponent(permissions: string[] = ['APPROVE_LOAN_CHECKER']) {
+    TestBed.resetTestingModule();
     TestBed.configureTestingModule({
       imports: [
         CheckerInboxAndTasksComponent,
@@ -131,6 +134,31 @@ describe('CheckerInboxAndTasksComponent', () => {
     expect(creditTab.getAttribute('href')).toBe('/checker-inbox-and-tasks/credit');
   });
 
+  it('shows Pending Prospects only for users who can read prospects', () => {
+    createComponent(['READ_PROSPECT']);
+
+    let tabLabels = Array.from(fixture.nativeElement.querySelectorAll('a[mat-tab-link]')).map((tab: HTMLElement) =>
+      tab.textContent?.trim()
+    );
+    expect(tabLabels).toContain('labels.inputs.Pending Prospects');
+
+    createComponent([]);
+    tabLabels = Array.from(fixture.nativeElement.querySelectorAll('a[mat-tab-link]')).map((tab: HTMLElement) =>
+      tab.textContent?.trim()
+    );
+    expect(tabLabels).not.toContain('labels.inputs.Pending Prospects');
+  });
+
+  it('routes Pending Prospects to the pending prospects page', async () => {
+    const routeElement = await navigateToComponent(['READ_PROSPECT']);
+
+    const pendingProspectsTab = Array.from(routeElement.querySelectorAll('a[mat-tab-link]')).find((tab: HTMLElement) =>
+      tab.textContent?.includes('labels.inputs.Pending Prospects')
+    ) as HTMLAnchorElement;
+
+    expect(pendingProspectsTab.getAttribute('href')).toBe('/checker-inbox-and-tasks/pending-prospects');
+  });
+
   it('uses CreditApplicationsComponent for both Requests and Credit routes', () => {
     const shellRoute = routes[0] as AngularRoute;
     const taskRoute = shellRoute.children?.find((route: AngularRoute) => route.path === '');
@@ -139,5 +167,16 @@ describe('CheckerInboxAndTasksComponent', () => {
 
     expect(requestsRoute?.component).toBe(CreditApplicationsComponent);
     expect(creditRoute?.component).toBe(CreditApplicationsComponent);
+  });
+
+  it('uses PendingProspectsComponent for the pending prospects route', () => {
+    const shellRoute = routes[0] as AngularRoute;
+    const taskRoute = shellRoute.children?.find((route: AngularRoute) => route.path === '');
+    const pendingProspectsRoute = taskRoute?.children?.find(
+      (route: AngularRoute) => route.path === 'pending-prospects'
+    );
+
+    expect(pendingProspectsRoute?.component).toBe(PendingProspectsComponent);
+    expect(pendingProspectsRoute?.data?.permissions).toEqual(['READ_PROSPECT']);
   });
 });

--- a/src/app/tasks/tasks-routing.module.ts
+++ b/src/app/tasks/tasks-routing.module.ts
@@ -20,6 +20,7 @@ import { ClientApprovalComponent } from './checker-inbox-and-tasks-tabs/client-a
 import { LoanApprovalComponent } from './checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component';
 import { CreditApplicationsComponent } from './checker-inbox-and-tasks-tabs/credit-applications/credit-applications.component';
 import { EnrollmentStatusComponent } from './checker-inbox-and-tasks-tabs/enrollment-status/enrollment-status.component';
+import { PendingProspectsComponent } from './checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component';
 import { CouncilApprovalComponent } from './checker-inbox-and-tasks-tabs/council-approval/council-approval.component';
 import { LoanDisbursalComponent } from './checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component';
 import { RescheduleLoanComponent } from './checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component';
@@ -83,6 +84,11 @@ export const routes: Routes = [
           path: 'enrollment-status',
           component: EnrollmentStatusComponent,
           data: { title: 'Enrollment Status' }
+        },
+        {
+          path: 'pending-prospects',
+          component: PendingProspectsComponent,
+          data: { title: 'Pending Prospects', permissions: ['READ_PROSPECT'] }
         },
         {
           path: 'council-approval',

--- a/src/app/tasks/tasks.module.ts
+++ b/src/app/tasks/tasks.module.ts
@@ -21,6 +21,7 @@ import { ClientApprovalComponent } from './checker-inbox-and-tasks-tabs/client-a
 import { LoanApprovalComponent } from './checker-inbox-and-tasks-tabs/loan-approval/loan-approval.component';
 import { CreditApplicationsComponent } from './checker-inbox-and-tasks-tabs/credit-applications/credit-applications.component';
 import { EnrollmentStatusComponent } from './checker-inbox-and-tasks-tabs/enrollment-status/enrollment-status.component';
+import { PendingProspectsComponent } from './checker-inbox-and-tasks-tabs/pending-prospects/pending-prospects.component';
 import { LoanDisbursalComponent } from './checker-inbox-and-tasks-tabs/loan-disbursal/loan-disbursal.component';
 import { RescheduleLoanComponent } from './checker-inbox-and-tasks-tabs/reschedule-loan/reschedule-loan.component';
 import { CouncilApprovalComponent } from './checker-inbox-and-tasks-tabs/council-approval/council-approval.component';
@@ -41,6 +42,7 @@ import { ViewCheckerInboxComponent } from './view-checker-inbox/view-checker-inb
     LoanApprovalComponent,
     CreditApplicationsComponent,
     EnrollmentStatusComponent,
+    PendingProspectsComponent,
     LoanDisbursalComponent,
     RescheduleLoanComponent,
     CouncilApprovalComponent,

--- a/src/app/tasks/tasks.service.spec.ts
+++ b/src/app/tasks/tasks.service.spec.ts
@@ -203,4 +203,52 @@ describe('TasksService maker-checker search', () => {
     expect(request.request.params.get('limit')).toBe('10');
     request.flush({ totalFilteredRecords: 0, pageItems: [] });
   });
+
+  it('requests pending prospects with only populated server-side parameters', () => {
+    service
+      .getPendingProspects({
+        q: 'acme',
+        registrationStatus: 'IN_PROGRESS',
+        createdFrom: '2026-01-01',
+        createdTo: '2026-01-31',
+        offset: 20,
+        limit: 10,
+        orderBy: 'lastUpdatedAt',
+        sortOrder: 'DESC'
+      })
+      .subscribe();
+
+    const request = httpMock.expectOne((req) => req.url === '/v2/prospects');
+    expect(request.request.params.get('q')).toBe('acme');
+    expect(request.request.params.get('registrationStatus')).toBe('IN_PROGRESS');
+    expect(request.request.params.get('createdFrom')).toBe('2026-01-01');
+    expect(request.request.params.get('createdTo')).toBe('2026-01-31');
+    expect(request.request.params.get('offset')).toBe('20');
+    expect(request.request.params.get('limit')).toBe('10');
+    expect(request.request.params.get('orderBy')).toBe('lastUpdatedAt');
+    expect(request.request.params.get('sortOrder')).toBe('DESC');
+    request.flush({ totalFilteredRecords: 0, pageItems: [] });
+  });
+
+  it('omits empty pending prospect filters', () => {
+    service
+      .getPendingProspects({
+        q: '',
+        registrationStatus: null as any,
+        createdFrom: undefined,
+        createdTo: '2026-01-31',
+        offset: 0,
+        limit: 10
+      })
+      .subscribe();
+
+    const request = httpMock.expectOne((req) => req.url === '/v2/prospects');
+    expect(request.request.params.has('q')).toBe(false);
+    expect(request.request.params.has('registrationStatus')).toBe(false);
+    expect(request.request.params.has('createdFrom')).toBe(false);
+    expect(request.request.params.get('createdTo')).toBe('2026-01-31');
+    expect(request.request.params.get('offset')).toBe('0');
+    expect(request.request.params.get('limit')).toBe('10');
+    request.flush({ totalFilteredRecords: 0, pageItems: [] });
+  });
 });

--- a/src/app/tasks/tasks.service.ts
+++ b/src/app/tasks/tasks.service.ts
@@ -81,6 +81,38 @@ export interface KycEvidence {
   amlScreening?: { status?: string; decision?: string };
 }
 
+export interface PendingProspectsSearchParams {
+  q?: string;
+  registrationStatus?: string;
+  createdFrom?: string;
+  createdTo?: string;
+  offset?: number;
+  limit?: number;
+  orderBy?: string;
+  sortOrder?: string;
+}
+
+export interface PendingProspectsResponse {
+  totalFilteredRecords?: number;
+  pageItems?: PendingProspect[];
+}
+
+export interface PendingProspect {
+  prospectId?: number | string;
+  externalRef?: string;
+  displayName?: string;
+  officeId?: number | string;
+  clientId?: number | string;
+  registrationStatus?: string;
+  createdAt?: string | number[];
+  submittedAt?: string | number[];
+  lastUpdatedAt?: string | number[];
+  currentStage?: string;
+  lastCompletedStage?: string;
+  stoppedAtStage?: string;
+  pendingCreditCount?: number;
+}
+
 /**
  * Tasks Service
  */
@@ -128,6 +160,14 @@ export class TasksService {
    */
   getEnrollmentCases(searchData: EnrollmentCasesSearchParams): Observable<EnrollmentCasesResponse> {
     return this.http.get<EnrollmentCasesResponse>('/v2/onboarding/cases', { params: this.buildHttpParams(searchData) });
+  }
+
+  /**
+   * Get pending prospects.
+   * @param {PendingProspectsSearchParams} searchData Pending prospects search, paging, and sorting parameters.
+   */
+  getPendingProspects(searchData?: PendingProspectsSearchParams): Observable<PendingProspectsResponse> {
+    return this.http.get<PendingProspectsResponse>('/v2/prospects', { params: this.buildHttpParams(searchData) });
   }
 
   /**

--- a/src/assets/translations/cs-CS.json
+++ b/src/assets/translations/cs-CS.json
@@ -3811,7 +3811,22 @@
       "Provider KYC Decision": "Rozhodnutí poskytovatele KYC",
       "Source": "Zdroj",
       "Started": "Zahájeno",
-      "Verification Session": "Ověřovací relace"
+      "Verification Session": "Ověřovací relace",
+      "Pending Prospects": "Nevyřízené prospekty",
+      "Prospect": "Prospekt",
+      "External Reference": "Externí reference",
+      "Current Stage": "Aktuální fáze",
+      "Last Completed Stage": "Poslední dokončená fáze",
+      "Stopped At": "Zastaveno ve fázi",
+      "Pending Credits": "Nevyřízené úvěry",
+      "Created": "Vytvořeno",
+      "Last Updated": "Naposledy aktualizováno",
+      "In Progress": "Probíhá",
+      "Submitted": "Odesláno",
+      "Withdrawn": "Staženo",
+      "Registration Status": "Stav registrace",
+      "Unknown": "Neznámé",
+      "Pending": "Nevyřízené"
     },
     "links": {
       "Community": "Společenství",
@@ -5080,8 +5095,10 @@
       "Counted in repayment periods": "Počítáno ve splátkových obdobích ({{unit}})",
       "Loading enrollment status": "Načítá se stav registrace",
       "No enrollment cases found": "Nebyly nalezeny žádné případy registrace",
-      "Select a client from the list": "Vyberte klienta ze seznamu",
-      "Unable to load enrollment status": "Nelze načíst stav registrace"
+      "Unable to load enrollment status": "Nelze načíst stav registrace",
+      "Loading pending prospects": "Načítání nevyřízených prospektů",
+      "No pending prospects found": "Nebyly nalezeny žádné nevyřízené prospekty",
+      "Unable to load pending prospects": "Nelze načíst nevyřízené prospekty"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/de-DE.json
+++ b/src/assets/translations/de-DE.json
@@ -3812,7 +3812,22 @@
       "Provider KYC Decision": "KYC-Entscheidung des Anbieters",
       "Source": "Quelle",
       "Started": "Gestartet",
-      "Verification Session": "Verifizierungssitzung"
+      "Verification Session": "Verifizierungssitzung",
+      "Pending Prospects": "Ausstehende Interessenten",
+      "Prospect": "Interessent",
+      "External Reference": "Externe Referenz",
+      "Current Stage": "Aktuelle Phase",
+      "Last Completed Stage": "Letzte abgeschlossene Phase",
+      "Stopped At": "Angehalten bei",
+      "Pending Credits": "Ausstehende Kredite",
+      "Created": "Erstellt",
+      "Last Updated": "Zuletzt aktualisiert",
+      "In Progress": "In Bearbeitung",
+      "Submitted": "Eingereicht",
+      "Withdrawn": "Zurückgezogen",
+      "Registration Status": "Registrierungsstatus",
+      "Unknown": "Unbekannt",
+      "Pending": "Ausstehend"
     },
     "links": {
       "Community": "Gemeinschaft",
@@ -5080,8 +5095,10 @@
       "Counted in repayment periods": "Wird in Rückzahlungsperioden gezählt ({{unit}})",
       "Loading enrollment status": "Registrierungsstatus wird geladen",
       "No enrollment cases found": "Keine Registrierungsfälle gefunden",
-      "Select a client from the list": "Wählen Sie einen Kunden aus der Liste aus",
-      "Unable to load enrollment status": "Registrierungsstatus konnte nicht geladen werden"
+      "Unable to load enrollment status": "Registrierungsstatus konnte nicht geladen werden",
+      "Loading pending prospects": "Ausstehende Interessenten werden geladen",
+      "No pending prospects found": "Keine ausstehenden Interessenten gefunden",
+      "Unable to load pending prospects": "Ausstehende Interessenten konnten nicht geladen werden"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/en-US.json
+++ b/src/assets/translations/en-US.json
@@ -3834,7 +3834,22 @@
       "Provider KYC Decision": "Provider KYC Decision",
       "Source": "Source",
       "Started": "Started",
-      "Verification Session": "Verification Session"
+      "Verification Session": "Verification Session",
+      "Pending Prospects": "Pending Prospects",
+      "Prospect": "Prospect",
+      "External Reference": "External Reference",
+      "Current Stage": "Current Stage",
+      "Last Completed Stage": "Last Completed Stage",
+      "Stopped At": "Stopped At",
+      "Pending Credits": "Pending Credits",
+      "Created": "Created",
+      "Last Updated": "Last Updated",
+      "In Progress": "In Progress",
+      "Submitted": "Submitted",
+      "Withdrawn": "Withdrawn",
+      "Registration Status": "Registration Status",
+      "Unknown": "Unknown",
+      "Pending": "Pending"
     },
     "links": {
       "Community": "Community",
@@ -5218,8 +5233,10 @@
       "Counted in repayment periods": "Counted in repayment periods ({{unit}})",
       "Loading enrollment status": "Loading enrollment status",
       "No enrollment cases found": "No enrollment cases found",
-      "Select a client from the list": "Select a client from the list",
-      "Unable to load enrollment status": "Unable to load enrollment status"
+      "Unable to load enrollment status": "Unable to load enrollment status",
+      "Loading pending prospects": "Loading pending prospects",
+      "No pending prospects found": "No pending prospects found",
+      "Unable to load pending prospects": "Unable to load pending prospects"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/es-CL.json
+++ b/src/assets/translations/es-CL.json
@@ -3811,7 +3811,22 @@
       "Provider KYC Decision": "Decisión KYC del proveedor",
       "Source": "Origen",
       "Started": "Iniciado",
-      "Verification Session": "Sesión de verificación"
+      "Verification Session": "Sesión de verificación",
+      "Pending Prospects": "Prospectos pendientes",
+      "Prospect": "Prospecto",
+      "External Reference": "Referencia externa",
+      "Current Stage": "Etapa actual",
+      "Last Completed Stage": "Última etapa completada",
+      "Stopped At": "Detenido en",
+      "Pending Credits": "Créditos pendientes",
+      "Created": "Creado",
+      "Last Updated": "Última actualización",
+      "In Progress": "En progreso",
+      "Submitted": "Enviado",
+      "Withdrawn": "Retirado",
+      "Registration Status": "Estado de registro",
+      "Unknown": "Desconocido",
+      "Pending": "Pendiente"
     },
     "links": {
       "Community": "Comunidad",
@@ -5080,8 +5095,10 @@
       "Counted in repayment periods": "Contado en períodos de pago ({{unit}})",
       "Loading enrollment status": "Cargando estado de enrolamiento",
       "No enrollment cases found": "No se encontraron casos de enrolamiento",
-      "Select a client from the list": "Seleccione un cliente de la lista",
-      "Unable to load enrollment status": "No se pudo cargar el estado de enrolamiento"
+      "Unable to load enrollment status": "No se pudo cargar el estado de enrolamiento",
+      "Loading pending prospects": "Cargando prospectos pendientes",
+      "No pending prospects found": "No se encontraron prospectos pendientes",
+      "Unable to load pending prospects": "No se pudieron cargar los prospectos pendientes"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/es-MX.json
+++ b/src/assets/translations/es-MX.json
@@ -3816,7 +3816,22 @@
       "Provider KYC Decision": "Decisión KYC del proveedor",
       "Source": "Origen",
       "Started": "Iniciado",
-      "Verification Session": "Sesión de verificación"
+      "Verification Session": "Sesión de verificación",
+      "Pending Prospects": "Prospectos pendientes",
+      "Prospect": "Prospecto",
+      "External Reference": "Referencia externa",
+      "Current Stage": "Etapa actual",
+      "Last Completed Stage": "Última etapa completada",
+      "Stopped At": "Detenido en",
+      "Pending Credits": "Créditos pendientes",
+      "Created": "Creado",
+      "Last Updated": "Última actualización",
+      "In Progress": "En progreso",
+      "Submitted": "Enviado",
+      "Withdrawn": "Retirado",
+      "Registration Status": "Estado de registro",
+      "Unknown": "Desconocido",
+      "Pending": "Pendiente"
     },
     "links": {
       "Community": "Comunidad",
@@ -5104,8 +5119,10 @@
       "Counted in repayment periods": "Contado en períodos de pago ({{unit}})",
       "Loading enrollment status": "Cargando estado de enrolamiento",
       "No enrollment cases found": "No se encontraron casos de enrolamiento",
-      "Select a client from the list": "Seleccione un cliente de la lista",
-      "Unable to load enrollment status": "No se pudo cargar el estado de enrolamiento"
+      "Unable to load enrollment status": "No se pudo cargar el estado de enrolamiento",
+      "Loading pending prospects": "Cargando prospectos pendientes",
+      "No pending prospects found": "No se encontraron prospectos pendientes",
+      "Unable to load pending prospects": "No se pudieron cargar los prospectos pendientes"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/fr-FR.json
+++ b/src/assets/translations/fr-FR.json
@@ -3813,7 +3813,22 @@
       "Provider KYC Decision": "Décision KYC du fournisseur",
       "Source": "Source",
       "Started": "Démarré",
-      "Verification Session": "Session de vérification"
+      "Verification Session": "Session de vérification",
+      "Pending Prospects": "Prospects en attente",
+      "Prospect": "Prospect",
+      "External Reference": "Référence externe",
+      "Current Stage": "Étape actuelle",
+      "Last Completed Stage": "Dernière étape terminée",
+      "Stopped At": "Arrêté à",
+      "Pending Credits": "Crédits en attente",
+      "Created": "Créé",
+      "Last Updated": "Dernière mise à jour",
+      "In Progress": "En cours",
+      "Submitted": "Soumis",
+      "Withdrawn": "Retiré",
+      "Registration Status": "Statut d’inscription",
+      "Unknown": "Inconnu",
+      "Pending": "En attente"
     },
     "links": {
       "Community": "Communauté",
@@ -5081,8 +5096,10 @@
       "Counted in repayment periods": "Compté en périodes de remboursement ({{unit}})",
       "Loading enrollment status": "Chargement du statut d'inscription",
       "No enrollment cases found": "Aucun dossier d'inscription trouvé",
-      "Select a client from the list": "Sélectionnez un client dans la liste",
-      "Unable to load enrollment status": "Impossible de charger le statut d'inscription"
+      "Unable to load enrollment status": "Impossible de charger le statut d'inscription",
+      "Loading pending prospects": "Chargement des prospects en attente",
+      "No pending prospects found": "Aucun prospect en attente trouvé",
+      "Unable to load pending prospects": "Impossible de charger les prospects en attente"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/it-IT.json
+++ b/src/assets/translations/it-IT.json
@@ -3810,7 +3810,22 @@
       "Provider KYC Decision": "Decisione KYC del provider",
       "Source": "Origine",
       "Started": "Avviato",
-      "Verification Session": "Sessione di verifica"
+      "Verification Session": "Sessione di verifica",
+      "Pending Prospects": "Prospect in sospeso",
+      "Prospect": "Prospect",
+      "External Reference": "Riferimento esterno",
+      "Current Stage": "Fase corrente",
+      "Last Completed Stage": "Ultima fase completata",
+      "Stopped At": "Interrotto a",
+      "Pending Credits": "Crediti in sospeso",
+      "Created": "Creato",
+      "Last Updated": "Ultimo aggiornamento",
+      "In Progress": "In corso",
+      "Submitted": "Inviato",
+      "Withdrawn": "Ritirato",
+      "Registration Status": "Stato registrazione",
+      "Unknown": "Sconosciuto",
+      "Pending": "In sospeso"
     },
     "links": {
       "Community": "Comunità",
@@ -5079,8 +5094,10 @@
       "Counted in repayment periods": "Conteggiato in periodi di rimborso ({{unit}})",
       "Loading enrollment status": "Caricamento dello stato registrazione",
       "No enrollment cases found": "Nessun caso di registrazione trovato",
-      "Select a client from the list": "Seleziona un cliente dall'elenco",
-      "Unable to load enrollment status": "Impossibile caricare lo stato registrazione"
+      "Unable to load enrollment status": "Impossibile caricare lo stato registrazione",
+      "Loading pending prospects": "Caricamento prospect in sospeso",
+      "No pending prospects found": "Nessun prospect in sospeso trovato",
+      "Unable to load pending prospects": "Impossibile caricare i prospect in sospeso"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/ko-KO.json
+++ b/src/assets/translations/ko-KO.json
@@ -3810,7 +3810,22 @@
       "Provider KYC Decision": "제공업체 KYC 결정",
       "Source": "출처",
       "Started": "시작됨",
-      "Verification Session": "확인 세션"
+      "Verification Session": "확인 세션",
+      "Pending Prospects": "대기 중인 잠재 고객",
+      "Prospect": "잠재 고객",
+      "External Reference": "외부 참조",
+      "Current Stage": "현재 단계",
+      "Last Completed Stage": "마지막 완료 단계",
+      "Stopped At": "중단 단계",
+      "Pending Credits": "대기 중인 크레딧",
+      "Created": "생성됨",
+      "Last Updated": "마지막 업데이트",
+      "In Progress": "진행 중",
+      "Submitted": "제출됨",
+      "Withdrawn": "철회됨",
+      "Registration Status": "등록 상태",
+      "Unknown": "알 수 없음",
+      "Pending": "대기 중"
     },
     "links": {
       "Community": "지역 사회",
@@ -5078,8 +5093,10 @@
       "Counted in repayment periods": "상환 주기 단위로 계산됩니다 ({{unit}})",
       "Loading enrollment status": "등록 상태를 불러오는 중",
       "No enrollment cases found": "등록 사례를 찾을 수 없습니다",
-      "Select a client from the list": "목록에서 고객을 선택하세요",
-      "Unable to load enrollment status": "등록 상태를 불러올 수 없습니다"
+      "Unable to load enrollment status": "등록 상태를 불러올 수 없습니다",
+      "Loading pending prospects": "대기 중인 잠재 고객을 불러오는 중",
+      "No pending prospects found": "대기 중인 잠재 고객이 없습니다",
+      "Unable to load pending prospects": "대기 중인 잠재 고객을 불러올 수 없습니다"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/lt-LT.json
+++ b/src/assets/translations/lt-LT.json
@@ -3809,7 +3809,22 @@
       "Provider KYC Decision": "Teikėjo KYC sprendimas",
       "Source": "Šaltinis",
       "Started": "Pradėta",
-      "Verification Session": "Patvirtinimo sesija"
+      "Verification Session": "Patvirtinimo sesija",
+      "Pending Prospects": "Laukiantys prospektai",
+      "Prospect": "Prospektas",
+      "External Reference": "Išorinė nuoroda",
+      "Current Stage": "Dabartinis etapas",
+      "Last Completed Stage": "Paskutinis užbaigtas etapas",
+      "Stopped At": "Sustota ties",
+      "Pending Credits": "Laukiantys kreditai",
+      "Created": "Sukurta",
+      "Last Updated": "Paskutinį kartą atnaujinta",
+      "In Progress": "Vykdoma",
+      "Submitted": "Pateikta",
+      "Withdrawn": "Atsiimta",
+      "Registration Status": "Registracijos būsena",
+      "Unknown": "Nežinoma",
+      "Pending": "Laukiama"
     },
     "links": {
       "Community": "bendruomenė",
@@ -5079,8 +5094,10 @@
       "Counted in repayment periods": "Skaičiuojama grąžinimo laikotarpiais ({{unit}})",
       "Loading enrollment status": "Įkeliama registracijos būsena",
       "No enrollment cases found": "Registracijos atvejų nerasta",
-      "Select a client from the list": "Pasirinkite klientą iš sąrašo",
-      "Unable to load enrollment status": "Nepavyko įkelti registracijos būsenos"
+      "Unable to load enrollment status": "Nepavyko įkelti registracijos būsenos",
+      "Loading pending prospects": "Įkeliami laukiantys prospektai",
+      "No pending prospects found": "Laukiančių prospektų nerasta",
+      "Unable to load pending prospects": "Nepavyko įkelti laukiančių prospektų"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/lv-LV.json
+++ b/src/assets/translations/lv-LV.json
@@ -3810,7 +3810,22 @@
       "Provider KYC Decision": "Pakalpojumu sniedzēja KYC lēmums",
       "Source": "Avots",
       "Started": "Sākts",
-      "Verification Session": "Pārbaudes sesija"
+      "Verification Session": "Pārbaudes sesija",
+      "Pending Prospects": "Neapstrādātie prospekti",
+      "Prospect": "Prospekts",
+      "External Reference": "Ārējā atsauce",
+      "Current Stage": "Pašreizējais posms",
+      "Last Completed Stage": "Pēdējais pabeigtais posms",
+      "Stopped At": "Apturēts pie",
+      "Pending Credits": "Neapstrādātie kredīti",
+      "Created": "Izveidots",
+      "Last Updated": "Pēdējoreiz atjaunināts",
+      "In Progress": "Procesā",
+      "Submitted": "Iesniegts",
+      "Withdrawn": "Atsaukts",
+      "Registration Status": "Reģistrācijas statuss",
+      "Unknown": "Nezināms",
+      "Pending": "Gaida"
     },
     "links": {
       "Community": "kopiena",
@@ -5078,8 +5093,10 @@
       "Counted in repayment periods": "Tiek skaitīts atmaksas periodos ({{unit}})",
       "Loading enrollment status": "Notiek reģistrācijas statusa ielāde",
       "No enrollment cases found": "Reģistrācijas gadījumi nav atrasti",
-      "Select a client from the list": "Atlasiet klientu no saraksta",
-      "Unable to load enrollment status": "Neizdevās ielādēt reģistrācijas statusu"
+      "Unable to load enrollment status": "Neizdevās ielādēt reģistrācijas statusu",
+      "Loading pending prospects": "Notiek neapstrādāto prospektu ielāde",
+      "No pending prospects found": "Neapstrādāti prospekti nav atrasti",
+      "Unable to load pending prospects": "Nevar ielādēt neapstrādātos prospektus"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/ne-NE.json
+++ b/src/assets/translations/ne-NE.json
@@ -3809,7 +3809,22 @@
       "Provider KYC Decision": "प्रदायकको KYC निर्णय",
       "Source": "स्रोत",
       "Started": "सुरु गरिएको",
-      "Verification Session": "प्रमाणीकरण सत्र"
+      "Verification Session": "प्रमाणीकरण सत्र",
+      "Pending Prospects": "विचाराधीन सम्भावित ग्राहकहरू",
+      "Prospect": "सम्भावित ग्राहक",
+      "External Reference": "बाह्य सन्दर्भ",
+      "Current Stage": "हालको चरण",
+      "Last Completed Stage": "अन्तिम पूरा चरण",
+      "Stopped At": "रोकिएको चरण",
+      "Pending Credits": "विचाराधीन क्रेडिटहरू",
+      "Created": "सिर्जना गरिएको",
+      "Last Updated": "अन्तिम अद्यावधिक",
+      "In Progress": "प्रगतिमा",
+      "Submitted": "पेश गरिएको",
+      "Withdrawn": "फिर्ता लिइएको",
+      "Registration Status": "दर्ता स्थिति",
+      "Unknown": "अज्ञात",
+      "Pending": "विचाराधीन"
     },
     "links": {
       "Community": "समुदाय",
@@ -5078,8 +5093,10 @@
       "Counted in repayment periods": "भुक्तानी अवधिमा गणना गरिन्छ ({{unit}})",
       "Loading enrollment status": "दर्ता स्थिति लोड हुँदैछ",
       "No enrollment cases found": "दर्ताका केसहरू फेला परेनन्",
-      "Select a client from the list": "सूचीबाट ग्राहक चयन गर्नुहोस्",
-      "Unable to load enrollment status": "दर्ता स्थिति लोड गर्न सकिएन"
+      "Unable to load enrollment status": "दर्ता स्थिति लोड गर्न सकिएन",
+      "Loading pending prospects": "विचाराधीन सम्भावित ग्राहकहरू लोड हुँदै",
+      "No pending prospects found": "विचाराधीन सम्भावित ग्राहकहरू फेला परेनन्",
+      "Unable to load pending prospects": "विचाराधीन सम्भावित ग्राहकहरू लोड गर्न सकिएन"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/pt-PT.json
+++ b/src/assets/translations/pt-PT.json
@@ -3809,7 +3809,22 @@
       "Provider KYC Decision": "Decisão KYC do fornecedor",
       "Source": "Origem",
       "Started": "Iniciado",
-      "Verification Session": "Sessão de verificação"
+      "Verification Session": "Sessão de verificação",
+      "Pending Prospects": "Prospectos pendentes",
+      "Prospect": "Prospecto",
+      "External Reference": "Referência externa",
+      "Current Stage": "Etapa atual",
+      "Last Completed Stage": "Última etapa concluída",
+      "Stopped At": "Parado em",
+      "Pending Credits": "Créditos pendentes",
+      "Created": "Criado",
+      "Last Updated": "Última atualização",
+      "In Progress": "Em progresso",
+      "Submitted": "Submetido",
+      "Withdrawn": "Retirado",
+      "Registration Status": "Estado do registo",
+      "Unknown": "Desconhecido",
+      "Pending": "Pendente"
     },
     "links": {
       "Community": "Comunidade",
@@ -5078,8 +5093,10 @@
       "Counted in repayment periods": "Contado em períodos de reembolso ({{unit}})",
       "Loading enrollment status": "A carregar o estado da inscrição",
       "No enrollment cases found": "Nenhum caso de inscrição encontrado",
-      "Select a client from the list": "Selecione um cliente da lista",
-      "Unable to load enrollment status": "Não foi possível carregar o estado da inscrição"
+      "Unable to load enrollment status": "Não foi possível carregar o estado da inscrição",
+      "Loading pending prospects": "A carregar prospectos pendentes",
+      "No pending prospects found": "Nenhum prospecto pendente encontrado",
+      "Unable to load pending prospects": "Não foi possível carregar os prospectos pendentes"
     },
     "permissions": {
       "actions": {

--- a/src/assets/translations/sw-SW.json
+++ b/src/assets/translations/sw-SW.json
@@ -3807,7 +3807,22 @@
       "Provider KYC Decision": "Uamuzi wa KYC wa mtoa huduma",
       "Source": "Chanzo",
       "Started": "Imeanza",
-      "Verification Session": "Kikao cha uthibitishaji"
+      "Verification Session": "Kikao cha uthibitishaji",
+      "Pending Prospects": "Watarajiwa wanaosubiri",
+      "Prospect": "Mtarajiwa",
+      "External Reference": "Rejeleo la nje",
+      "Current Stage": "Hatua ya sasa",
+      "Last Completed Stage": "Hatua ya mwisho iliyokamilika",
+      "Stopped At": "Ilisimama kwenye",
+      "Pending Credits": "Mikopo inayosubiri",
+      "Created": "Imeundwa",
+      "Last Updated": "Ilisasishwa mwisho",
+      "In Progress": "Inaendelea",
+      "Submitted": "Imewasilishwa",
+      "Withdrawn": "Imeondolewa",
+      "Registration Status": "Hali ya usajili",
+      "Unknown": "Haijulikani",
+      "Pending": "Inasubiri"
     },
     "links": {
       "Community": "Jumuiya",
@@ -5075,8 +5090,10 @@
       "Counted in repayment periods": "Huhesabiwa kwa vipindi vya marejesho ({{unit}})",
       "Loading enrollment status": "Inapakia hali ya usajili",
       "No enrollment cases found": "Hakuna kesi za usajili zilizopatikana",
-      "Select a client from the list": "Chagua mteja kutoka kwenye orodha",
-      "Unable to load enrollment status": "Imeshindwa kupakia hali ya usajili"
+      "Unable to load enrollment status": "Imeshindwa kupakia hali ya usajili",
+      "Loading pending prospects": "Inapakia watarajiwa wanaosubiri",
+      "No pending prospects found": "Hakuna watarajiwa wanaosubiri waliopatikana",
+      "Unable to load pending prospects": "Imeshindwa kupakia watarajiwa wanaosubiri"
     },
     "permissions": {
       "actions": {


### PR DESCRIPTION
## Description

Adds the WEB-1057 Pending Prospects section to Checker Inbox & Tasks using the `/v2/prospects` API.

The new view supports date and registration-status filtering, server-side pagination, prospect stage visibility, pending credit counts, permission-aware access, and safe handling of unknown or unavailable stage data.

## Related issues and discussion

WEB-1057

## Screenshots, if any


https://github.com/user-attachments/assets/c8b02fdc-7221-4196-8c1b-ba84b76a25fa



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a permission-based **Pending Prospects** tab in Tasks.
  * Added searchable, filterable, sortable, and paginated prospect results.
  * Added date-range validation, loading, error, and empty states.
  * Added navigation to available client records.
  * Added localized labels and messages across supported languages.

* **Tests**
  * Added coverage for filtering, sorting, pagination, permissions, routing, and request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->